### PR TITLE
feat: skill system via .deile/skills/ directories (refs #41)

### DIFF
--- a/deile/commands/skill_loader.py
+++ b/deile/commands/skill_loader.py
@@ -1,0 +1,226 @@
+"""Skill loader — discovers .md skill files and registers them as slash commands.
+
+Scans two directories in order (user skills first, project skills second):
+  • ~/.deile/skills/   — per-user skills (created automatically if absent)
+  • <cwd>/.deile/skills/ — per-project skills (optional, not auto-created)
+
+Project skills take priority: if a user skill and a project skill share the
+same name the project skill wins and the user skill is silently dropped.
+
+Skill file format (YAML front-matter + Markdown body):
+  ---
+  name: my-skill
+  description: One-line description shown in /help and autocomplete
+  ---
+  Prompt body sent to the LLM when the skill is invoked.
+
+The ``name`` field is optional; when absent the stem of the file name is used
+(spaces/underscores replaced with hyphens, lowercased).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_FRONTMATTER_RE = re.compile(r"^---[ \t]*\n(.*?)\n---[ \t]*\n", re.DOTALL)
+_VALID_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9\-]{0,63}$")
+
+
+@dataclass
+class SkillDefinition:
+    """Parsed representation of a single skill file."""
+
+    name: str
+    description: str
+    body: str
+    source: str  # "user" | "project"
+    file_path: Path = field(default_factory=Path)
+
+
+def _normalize_name(raw: str) -> str:
+    """Lower-case, replace whitespace/underscores with hyphens, strip extras."""
+    name = raw.strip().lower()
+    name = re.sub(r"[\s_]+", "-", name)
+    name = re.sub(r"[^a-z0-9\-]", "", name)
+    name = name.strip("-")
+    return name
+
+
+def _name_from_stem(stem: str) -> str:
+    return _normalize_name(stem)
+
+
+def _parse_skill_file(path: Path, source: str) -> Optional[SkillDefinition]:
+    """Return a SkillDefinition from *path*, or None on unrecoverable error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Cannot read skill file %s: %s", path, exc)
+        return None
+
+    frontmatter_data: Dict[str, str] = {}
+    body = text
+
+    match = _FRONTMATTER_RE.match(text)
+    if match:
+        import yaml  # already in requirements (PyYAML)
+
+        try:
+            parsed = yaml.safe_load(match.group(1)) or {}
+            if isinstance(parsed, dict):
+                frontmatter_data = {str(k): str(v) for k, v in parsed.items()}
+        except Exception as exc:
+            logger.warning("Invalid YAML front-matter in %s: %s", path, exc)
+        body = text[match.end():]
+
+    raw_name = frontmatter_data.get("name", "") or _name_from_stem(path.stem)
+    name = _normalize_name(raw_name)
+
+    if not _VALID_NAME_RE.match(name):
+        logger.warning(
+            "Skill file %s produces invalid name %r — skipped", path, name
+        )
+        return None
+
+    description = frontmatter_data.get("description", "") or f"Skill: {name}"
+    body = body.strip()
+
+    if not body:
+        logger.warning("Skill file %s has an empty body — skipped", path)
+        return None
+
+    return SkillDefinition(
+        name=name,
+        description=description,
+        body=body,
+        source=source,
+        file_path=path,
+    )
+
+
+class SkillLoader:
+    """Discovers skill files and produces SkillDefinition objects.
+
+    Args:
+        project_dir: Root of the current project (defaults to ``Path.cwd()``).
+        user_home:   User's home directory (defaults to ``Path.home()``).
+    """
+
+    def __init__(
+        self,
+        project_dir: Optional[Path] = None,
+        user_home: Optional[Path] = None,
+    ) -> None:
+        self._project_dir = project_dir or Path.cwd()
+        self._user_home = user_home or Path.home()
+
+    @property
+    def user_skills_dir(self) -> Path:
+        return self._user_home / ".deile" / "skills"
+
+    @property
+    def project_skills_dir(self) -> Path:
+        return self._project_dir / ".deile" / "skills"
+
+    def _ensure_user_dir(self) -> None:
+        """Create ~/.deile/skills/ if it doesn't exist."""
+        try:
+            self.user_skills_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.warning("Cannot create user skills dir %s: %s", self.user_skills_dir, exc)
+
+    def load_skills(self) -> List[SkillDefinition]:
+        """Scan both skill directories and return merged skill list.
+
+        Project skills override user skills when names collide.
+        """
+        self._ensure_user_dir()
+
+        # Gather user skills first (lower priority)
+        merged: Dict[str, SkillDefinition] = {}
+        for skill in self._scan_directory(self.user_skills_dir, source="user"):
+            merged[skill.name] = skill
+
+        # Project skills override user skills
+        for skill in self._scan_directory(self.project_skills_dir, source="project"):
+            if skill.name in merged:
+                logger.debug(
+                    "Project skill %r overrides user skill from %s",
+                    skill.name,
+                    merged[skill.name].file_path,
+                )
+            merged[skill.name] = skill
+
+        skills = list(merged.values())
+        if skills:
+            logger.info(
+                "Loaded %d skill(s) from %s",
+                len(skills),
+                ", ".join(sorted({s.source for s in skills})),
+            )
+        return skills
+
+    def _scan_directory(self, directory: Path, source: str) -> List[SkillDefinition]:
+        if not directory.is_dir():
+            return []
+
+        skills: List[SkillDefinition] = []
+        for md_file in sorted(directory.glob("*.md")):
+            skill = _parse_skill_file(md_file, source)
+            if skill is not None:
+                skills.append(skill)
+
+        return skills
+
+    def load_into_registry(self, registry) -> int:
+        """Load skills and register them in *registry*.
+
+        Returns:
+            Number of skills registered.
+        """
+        from .base import CommandContext, CommandResult, CommandStatus, SlashCommand
+        from ..config.manager import CommandConfig
+
+        skills = self.load_skills()
+
+        registered = 0
+        for skill in skills:
+            # Capture skill in closure
+            def _make_command(sk: SkillDefinition) -> SlashCommand:
+                class _SkillCommand(SlashCommand):
+                    def __init__(self) -> None:
+                        cfg = CommandConfig(
+                            name=sk.name,
+                            description=sk.description,
+                        )
+                        super().__init__(cfg)
+                        self.category = "skills"
+                        self._skill_body = sk.body
+
+                    async def execute(self, ctx: CommandContext) -> CommandResult:
+                        prompt = self._skill_body
+                        if ctx.args and ctx.args.strip():
+                            prompt = f"{prompt}\n\nArguments: {ctx.args.strip()}"
+                        return CommandResult(
+                            success=True,
+                            content=prompt,
+                            content_type="llm_prompt",
+                            status=CommandStatus.SUCCESS,
+                        )
+
+                return _SkillCommand()
+
+            cmd = _make_command(skill)
+            try:
+                registry.register_command(cmd)
+                registered += 1
+            except Exception as exc:
+                logger.warning("Failed to register skill %r: %s", skill.name, exc)
+
+        return registered

--- a/deile/core/agent.py
+++ b/deile/core/agent.py
@@ -1483,7 +1483,38 @@ class DeileAgent:
             
             # Executa comando
             command_result = await self.command_registry.execute_command(command_name, context)
-            
+
+            # Skills (and future LLM commands) return content_type="llm_prompt".
+            # Route the prompt through the LLM pipeline instead of returning it raw.
+            if command_result.content_type == "llm_prompt" and command_result.content:
+                prompt = str(command_result.content)
+                # Replace the slash-command user turn in history with the real prompt
+                # so the LLM sees the skill body, not the raw "/skill-name args".
+                for entry in reversed(session.conversation_history):
+                    if entry["role"] == "user":
+                        entry["content"] = prompt
+                        break
+                response_content, tool_results = await self._process_iterative_function_calling(
+                    prompt, None, session
+                )
+                response = AgentResponse(
+                    content=response_content,
+                    status=AgentStatus.IDLE,
+                    tool_results=tool_results,
+                    parse_result=None,
+                    execution_time=time.time() - start_time,
+                    metadata={
+                        "command_executed": command_name,
+                        "command_status": command_result.status.value,
+                        "is_slash_command": True,
+                    },
+                )
+                session.add_to_history("assistant", response_content, {
+                    "command": command_name,
+                    "command_status": command_result.status.value,
+                })
+                return response
+
             # Converte resultado do comando para AgentResponse
             response = AgentResponse(
                 content=command_result.content or f"Command /{command_name} executed",
@@ -1497,13 +1528,13 @@ class DeileAgent:
                     "is_slash_command": True
                 }
             )
-            
+
             # Adiciona resposta ao histórico
             session.add_to_history("assistant", response.content, {
                 "command": command_name,
                 "command_status": command_result.status.value
             })
-            
+
             return response
             
         except Exception as e:
@@ -2487,7 +2518,16 @@ class DeileAgent:
             builtin_commands = self.command_registry.auto_discover_builtin_commands()
             config_commands = self.command_registry.load_commands_from_config()
             self._register_command_actions()
-            
+
+            # Load user/project skills as slash commands
+            try:
+                from ..commands.skill_loader import SkillLoader
+                project_dir = getattr(self.settings, "working_directory", None)
+                skill_loader = SkillLoader(project_dir=project_dir)
+                skill_loader.load_into_registry(self.command_registry)
+            except Exception as _skill_exc:
+                self.logger.warning("Skill loading failed: %s", _skill_exc)
+
             # self.logger.info(
             #     f"Auto-discovery completed: {tools_discovered} tools, "
             #     f"{parsers_discovered} parsers, {builtin_commands + config_commands} commands"

--- a/deile/tests/test_skill_loader.py
+++ b/deile/tests/test_skill_loader.py
@@ -1,0 +1,283 @@
+"""Tests: SkillLoader — issue #41."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from deile.commands.skill_loader import (
+    SkillDefinition,
+    SkillLoader,
+    _normalize_name,
+    _parse_skill_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_name
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeName:
+    def test_lowercases(self):
+        assert _normalize_name("MySkill") == "myskill"
+
+    def test_replaces_spaces_with_hyphens(self):
+        assert _normalize_name("my skill") == "my-skill"
+
+    def test_replaces_underscores_with_hyphens(self):
+        assert _normalize_name("my_skill") == "my-skill"
+
+    def test_strips_leading_trailing_hyphens(self):
+        assert _normalize_name("-my-skill-") == "my-skill"
+
+    def test_removes_invalid_chars(self):
+        assert _normalize_name("my@skill!") == "myskill"
+
+
+# ---------------------------------------------------------------------------
+# _parse_skill_file
+# ---------------------------------------------------------------------------
+
+
+class TestParseSkillFile:
+    def test_full_frontmatter(self, tmp_path):
+        md = tmp_path / "review.md"
+        md.write_text(
+            "---\nname: code-review\ndescription: Review the code\n---\nPlease review this code.",
+            encoding="utf-8",
+        )
+        skill = _parse_skill_file(md, source="user")
+        assert skill is not None
+        assert skill.name == "code-review"
+        assert skill.description == "Review the code"
+        assert skill.body == "Please review this code."
+        assert skill.source == "user"
+
+    def test_name_falls_back_to_stem(self, tmp_path):
+        md = tmp_path / "my-skill.md"
+        md.write_text(
+            "---\ndescription: A skill\n---\nDo something.",
+            encoding="utf-8",
+        )
+        skill = _parse_skill_file(md, source="user")
+        assert skill is not None
+        assert skill.name == "my-skill"
+
+    def test_no_frontmatter_uses_filename(self, tmp_path):
+        md = tmp_path / "quick-fix.md"
+        md.write_text("Fix the most obvious bug.", encoding="utf-8")
+        skill = _parse_skill_file(md, source="project")
+        assert skill is not None
+        assert skill.name == "quick-fix"
+        assert skill.body == "Fix the most obvious bug."
+
+    def test_empty_body_returns_none(self, tmp_path):
+        md = tmp_path / "empty.md"
+        md.write_text("---\nname: empty\n---\n", encoding="utf-8")
+        skill = _parse_skill_file(md, source="user")
+        assert skill is None
+
+    def test_invalid_name_returns_none(self, tmp_path):
+        md = tmp_path / "!!.md"
+        md.write_text("---\nname: !!invalid!!\n---\nDo something.", encoding="utf-8")
+        skill = _parse_skill_file(md, source="user")
+        assert skill is None
+
+    def test_source_tagged_correctly(self, tmp_path):
+        md = tmp_path / "s.md"
+        md.write_text("Do it.", encoding="utf-8")
+        skill = _parse_skill_file(md, source="project")
+        assert skill is not None
+        assert skill.source == "project"
+
+    def test_missing_file_returns_none(self, tmp_path):
+        missing = tmp_path / "does_not_exist.md"
+        skill = _parse_skill_file(missing, source="user")
+        assert skill is None
+
+
+# ---------------------------------------------------------------------------
+# SkillLoader.load_skills
+# ---------------------------------------------------------------------------
+
+
+class TestSkillLoaderLoadSkills:
+    def _make_loader(self, tmp_path: Path) -> SkillLoader:
+        return SkillLoader(
+            project_dir=tmp_path / "project",
+            user_home=tmp_path / "home",
+        )
+
+    def _write_skill(self, directory: Path, filename: str, name: str, body: str) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / filename).write_text(
+            f"---\nname: {name}\ndescription: {name} skill\n---\n{body}",
+            encoding="utf-8",
+        )
+
+    def test_returns_empty_when_no_skills(self, tmp_path):
+        loader = self._make_loader(tmp_path)
+        skills = loader.load_skills()
+        assert skills == []
+
+    def test_user_skills_loaded(self, tmp_path):
+        loader = self._make_loader(tmp_path)
+        self._write_skill(loader.user_skills_dir, "foo.md", "foo", "Do foo.")
+        skills = loader.load_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "foo"
+        assert skills[0].source == "user"
+
+    def test_project_skills_loaded(self, tmp_path):
+        loader = self._make_loader(tmp_path)
+        self._write_skill(loader.project_skills_dir, "bar.md", "bar", "Do bar.")
+        skills = loader.load_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "bar"
+        assert skills[0].source == "project"
+
+    def test_project_overrides_user_on_name_conflict(self, tmp_path):
+        loader = self._make_loader(tmp_path)
+        self._write_skill(loader.user_skills_dir, "skill.md", "my-skill", "User body.")
+        self._write_skill(loader.project_skills_dir, "skill.md", "my-skill", "Project body.")
+        skills = loader.load_skills()
+        assert len(skills) == 1
+        assert skills[0].source == "project"
+        assert skills[0].body == "Project body."
+
+    def test_user_dir_created_automatically(self, tmp_path):
+        loader = self._make_loader(tmp_path)
+        assert not loader.user_skills_dir.exists()
+        loader.load_skills()
+        assert loader.user_skills_dir.is_dir()
+
+    def test_both_sources_merged(self, tmp_path):
+        loader = self._make_loader(tmp_path)
+        self._write_skill(loader.user_skills_dir, "a.md", "skill-a", "Body A.")
+        self._write_skill(loader.project_skills_dir, "b.md", "skill-b", "Body B.")
+        skills = loader.load_skills()
+        names = {s.name for s in skills}
+        assert names == {"skill-a", "skill-b"}
+
+
+# ---------------------------------------------------------------------------
+# SkillLoader.load_into_registry
+# ---------------------------------------------------------------------------
+
+
+class TestLoadIntoRegistry:
+    def _make_loader(self, tmp_path: Path) -> SkillLoader:
+        return SkillLoader(
+            project_dir=tmp_path / "project",
+            user_home=tmp_path / "home",
+        )
+
+    def _write_skill(self, directory: Path, filename: str, name: str, body: str) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / filename).write_text(
+            f"---\nname: {name}\ndescription: A skill\n---\n{body}",
+            encoding="utf-8",
+        )
+
+    def test_registers_skill_in_registry(self, tmp_path):
+        from deile.commands.registry import CommandRegistry
+
+        loader = self._make_loader(tmp_path)
+        self._write_skill(loader.user_skills_dir, "foo.md", "foo-skill", "Do foo.")
+        registry = CommandRegistry()
+        count = loader.load_into_registry(registry)
+        assert count == 1
+        cmd = registry.get_command("foo-skill")
+        assert cmd is not None
+        assert cmd.name == "foo-skill"
+
+    def test_returns_count_of_registered_skills(self, tmp_path):
+        from deile.commands.registry import CommandRegistry
+
+        loader = self._make_loader(tmp_path)
+        self._write_skill(loader.user_skills_dir, "a.md", "skill-a", "Body A.")
+        self._write_skill(loader.user_skills_dir, "b.md", "skill-b", "Body B.")
+        registry = CommandRegistry()
+        count = loader.load_into_registry(registry)
+        assert count == 2
+
+    def test_zero_skills_returns_zero(self, tmp_path):
+        from deile.commands.registry import CommandRegistry
+
+        loader = self._make_loader(tmp_path)
+        registry = CommandRegistry()
+        assert loader.load_into_registry(registry) == 0
+
+
+# ---------------------------------------------------------------------------
+# SkillCommand.execute
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCommandExecute:
+    def _make_skill_command(self, tmp_path: Path, body: str = "Do something."):
+        from deile.commands.registry import CommandRegistry
+        from deile.commands.skill_loader import SkillLoader
+
+        loader = SkillLoader(
+            project_dir=tmp_path / "project",
+            user_home=tmp_path / "home",
+        )
+        skills_dir = loader.user_skills_dir
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        (skills_dir / "test-skill.md").write_text(
+            f"---\nname: test-skill\ndescription: Test\n---\n{body}",
+            encoding="utf-8",
+        )
+        registry = CommandRegistry()
+        loader.load_into_registry(registry)
+        return registry.get_command("test-skill")
+
+    async def test_execute_returns_llm_prompt(self, tmp_path):
+        from deile.commands.base import CommandContext
+
+        cmd = self._make_skill_command(tmp_path)
+        assert cmd is not None
+        ctx = CommandContext(user_input="/test-skill", args="")
+        result = await cmd.execute(ctx)
+        assert result.success is True
+        assert result.content_type == "llm_prompt"
+        assert result.content == "Do something."
+
+    async def test_execute_appends_args(self, tmp_path):
+        from deile.commands.base import CommandContext
+
+        cmd = self._make_skill_command(tmp_path, body="Review this.")
+        ctx = CommandContext(user_input="/test-skill src/main.py", args="src/main.py")
+        result = await cmd.execute(ctx)
+        assert "Arguments: src/main.py" in result.content
+        assert result.content.startswith("Review this.")
+
+    async def test_execute_no_args_no_suffix(self, tmp_path):
+        from deile.commands.base import CommandContext
+
+        cmd = self._make_skill_command(tmp_path, body="List issues.")
+        ctx = CommandContext(user_input="/test-skill", args="   ")
+        result = await cmd.execute(ctx)
+        assert result.content == "List issues."
+
+    def test_skill_appears_in_suggestions(self, tmp_path):
+        from deile.commands.registry import CommandRegistry
+
+        loader = SkillLoader(
+            project_dir=tmp_path / "project",
+            user_home=tmp_path / "home",
+        )
+        loader.user_skills_dir.mkdir(parents=True, exist_ok=True)
+        (loader.user_skills_dir / "rev.md").write_text(
+            "---\nname: revisar\ndescription: Revisa código\n---\nRevise o código.",
+            encoding="utf-8",
+        )
+        registry = CommandRegistry()
+        loader.load_into_registry(registry)
+        suggestions = registry.get_command_suggestions("rev")
+        names = [s["name"] for s in suggestions]
+        assert "revisar" in names


### PR DESCRIPTION
## Summary
Refs #41.

- Adds `deile/commands/skill_loader.py`: `SkillLoader` scans `~/.deile/skills/` (user) and `.deile/skills/` (project) for `.md` skill files and registers each as a slash command in the `CommandRegistry`.
- Wires skill loading into `DeileAgent._auto_discover_components` after builtins, isolated so a broken skill directory never crashes startup.
- Extends `_process_slash_command` in `agent.py` to detect `content_type="llm_prompt"` and route the skill body through `_process_iterative_function_calling`, so the LLM actually responds.

## What I investigated
- `deile/commands/base.py` — `SlashCommand`, `CommandResult`, `CommandStatus`; confirmed correct `CommandConfig`-based pattern (not instance-attribute override used in `CompactCommand`)
- `deile/commands/registry.py` — `CommandRegistry.register_command`, `get_command_suggestions` (autocomplete), `execute_command`
- `deile/commands/builtin/help_command.py` — reference for creating a `DirectCommand` with `CommandConfig`
- `deile/config/manager.py` — `CommandConfig` dataclass fields
- `deile/core/agent.py` — `_auto_discover_components` (where skills hook in), `_process_slash_command` (where `llm_prompt` routing was added), `process_input`, `_process_iterative_function_calling` (signature + return type)
- `docs/system_design/02-ARQUITETURA.md`, `docs/system_design/04-MODELO-COMPONENTES.md` — architectural rules for commands

## How this addresses the issue
Skills are `.md` files with YAML front-matter (`name`, `description`) and a Markdown body. The body becomes the LLM prompt when the skill is invoked as `/skill-name [args]`. Project skills (`.deile/skills/`) override user skills (`~/.deile/skills/`) when names collide. The `~/.deile/skills/` directory is created automatically on startup if absent.

Autocomplete via `CommandRegistry.get_command_suggestions()` works immediately because skills are registered as regular `SlashCommand` instances.

**Note on branch naming**: git does not allow a branch `issue/41-skills-slash-commands` and a sub-path branch `issue/41-skills-slash-commands/work-*` to coexist in the same remote ref namespace (directory vs. file conflict), so the work branch uses the flat `work/41-*` prefix instead.

## Tests
- Baseline: 679 pass / 1 fail / 10 err
- After change: 704 pass / 1 fail / 10 err
- New tests added: `deile/tests/test_skill_loader.py` — 25 tests covering name normalisation, YAML front-matter parsing, filename fallback, empty body rejection, directory scanning, user/project merge, project-overrides-user priority, auto-creation of `~/.deile/skills/`, registry registration, `SkillCommand.execute()` with and without args, and autocomplete suggestions.

## Reviewer focus (Task 3 OPUS agent)
- **`_process_slash_command` change** in `agent.py`: the history replacement (`entry["content"] = prompt`) mutates `session.conversation_history` in-place so the LLM sees the skill body rather than `/skill-name args`. Verify this is safe for multi-turn sessions.
- **Name collision with builtins**: skills load after builtins, so a skill named `help` would silently replace `/help`. The registry already warns in the log; consider whether an explicit guard is needed.
- **Streaming path**: skills are routed non-streaming (via `_process_slash_command` → `_process_iterative_function_calling`). The streaming `process_input_stream` path handles slash commands non-streaming anyway, so the result is consistent — but reviewers should confirm the streaming UI shows the response correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR5i3Z59qGou11GKHteqHd)_