### PR TITLE
fix(tests): rename test_* runners to run_* in bot pipeline live script (refs #45)

### DIFF
--- a/deile/tests/might/test_bot_pipeline_live.py
+++ b/deile/tests/might/test_bot_pipeline_live.py
@@ -245,9 +245,9 @@ def _slash_envelope(text: str, user_id: str = "test-user-001") -> "MessageEnvelo
     )
 
 
-# ─── tests ──────────────────────────────────────────────────────────────────
+# ─── runners (not test_* — standalone runner called from _run_all, not pytest) ─
 
-async def test_01_dm_basic_response(pipeline, adapter):
+async def run_01_dm_basic_response(pipeline, adapter):
     """DM → agent must reply with non-empty text."""
     env = _dm_envelope("olá! diga uma frase curta de apresentação")
     await pipeline.handle(env, adapter)
@@ -258,7 +258,7 @@ async def test_01_dm_basic_response(pipeline, adapter):
     return ok
 
 
-async def test_02_group_no_mention_ignored(pipeline, adapter):
+async def run_02_group_no_mention_ignored(pipeline, adapter):
     """Group message without mention → bot must NOT respond."""
     adapter.inbox.clear()
     env = _group_envelope("que horas são agora?", user_id="user-002")
@@ -269,7 +269,7 @@ async def test_02_group_no_mention_ignored(pipeline, adapter):
     return ok
 
 
-async def test_03_group_with_mention_responds(pipeline, adapter):
+async def run_03_group_with_mention_responds(pipeline, adapter):
     """Group message with bot mention → agent responds."""
     adapter.inbox.clear()
     # FakeProviderAdapter.self_user_id == "fake-bot-self"
@@ -283,7 +283,7 @@ async def test_03_group_with_mention_responds(pipeline, adapter):
     return ok
 
 
-async def test_04_slash_force_respond(pipeline, adapter):
+async def run_04_slash_force_respond(pipeline, adapter):
     """force_respond=True (slash /deile) → always responds."""
     adapter.inbox.clear()
     env = _slash_envelope("quanto é 2 + 2?", user_id="user-004")
@@ -295,7 +295,7 @@ async def test_04_slash_force_respond(pipeline, adapter):
     return ok
 
 
-async def test_05_dm_session_continuity(pipeline, adapter, bridge):
+async def run_05_dm_session_continuity(pipeline, adapter, bridge):
     """Two DM messages from same user share session → context carries over."""
     adapter.inbox.clear()
     uid = "user-session-005"
@@ -313,7 +313,7 @@ async def test_05_dm_session_continuity(pipeline, adapter, bridge):
     return ok
 
 
-async def test_06_persona_dm_is_discord_developer(pipeline, adapter, bridge):
+async def run_06_persona_dm_is_discord_developer(pipeline, adapter, bridge):
     """DM scope with provider=discord → persona selector must pick discord_developer.
 
     The persona rule is `when: { provider: discord, scope: DM }`.
@@ -359,7 +359,7 @@ async def test_06_persona_dm_is_discord_developer(pipeline, adapter, bridge):
     return False
 
 
-async def test_07_rate_limit_burst(pipeline, adapter):
+async def run_07_rate_limit_burst(pipeline, adapter):
     """Concurrent burst from same user → rate limit triggers within burst quota.
 
     Uses concurrent tasks so the LLM processing time cannot refill the bucket
@@ -379,7 +379,7 @@ async def test_07_rate_limit_burst(pipeline, adapter):
     return ok
 
 
-async def test_08_empty_message_ignored(pipeline, adapter):
+async def run_08_empty_message_ignored(pipeline, adapter):
     """Empty/whitespace DM → pipeline skips (too_short heuristic)."""
     adapter.inbox.clear()
     env = _dm_envelope("hi", user_id="user-short-008")  # < 4 chars → too_short in GROUP, but DM returns True always
@@ -392,7 +392,7 @@ async def test_08_empty_message_ignored(pipeline, adapter):
     return ok
 
 
-async def test_09_permission_blocklist(pipeline, adapter):
+async def run_09_permission_blocklist(pipeline, adapter):
     """Blocklisted user → pipeline denies without invoking agent."""
     from deile_bot.foundation.settings import BotSettings, PermissionsSettings
     # We'll use a temporary pipeline with a blocklist
@@ -411,7 +411,7 @@ async def test_09_permission_blocklist(pipeline, adapter):
     return True
 
 
-async def test_10_multi_user_no_leak(pipeline, adapter, bridge):
+async def run_10_multi_user_no_leak(pipeline, adapter, bridge):
     """Two different users, DMs interleaved → sessions don't bleed."""
     adapter.inbox.clear()
     bridge.invocations.clear()
@@ -462,16 +462,16 @@ async def _run_all():
         pipeline, adapter, bridge = await _make_pipeline(store, agent)
 
         tests = [
-            (test_01_dm_basic_response,          [pipeline, adapter]),
-            (test_02_group_no_mention_ignored,   [pipeline, adapter]),
-            (test_03_group_with_mention_responds,[pipeline, adapter]),
-            (test_04_slash_force_respond,        [pipeline, adapter]),
-            (test_05_dm_session_continuity,      [pipeline, adapter, bridge]),
-            (test_06_persona_dm_is_discord_developer, [pipeline, adapter, bridge]),
-            (test_07_rate_limit_burst,           [pipeline, adapter]),
-            (test_08_empty_message_ignored,      [pipeline, adapter]),
-            (test_09_permission_blocklist,       [pipeline, adapter]),
-            (test_10_multi_user_no_leak,         [pipeline, adapter, bridge]),
+            (run_01_dm_basic_response,          [pipeline, adapter]),
+            (run_02_group_no_mention_ignored,   [pipeline, adapter]),
+            (run_03_group_with_mention_responds,[pipeline, adapter]),
+            (run_04_slash_force_respond,        [pipeline, adapter]),
+            (run_05_dm_session_continuity,      [pipeline, adapter, bridge]),
+            (run_06_persona_dm_is_discord_developer, [pipeline, adapter, bridge]),
+            (run_07_rate_limit_burst,           [pipeline, adapter]),
+            (run_08_empty_message_ignored,      [pipeline, adapter]),
+            (run_09_permission_blocklist,       [pipeline, adapter]),
+            (run_10_multi_user_no_leak,         [pipeline, adapter, bridge]),
         ]
 
         for fn, args in tests:

--- a/deile/tests/might/test_pipeline_live_no_fixture_leak.py
+++ b/deile/tests/might/test_pipeline_live_no_fixture_leak.py
@@ -1,0 +1,28 @@
+"""Regression test for issue #45.
+
+Ensures test_bot_pipeline_live.py contains no async def test_* functions that
+pytest would collect and fail with 'fixture not found'.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_bot_pipeline_live_has_no_pytest_collectible_async_test_funcs():
+    src_path = Path(__file__).parent / "test_bot_pipeline_live.py"
+    tree = ast.parse(src_path.read_text())
+
+    leaked = [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name.startswith("test_")
+    ]
+
+    assert not leaked, (
+        f"Found async def test_* functions in test_bot_pipeline_live.py that pytest "
+        f"would collect and fail with 'fixture not found': {leaked}"
+    )


### PR DESCRIPTION
## Summary
Refs #45.

- Renamed all 10 `async def test_0N_*` functions in `test_bot_pipeline_live.py` to `run_0N_*` so pytest stops collecting them as test functions
- Updated the dispatch table in `_run_all()` to reference the renamed functions
- Added `test_pipeline_live_no_fixture_leak.py` — a regression test that uses `ast.parse` to assert no `async def test_*` functions remain in the runner

## What I investigated
- `deile/tests/might/test_bot_pipeline_live.py` — standalone runner with `async def test_*` functions called positionally from `main()`; pytest collects them and injects `pipeline`/`adapter`/`bridge` as fixtures, finding none
- `pytest.ini` — `python_functions = test_*` is the collection trigger; `asyncio_mode = auto` and `--strict-markers` active
- `docs/system_design/12-PADROES-CODIGO.md` — testing patterns (confirmed `@pytest.mark.unit` for new test)

## How this addresses the issue
The root cause is that pytest's collection rules (`python_functions = test_*`) matched the standalone runner's function names. Renaming them to `run_*` is the minimal, clean fix: pytest skips them entirely, and the standalone `python deile/tests/might/test_bot_pipeline_live.py` runner is unaffected because `_run_all()` calls the functions by reference, not by name pattern.

The regression test uses `ast.parse` to statically verify the runner never re-introduces `async def test_*` functions without being noticed.

## Tests
- Baseline: 420 pass / 262 fail / 10 err
- After change: 421 pass / 262 fail / 0 err
- New tests added: `deile/tests/might/test_pipeline_live_no_fixture_leak.py::test_bot_pipeline_live_has_no_pytest_collectible_async_test_funcs`

## Reviewer focus (Task 3 OPUS agent)
- The `_run_all()` dispatch table references all 10 renamed functions — verify no stale `test_*` reference was missed
- The new regression test uses `ast.AsyncFunctionDef` + `node.name.startswith("test_")` — this catches the exact failure mode; sync `def test_*` functions would also be caught by pytest but the file has none so an `ast.FunctionDef` check was omitted intentionally (YAGNI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCqvoR1dew8XsMo6xbRd2J)_