### PR TITLE
fix(tests): extend regression guard to catch sync def test_* leaks (refs #45)

### DIFF
--- a/deile/tests/might/test_pipeline_live_no_fixture_leak.py
+++ b/deile/tests/might/test_pipeline_live_no_fixture_leak.py
@@ -1,7 +1,7 @@
 """Regression test for issue #45.
 
-Ensures test_bot_pipeline_live.py contains no async def test_* functions that
-pytest would collect and fail with 'fixture not found'.
+Ensures test_bot_pipeline_live.py contains no test_* functions (sync or async)
+that pytest would collect and fail with 'fixture not found'.
 """
 from __future__ import annotations
 
@@ -12,17 +12,18 @@ import pytest
 
 
 @pytest.mark.unit
-def test_bot_pipeline_live_has_no_pytest_collectible_async_test_funcs():
+def test_bot_pipeline_live_has_no_pytest_collectible_test_funcs():
     src_path = Path(__file__).parent / "test_bot_pipeline_live.py"
     tree = ast.parse(src_path.read_text())
 
     leaked = [
         node.name
         for node in ast.walk(tree)
-        if isinstance(node, ast.AsyncFunctionDef) and node.name.startswith("test_")
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name.startswith("test_")
     ]
 
     assert not leaked, (
-        f"Found async def test_* functions in test_bot_pipeline_live.py that pytest "
+        f"Found def test_* functions in test_bot_pipeline_live.py that pytest "
         f"would collect and fail with 'fixture not found': {leaked}"
     )


### PR DESCRIPTION
## Summary
Refs #45.

- Extends the regression guard in `test_pipeline_live_no_fixture_leak.py` to catch both `async def test_*` AND `def test_*` (sync) functions — the original only checked `ast.AsyncFunctionDef`, leaving a gap where a sync test_ function would also cause pytest "fixture not found" errors but pass the guard unnoticed.
- Updates the test name from `test_bot_pipeline_live_has_no_pytest_collectible_async_test_funcs` → `test_bot_pipeline_live_has_no_pytest_collectible_test_funcs` (removes the misleading "async_" qualifier).
- Updates docstring and error message accordingly.

## What I investigated
- `deile/tests/might/test_pipeline_live_no_fixture_leak.py` — original regression test; only guarded `ast.AsyncFunctionDef`
- `deile/tests/might/test_bot_pipeline_live.py` — confirmed all 10 functions are now `run_*` (no sync `def test_*` either), so the extended guard passes immediately
- `docs/system_design/12-PADROES-CODIGO.md` — testing requirements section for patterns

## How this addresses the issue
The issue branch (`issue/45-bot-pipeline-test-fixture`) already fixed the root cause by renaming the 10 `async def test_*` runners to `run_*`. This PR extends the regression test so that a future contributor cannot accidentally reintroduce the problem by adding a plain (sync) `def test_something` helper — that would also be collected by pytest with the same "fixture not found" error, but the original guard would silently miss it.

## Tests
- Baseline (on main): 679 pass / 1 fail / 10 errors
- After change (on this branch, which includes the issue-45 rename fix): 680 pass / 1 fail / 0 errors
- New tests added: `test_bot_pipeline_live_has_no_pytest_collectible_test_funcs` (renamed + extended from previous)

The remaining 1 failure (`test_streaming_ui_empirical`) is the pre-existing env-pollution bug tracked in issue #44, unrelated to this change.

## Reviewer focus (Task 3 OPUS agent)
- The `ast.walk` approach traverses all nested scopes; a `def test_*` inside a class body would also be caught. This is intentionally conservative — if someone adds a `TestClass` with `def test_*` methods in this standalone runner, pytest would collect them the same way.
- The 0-error baseline is the main win: the 10 `test_bot_pipeline_live.py::test_*` fixture errors are gone entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyQyen4cbCrn1ZsRoGQ2Vm)_