### PR TITLE
docs+scripts: README badges and self-analysis scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 
 
-Versão
-Python
-Licença
+![Version](https://img.shields.io/badge/version-5.1.0-blue.svg?style=for-the-badge)
+![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg?style=for-the-badge)
+![License](https://img.shields.io/badge/license-MIT-green.svg?style=for-the-badge)
 
 **Agente de IA autônomo, multi-provedor, executado via CLI, voltado ao desenvolvimento de software.**
 
@@ -627,6 +627,36 @@ Contribuições são bem-vindas — desde correção de typos até novas ferrame
 
 
 > 💬 PRs grandes ou que mexam em arquitetura de núcleo: abra primeiro uma **issue de discussão** descrevendo a proposta, para alinhar antes do código.
+
+---
+
+## 🪞 Auto-análise — DEILE analisando o próprio DEILE
+
+Um dos diferenciais do projeto é que o próprio agente pode ser usado como ferramenta de **revisão arquitetural** e **caça a bugs** sobre o próprio código. Como o DEILE roda dentro do diretório de trabalho atual, basta executá-lo na raiz do repositório.
+
+### Modo interativo (mais flexível)
+
+| Passo | Comando |
+|---|---|
+| Subir o agente na raiz do projeto | `./deile.sh` |
+| Pedir uma análise | Dentro do prompt, peça em linguagem natural — por exemplo: *"analise o pacote `deile/core/` e me liste 5 melhorias arquiteturais essenciais com base nas melhores práticas"* |
+
+### Modo one-shot via scripts dedicados
+
+Dois scripts pré-formatados disparam o DEILE em modo one-shot com prompts focados e gravam o relatório em disco. Pré-requisito: ter rodado `./deile.sh` ao menos uma vez (para criar `.venv` e `.env`).
+
+| Script | O que faz | Saída gerada |
+|---|---|---|
+| `./self-improve.sh` | Análise arquitetural crítica do pacote `deile/` com priorização P0/P1/P2 e quick wins | `docs/self-improve/<timestamp>-self-improvement.md` |
+| `./self-fix.sh` | Caça a bugs, awaitables não awaited, exceções silenciadas, race conditions, validações ausentes, com classificação de severidade | `docs/self-fix/<timestamp>-self-fix.md` |
+
+Ambos os scripts:
+
+- 🔒 Instruem o agente a **não modificar código fonte** — apenas ler arquivos e gravar o relatório.
+- 🏷️ Carimbam o relatório com data, branch e commit hash automaticamente.
+- 🧠 Usam o `default_model` configurado em `deile/config/model_providers.yaml` (cobertura via cascata do tier).
+
+> ⚠️ A qualidade da análise depende do modelo escolhido e da chave de API disponível. Análises arquiteturais profundas se beneficiam de um modelo tier 1; caça a bugs simples roda bem em tier 3. Ajuste a tier ou força um modelo via `/model use <provider:model_id>` se necessário antes de rodar o script.
 
 ---
 

--- a/self-fix.sh
+++ b/self-fix.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# self-fix.sh — pede ao próprio DEILE uma caça a bugs e inconsistências.
+#
+# Roda o agente em modo one-shot com um prompt direcionado a:
+#   1. Varrer o pacote deile/ procurando bugs, riscos e regressões.
+#   2. Classificar findings por severidade (CRÍTICO / ALTO / MÉDIO / BAIXO).
+#   3. Gravar o relatório em docs/self-fix/<timestamp>-self-fix.md
+#
+# Pré-requisito: ter rodado ./deile.sh ao menos uma vez (cria .venv e .env).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [[ -t 1 ]]; then
+    GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; RED=$'\033[0;31m'
+    BLUE=$'\033[0;34m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+    GREEN=''; YELLOW=''; RED=''; BLUE=''; BOLD=''; RESET=''
+fi
+
+if [[ ! -f deile.py ]]; then
+    printf "%s✗%s deile.py não encontrado em %s\n" "$RED" "$RESET" "$SCRIPT_DIR" >&2
+    exit 1
+fi
+
+if [[ ! -d .venv ]]; then
+    printf "%s✗%s .venv não existe — rode %s./deile.sh%s primeiro.\n" "$RED" "$RESET" "$BOLD" "$RESET" >&2
+    exit 1
+fi
+
+if [[ ! -f .env ]]; then
+    printf "%s✗%s .env não existe — rode %s./deile.sh%s primeiro para configurar suas chaves de API.\n" "$RED" "$RESET" "$BOLD" "$RESET" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+TS=$(date '+%Y-%m-%d-%H%M%S')
+OUT_DIR="docs/self-fix"
+OUT_FILE="${OUT_DIR}/${TS}-self-fix.md"
+mkdir -p "$OUT_DIR"
+
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+printf "\n%s▶ DEILE self-fix (bug hunt)%s\n" "$BOLD$BLUE" "$RESET"
+printf "  branch : %s\n"  "$BRANCH"
+printf "  commit : %s\n"  "$COMMIT"
+printf "  saída  : %s\n\n" "$OUT_FILE"
+
+PROMPT=$(cat <<EOF
+Você está rodando DENTRO do próprio repositório do projeto DEILE — você é o agente caçando bugs no seu próprio código fonte. Branch atual: ${BRANCH}, commit: ${COMMIT}, data: ${TS}.
+
+Sua missão é uma CAÇA A BUGS: identificar inconsistências, regressões silenciosas e riscos no código atual e produzir um relatório priorizado para revisão humana.
+
+ETAPAS OBRIGATÓRIAS:
+
+1. Use list_files (recursive=true, pattern="*.py") e read_file para varrer o pacote 'deile/'. Procure especialmente por:
+   - Awaitables não awaited (chamada de coroutine sem 'await').
+   - try/except que silenciam exceções (bare except, 'except Exception: pass', except com 'logger.warning' e nada mais).
+   - Race conditions em estado compartilhado (singletons, registries, caches sem lock).
+   - Validação de input ausente em fronteiras (CLI, file paths, parâmetros de tool vindos do LLM).
+   - Vazamento de recursos (file handles abertos sem 'with', conexões DB, processos).
+   - Discrepâncias entre o JSON Schema declarado por uma tool e o uso real dos parâmetros (parâmetros declarados mas não usados, ou usados mas não declarados, coerção implícita de tipo).
+   - Código inalcançável ou regressões silenciosas (variável calculada e descartada, branch morto, return cedo).
+   - Dependências entre módulos com import circular ou import lateral oculto.
+   - Funções que retornam tipos diferentes em caminhos diferentes sem documentação.
+
+2. Para cada finding, classifique severidade: CRÍTICO (corrompe estado / vaza dados) | ALTO (falha em runtime ou path comum) | MÉDIO (degrada UX/manutenção) | BAIXO (cosmético).
+
+3. Use write_file para gravar UM ÚNICO documento Markdown EXATAMENTE em '${OUT_FILE}', estruturado:
+   - # Self-fix report (data, branch, commit)
+   - ## 1. Resumo executivo (contagem por severidade)
+   - ## 2. Findings — uma seção por finding, com: ID (FIX-001, FIX-002, ...), título, severidade (badge), arquivo:linha, descrição do problema, reprodução (se aplicável), fix sugerido (sem patch — só descrição).
+   - ## 3. Padrões recorrentes detectados
+   - ## 4. Recomendações de tooling (linters, type checks, hooks que poderiam prevenir essa classe de bugs)
+
+REGRAS:
+- NÃO modifique código fonte. Apenas leitura + write_file no documento de saída.
+- NÃO tente fixar nada. Reporte para revisão humana.
+- Cada finding precisa apontar arquivos e linhas concretas.
+- Não invente: se não tem certeza de que é bug, marque como SUSPEITO em vez de afirmar.
+- Termine sua resposta confirmando o caminho do documento criado.
+EOF
+)
+
+exec python deile.py "$PROMPT"

--- a/self-improve.sh
+++ b/self-improve.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# self-improve.sh — pede ao próprio DEILE uma análise arquitetural do código.
+#
+# Roda o agente em modo one-shot com um prompt direcionado a:
+#   1. Mapear o pacote deile/ usando list_files / read_file.
+#   2. Identificar melhorias arquiteturais alinhadas a melhores práticas.
+#   3. Gravar o relatório em docs/self-improve/<timestamp>-self-improvement.md
+#
+# Pré-requisito: ter rodado ./deile.sh ao menos uma vez (cria .venv e .env).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [[ -t 1 ]]; then
+    GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; RED=$'\033[0;31m'
+    BLUE=$'\033[0;34m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+    GREEN=''; YELLOW=''; RED=''; BLUE=''; BOLD=''; RESET=''
+fi
+
+if [[ ! -f deile.py ]]; then
+    printf "%s✗%s deile.py não encontrado em %s\n" "$RED" "$RESET" "$SCRIPT_DIR" >&2
+    exit 1
+fi
+
+if [[ ! -d .venv ]]; then
+    printf "%s✗%s .venv não existe — rode %s./deile.sh%s primeiro.\n" "$RED" "$RESET" "$BOLD" "$RESET" >&2
+    exit 1
+fi
+
+if [[ ! -f .env ]]; then
+    printf "%s✗%s .env não existe — rode %s./deile.sh%s primeiro para configurar suas chaves de API.\n" "$RED" "$RESET" "$BOLD" "$RESET" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+TS=$(date '+%Y-%m-%d-%H%M%S')
+OUT_DIR="docs/self-improve"
+OUT_FILE="${OUT_DIR}/${TS}-self-improvement.md"
+mkdir -p "$OUT_DIR"
+
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+printf "\n%s▶ DEILE self-improvement%s\n" "$BOLD$BLUE" "$RESET"
+printf "  branch : %s\n"  "$BRANCH"
+printf "  commit : %s\n"  "$COMMIT"
+printf "  saída  : %s\n\n" "$OUT_FILE"
+
+PROMPT=$(cat <<EOF
+Você está rodando DENTRO do próprio repositório do projeto DEILE — você é o agente analisando o seu próprio código fonte. Branch atual: ${BRANCH}, commit: ${COMMIT}, data: ${TS}.
+
+Sua missão é produzir uma ANÁLISE ARQUITETURAL CRÍTICA do código e identificar melhorias essenciais para alinhar o projeto com melhores práticas de engenharia de software.
+
+ETAPAS OBRIGATÓRIAS:
+
+1. Use list_files (recursive=true, pattern="*.py") e read_file para mapear o pacote 'deile/'. Foque nos subpacotes: core/, core/models/, tools/, commands/, events/, memory/, security/, storage/, orchestration/, ui/, config/, parsers/, personas/, plugins/, evolution/, infrastructure/.
+
+2. Em cada área, avalie:
+   - Aderência aos princípios do projeto (registries para artefatos extensíveis, async-correctness, hexagonal/separação de camadas, segurança, observabilidade).
+   - Code smells: deep nesting, métodos longos (>50 linhas), acoplamento alto, duplicação, god classes, abstrações vazadas.
+   - Caminhos críticos sem testes (use find_in_files para correlacionar fontes com testes em deile/tests/).
+   - Oportunidades de refatoração com alto impacto/baixo risco.
+   - Inconsistências entre módulos similares (ex.: providers que divergem na forma de tratar erros).
+
+3. Use write_file para gravar UM ÚNICO documento Markdown EXATAMENTE no caminho '${OUT_FILE}', estruturado nesta ordem:
+   - # Self-improvement report (com data, branch e commit no cabeçalho)
+   - ## 1. Escopo e metodologia
+   - ## 2. Mapa arquitetural resumido (1 parágrafo por subpacote relevante)
+   - ## 3. Achados priorizados — três tabelas: P0 (essencial), P1 (importante), P2 (nice-to-have). Cada linha: título | problema | solução proposta | arquivos afetados (com paths) | esforço S/M/L | impacto esperado.
+   - ## 4. Quick wins (mudanças <100 linhas que destravam manutenção)
+   - ## 5. Padrões recorrentes detectados
+   - ## 6. Próximos passos recomendados (ordem sugerida de execução)
+
+REGRAS:
+- NÃO modifique NENHUM arquivo do código fonte. Apenas leitura + write_file no documento de saída.
+- NÃO execute testes (pytest, ruff, etc).
+- Foque em melhorias ARQUITETURAIS — typos, formatação e cosméticos NÃO entram.
+- Seja específico: cite arquivos e linhas concretas em cada achado.
+- Não invente: se não tem certeza, abra o arquivo antes de afirmar.
+- Termine sua resposta confirmando o caminho do documento criado.
+EOF
+)
+
+exec python deile.py "$PROMPT"


### PR DESCRIPTION
## Summary

Três commits que ficaram fora da PR #35 (já mergeada):

- **`52aff29`** — restaura os shields.io badges (`Version`, `Python`, `License`) que tinham virado texto puro no topo do README, e bumpa a versão pra `5.1.0`.
- **`e17376a`** — adiciona `self-improve.sh` e `self-fix.sh`, os dois wrappers one-shot do DEILE referenciados pela seção "Auto-análise" do README.
- **`74df000`** — corrige a frase "100% Python" no README; o agente segue 100% Python, mas os wrappers de bootstrap (`deile.sh`) e auto-análise (`self-*.sh`) são shell scripts.

## Test plan

- [ ] README renderiza os 3 badges no topo no GitHub
- [ ] `./self-improve.sh` roda em diretório com `.venv` (gerado por `./deile.sh`) e grava em `docs/self-improve/<ts>-self-improvement.md`
- [ ] `./self-fix.sh` idem para `docs/self-fix/<ts>-self-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)