### PR TITLE
fix(security): address SAST findings from audit #84

### DIFF
--- a/deile/commands/actions.py
+++ b/deile/commands/actions.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import os
-import subprocess
 import sys
 import time
 from pathlib import Path
@@ -242,10 +241,7 @@ class CommandActions:
                     if hasattr(self.ui_manager, 'show_welcome'):
                         self.ui_manager.show_welcome()
                 else:
-                    if os.name == 'nt':
-                        subprocess.run(['cmd', '/c', 'cls'], check=False)
-                    else:
-                        subprocess.run(['clear'], check=False)
+                    print("\033c", end="", flush=True)
                 
                 # Mensagem de reset completo
                 reset_panel = Panel(
@@ -280,11 +276,7 @@ class CommandActions:
                     if hasattr(self.ui_manager, 'show_welcome'):
                         self.ui_manager.show_welcome()
                 else:
-                    # Fallback: clear via console
-                    if os.name == 'nt':
-                        subprocess.run(['cmd', '/c', 'cls'], check=False)
-                    else:
-                        subprocess.run(['clear'], check=False)
+                    print("\033c", end="", flush=True)
             
             # Mensagem de confirmação
             success_panel = Panel(

--- a/deile/commands/actions.py
+++ b/deile/commands/actions.py
@@ -3,21 +3,23 @@
 import asyncio
 import logging
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from rich.console import Console
-from rich.table import Table
-from rich.panel import Panel
-from rich.text import Text
 from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
 
-from .base import CommandResult, CommandContext
-from ..tools.execution_tools import EnhancedExecutionTool
-from ..tools.base import ToolContext
 from deile.config.settings import get_settings
+
+from ..tools.base import ToolContext
+from ..tools.execution_tools import EnhancedExecutionTool
+from .base import CommandContext, CommandResult
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +242,10 @@ class CommandActions:
                     if hasattr(self.ui_manager, 'show_welcome'):
                         self.ui_manager.show_welcome()
                 else:
-                    os.system('cls' if os.name == 'nt' else 'clear')
+                    if os.name == 'nt':
+                        subprocess.run(['cmd', '/c', 'cls'], check=False)
+                    else:
+                        subprocess.run(['clear'], check=False)
                 
                 # Mensagem de reset completo
                 reset_panel = Panel(
@@ -276,7 +281,10 @@ class CommandActions:
                         self.ui_manager.show_welcome()
                 else:
                     # Fallback: clear via console
-                    os.system('cls' if os.name == 'nt' else 'clear')
+                    if os.name == 'nt':
+                        subprocess.run(['cmd', '/c', 'cls'], check=False)
+                    else:
+                        subprocess.run(['clear'], check=False)
             
             # Mensagem de confirmação
             success_panel = Panel(

--- a/deile/core/intent_analyzer.py
+++ b/deile/core/intent_analyzer.py
@@ -11,21 +11,21 @@ otimizado para agentes autônomos, seguindo as melhores práticas:
 - Métricas e observabilidade
 """
 
-import re
-import time
 import hashlib
 import logging
-from typing import Dict, List, Optional, Tuple, Any, Set
+import re
+import time
+from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-import yaml
+from typing import Any, Dict, List, Optional, Set, Tuple
+
 import numpy as np
-from collections import defaultdict, deque
+import yaml
 
-from .exceptions import DEILEError
 from ..parsers.base import ParseResult
-
+from .exceptions import DEILEError
 
 logger = logging.getLogger(__name__)
 
@@ -666,7 +666,7 @@ class IntentAnalyzer:
             cache_data += f"|tools:{len(parse_result.tool_requests or [])}"
             cache_data += f"|files:{len(parse_result.file_references or [])}"
 
-        return hashlib.md5(cache_data.encode()).hexdigest()
+        return hashlib.md5(cache_data.encode(), usedforsecurity=False).hexdigest()
 
     def _get_from_cache(self, cache_key: str) -> Optional[IntentAnalysisResult]:
         """Recupera resultado do cache"""

--- a/deile/infrastructure/google_file_api.py
+++ b/deile/infrastructure/google_file_api.py
@@ -1,19 +1,18 @@
 """Google File API Integration - Enterprise Grade Implementation"""
 
 import asyncio
+import hashlib
 import logging
+import mimetypes
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Any, Optional, List
-import mimetypes
-import hashlib
+from typing import Any, Dict, List, Optional
 
 from google import genai
 from google.genai import errors as genai_errors
 
 from ..core.exceptions import DEILEError
-
 
 logger = logging.getLogger(__name__)
 
@@ -286,7 +285,7 @@ class GoogleFileUploader:
         """Calcula hash MD5 do arquivo para cache"""
         try:
             def _hash_file():
-                hash_md5 = hashlib.md5()
+                hash_md5 = hashlib.md5(usedforsecurity=False)
                 with open(file_path, "rb") as f:
                     for chunk in iter(lambda: f.read(4096), b""):
                         hash_md5.update(chunk)

--- a/deile/infrastructure/monitoring/cost_tracker.py
+++ b/deile/infrastructure/monitoring/cost_tracker.py
@@ -13,12 +13,12 @@ import logging
 import sqlite3
 import threading
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-from pathlib import Path
-from typing import Dict, Any, List, Optional, Union, Callable
 from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from deile.core.context_manager import ContextManager
 
@@ -638,36 +638,35 @@ class CostTracker:
                 
                 where_sql = " AND ".join(where_clauses)
                 
-                # Total amount and entry count
+                # nosec B608 — where_sql is built from hardcoded clause strings only;
+                # all user-controlled values are bound via the `params` list (parameterised query).
                 cursor = conn.execute(f"""
                     SELECT COALESCE(SUM(amount), 0), COUNT(*)
                     FROM cost_entries
                     WHERE {where_sql}
-                """, params)
-                
+                """, params)  # nosec B608
+
                 total_amount, entry_count = cursor.fetchone()
-                
-                # Category breakdown
+
                 cursor = conn.execute(f"""
                     SELECT category, COALESCE(SUM(amount), 0)
                     FROM cost_entries
                     WHERE {where_sql}
                     GROUP BY category
                     ORDER BY SUM(amount) DESC
-                """, params)
-                
+                """, params)  # nosec B608
+
                 categories = {}
                 for row in cursor.fetchall():
                     categories[row[0]] = Decimal(str(row[1]))
-                
-                # Top expenses
+
                 cursor = conn.execute(f"""
                     SELECT category, subcategory, amount, description, timestamp
                     FROM cost_entries
                     WHERE {where_sql}
                     ORDER BY amount DESC
                     LIMIT 10
-                """, params)
+                """, params)  # nosec B608
                 
                 top_expenses = []
                 for row in cursor.fetchall():

--- a/deile/memory/working_memory.py
+++ b/deile/memory/working_memory.py
@@ -1,13 +1,13 @@
 """Working Memory - Cache de curto prazo e contexto ativo"""
 
 import asyncio
+import hashlib
+import json
 import logging
 import time
-from typing import Dict, List, Optional, Any, Set
-from dataclasses import dataclass, field
 from collections import OrderedDict
-import json
-import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ class WorkingMemory:
             str: ID da entrada criada
         """
         # Gera ID baseado no conteúdo e timestamp
-        content_hash = hashlib.md5(content.encode()).hexdigest()[:8]
+        content_hash = hashlib.md5(content.encode(), usedforsecurity=False).hexdigest()[:8]
         entry_id = f"{entry_type}_{content_hash}_{int(time.time())}"
 
         # Cria entrada

--- a/deile/orchestration/artifact_manager.py
+++ b/deile/orchestration/artifact_manager.py
@@ -1,15 +1,14 @@
 """Artifact Management System for DEILE"""
 
-from pathlib import Path
-import json
-import time
-import hashlib
-import uuid
-from typing import Dict, Any, Optional, List
-from dataclasses import dataclass, asdict
-import logging
 import gzip
-
+import hashlib
+import json
+import logging
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,7 @@ class ArtifactManager:
     def _hash_input(self, input_data: Any) -> str:
         """Generate hash of input data"""
         input_str = json.dumps(input_data, sort_keys=True)
-        return hashlib.md5(input_str.encode()).hexdigest()
+        return hashlib.md5(input_str.encode(), usedforsecurity=False).hexdigest()
         
     def _should_compress(self, data_size: int) -> bool:
         """Determine if data should be compressed (>10KB)"""

--- a/deile/personas/base.py
+++ b/deile/personas/base.py
@@ -9,17 +9,18 @@ Version: 3.0.0 ULTRA
 License: MIT
 """
 
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Any, Set, Tuple, Callable, Union
-from enum import Enum, auto
-from pydantic import BaseModel, Field, field_validator, model_validator
-import logging
-import time
 import hashlib
 import json
+import logging
+import time
+from abc import ABC, abstractmethod
 from collections import deque
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from enum import Enum, auto
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -508,7 +509,7 @@ class AgentContext:
 
     def cache_tool_result(self, tool_call: str, result: Any, ttl_seconds: int = 300):
         """Cache tool execution result"""
-        cache_key = hashlib.md5(tool_call.encode()).hexdigest()
+        cache_key = hashlib.md5(tool_call.encode(), usedforsecurity=False).hexdigest()
         self.tool_results_cache[cache_key] = {
             "result": result,
             "timestamp": time.time(),
@@ -517,7 +518,7 @@ class AgentContext:
 
     def get_cached_tool_result(self, tool_call: str) -> Optional[Any]:
         """Get cached tool result if still valid"""
-        cache_key = hashlib.md5(tool_call.encode()).hexdigest()
+        cache_key = hashlib.md5(tool_call.encode(), usedforsecurity=False).hexdigest()
         if cache_key in self.tool_results_cache:
             cached = self.tool_results_cache[cache_key]
             if time.time() - cached['timestamp'] < cached['ttl']:
@@ -754,7 +755,7 @@ After completing the task:
 
         # Create plan
         plan = ToolOrchestrationPlan(
-            task_id=hashlib.md5(task.encode()).hexdigest()[:8],
+            task_id=hashlib.md5(task.encode(), usedforsecurity=False).hexdigest()[:8],
             tools_required=required_tools,
             execution_strategy=strategy,
             dependencies=dependencies,
@@ -835,7 +836,7 @@ After completing the task:
 
     def _get_cache_key(self, task: str, context_hash: str) -> str:
         """Generate cache key for response"""
-        return hashlib.md5(f"{task}:{context_hash}".encode()).hexdigest()
+        return hashlib.md5(f"{task}:{context_hash}".encode(), usedforsecurity=False).hexdigest()
 
     def _should_use_cache(self, cache_key: str) -> bool:
         """Check if cached response should be used"""

--- a/deile/tests/security/test_security_audit_84.py
+++ b/deile/tests/security/test_security_audit_84.py
@@ -19,10 +19,7 @@ Four invariants pinned by this file:
 from __future__ import annotations
 
 import ast
-import io
 import re
-import sys
-import tokenize
 from pathlib import Path
 
 import pytest
@@ -100,6 +97,7 @@ def test_md5_has_usedforsecurity_false(rel_path: str) -> None:
 OS_SYSTEM_FREE_FILES = [
     "deile/commands/actions.py",
     "deile/ui/cli.py",
+    "deile/ui/emoji_support.py",
 ]
 
 

--- a/deile/tests/security/test_security_audit_84.py
+++ b/deile/tests/security/test_security_audit_84.py
@@ -1,0 +1,203 @@
+"""Security regression tests — issue #84.
+
+Four invariants pinned by this file:
+
+1. hashlib.md5() always carries usedforsecurity=False in non-cryptographic
+   usages (content-hashing, cache-keying). Prevents misleading SAST reports.
+
+2. os.system() is absent from actions.py and ui/cli.py — replaced by
+   subprocess.run with a list argument (no shell spawning).
+
+3. The SQL queries in cost_tracker.py always bind user-controlled values via
+   parameterised placeholders (?), never via f-string interpolation of raw
+   values. where_sql is built from a hard-coded list of clause strings.
+
+4. pyproject.toml declares cryptography>=44.0.0 to address CVE-2023-50782,
+   CVE-2024-0727, and PYSEC-2024-225.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import re
+import sys
+import tokenize
+from pathlib import Path
+
+import pytest
+
+DEILE_ROOT = Path(__file__).parent.parent.parent.parent  # repo root
+DEILE_PKG = DEILE_ROOT / "deile"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _source(rel: str) -> str:
+    return (DEILE_ROOT / rel).read_text(encoding="utf-8")
+
+
+def _ast(rel: str) -> ast.Module:
+    return ast.parse(_source(rel))
+
+
+# ---------------------------------------------------------------------------
+# 1. hashlib.md5 — usedforsecurity=False
+# ---------------------------------------------------------------------------
+
+MD5_FILES = [
+    "deile/core/intent_analyzer.py",
+    "deile/infrastructure/google_file_api.py",
+    "deile/memory/working_memory.py",
+    "deile/orchestration/artifact_manager.py",
+    "deile/personas/base.py",
+]
+
+
+def _md5_calls_without_flag(tree: ast.Module) -> list[ast.Call]:
+    """Return Call nodes that look like hashlib.md5(...) but lack usedforsecurity=False."""
+    bad: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_md5 = (
+            (isinstance(func, ast.Attribute) and func.attr == "md5")
+            or (isinstance(func, ast.Name) and func.id == "md5")
+        )
+        if not is_md5:
+            continue
+        has_flag = any(
+            kw.arg == "usedforsecurity"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is False
+            for kw in node.keywords
+        )
+        if not has_flag:
+            bad.append(node)
+    return bad
+
+
+@pytest.mark.security
+@pytest.mark.parametrize("rel_path", MD5_FILES)
+def test_md5_has_usedforsecurity_false(rel_path: str) -> None:
+    """Every hashlib.md5() call must carry usedforsecurity=False."""
+    tree = _ast(rel_path)
+    bad = _md5_calls_without_flag(tree)
+    lines = [n.lineno for n in bad]
+    assert not bad, (
+        f"{rel_path}: found hashlib.md5() without usedforsecurity=False "
+        f"on lines {lines}. Add usedforsecurity=False (content-hashing only)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. os.system absent from actions.py and ui/cli.py
+# ---------------------------------------------------------------------------
+
+OS_SYSTEM_FREE_FILES = [
+    "deile/commands/actions.py",
+    "deile/ui/cli.py",
+]
+
+
+def _os_system_calls(tree: ast.Module) -> list[ast.Call]:
+    """Return Call nodes for os.system(...)."""
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "system"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "os"
+        ):
+            hits.append(node)
+    return hits
+
+
+@pytest.mark.security
+@pytest.mark.parametrize("rel_path", OS_SYSTEM_FREE_FILES)
+def test_no_os_system(rel_path: str) -> None:
+    """os.system() must not appear in actions.py or ui/cli.py (use subprocess.run)."""
+    tree = _ast(rel_path)
+    bad = _os_system_calls(tree)
+    lines = [n.lineno for n in bad]
+    assert not bad, (
+        f"{rel_path}: os.system() found on lines {lines}. "
+        "Use subprocess.run(['clear'], check=False) instead."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. cost_tracker.py — SQL parameterisation safety
+# ---------------------------------------------------------------------------
+
+@pytest.mark.security
+def test_cost_tracker_sql_uses_params() -> None:
+    """cost_tracker.py must pass a `params` list to every f-string execute call."""
+    source = _source("deile/infrastructure/monitoring/cost_tracker.py")
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Look for conn.execute(f"...", params) patterns
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "execute"):
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        # If the first arg is an f-string (JoinedStr), ensure a second arg (params) exists
+        if isinstance(first_arg, ast.JoinedStr):
+            assert len(node.args) >= 2, (
+                f"cost_tracker.py line {node.lineno}: "
+                "f-string passed to .execute() without a params argument — "
+                "this is a SQL injection risk."
+            )
+
+
+@pytest.mark.security
+def test_cost_tracker_where_clauses_hardcoded() -> None:
+    """where_clauses in cost_tracker.py must only append string literals."""
+    source = _source("deile/infrastructure/monitoring/cost_tracker.py")
+
+    # Find all where_clauses.append(...) calls in the source
+    pattern = re.compile(r'where_clauses\.append\(([^)]+)\)')
+    for m in pattern.finditer(source):
+        arg = m.group(1).strip()
+        # Argument must be a plain string literal (starts and ends with quote)
+        is_string_literal = (
+            (arg.startswith('"') and arg.endswith('"'))
+            or (arg.startswith("'") and arg.endswith("'"))
+        )
+        assert is_string_literal, (
+            f"where_clauses.append() called with non-literal argument: {arg!r}. "
+            "Only hardcoded SQL clause strings are allowed."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. pyproject.toml — cryptography minimum version
+# ---------------------------------------------------------------------------
+
+@pytest.mark.security
+def test_pyproject_pins_cryptography() -> None:
+    """pyproject.toml must declare cryptography>=44.0.0 to address 2024 CVEs."""
+    content = _source("pyproject.toml")
+    # Accept any lower-bound >= 44 (e.g. >=44.0.0, >=44, >=44.0)
+    match = re.search(r'"cryptography\s*>=\s*(\d+)', content)
+    assert match, (
+        "pyproject.toml: cryptography dependency not found or missing >= lower bound. "
+        "Add 'cryptography>=44.0.0' to fix CVE-2023-50782, CVE-2024-0727, PYSEC-2024-225."
+    )
+    major = int(match.group(1))
+    assert major >= 44, (
+        f"pyproject.toml: cryptography>={major}.x.x is below the required >=44.0.0. "
+        "Bump to >=44.0.0 to address the 2024 CVEs."
+    )

--- a/deile/tools/bash_tool.py
+++ b/deile/tools/bash_tool.py
@@ -1,14 +1,14 @@
 """Enhanced Bash Tool - PTY support, tee, security and artifacts - SITUAÇÃO 4"""
 
+import logging
 import os
+import platform
+import re
+import subprocess
 import sys
 import time
-import subprocess
-import platform
-from typing import Dict, Any, Optional, List, Tuple
 from pathlib import Path
-import logging
-import re
+from typing import Any, Dict, List, Optional, Tuple
 
 # PTY imports for Unix-like systems
 try:
@@ -20,11 +20,10 @@ except ImportError as e:
     logging.warning(f"PTY modules not available: {e}")
     PTY_AVAILABLE = False
 
-from .base import SyncTool, ToolContext, ToolResult, ToolStatus, DisplayPolicy
 from ..core.exceptions import ToolError
-from ..security.permissions import PermissionManager
 from ..orchestration.artifact_manager import ArtifactManager
-
+from ..security.permissions import PermissionManager
+from .base import DisplayPolicy, SyncTool, ToolContext, ToolResult, ToolStatus
 
 logger = logging.getLogger(__name__)
 
@@ -202,14 +201,14 @@ class BashExecuteTool(SyncTool):
         try:
             import pty
             import select
-            
+
             # Create master and slave PTY
             master_fd, slave_fd = pty.openpty()
             
             # Start process with PTY
             process = subprocess.Popen(
                 command,
-                shell=True,
+                shell=True,  # nosec B602 — intentional: BashExecuteTool is a shell-execution primitive; command passes security assessment before reaching here
                 cwd=working_dir,
                 env=env,
                 stdin=slave_fd,

--- a/deile/tools/execution_tools.py
+++ b/deile/tools/execution_tools.py
@@ -12,12 +12,12 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import List, Optional, Dict, Any, Callable, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 if platform.system() == "Windows":
     WINDOWS_PTY_AVAILABLE = False
-    import msvcrt
     import ctypes
+    import msvcrt
     from ctypes import wintypes
 else:
     try:
@@ -27,8 +27,8 @@ else:
     except ImportError:
         UNIX_PTY_AVAILABLE = False
 
-from .base import SyncTool, AsyncTool, ToolContext, ToolResult, ToolStatus
 from ..core.exceptions import ToolError, ValidationError
+from .base import AsyncTool, SyncTool, ToolContext, ToolResult, ToolStatus
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ class PTYSession:
                     
             self.process = subprocess.Popen(
                 self.command,
-                shell=True,
+                shell=True,  # nosec B602 — intentional: EnhancedExecutionTool is a shell-execution primitive; caller validates command before dispatch
                 cwd=self.working_dir,
                 env=self.env,
                 stdin=subprocess.PIPE,
@@ -110,7 +110,7 @@ class PTYSession:
             
             self.process = subprocess.Popen(
                 self.command,
-                shell=True,
+                shell=True,  # nosec B602 — intentional: PTY mode; same security boundary as non-PTY path
                 cwd=self.working_dir,
                 env=self.env,
                 stdin=self.slave_fd,
@@ -503,7 +503,7 @@ class EnhancedExecutionTool(SyncTool):
             # Execute with timeout
             result = subprocess.run(
                 command,
-                shell=True,
+                shell=True,  # nosec B602 — intentional: execution tool; command validated upstream
                 cwd=context.working_directory,
                 env=full_env,
                 capture_output=True,

--- a/deile/ui/cli.py
+++ b/deile/ui/cli.py
@@ -1,8 +1,10 @@
 """Interface CLI principal"""
 
-from typing import Optional, Dict, Any
 import os
+import subprocess
 import sys
+from typing import Any, Dict, Optional
+
 from rich.console import Console
 from rich.prompt import Prompt
 from rich.table import Table
@@ -130,7 +132,10 @@ class CLI:
     
     def clear_screen(self) -> None:
         """Limpa a tela"""
-        os.system('cls' if os.name == 'nt' else 'clear')
+        if os.name == 'nt':
+            subprocess.run(['cmd', '/c', 'cls'], check=False)
+        else:
+            subprocess.run(['clear'], check=False)
     
     def print_goodbye(self) -> None:
         """Mensagem de despedida"""

--- a/deile/ui/emoji_support.py
+++ b/deile/ui/emoji_support.py
@@ -4,8 +4,9 @@ This module provides intelligent emoji rendering that falls back to text
 equivalents on systems that don't support Unicode emojis properly.
 """
 
-import sys
 import os
+import subprocess
+import sys
 from typing import Dict, Optional
 
 
@@ -36,7 +37,7 @@ class EmojiManager:
         if sys.platform == "win32":
             try:
                 # Try to set console to UTF-8
-                os.system('chcp 65001 >nul 2>&1')
+                subprocess.run(['cmd', '/c', 'chcp', '65001'], capture_output=True, check=False)
                 # Most modern Windows terminals support emojis now
                 return True
             except:
@@ -136,7 +137,7 @@ class EmojiManager:
         if sys.platform == "win32":
             try:
                 # Set console code page to UTF-8
-                os.system('chcp 65001 >nul 2>&1')
+                subprocess.run(['cmd', '/c', 'chcp', '65001'], capture_output=True, check=False)
                 
                 # Set environment variables for better Unicode support
                 os.environ['PYTHONIOENCODING'] = 'utf-8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "requests>=2.0",
     "urllib3>=2.0",
     "certifi>=2024",
+    "cryptography>=44.0.0",
     "charset-normalizer>=3.0",
     "idna>=3.0",
     "uritemplate>=4.0",


### PR DESCRIPTION
## Resumo

Auditoria de segurança completa (#84) com correção dos achados acionáveis e regressões para cada fix.

### Achados e correções

| Severidade | Arquivo(s) | Problema (bandit) | Fix |
|---|---|---|---|
| HIGH | `core/intent_analyzer.py`, `infrastructure/google_file_api.py`, `memory/working_memory.py`, `orchestration/artifact_manager.py`, `personas/base.py` (8 calls) | B324 — `hashlib.md5()` sem `usedforsecurity=False` | Adicionado `usedforsecurity=False` em todos os 8 call sites |
| HIGH | `commands/actions.py:243,279`, `ui/cli.py:133` | B605 — `os.system('cls'/'clear')` | Substituído por `subprocess.run(['clear'], check=False)` (sem shell) |
| HIGH | `tools/bash_tool.py:212`, `tools/execution_tools.py:82,113,506` | B602 — `shell=True` | `# nosec B602` com justificativa (primitiva de execução intencional) |
| MEDIUM | `infrastructure/monitoring/cost_tracker.py:642,651,664` | B608 — f-string em SQL | `# nosec B608` com explicação (valores via `?` parameterizados; `where_sql` são strings hardcoded) |
| HIGH | `cryptography 41.0.7` (transitivo via `google-auth`) | CVE-2023-50782, CVE-2024-0727, PYSEC-2024-225 | `cryptography>=44.0.0` em `pyproject.toml` |

### Não-achados confirmados

- HTTP tool: `verify_ssl=True` por padrão ✓
- `.env.example`: sem credenciais reais ✓
- `os.system` nas outras ocorrências: nenhum vetor de injeção via input de usuário
- `bash_tool.py`/`execution_tools.py` `shell=True`: intencional por design (ferramentas de execução bash) ✓

### Fora de escopo (documentado)

- `deilebot` — repo separado (decisão #17)
- `pyjwt 2.7.0` — orphan install, não é dependência do deile
- `pip`/`setuptools`/`wheel` — ferramentas do sistema
- CVEs 2026 em `cryptography ≥46.0.5` — versão ainda não estável

### Testes

10 novos testes de regressão em `deile/tests/security/test_security_audit_84.py`:
- AST-based: verifica `usedforsecurity=False` em todos os arquivos relevantes
- AST-based: verifica ausência de `os.system()` em `actions.py` e `ui/cli.py`
- Verifica que SQL em `cost_tracker.py` sempre tem `params` como segundo argumento
- Verifica que `where_clauses.append()` usa apenas literais de string
- Verifica `cryptography>=44` em `pyproject.toml`

### Checklist

- [x] `pytest deile/tests/ -q` → 950 passed, 1 failed (pre-existing: `test_openai_tool_calling` — `AttributeError: get_tool_registry` não existe em main)
- [x] `ruff check deile/` → 0 erros novos (baseline pré-existente inalterado)
- [x] `isort` aplicado nos 11 arquivos tocados
- [x] Coverage mantida (53% — pre-existing, não regressão)
- [x] Sem `--no-verify`, sem force push, sem log de secrets

### Decisões-chave

1. **MD5 `usedforsecurity=False`**: mínima mudança de comportamento — apenas sinaliza ao Python/FIPS que o hash não é usado para fins criptográficos; a função de hash permanece idêntica.
2. **`os.system` → `subprocess.run(list)`**: elimina o shell intermediário; `['clear']` ou `['cmd', '/c', 'cls']` são passados diretamente ao exec sem shell spawning.
3. **`cryptography>=44`**: pin explícito em `pyproject.toml` para sobrescrever a dep transitiva desbloqueada; não altera nenhum código de runtime.

Closes #84

https://claude.ai/code/session_01Ln46PMPBSva2khpRkRZEyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ln46PMPBSva2khpRkRZEyc)_