### PR TITLE
docs: document skills system in 01-CAPACIDADES.md (refs #41)

### DIFF
--- a/docs/system_design/01-CAPACIDADES.md
+++ b/docs/system_design/01-CAPACIDADES.md
@@ -41,6 +41,7 @@
 | Auto-discovery de tools | `ToolRegistry.auto_discover()` para conjunto-padrão; demais via `register_tool()` |
 | Categorias declaradas | `ToolCategory` em `deile/tools/base.py` (file, execution, search, system, analysis, network, database, other) |
 | Slash commands | Processados por `deile/parsers/command_parser.py`, despachados pelo `CommandRegistry`; conjunto exato em `deile/commands/builtin/*.py` |
+| Skills definidas pelo usuário | Arquivos `.md` em `~/.deile/skills/` (usuário) e `.deile/skills/` (projeto) são carregados na inicialização como slash commands; project skills têm prioridade sobre user skills em conflito de nomes. Implementado em `deile/commands/skill_loader.py`. Formato: frontmatter YAML opcional (`name`, `description`) + corpo em Markdown que será enviado ao LLM como prompt ao invocar o comando. O diretório `~/.deile/skills/` é criado automaticamente se ausente. |
 | Pipeline de parsing | Em ordem de prioridade: comandos slash, referências a arquivos, diffs (`deile/parsers/`) |
 | Personas | Markdown + YAML; hot-reload das instruções via `PersonaManager` quando habilitado |
 


### PR DESCRIPTION
## Summary
Refs #41.

- Adds the final unchecked acceptance criterion: documentation with instructions on how to create and manage user-defined skills.
- One new row in the "Tools, comandos, parsers e personas" table in `docs/system_design/01-CAPACIDADES.md` covering discovery locations, YAML frontmatter format, conflict-resolution rule, and auto-creation of `~/.deile/skills/`.

## What I investigated
- `deile/commands/skill_loader.py` — read to verify discovery paths, frontmatter format, conflict resolution (project wins), and auto-creation of user dir.
- `deile/core/agent.py` (issue branch diff) — confirmed skills are loaded at startup via `SkillLoader.load_into_registry()`.
- `deile/tests/test_skill_loader.py` — 25 tests, all passing on the issue branch.
- `docs/system_design/01-CAPACIDADES.md` — identified the right table to extend (no skills row existed).

## How this addresses the issue
The implementation in the issue branch (`skill_loader.py` + `agent.py`) already met 5 of 6 acceptance criteria. This PR completes the last one: *"Documentação atualizada com instruções de como criar e gerenciar skills"*. The new table row in `01-CAPACIDADES.md` documents the two discovery directories, the YAML frontmatter format, the project-overrides-user conflict rule, and the automatic creation of the user-level skills directory.

## Tests
- Baseline (issue branch): 687 pass / 18 fail / 10 err
- After change: 687 pass / 18 fail / 10 err
- New tests added: none (documentation-only change)
- Pre-existing failures (test_autonomy_integration, test_path_normalization, test_bot_pipeline_live) are unchanged from the issue branch baseline — none caused by this PR.

## Reviewer focus (Task 3 OPUS agent)
- The 18 failures and 10 errors are all pre-existing on main/issue branch (autonomy integration, path normalization, bot pipeline live fixture). No regression introduced.
- Documentation row is intentionally concise per the project's table style — full API details live in `skill_loader.py` docstring.
- `~/.deile/skills/` auto-creation is confirmed by `test_user_dir_created_automatically` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014pCq9deLqFCF6NurKuc6HN)_