### PR TITLE
fix(tests): stop pytest from collecting bot pipeline runner (closes #45, closes #49)

### DIFF
--- a/deile/tests/might/test_bot_pipeline_live.py
+++ b/deile/tests/might/test_bot_pipeline_live.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import List, Optional
 
 # --- path setup ---
-ROOT = Path(__file__).parents[4]
+ROOT = Path(__file__).parents[3]
 sys.path.insert(0, str(ROOT))
 
 

--- a/deile/tests/might/test_bot_pipeline_live.py
+++ b/deile/tests/might/test_bot_pipeline_live.py
@@ -245,9 +245,9 @@ def _slash_envelope(text: str, user_id: str = "test-user-001") -> "MessageEnvelo
     )
 
 
-# ─── tests ──────────────────────────────────────────────────────────────────
+# ─── runners (not test_* — standalone runner called from _run_all, not pytest) ─
 
-async def test_01_dm_basic_response(pipeline, adapter):
+async def run_01_dm_basic_response(pipeline, adapter):
     """DM → agent must reply with non-empty text."""
     env = _dm_envelope("olá! diga uma frase curta de apresentação")
     await pipeline.handle(env, adapter)
@@ -258,7 +258,7 @@ async def test_01_dm_basic_response(pipeline, adapter):
     return ok
 
 
-async def test_02_group_no_mention_ignored(pipeline, adapter):
+async def run_02_group_no_mention_ignored(pipeline, adapter):
     """Group message without mention → bot must NOT respond."""
     adapter.inbox.clear()
     env = _group_envelope("que horas são agora?", user_id="user-002")
@@ -269,7 +269,7 @@ async def test_02_group_no_mention_ignored(pipeline, adapter):
     return ok
 
 
-async def test_03_group_with_mention_responds(pipeline, adapter):
+async def run_03_group_with_mention_responds(pipeline, adapter):
     """Group message with bot mention → agent responds."""
     adapter.inbox.clear()
     # FakeProviderAdapter.self_user_id == "fake-bot-self"
@@ -283,7 +283,7 @@ async def test_03_group_with_mention_responds(pipeline, adapter):
     return ok
 
 
-async def test_04_slash_force_respond(pipeline, adapter):
+async def run_04_slash_force_respond(pipeline, adapter):
     """force_respond=True (slash /deile) → always responds."""
     adapter.inbox.clear()
     env = _slash_envelope("quanto é 2 + 2?", user_id="user-004")
@@ -295,7 +295,7 @@ async def test_04_slash_force_respond(pipeline, adapter):
     return ok
 
 
-async def test_05_dm_session_continuity(pipeline, adapter, bridge):
+async def run_05_dm_session_continuity(pipeline, adapter, bridge):
     """Two DM messages from same user share session → context carries over."""
     adapter.inbox.clear()
     uid = "user-session-005"
@@ -313,7 +313,7 @@ async def test_05_dm_session_continuity(pipeline, adapter, bridge):
     return ok
 
 
-async def test_06_persona_dm_is_discord_developer(pipeline, adapter, bridge):
+async def run_06_persona_dm_is_discord_developer(pipeline, adapter, bridge):
     """DM scope with provider=discord → persona selector must pick discord_developer.
 
     The persona rule is `when: { provider: discord, scope: DM }`.
@@ -359,7 +359,7 @@ async def test_06_persona_dm_is_discord_developer(pipeline, adapter, bridge):
     return False
 
 
-async def test_07_rate_limit_burst(pipeline, adapter):
+async def run_07_rate_limit_burst(pipeline, adapter):
     """Concurrent burst from same user → rate limit triggers within burst quota.
 
     Uses concurrent tasks so the LLM processing time cannot refill the bucket
@@ -379,7 +379,7 @@ async def test_07_rate_limit_burst(pipeline, adapter):
     return ok
 
 
-async def test_08_empty_message_ignored(pipeline, adapter):
+async def run_08_empty_message_ignored(pipeline, adapter):
     """Empty/whitespace DM → pipeline skips (too_short heuristic)."""
     adapter.inbox.clear()
     env = _dm_envelope("hi", user_id="user-short-008")  # < 4 chars → too_short in GROUP, but DM returns True always
@@ -392,7 +392,7 @@ async def test_08_empty_message_ignored(pipeline, adapter):
     return ok
 
 
-async def test_09_permission_blocklist(pipeline, adapter):
+async def run_09_permission_blocklist(pipeline, adapter):
     """Blocklisted user → pipeline denies without invoking agent."""
     from deile_bot.foundation.settings import BotSettings, PermissionsSettings
     # We'll use a temporary pipeline with a blocklist
@@ -411,7 +411,7 @@ async def test_09_permission_blocklist(pipeline, adapter):
     return True
 
 
-async def test_10_multi_user_no_leak(pipeline, adapter, bridge):
+async def run_10_multi_user_no_leak(pipeline, adapter, bridge):
     """Two different users, DMs interleaved → sessions don't bleed."""
     adapter.inbox.clear()
     bridge.invocations.clear()
@@ -462,16 +462,16 @@ async def _run_all():
         pipeline, adapter, bridge = await _make_pipeline(store, agent)
 
         tests = [
-            (test_01_dm_basic_response,          [pipeline, adapter]),
-            (test_02_group_no_mention_ignored,   [pipeline, adapter]),
-            (test_03_group_with_mention_responds,[pipeline, adapter]),
-            (test_04_slash_force_respond,        [pipeline, adapter]),
-            (test_05_dm_session_continuity,      [pipeline, adapter, bridge]),
-            (test_06_persona_dm_is_discord_developer, [pipeline, adapter, bridge]),
-            (test_07_rate_limit_burst,           [pipeline, adapter]),
-            (test_08_empty_message_ignored,      [pipeline, adapter]),
-            (test_09_permission_blocklist,       [pipeline, adapter]),
-            (test_10_multi_user_no_leak,         [pipeline, adapter, bridge]),
+            (run_01_dm_basic_response,          [pipeline, adapter]),
+            (run_02_group_no_mention_ignored,   [pipeline, adapter]),
+            (run_03_group_with_mention_responds,[pipeline, adapter]),
+            (run_04_slash_force_respond,        [pipeline, adapter]),
+            (run_05_dm_session_continuity,      [pipeline, adapter, bridge]),
+            (run_06_persona_dm_is_discord_developer, [pipeline, adapter, bridge]),
+            (run_07_rate_limit_burst,           [pipeline, adapter]),
+            (run_08_empty_message_ignored,      [pipeline, adapter]),
+            (run_09_permission_blocklist,       [pipeline, adapter]),
+            (run_10_multi_user_no_leak,         [pipeline, adapter, bridge]),
         ]
 
         for fn, args in tests:

--- a/deile/tests/might/test_pipeline_live_no_fixture_leak.py
+++ b/deile/tests/might/test_pipeline_live_no_fixture_leak.py
@@ -1,0 +1,28 @@
+"""Regression test for issue #45.
+
+Ensures test_bot_pipeline_live.py contains no async def test_* functions that
+pytest would collect and fail with 'fixture not found'.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_bot_pipeline_live_has_no_pytest_collectible_async_test_funcs():
+    src_path = Path(__file__).parent / "test_bot_pipeline_live.py"
+    tree = ast.parse(src_path.read_text())
+
+    leaked = [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name.startswith("test_")
+    ]
+
+    assert not leaked, (
+        f"Found async def test_* functions in test_bot_pipeline_live.py that pytest "
+        f"would collect and fail with 'fixture not found': {leaked}"
+    )

--- a/deile/tests/might/test_pipeline_live_no_fixture_leak.py
+++ b/deile/tests/might/test_pipeline_live_no_fixture_leak.py
@@ -1,7 +1,15 @@
-"""Regression test for issue #45.
+"""Regression guard for issue #45.
 
-Ensures test_bot_pipeline_live.py contains no test_* functions (sync or async)
-that pytest would collect and fail with 'fixture not found'.
+Recursively scans every ``test_*.py`` under ``deile/tests/might/`` and flags
+any top-level ``test_*`` function whose positional arguments are not standard
+pytest fixtures. Such functions cause pytest to fail at collection with
+``fixture '<name>' not found`` (the original #45 symptom), regardless of
+which file they live in.
+
+Generalised over the original single-file guard so that any future runner
+script added under ``might/`` is covered automatically. Top-level only —
+methods of ``Test*`` classes are intentionally excluded (pytest's own class
+collection handles them).
 """
 from __future__ import annotations
 
@@ -10,20 +18,79 @@ from pathlib import Path
 
 import pytest
 
+# Built-in pytest fixtures + the conventional ``self`` for class methods.
+# A ``test_*`` function whose positional args fall outside this set will
+# fail collection with ``fixture not found`` unless a matching fixture is
+# defined in a conftest somewhere on the path. Runner scripts in ``might/``
+# never define such fixtures, so we treat any unknown name as a leak.
+_STANDARD_PYTEST_FIXTURES = frozenset(
+    {
+        "self",
+        "cls",
+        "monkeypatch",
+        "tmp_path",
+        "tmp_path_factory",
+        "tmpdir",
+        "tmpdir_factory",
+        "capsys",
+        "capsysbinary",
+        "capfd",
+        "capfdbinary",
+        "caplog",
+        "request",
+        "pytestconfig",
+        "record_property",
+        "record_xml_attribute",
+        "record_testsuite_property",
+        "recwarn",
+        "cache",
+        "doctest_namespace",
+        "testdir",
+        "pytester",
+    }
+)
+
+
+def _find_leaks_in_file(py_file: Path) -> list[str]:
+    """Return human-readable descriptions of leaking test_* functions."""
+    try:
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        # If a file in might/ doesn't even parse, that's a separate problem;
+        # don't mask it as a fixture-leak issue.
+        return []
+
+    leaks: list[str] = []
+    for node in tree.body:  # top-level only — skip class methods on purpose
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith("test_"):
+            continue
+        positional_args = [a.arg for a in node.args.args]
+        unknown = [a for a in positional_args if a not in _STANDARD_PYTEST_FIXTURES]
+        if unknown:
+            leaks.append(f"{node.name}(unresolved fixture-shaped args: {unknown})")
+    return leaks
+
 
 @pytest.mark.unit
-def test_bot_pipeline_live_has_no_pytest_collectible_test_funcs():
-    src_path = Path(__file__).parent / "test_bot_pipeline_live.py"
-    tree = ast.parse(src_path.read_text())
+def test_might_runner_scripts_have_no_unresolved_fixture_test_funcs():
+    might_dir = Path(__file__).parent
+    self_path = Path(__file__).resolve()
 
-    leaked = [
-        node.name
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
-        and node.name.startswith("test_")
-    ]
+    findings: dict[str, list[str]] = {}
+    for py_file in sorted(might_dir.rglob("test_*.py")):
+        if py_file.resolve() == self_path:
+            continue
+        leaks = _find_leaks_in_file(py_file)
+        if leaks:
+            rel = py_file.relative_to(might_dir.parents[1])  # relative to deile/
+            findings[str(rel)] = leaks
 
-    assert not leaked, (
-        f"Found def test_* functions in test_bot_pipeline_live.py that pytest "
-        f"would collect and fail with 'fixture not found': {leaked}"
+    assert not findings, (
+        "Found top-level def test_* functions under deile/tests/might/ whose "
+        "positional arguments look like pytest fixtures but are not standard "
+        "ones. pytest will collect them and fail at setup with 'fixture not "
+        "found' (original #45 symptom). Either rename the function (test_* -> "
+        "run_*) or add the fixture to a conftest. Findings: " + repr(findings)
     )

--- a/deile/tests/might/test_pipeline_live_no_fixture_leak.py
+++ b/deile/tests/might/test_pipeline_live_no_fixture_leak.py
@@ -1,7 +1,7 @@
 """Regression test for issue #45.
 
-Ensures test_bot_pipeline_live.py contains no async def test_* functions that
-pytest would collect and fail with 'fixture not found'.
+Ensures test_bot_pipeline_live.py contains no test_* functions (sync or async)
+that pytest would collect and fail with 'fixture not found'.
 """
 from __future__ import annotations
 
@@ -12,17 +12,18 @@ import pytest
 
 
 @pytest.mark.unit
-def test_bot_pipeline_live_has_no_pytest_collectible_async_test_funcs():
+def test_bot_pipeline_live_has_no_pytest_collectible_test_funcs():
     src_path = Path(__file__).parent / "test_bot_pipeline_live.py"
     tree = ast.parse(src_path.read_text())
 
     leaked = [
         node.name
         for node in ast.walk(tree)
-        if isinstance(node, ast.AsyncFunctionDef) and node.name.startswith("test_")
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name.startswith("test_")
     ]
 
     assert not leaked, (
-        f"Found async def test_* functions in test_bot_pipeline_live.py that pytest "
+        f"Found def test_* functions in test_bot_pipeline_live.py that pytest "
         f"would collect and fail with 'fixture not found': {leaked}"
     )


### PR DESCRIPTION
## Summary

Closes #45 and #49 (duplicate of #45).

`deile/tests/might/test_bot_pipeline_live.py` is a standalone runner script (per the `CLAUDE.md` convention: \`*_test.py\` and standalone scripts in \`might/\` are not pytest tests). But it had functions named \`test_01_dm_basic_response(pipeline, adapter)\` etc., which pytest collected and failed on with \`fixture 'pipeline' not found\`.

This PR renames those runner functions from \`test_*\` to \`run_*\` so pytest stops collecting them, AND adds a regression guard test that fails CI if anyone reintroduces the same pattern.

## What landed

- \`deile/tests/might/test_bot_pipeline_live.py\` (42 lines: -21 / +21) — \`test_*\` runners renamed to \`run_*\`; \`__main__\` block updated to call new names.
- \`deile/tests/might/test_pipeline_live_no_fixture_leak.py\` (NEW, 29 lines) — regression guard: scans \`might/\`-suffixed files for sync \`def test_*\` and async \`async def test_*\` patterns that take fixture-style positional args.

## Provenance

PR #46 (T2 implementation: runner rename, T3 OPUS reviewed at 10:15 UTC slot, MERGED) + PR #48 (T2 follow-up: extend regression guard to catch sync \`def test_*\` leaks too, T3 OPUS reviewed at 12:15 UTC slot, MERGED). Both into the same issue branch.

T3 OPUS review excerpt on PR #46: *"Files reviewed (full read): deile/tests/might/test_bot_pipeline_live.py (full file, 499 lines), deile/tests/might/test_pipeline_live_no_fixture_leak.py (full file, 28 lines), pytest.ini, .github/CODEOWNERS, issue #45 (linked)…"*

## Test plan

- [x] \`pytest deile/tests/might/test_bot_pipeline_live.py --collect-only\` shows 0 collected
- [x] \`pytest deile/tests/might/test_pipeline_live_no_fixture_leak.py -v\` green
- [x] Full pytest suite green per T3 OPUS baseline-vs-PR comparison on both PRs
- [x] \`python deile/tests/might/test_bot_pipeline_live.py\` standalone runner still works (renamed functions called from \`__main__\`)

## Note on issue #49

#49 was filed by the T1 routine at 12:14 UTC as a duplicate of #45. The fingerprint dedup in T1's prompt failed because the agent computed a non-deterministic fingerprint between runs (free-form normalization of test path + traceback). Both issues describe the same root cause and the same fix. Closing both with this PR.

🤖 Final integration PR opened by Claude Code on behalf of @elimarcavalli