### PR TITLE
fix(tests): replace os.environ.setdefault with monkeypatch.setenv (refs #44)

### DIFF
--- a/deile/tests/core/models/test_anthropic_provider_stream.py
+++ b/deile/tests/core/models/test_anthropic_provider_stream.py
@@ -6,7 +6,6 @@ mapping, not network behaviour.
 
 from __future__ import annotations
 
-import os
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import List
@@ -18,7 +17,7 @@ from deile.core.models.base import ModelMessage
 from deile.core.models.stream_events import StreamEventType
 
 
-def _make_provider():
+def _make_provider(monkeypatch):
     from deile.core.models.anthropic_provider import AnthropicProvider
     from deile.core.models.catalog import ModelHandle, ModelPricing
     from deile.core.models.tier import ModelTier
@@ -37,8 +36,13 @@ def _make_provider():
     cfg = ProviderConfig(
         provider_id="anthropic", api_key_env="ANTHROPIC_API_KEY", base_url=None
     )
-    os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-fake")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
     return AnthropicProvider(model_handle=handle, provider_config=cfg)
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    return _make_provider(monkeypatch)
 
 
 def _e(etype, **kw):
@@ -66,8 +70,7 @@ async def _fake_stream(events: List, final_message):
 
 
 @pytest.mark.asyncio
-async def test_text_stream_only():
-    provider = _make_provider()
+async def test_text_stream_only(provider):
     final = SimpleNamespace(
         usage=SimpleNamespace(
             input_tokens=10,
@@ -103,8 +106,7 @@ async def test_text_stream_only():
 
 
 @pytest.mark.asyncio
-async def test_tool_use_stream_emits_lifecycle():
-    provider = _make_provider()
+async def test_tool_use_stream_emits_lifecycle(provider):
     final = SimpleNamespace(
         usage=SimpleNamespace(
             input_tokens=12,
@@ -152,8 +154,7 @@ async def test_tool_use_stream_emits_lifecycle():
     assert end_evt.arguments == {"command": "ls"}
 
 
-def test_format_assistant_tool_use_message_structure():
-    provider = _make_provider()
+def test_format_assistant_tool_use_message_structure(provider):
     msg = provider.format_assistant_tool_use_message(
         [("t1", "list_files", {"path": "."})], text_so_far="ok"
     )
@@ -165,8 +166,7 @@ def test_format_assistant_tool_use_message_structure():
     assert blocks[1]["input"] == {"path": "."}
 
 
-def test_format_tool_result_message_round_trip():
-    provider = _make_provider()
+def test_format_tool_result_message_round_trip(provider):
     msg = provider.format_tool_result_message("t1", "list_files", {"items": ["a.py"]})
     block = msg.metadata["_anthropic_content_blocks"][0]
     assert block["type"] == "tool_result"


### PR DESCRIPTION
## Summary
Refs #44.
- Replaces `os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-fake")` in `_make_provider()` with `monkeypatch.setenv(...)` via a pytest fixture, eliminating the cross-test environment pollution
- All 4 test functions now receive the provider through the `provider` fixture and monkeypatch guarantees teardown after each test
- Removes unused `import os`

## What I investigated
- `deile/tests/core/models/test_anthropic_provider_stream.py` — source of the pollution: `os.environ.setdefault` at module-function level, never torn down
- `deile/tests/might/streaming-ui/test_streaming_ui.py` — affected test: uses `pytest.skip()` when `ANTHROPIC_API_KEY` is absent, but the leaked fake key bypassed the guard and caused the test to attempt a live API call with a rejected key

## How this addresses the issue
`os.environ.setdefault` mutates the process environment permanently; every subsequent test in the same pytest session sees `ANTHROPIC_API_KEY=sk-test-fake`. `monkeypatch.setenv` records the original value and restores it (or deletes the key) when the test tears down, so no state leaks across tests.

After the fix, `test_streaming_ui_empirical` correctly SKIPs when no real `ANTHROPIC_API_KEY` is present in the environment, matching the expected behavior.

## Tests
- Baseline: 679 pass / 1 fail / 10 err
- After change: 679 pass / 0 fail / 10 err
- New tests added: none needed (the regression is caught by the existing `test_streaming_ui_empirical` moving from FAIL→SKIP)

## Reviewer focus (Task 3 OPUS agent)
- The 10 errors are pre-existing `test_bot_pipeline_live.py` fixture-not-found errors (issue #45), not introduced by this PR
- `_make_provider(monkeypatch)` is now a helper called only from the `provider` fixture; if future tests need a custom handle/config they should add a new fixture rather than calling the helper directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPrMWdsoL6Fr8kxctDnhW9)_