### PR TITLE
feat(pipeline): autonomous DEILE-bot → DEILE → Claude Code loop (closes #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,60 @@
 
 ---
 
+## 🤖 Pipeline autônomo
+
+O DEILE pode operar **autonomamente** sobre o repositório GitHub: quando uma issue recebe o label `~workflow:nova`, o pipeline a implementa e abre uma PR sem intervenção humana.
+
+### Fluxo completo
+
+```
+Discord: "/ideia implementar feature X"
+  → DEILE cria issue com ~workflow:nova
+  → PipelineMonitor tick
+    → Stage 1: DEILE revisa issue → ~workflow:revisada
+    → Stage 2: Claude Code implementa em worktree → PR aberta → ~workflow:em_pr
+    → Stage 3: Claude Code revisa PR → merge → ~review:concluida
+  → Discord: DM com URL da PR
+```
+
+### Quick start do pipeline
+
+Configure as variáveis de ambiente:
+
+```bash
+export DEILE_PIPELINE_REPO=owner/repo
+export DEILE_PIPELINE_BASE_PATH=/caminho/para/repo
+export DEILE_PIPELINE_NOTIFY_USER_ID=123456789012345678  # Discord snowflake (opcional)
+```
+
+Inicie de dentro do REPL:
+
+```
+> /pipeline start          # inicia o loop de polling (1 min)
+> /pipeline status         # mostra contadores
+> /pipeline stop           # para o loop
+```
+
+Ou configure `DEILE_PIPELINE_AUTOSTART=1` para iniciar automaticamente com o daemon.
+
+### Agendamento de tarefas
+
+```
+# Agendar revisão de issues a cada 10 minutos
+→ pipeline_schedule(action="add_recurring", trigger_action="review", cron="*/10 * * * *")
+
+# Agendar prompt natural toda segunda às 9h
+→ cron_create(prompt="Gere relatório de custos", cron="0 9 * * 1")
+
+# One-shot: implementar issue 99 amanhã às 18h
+→ pipeline_schedule(action="add_oneshot", trigger_action="implement",
+    run_at="2026-05-07T18:00:00Z", target_issue=99)
+```
+
+Documentação completa: [`docs/2026-05-06_PIPELINE-AUTONOMO.md`](docs/2026-05-06_PIPELINE-AUTONOMO.md)
+
+---
+
 ## 🚀 Visão geral
 
 DEILE é um **agente de IA autônomo para desenvolvimento de software**, executado diretamente no terminal. Você conversa com ele em linguagem natural — em português ou inglês — e ele lê, escreve e edita arquivos do seu projeto, roda comandos, instala pacotes, executa testes, busca trechos no repositório, planeja tarefas e acompanha custo de uso, tudo dentro do diretório de trabalho atual.

--- a/config/deilebot.example.yaml
+++ b/config/deilebot.example.yaml
@@ -36,3 +36,54 @@ personas:
 
 providers:
   enabled_providers: ["discord"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pipeline autônomo (intent #87) — todas as variáveis abaixo são opcionais.
+# Sem elas o pipeline não inicia e as tools pipeline/pipeline_schedule não
+# têm efeito ao ser invocadas.
+# Equivalentes env: DEILE_PIPELINE_* (ver docs/system_design/09-CONFIGURACAO.md)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# pipeline:
+#   # Repositório GitHub alvo no formato "owner/repo"
+#   # Env var: DEILE_PIPELINE_REPO
+#   repo: elimarcavalli/deile
+#
+#   # Caminho absoluto da raiz do repositório local (onde .worktrees/ será criado)
+#   # Env var: DEILE_PIPELINE_BASE_PATH
+#   # Detectado automaticamente se omitido (busca ancestral com .git + deile.py)
+#   base_path: /home/runner/deile
+#
+#   # Discord snowflake do usuário que receberá DMs de notificação a cada transição
+#   # Env var: DEILE_PIPELINE_NOTIFY_USER_ID
+#   notify_user_id: "123456789012345678"
+#
+#   # Identificador único desta instância do monitor (1-32 chars [a-zA-Z0-9_-])
+#   # Afeta branch names (auto/<monitor_id>/issue-N) e ownership labels (~by:<monitor_id>)
+#   # Env var: DEILE_PIPELINE_MONITOR_ID
+#   monitor_id: default
+#
+#   # Sharding horizontal: índice [0, shard_count) deste monitor
+#   # Env var: DEILE_PIPELINE_SHARD_INDEX
+#   shard_index: 0
+#
+#   # Sharding horizontal: total de monitores paralelos no deploy
+#   # Env var: DEILE_PIPELINE_SHARD_COUNT
+#   shard_count: 1
+#
+#   # Se true (ou DEILE_PIPELINE_AUTOSTART=1), o daemon sobe o PipelineMonitor no boot
+#   autostart: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cron genérico (intent #86) — agendador de prompts naturais do usuário
+# Equivalentes env: DEILE_CRON_* (ver docs/system_design/09-CONFIGURACAO.md)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# cron:
+#   # Se true (ou DEILE_CRON_AUTOSTART=1), o daemon sobe o CronRunner no boot
+#   autostart: false
+#
+#   # Caminho absoluto do SQLite do CronStore (tabela cron_entries)
+#   # Env var: DEILE_CRON_DB_PATH
+#   # Default: <base_path>/data/cron.db  ou  <cwd>/data/cron.db
+#   db_path: /home/runner/deile/data/cron.db

--- a/deile/commands/builtin/__init__.py
+++ b/deile/commands/builtin/__init__.py
@@ -27,6 +27,7 @@ from .logs_command import LogsCommand
 from .memory_command import MemoryCommand
 from .welcome_command import WelcomeCommand
 from .pipeline_command import PipelineCommand
+from .pipeline_schedule_command import PipelineScheduleCommand
 
 __all__ = [
     "HelpCommand",
@@ -52,4 +53,5 @@ __all__ = [
     "MemoryCommand",
     "WelcomeCommand",
     "PipelineCommand",
+    "PipelineScheduleCommand",
 ]

--- a/deile/commands/builtin/__init__.py
+++ b/deile/commands/builtin/__init__.py
@@ -26,10 +26,11 @@ except ImportError:
 from .logs_command import LogsCommand
 from .memory_command import MemoryCommand
 from .welcome_command import WelcomeCommand
+from .pipeline_command import PipelineCommand
 
 __all__ = [
     "HelpCommand",
-    "DebugCommand", 
+    "DebugCommand",
     "ClearCommand",
     "StatusCommand",
     "ConfigCommand",
@@ -41,7 +42,7 @@ __all__ = [
     "PlanCommand",
     "RunCommand",
     "ApproveCommand",
-    "StopCommand", 
+    "StopCommand",
     "DiffCommand",
     "PatchCommand",
     "ApplyCommand",
@@ -49,5 +50,6 @@ __all__ = [
     "SandboxCommand",
     "LogsCommand",
     "MemoryCommand",
-    "WelcomeCommand"
+    "WelcomeCommand",
+    "PipelineCommand",
 ]

--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -1,0 +1,104 @@
+"""``/pipeline`` command — start/stop/status of the autonomous pipeline.
+
+Usage:
+    /pipeline start         start the 1-min polling loop
+    /pipeline stop          stop the polling loop
+    /pipeline status        print stats + current state
+    /pipeline tick          run a single tick synchronously (debug)
+
+The command is idempotent: running ``start`` twice does nothing on the second
+call. The monitor instance is held on ``context.agent.pipeline_monitor``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from deile.commands.base import CommandContext, CommandResult, DirectCommand
+from deile.config.manager import CommandConfig
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+
+
+_DEFAULT_REPO = "elimarcavalli/deile"
+
+
+def _resolve_repo() -> str:
+    return os.environ.get("DEILE_PIPELINE_REPO", _DEFAULT_REPO)
+
+
+def _resolve_base_path() -> Path:
+    """Find the DEILE repo root from the current working directory."""
+    raw = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if raw:
+        return Path(raw).resolve()
+    cwd = Path.cwd()
+    for ancestor in (cwd, *cwd.parents):
+        if (ancestor / ".git").is_dir() and (ancestor / "deile.py").is_file():
+            return ancestor
+    return cwd
+
+
+class PipelineCommand(DirectCommand):
+    """``/pipeline {start|stop|status|tick}``."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            CommandConfig(
+                name="pipeline",
+                description="Controla o pipeline autônomo de issues/PRs (start|stop|status|tick)",
+                action="pipeline",
+            )
+        )
+        self.category = "orchestration"
+
+    async def execute(self, context: CommandContext) -> CommandResult:
+        sub = (context.args.strip().split(" ", 1) + [""])[0].lower() or "status"
+        agent = context.agent
+        monitor: Optional[PipelineMonitor] = getattr(agent, "pipeline_monitor", None)
+
+        if monitor is None:
+            cfg = PipelineConfig(
+                repo=_resolve_repo(),
+                base_repo_path=_resolve_base_path(),
+                notify_user_id=os.environ.get("DEILE_PIPELINE_NOTIFY_USER_ID"),
+            )
+            monitor = PipelineMonitor(cfg)
+            agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
+
+        if sub == "start":
+            await monitor.start()
+            return CommandResult(
+                success=True,
+                content=(
+                    f"✅ pipeline iniciado (repo={monitor.config.repo}, "
+                    f"interval={monitor.config.poll_interval_seconds}s)"
+                ),
+            )
+        if sub == "stop":
+            await monitor.stop()
+            return CommandResult(success=True, content="🛑 pipeline parado")
+        if sub == "tick":
+            await monitor.tick()
+            s = monitor.stats
+            return CommandResult(
+                success=True,
+                content=(
+                    f"🔄 single tick OK — ticks={s.ticks} "
+                    f"reviewed={s.issues_reviewed} implemented={s.issues_implemented} "
+                    f"prs={s.prs_reviewed} errors={s.errors}"
+                ),
+            )
+        # default: status
+        s = monitor.stats
+        running = monitor._task is not None and not monitor._task.done()  # type: ignore[union-attr]
+        return CommandResult(
+            success=True,
+            content=(
+                f"📊 pipeline {'rodando' if running else 'parado'} | repo={monitor.config.repo}\n"
+                f"  ticks={s.ticks}  reviewed={s.issues_reviewed}  "
+                f"implemented={s.issues_implemented}  prs={s.prs_reviewed}  errors={s.errors}"
+            ),
+        )

--- a/deile/commands/builtin/pipeline_schedule_command.py
+++ b/deile/commands/builtin/pipeline_schedule_command.py
@@ -1,0 +1,208 @@
+"""``/pipeline-schedule`` command — manage the autonomous pipeline schedule.
+
+Usage:
+    /pipeline-schedule list
+        List all recurring and oneshot schedule entries.
+
+    /pipeline-schedule add-recurring trigger:<action> cron:<expr>
+        Add a cron-driven recurring entry.
+        trigger: one of ``review``, ``implement``, ``pr_review``
+        cron: 5-field cron expression, e.g. ``*/5 * * * *``
+
+    /pipeline-schedule add-oneshot trigger:<action> at:<iso>
+        Add a one-time run at a specific UTC datetime.
+        at: ISO-8601 UTC, e.g. ``2026-05-06T18:00:00Z``
+
+    /pipeline-schedule remove id:<entry_id>
+        Delete a recurring or oneshot entry.
+
+    /pipeline-schedule enable id:<entry_id>
+    /pipeline-schedule disable id:<entry_id>
+        Toggle a recurring entry on or off.
+
+The command delegates to :class:`PipelineScheduleTool` for all mutations so
+that validation and persistence logic stay in one place (the tool).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+from deile.commands.base import CommandContext, CommandResult, DirectCommand
+from deile.config.manager import CommandConfig
+from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.tools.base import ToolContext
+from deile.tools.pipeline_schedule_tool import PipelineScheduleTool
+
+logger = logging.getLogger(__name__)
+
+# Pre-compiled lookahead for the start of a new key:value pair.
+# A new key is a word boundary followed by ``word_chars:``.
+_KEY_START_RE = re.compile(r"\s+\w[\w-]*:")
+
+
+def _parse_kv(text: str) -> Dict[str, str]:
+    """Parse a ``key:value key2:val2 …`` string into a dict.
+
+    Handles multi-word values (e.g. ``cron:*/5 * * * *``) and values with
+    colons (e.g. ``at:2026-05-06T18:00:00Z``) by consuming everything up to
+    the next ``<space>key:`` boundary or end-of-string.
+
+    Algorithm: split on boundaries where a space is followed by a ``word:``
+    pattern, then parse each segment as ``key:rest-of-line``.
+    """
+    result: Dict[str, str] = {}
+    # Insert sentinels so the pattern can split cleanly.
+    # Replace "  key:" boundaries with a null-byte separator.
+    normalised = _KEY_START_RE.sub(lambda m: "\x00" + m.group(0).lstrip(), text.strip())
+    for segment in normalised.split("\x00"):
+        segment = segment.strip()
+        if not segment:
+            continue
+        colon = segment.find(":")
+        if colon <= 0:
+            continue
+        key = segment[:colon].strip()
+        value = segment[colon + 1:].strip()
+        if key:
+            result[key] = value
+    return result
+
+
+class PipelineScheduleCommand(DirectCommand):
+    """``/pipeline-schedule {list|add-recurring|add-oneshot|remove|enable|disable}``."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            CommandConfig(
+                name="pipeline-schedule",
+                description=(
+                    "Gerencia o schedule do pipeline autônomo "
+                    "(list|add-recurring|add-oneshot|remove|enable|disable)"
+                ),
+                action="pipeline-schedule",
+            )
+        )
+        self.category = "orchestration"
+        self._tool = PipelineScheduleTool()
+
+    async def execute(self, context: CommandContext) -> CommandResult:
+        raw = (context.args or "").strip()
+        parts = raw.split(None, 1)
+        sub = parts[0].lower() if parts else "list"
+        rest = parts[1] if len(parts) > 1 else ""
+
+        tool_args: Dict[str, Any] = {}
+
+        if sub == "list":
+            tool_args = {"action": "list"}
+
+        elif sub == "add-recurring":
+            kv = _parse_kv(rest)
+            trigger = kv.get("trigger")
+            cron = kv.get("cron")
+            if not trigger or not cron:
+                return CommandResult.error_result(
+                    "add-recurring requires trigger:<action> and cron:<expr>\n"
+                    "Example: /pipeline-schedule add-recurring trigger:review cron:*/5 * * * *"
+                )
+            tool_args = {
+                "action": "add_recurring",
+                "trigger_action": trigger,
+                "cron": cron,
+            }
+            if "id" in kv:
+                tool_args["id"] = kv["id"]
+
+        elif sub == "add-oneshot":
+            kv = _parse_kv(rest)
+            trigger = kv.get("trigger")
+            at = kv.get("at")
+            if not trigger or not at:
+                return CommandResult.error_result(
+                    "add-oneshot requires trigger:<action> and at:<iso-datetime>\n"
+                    "Example: /pipeline-schedule add-oneshot trigger:review at:2026-05-06T18:00:00Z"
+                )
+            tool_args = {
+                "action": "add_oneshot",
+                "trigger_action": trigger,
+                "run_at": at,
+            }
+            if "id" in kv:
+                tool_args["id"] = kv["id"]
+
+        elif sub == "remove":
+            kv = _parse_kv(rest)
+            entry_id = kv.get("id")
+            if not entry_id:
+                return CommandResult.error_result(
+                    "remove requires id:<entry_id>\n"
+                    "Example: /pipeline-schedule remove id:review_loop"
+                )
+            tool_args = {"action": "remove", "id": entry_id}
+
+        elif sub in ("enable", "disable"):
+            kv = _parse_kv(rest)
+            entry_id = kv.get("id")
+            if not entry_id:
+                return CommandResult.error_result(
+                    f"{sub} requires id:<entry_id>\n"
+                    f"Example: /pipeline-schedule {sub} id:review_loop"
+                )
+            tool_args = {"action": sub, "id": entry_id}
+
+        else:
+            return CommandResult.error_result(
+                f"Unknown sub-command: {sub!r}\n"
+                "Valid sub-commands: list, add-recurring, add-oneshot, remove, enable, disable"
+            )
+
+        try:
+            tool_ctx = ToolContext(user_input=raw, parsed_args=tool_args)
+            result = await self._tool.execute(tool_ctx)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("pipeline-schedule tool error: %s", exc, exc_info=True)
+            return CommandResult.error_result(
+                f"{type(exc).__name__}: {exc}", error=exc
+            )
+
+        if not result.is_success:
+            return CommandResult.error_result(result.message or "tool returned error")
+
+        return CommandResult(
+            success=True,
+            content=_format_result(sub, result.data, result.message),
+        )
+
+
+# ---------------------------------------------------------------------------
+# display helpers
+# ---------------------------------------------------------------------------
+
+def _format_result(sub: str, data: Any, message: Optional[str]) -> str:
+    if sub == "list":
+        if not data:
+            return message or "no schedule data"
+        recurring = data.get("recurring", [])
+        oneshot = data.get("oneshot", [])
+        lines = [f"Monitor: {data.get('monitor_id', '?')}"]
+        if recurring:
+            lines.append("\nRecurring:")
+            for e in recurring:
+                status = "on" if e.get("enabled", True) else "off"
+                lines.append(
+                    f"  [{status}] {e['id']}  {e['action']}  @  {e['cron']}"
+                )
+        if oneshot:
+            lines.append("\nOneshot:")
+            for e in oneshot:
+                lines.append(
+                    f"  {e['id']}  {e['action']}  at  {e.get('run_at', '?')}"
+                )
+        if not recurring and not oneshot:
+            lines.append("  (empty)")
+        return "\n".join(lines)
+
+    return message or str(data)

--- a/deile/cron/__init__.py
+++ b/deile/cron/__init__.py
@@ -1,0 +1,19 @@
+"""Generic task scheduler for DEILE — implements intent #86.
+
+Lets a user ask "lembra de me mandar o relatório toda segunda às 9h" and
+have DEILE persist + execute that prompt at the right time. Distinct from
+``deile/orchestration/pipeline/scheduler.py``, which schedules pipeline
+*stages* (review/implement/pr_review). This package schedules **arbitrary
+natural-language prompts** that get fed back into the agent on fire.
+
+Components:
+    store    — CronEntry + CronStore (SQLite-backed persistence)
+    runner   — CronRunner async loop that polls, fires entries, captures result
+
+The three LLM-callable tools (CronCreate / CronList / CronDelete) live
+under ``deile/tools/`` for registry auto-discovery.
+"""
+
+from deile.cron.store import CronEntry, CronStore
+
+__all__ = ["CronEntry", "CronStore"]

--- a/deile/cron/agent_bridge.py
+++ b/deile/cron/agent_bridge.py
@@ -1,0 +1,116 @@
+"""Cron → Agent bridge for intent #86 (autonomous pipeline).
+
+This module closes the loop between the CronRunner and the DEILE agent:
+the CronRunner fires a scheduled entry by calling a ``FireCallback``; this
+module provides ``make_fire_callback``, which manufactures that callback
+from a lazy ``agent_provider`` factory.
+
+Integration point
+-----------------
+CronRunner receives a ``fire_callback: FireCallback`` at construction time.
+Callers that bootstrap the full agent stack should wire it like this::
+
+    from deile.cron.agent_bridge import make_fire_callback
+
+    async def agent_provider():
+        return my_deile_agent  # DeileAgent instance
+
+    runner = CronRunner(store, fire_callback=make_fire_callback(agent_provider))
+
+Design notes
+------------
+- ``agent_provider`` is a **lazy async factory** so the bridge does not
+  require the agent to be initialised at module import time.  The provider
+  is called once per ``tick``; callers may cache the agent themselves or
+  return a freshly-built one — both are valid patterns.
+- All exceptions are caught and converted to a human-readable error string
+  so the runner can persist a ``last_result`` without raising.  The runner
+  itself already guards its outer loop, but defence-in-depth here prevents
+  a single bad entry from surfacing an unhandled exception.
+- The ``session_id`` format ``"cron-{entry.id}"`` deliberately encodes the
+  entry id so agent memory layers can correlate turns across recurring fires.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+from deile.cron.store import CronEntry
+from deile.cron.runner import FireCallback
+
+logger = logging.getLogger(__name__)
+
+AgentProvider = Callable[[], Awaitable[Any]]
+
+
+def make_fire_callback(
+    agent_provider: AgentProvider,
+    *,
+    max_summary_chars: int = 500,
+) -> FireCallback:
+    """Return a :data:`FireCallback` that routes a :class:`CronEntry` through DEILE.
+
+    Parameters
+    ----------
+    agent_provider:
+        Async factory that returns a :class:`~deile.core.agent.DeileAgent`
+        (or any object with ``async process_input(prompt, session_id=...)``).
+        Called on every fire so the caller controls caching / lifecycle.
+    max_summary_chars:
+        Maximum length of the returned summary string.  Longer responses
+        are truncated with an ellipsis.  Defaults to 500.
+
+    Returns
+    -------
+    FireCallback
+        An ``async (entry: CronEntry) -> str`` callable ready to pass to
+        :class:`~deile.cron.runner.CronRunner`.
+    """
+
+    async def _fire(entry: CronEntry) -> str:
+        try:
+            agent = await agent_provider()
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "cron agent_provider failed for entry %s: %s",
+                entry.id,
+                exc,
+                exc_info=True,
+            )
+            return f"error: {type(exc).__name__}: {exc}"
+
+        try:
+            response = await agent.process_input(
+                entry.prompt,
+                session_id=f"cron-{entry.id}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "cron agent.process_input failed for entry %s: %s",
+                entry.id,
+                exc,
+                exc_info=True,
+            )
+            return f"error: {type(exc).__name__}: {exc}"
+
+        # Extract text: prefer .content attribute (AgentResponse), fall back
+        # to str() for duck-typed responses.
+        try:
+            text = response.content if hasattr(response, "content") else str(response)
+        except Exception:  # noqa: BLE001
+            text = ""
+
+        if not text:
+            text = str(response) if response is not None else ""
+
+        summary = text[:max_summary_chars]
+        if len(text) > max_summary_chars:
+            summary = summary[: max_summary_chars - 1] + "…"
+
+        logger.debug(
+            "cron entry %s fired; summary length=%d", entry.id, len(summary)
+        )
+        return summary
+
+    return _fire

--- a/deile/cron/runner.py
+++ b/deile/cron/runner.py
@@ -1,0 +1,133 @@
+"""CronRunner — async loop that fires due CronEntries through DEILE.
+
+When a :class:`CronEntry` becomes due, the runner:
+
+1. Loads the entry from :class:`CronStore`.
+2. Builds a fresh DEILE turn using ``entry.prompt`` (the user's natural-
+   language scheduled instruction).
+3. Calls a host-supplied ``fire_callback(prompt, entry)`` which is expected
+   to invoke the agent and return a short summary string.
+4. Persists ``last_fired_at`` / ``next_fire_at`` (recurring) or disables
+   (one-shot) and records the summary in ``last_result``.
+5. Optionally DMs the result to ``entry.notify_user_id`` via Discord.
+
+The runner is single-instance per host: two CronRunners on the same DB
+file would both fire the same entry. For multi-host deployments, gate
+with the existing pipeline lockfile pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+from deile.cron.store import CronEntry, CronStore
+
+logger = logging.getLogger(__name__)
+
+
+FireCallback = Callable[[CronEntry], Awaitable[str]]
+
+
+def _default_fire_callback_factory(_entry: CronEntry) -> str:
+    return "(no fire callback wired)"
+
+
+class CronRunner:
+    """Polls :class:`CronStore` and fires due entries via callback."""
+
+    def __init__(
+        self,
+        store: CronStore,
+        *,
+        fire_callback: Optional[FireCallback] = None,
+        poll_interval_seconds: int = 30,
+        notify_dm: Optional[Callable[[str, str], Awaitable[dict]]] = None,
+    ) -> None:
+        self.store = store
+        self.fire_callback = fire_callback
+        self.poll_interval_seconds = poll_interval_seconds
+        self.notify_dm = notify_dm
+        self._stop_event = asyncio.Event()
+        self._task: Optional[asyncio.Task] = None
+        self._fired_count = 0
+
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    @property
+    def fired_count(self) -> int:
+        return self._fired_count
+
+    async def start(self) -> None:
+        if self.is_running:
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run_forever(), name="cron-runner")
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=5)
+            except asyncio.TimeoutError:
+                self._task.cancel()
+                try:
+                    await self._task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+
+    async def tick(self) -> int:
+        """Run one polling pass — returns number of entries fired."""
+        try:
+            due = self.store.list_due()
+        except Exception:  # noqa: BLE001 — never let the loop die
+            logger.exception("cron list_due failed")
+            return 0
+        fired = 0
+        for entry in due:
+            try:
+                await self._fire(entry)
+                fired += 1
+                self._fired_count += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("cron entry %s fire failed: %s", entry.id, exc)
+                # Even on error, mark fired so we don't loop on a poison entry.
+                self.store.mark_fired(
+                    entry.id, when=datetime.now(timezone.utc),
+                    result=f"error: {type(exc).__name__}: {exc}"[:500],
+                )
+        return fired
+
+    async def _fire(self, entry: CronEntry) -> None:
+        cb = self.fire_callback
+        if cb is None:
+            logger.warning("CronRunner has no fire_callback wired; skipping %s", entry.id)
+            self.store.mark_fired(entry.id, result="skipped: no callback")
+            return
+        result_summary = await cb(entry)
+        self.store.mark_fired(entry.id, result=str(result_summary)[:500])
+        if self.notify_dm and entry.notify_user_id and result_summary:
+            try:
+                msg = (
+                    f"⏰ **Tarefa agendada executada** ({entry.id})\n"
+                    f"> {entry.prompt[:300]}\n\n"
+                    f"**Resultado:** {str(result_summary)[:1500]}"
+                )
+                await self.notify_dm(entry.notify_user_id, msg)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("cron DM failed for %s: %s", entry.id, exc)
+
+    async def _run_forever(self) -> None:
+        while not self._stop_event.is_set():
+            await self.tick()
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=self.poll_interval_seconds
+                )
+            except asyncio.TimeoutError:
+                pass

--- a/deile/cron/store.py
+++ b/deile/cron/store.py
@@ -1,0 +1,264 @@
+"""SQLite-backed persistence for user-scheduled prompts (intent #86).
+
+Design choice: SQLite over YAML because (a) atomic writes are critical when
+multiple processes/threads might add entries, (b) querying "what fires
+between T1 and T2?" is trivial, (c) the data/ directory already houses
+``usage.db`` so we keep the operational footprint consistent.
+
+A single table backs both recurring and one-shot entries — they share most
+columns; ``cron`` is NULL for one-shots and ``run_at`` is NULL for cron
+entries. The ``next_fire_at`` column is denormalized so the runner can
+``ORDER BY next_fire_at LIMIT 1`` in O(log N).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+from deile.core.exceptions import DEILEError
+from deile.orchestration.pipeline.cron import CronExpressionError, next_after
+
+logger = logging.getLogger(__name__)
+
+
+class CronStoreError(DEILEError):
+    """Raised on scheduling / persistence problems."""
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_iso(dt: Optional[datetime]) -> Optional[str]:
+    if dt is None:
+        return None
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _from_iso(value: Optional[str]) -> Optional[datetime]:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.rstrip("Z")).replace(tzinfo=timezone.utc)
+
+
+@dataclass
+class CronEntry:
+    """A scheduled prompt — recurring (cron) OR one-shot (run_at)."""
+
+    id: str
+    prompt: str
+    cron: Optional[str] = None
+    run_at: Optional[datetime] = None  # for one-shot
+    next_fire_at: Optional[datetime] = None
+    last_fired_at: Optional[datetime] = None
+    created_by: Optional[str] = None  # provider:user_id (e.g. "discord:1234")
+    notify_user_id: Optional[str] = None  # Discord snowflake to DM result to
+    enabled: bool = True
+    created_at: datetime = field(default_factory=_now_utc)
+    last_result: Optional[str] = None  # short summary of last fire outcome
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise CronStoreError("id required")
+        if not self.prompt or not self.prompt.strip():
+            raise CronStoreError("prompt required and must be non-empty")
+        if self.cron and self.run_at:
+            raise CronStoreError("provide either cron OR run_at, not both")
+        if not self.cron and not self.run_at:
+            raise CronStoreError("must provide cron OR run_at")
+        # Validate cron eagerly.
+        if self.cron:
+            try:
+                anchor = self.last_fired_at or self.created_at
+                self.next_fire_at = next_after(self.cron, anchor)
+            except CronExpressionError as exc:
+                raise CronStoreError(f"invalid cron {self.cron!r}: {exc}") from exc
+        else:
+            # one-shot: tz-normalize run_at, set next_fire_at = run_at
+            if self.run_at.tzinfo is None:  # type: ignore[union-attr]
+                self.run_at = self.run_at.replace(tzinfo=timezone.utc)  # type: ignore[union-attr]
+            self.next_fire_at = self.run_at
+
+    @property
+    def is_oneshot(self) -> bool:
+        return self.cron is None
+
+    def advance(self, *, after: Optional[datetime] = None) -> None:
+        """Move ``next_fire_at`` forward after a fire (recurring) or mark done."""
+        if self.is_oneshot:
+            self.enabled = False
+            self.next_fire_at = None
+        else:
+            anchor = after or _now_utc()
+            try:
+                self.next_fire_at = next_after(self.cron, anchor)  # type: ignore[arg-type]
+            except CronExpressionError:
+                self.enabled = False
+                self.next_fire_at = None
+
+
+class CronStore:
+    """Thread-safe SQLite-backed CRUD for :class:`CronEntry`."""
+
+    SCHEMA = """
+    CREATE TABLE IF NOT EXISTS cron_entries (
+        id TEXT PRIMARY KEY,
+        prompt TEXT NOT NULL,
+        cron TEXT,
+        run_at TEXT,
+        next_fire_at TEXT,
+        last_fired_at TEXT,
+        created_by TEXT,
+        notify_user_id TEXT,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL,
+        last_result TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_cron_next_fire
+        ON cron_entries(enabled, next_fire_at);
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = Path(db_path).resolve()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        with self._connect() as conn:
+            conn.executescript(self.SCHEMA)
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        # SQLite is synchronous — wrap in a lock so concurrent async tasks
+        # don't trample each other. We open per-call to avoid threading
+        # surprises with the default check_same_thread=True.
+        with self._lock:
+            conn = sqlite3.connect(self.db_path)
+            conn.row_factory = sqlite3.Row
+            try:
+                yield conn
+                conn.commit()
+            finally:
+                conn.close()
+
+    # -- CRUD -------------------------------------------------------
+
+    def add(self, entry: CronEntry) -> None:
+        with self._connect() as conn:
+            try:
+                conn.execute(
+                    """INSERT INTO cron_entries
+                       (id, prompt, cron, run_at, next_fire_at, last_fired_at,
+                        created_by, notify_user_id, enabled, created_at, last_result)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        entry.id, entry.prompt, entry.cron,
+                        _to_iso(entry.run_at), _to_iso(entry.next_fire_at),
+                        _to_iso(entry.last_fired_at), entry.created_by,
+                        entry.notify_user_id, int(entry.enabled),
+                        _to_iso(entry.created_at), entry.last_result,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise CronStoreError(f"id already exists: {entry.id}") from exc
+
+    def get(self, entry_id: str) -> Optional[CronEntry]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM cron_entries WHERE id = ?", (entry_id,)
+            ).fetchone()
+        return self._row_to_entry(row) if row else None
+
+    def list_all(self, *, only_enabled: bool = False) -> List[CronEntry]:
+        sql = "SELECT * FROM cron_entries"
+        if only_enabled:
+            sql += " WHERE enabled = 1"
+        sql += " ORDER BY next_fire_at IS NULL, next_fire_at ASC"
+        with self._connect() as conn:
+            rows = conn.execute(sql).fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    def list_due(self, *, now: Optional[datetime] = None) -> List[CronEntry]:
+        """Return enabled entries whose ``next_fire_at <= now``."""
+        now = now or _now_utc()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """SELECT * FROM cron_entries
+                   WHERE enabled = 1 AND next_fire_at IS NOT NULL
+                     AND next_fire_at <= ?
+                   ORDER BY next_fire_at ASC""",
+                (_to_iso(now),),
+            ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    def remove(self, entry_id: str) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM cron_entries WHERE id = ?", (entry_id,)
+            )
+            return cur.rowcount > 0
+
+    def mark_fired(self, entry_id: str, *, when: Optional[datetime] = None,
+                   result: Optional[str] = None) -> None:
+        """Update ``last_fired_at`` + ``next_fire_at`` after firing."""
+        when = when or _now_utc()
+        entry = self.get(entry_id)
+        if entry is None:
+            return
+        entry.last_fired_at = when
+        if result is not None:
+            entry.last_result = result[:1000]
+        entry.advance(after=when)
+        with self._connect() as conn:
+            conn.execute(
+                """UPDATE cron_entries
+                   SET last_fired_at = ?, next_fire_at = ?, enabled = ?,
+                       last_result = ?
+                   WHERE id = ?""",
+                (
+                    _to_iso(entry.last_fired_at),
+                    _to_iso(entry.next_fire_at),
+                    int(entry.enabled),
+                    entry.last_result,
+                    entry_id,
+                ),
+            )
+
+    def set_enabled(self, entry_id: str, enabled: bool) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "UPDATE cron_entries SET enabled = ? WHERE id = ?",
+                (int(enabled), entry_id),
+            )
+            return cur.rowcount > 0
+
+    # -- helpers ----------------------------------------------------
+
+    @staticmethod
+    def _row_to_entry(row: sqlite3.Row) -> CronEntry:
+        # Build via __new__ to bypass __post_init__'s next_fire_at recompute
+        # (we trust the persisted value).
+        e = CronEntry.__new__(CronEntry)
+        e.id = row["id"]
+        e.prompt = row["prompt"]
+        e.cron = row["cron"]
+        e.run_at = _from_iso(row["run_at"])
+        e.next_fire_at = _from_iso(row["next_fire_at"])
+        e.last_fired_at = _from_iso(row["last_fired_at"])
+        e.created_by = row["created_by"]
+        e.notify_user_id = row["notify_user_id"]
+        e.enabled = bool(row["enabled"])
+        e.created_at = _from_iso(row["created_at"]) or _now_utc()
+        e.last_result = row["last_result"]
+        return e
+
+
+def make_id() -> str:
+    """Return a short, unique entry id."""
+    return f"cron-{uuid.uuid4().hex[:10]}"

--- a/deile/orchestration/pipeline/__init__.py
+++ b/deile/orchestration/pipeline/__init__.py
@@ -1,0 +1,36 @@
+"""Autonomous DEILE-bot → DEILE → Claude Code pipeline.
+
+This package implements intent #87 (elimarcavalli/deile#87): a continuous
+3-agent loop that turns Discord-submitted ideas into merged code changes.
+
+Components
+----------
+labels            Constants for ~workflow:*, ~review:*, ~batch:* labels.
+github_client     `gh` CLI wrapper for issue/PR/label operations.
+worktree_manager  `.worktrees/<branch>` setup for isolated implementation.
+claude_dispatcher Subprocess invocation of `claude -p "<prompt>"`.
+notifier          Discord-DM notifier that ties to elimar.ciss.
+monitor           1-minute polling loop that drives the whole pipeline.
+"""
+
+from deile.orchestration.pipeline.labels import (BATCH_LABEL_PREFIX,
+                                                 REVIEW_CONCLUDED,
+                                                 REVIEW_IN_PROGRESS,
+                                                 REVIEW_PENDING, WORKFLOW_DONE,
+                                                 WORKFLOW_IMPLEMENTING,
+                                                 WORKFLOW_NEW, WORKFLOW_PR,
+                                                 WORKFLOW_REVIEWED,
+                                                 WORKFLOW_REVIEWING)
+
+__all__ = [
+    "BATCH_LABEL_PREFIX",
+    "WORKFLOW_NEW",
+    "WORKFLOW_REVIEWING",
+    "WORKFLOW_REVIEWED",
+    "WORKFLOW_IMPLEMENTING",
+    "WORKFLOW_PR",
+    "WORKFLOW_DONE",
+    "REVIEW_PENDING",
+    "REVIEW_IN_PROGRESS",
+    "REVIEW_CONCLUDED",
+]

--- a/deile/orchestration/pipeline/claude_dispatcher.py
+++ b/deile/orchestration/pipeline/claude_dispatcher.py
@@ -46,9 +46,39 @@ class ClaudeDispatcher:
         *,
         claude_path: Optional[str] = None,
         timeout_seconds: int = 1800,
+        prefer_subscription_auth: bool = True,
     ) -> None:
         self._claude = claude_path or shutil.which("claude") or "claude"
         self.timeout_seconds = timeout_seconds
+        # When True, strip ANTHROPIC_API_KEY (and friends) from the subprocess
+        # env so `claude` falls back to the operator's Claude Pro/Max
+        # subscription. Most local-dev setups carry an API key in `.env` for
+        # the DEILE agent itself, but that key is often on a *different*
+        # billing account than the subscription paying for Claude Code.
+        self.prefer_subscription_auth = prefer_subscription_auth
+
+    _STRIP_KEYS = (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BEARER_TOKEN",
+    )
+
+    def _build_env(self, override: Optional[Mapping[str, str]]) -> Optional[dict]:
+        """Return the env dict to pass to ``claude``, or None to inherit.
+
+        If ``prefer_subscription_auth`` is True (default), copies the parent
+        env minus the keys that would force API-key auth. If False, behaves
+        like before: explicit ``override`` wins, otherwise inherits.
+        """
+        if override is not None:
+            return dict(override)
+        if not self.prefer_subscription_auth:
+            return None
+        import os as _os
+        env = dict(_os.environ)
+        for k in self._STRIP_KEYS:
+            env.pop(k, None)
+        return env
 
     async def run(
         self,
@@ -73,7 +103,7 @@ class ClaudeDispatcher:
             cwd=str(cwd),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env=dict(env) if env is not None else None,
+            env=self._build_env(env),
         )
         try:
             stdout_b, stderr_b = await asyncio.wait_for(

--- a/deile/orchestration/pipeline/claude_dispatcher.py
+++ b/deile/orchestration/pipeline/claude_dispatcher.py
@@ -1,0 +1,156 @@
+"""Programmatic invocation of ``claude -p "<prompt>"`` (Claude Code one-shot).
+
+The autonomous pipeline delegates the actual implementation/review work to
+Claude Code via its non-interactive (``-p``/``--print``) mode. This module
+encapsulates the subprocess plumbing and prompt templates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import shutil
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Mapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ClaudeRunResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_seconds: float
+    cmd: tuple
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+class ClaudeDispatcher:
+    """Run ``claude -p "<prompt>"`` inside a chosen working directory.
+
+    The dispatcher is intentionally narrow: it just executes the command,
+    captures stdout/stderr, and surfaces the result. Higher-level decisions
+    (which prompt, when to retry, how to interpret the output) live in
+    :mod:`monitor`.
+    """
+
+    def __init__(
+        self,
+        *,
+        claude_path: Optional[str] = None,
+        timeout_seconds: int = 1800,
+    ) -> None:
+        self._claude = claude_path or shutil.which("claude") or "claude"
+        self.timeout_seconds = timeout_seconds
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        cwd: Path,
+        env: Optional[Mapping[str, str]] = None,
+        extra_args: Sequence[str] = (),
+    ) -> ClaudeRunResult:
+        if not prompt or not prompt.strip():
+            raise ValueError("prompt must not be empty")
+        if not cwd.exists():
+            raise FileNotFoundError(f"cwd does not exist: {cwd}")
+
+        cmd: List[str] = [self._claude, *extra_args, "-p", prompt]
+        logger.info("invoking Claude Code: %s in %s", shlex.join(cmd[:3]) + " …", cwd)
+
+        loop = asyncio.get_event_loop()
+        start = loop.time()
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=dict(env) if env is not None else None,
+        )
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(), timeout=self.timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            duration = loop.time() - start
+            return ClaudeRunResult(
+                returncode=124,
+                stdout="",
+                stderr=f"claude -p timed out after {self.timeout_seconds}s",
+                duration_seconds=duration,
+                cmd=tuple(cmd),
+            )
+        duration = loop.time() - start
+        return ClaudeRunResult(
+            returncode=proc.returncode or 0,
+            stdout=stdout_b.decode("utf-8", "replace"),
+            stderr=stderr_b.decode("utf-8", "replace"),
+            duration_seconds=duration,
+            cmd=tuple(cmd),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Canonical prompt templates
+# ---------------------------------------------------------------------------
+
+IMPLEMENT_PROMPT_TEMPLATE = textwrap.dedent(
+    """\
+    Você está numa worktree isolada (.worktrees/<branch>) do repositório {repo}.
+    Sua tarefa: pegar a issue #{number} ({title}), implementar a feature seguindo
+    o workflow do projeto, criar testes para todos os casos de uso, rodar tudo
+    com 100% de aprovação e abrir uma Pull Request com branch já criado.
+
+    Restrições:
+    - NÃO troque de diretório — você JÁ está no worktree certo.
+    - Faça commits pequenos e atômicos.
+    - Adicione testes ANTES de finalizar; rode `pytest` e ajuste até 100% pass.
+    - Push do branch e abra PR via `gh pr create`. Use o título e corpo
+      coerentes com a issue. Adicione `Closes #{number}` no corpo.
+    - Quando terminar, responda EXATAMENTE com a URL da PR aberta numa única
+      linha (ex: https://github.com/{repo}/pull/N). Sem prosa adicional.
+
+    Contexto da issue:
+    {issue_body}
+    """
+)
+
+
+REVIEW_PROMPT_TEMPLATE = textwrap.dedent(
+    """\
+    Você está numa worktree isolada do repositório {repo} (PR #{number}: {title}).
+    Sua tarefa: revisar a PR, corrigir o que estiver errado, cobrir todos os
+    casos de uso com testes, garantir 100% de aprovação dos testes, documentar
+    correções no corpo da PR e dar merge quando estiver pronto pra produção.
+
+    Restrições:
+    - NÃO faça force-push.
+    - Use `gh pr review --approve` apenas após todos os checks passarem.
+    - Use `gh pr merge --merge` (não squash) e respeite a config do repo.
+    - Quando terminar, responda EXATAMENTE com a URL da PR mergeada numa
+      única linha (ex: https://github.com/{repo}/pull/N). Sem prosa adicional.
+    """
+)
+
+
+def render_implement_prompt(repo: str, number: int, title: str, issue_body: str) -> str:
+    return IMPLEMENT_PROMPT_TEMPLATE.format(
+        repo=repo,
+        number=number,
+        title=title,
+        issue_body=issue_body.strip()[:6000],
+    )
+
+
+def render_review_prompt(repo: str, number: int, title: str) -> str:
+    return REVIEW_PROMPT_TEMPLATE.format(repo=repo, number=number, title=title)

--- a/deile/orchestration/pipeline/cron.py
+++ b/deile/orchestration/pipeline/cron.py
@@ -1,0 +1,175 @@
+"""Tiny cron expression evaluator (5-field minute-precision).
+
+Supports the standard 5-field crontab syntax:
+
+    minute  hour  day_of_month  month  day_of_week
+    0-59    0-23  1-31          1-12   0-6 (Sun=0)
+
+Field tokens:
+    *           any value
+    N           literal
+    N-M         range (inclusive)
+    A,B,C       list
+    */N         every N starting from field minimum
+    A-B/N       step within a range
+
+Special predefined strings:
+    @hourly = "0 * * * *"
+    @daily  = "0 0 * * *"
+    @weekly = "0 0 * * 0"
+    @monthly= "0 0 1 * *"
+
+The implementation is deliberately minimal — no L/W/# extensions, no
+seconds field. This is enough for the autonomous pipeline use cases:
+"every N minutes", "at HH:MM weekdays", "at HH:MM on the 1st", etc.
+
+Why no external dep: ``croniter`` is fine but cron is small. We avoid an
+extra wheel/version churn for ~150 lines.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import List, Tuple
+
+_FIELD_RANGES: List[Tuple[int, int]] = [
+    (0, 59),  # minute
+    (0, 23),  # hour
+    (1, 31),  # day_of_month
+    (1, 12),  # month
+    (0, 6),   # day_of_week (Sun=0)
+]
+
+_PREDEFINED = {
+    "@hourly": "0 * * * *",
+    "@daily": "0 0 * * *",
+    "@weekly": "0 0 * * 0",
+    "@monthly": "0 0 1 * *",
+    "@yearly": "0 0 1 1 *",
+    "@annually": "0 0 1 1 *",
+}
+
+
+class CronExpressionError(ValueError):
+    """Raised for malformed cron expressions."""
+
+
+def _parse_field(token: str, lo: int, hi: int) -> List[int]:
+    """Expand one cron field token into a sorted list of integers."""
+    if token == "*":
+        return list(range(lo, hi + 1))
+    out: List[int] = []
+    for part in token.split(","):
+        part = part.strip()
+        if not part:
+            raise CronExpressionError(f"empty field token in {token!r}")
+        step = 1
+        if "/" in part:
+            base, step_str = part.split("/", 1)
+            try:
+                step = int(step_str)
+            except ValueError as exc:
+                raise CronExpressionError(f"invalid step {step_str!r}") from exc
+            if step <= 0:
+                raise CronExpressionError(f"step must be > 0, got {step}")
+        else:
+            base = part
+        if base == "*":
+            start, end = lo, hi
+        elif "-" in base:
+            try:
+                a, b = base.split("-", 1)
+                start, end = int(a), int(b)
+            except ValueError as exc:
+                raise CronExpressionError(f"invalid range {base!r}") from exc
+        else:
+            try:
+                start = end = int(base)
+            except ValueError as exc:
+                raise CronExpressionError(f"invalid literal {base!r}") from exc
+        if start < lo or end > hi or start > end:
+            raise CronExpressionError(
+                f"field value out of range [{lo}, {hi}]: {base!r}"
+            )
+        out.extend(range(start, end + 1, step))
+    return sorted(set(out))
+
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def parse(expression: str) -> List[List[int]]:
+    """Parse a cron expression into 5 lists of allowed values."""
+    expr = expression.strip()
+    if expr in _PREDEFINED:
+        expr = _PREDEFINED[expr]
+    fields = _WHITESPACE.split(expr)
+    if len(fields) != 5:
+        raise CronExpressionError(
+            f"expected 5 fields (m h dom mon dow), got {len(fields)}: {expression!r}"
+        )
+    return [
+        _parse_field(token, lo, hi)
+        for token, (lo, hi) in zip(fields, _FIELD_RANGES)
+    ]
+
+
+def matches(expression: str, when: datetime) -> bool:
+    """Return True iff ``when`` (UTC, minute precision) satisfies the cron."""
+    minute_set, hour_set, dom_set, mon_set, dow_set = parse(expression)
+    # Vixie-cron rule: when both DOM and DOW are restricted (not "*"), ANY
+    # match counts. We approximate "is restricted" by len < full range.
+    dom_restricted = len(dom_set) != 31
+    dow_restricted = len(dow_set) != 7
+    dom_match = when.day in dom_set
+    # datetime.weekday(): Mon=0..Sun=6. cron: Sun=0..Sat=6.
+    cron_dow = (when.weekday() + 1) % 7
+    dow_match = cron_dow in dow_set
+    if dom_restricted and dow_restricted:
+        date_ok = dom_match or dow_match
+    else:
+        date_ok = dom_match and dow_match
+    return (
+        when.minute in minute_set
+        and when.hour in hour_set
+        and when.month in mon_set
+        and date_ok
+    )
+
+
+def next_after(expression: str, after: datetime, *, max_iterations: int = 525600) -> datetime:
+    """Return the next datetime *strictly after* ``after`` that matches.
+
+    Search is by 1-minute increments — fast enough for short horizons,
+    bounded by ``max_iterations`` (default 1 year of minutes) to avoid
+    pathological infinite loops on impossible expressions.
+    """
+    if after.tzinfo is None:
+        after = after.replace(tzinfo=timezone.utc)
+    # Round up to the next minute boundary (crons fire on minute boundaries).
+    candidate = (after + timedelta(minutes=1)).replace(second=0, microsecond=0)
+    for _ in range(max_iterations):
+        if matches(expression, candidate):
+            return candidate
+        candidate += timedelta(minutes=1)
+    raise CronExpressionError(
+        f"no match within {max_iterations} minutes for {expression!r}"
+    )
+
+
+def previous_or_equal(expression: str, before: datetime, *, max_iterations: int = 525600) -> datetime:
+    """Return the latest datetime *<=* ``before`` that matches the cron.
+
+    Useful for "did this entry miss its slot?" computations.
+    """
+    if before.tzinfo is None:
+        before = before.replace(tzinfo=timezone.utc)
+    candidate = before.replace(second=0, microsecond=0)
+    for _ in range(max_iterations):
+        if matches(expression, candidate):
+            return candidate
+        candidate -= timedelta(minutes=1)
+    raise CronExpressionError(
+        f"no match within last {max_iterations} minutes for {expression!r}"
+    )

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -250,8 +250,21 @@ class GitHubClient:
         if current.batch_id is not None:
             return None
         batch_id = compute_batch_id(title)
-        await self.add_labels(kind, number, [make_batch_label(batch_id)])
+        label = make_batch_label(batch_id)
+        await self._ensure_label(label, color="d73a4a", description="Pipeline batch lock")
+        await self.add_labels(kind, number, [label])
         return batch_id
+
+    async def _ensure_label(self, name: str, *, color: str, description: str) -> None:
+        """Create label if it doesn't exist; ignore "already exists" errors."""
+        rc, _, err = await self._run(
+            "label", "create", name,
+            "--repo", self.repo,
+            "--color", color,
+            "--description", description,
+        )
+        if rc != 0 and "already exists" not in err.lower():
+            logger.debug("ensure_label %s: rc=%d err=%s", name, rc, err.strip()[:200])
 
     async def ensure_pipeline_labels(self) -> None:
         """Create all pipeline-managed labels on the repo if they don't exist."""

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -1,0 +1,283 @@
+"""Async wrapper around the `gh` CLI for issue/PR/label operations.
+
+The autonomous pipeline does not need (or want) a full GitHub-API client —
+``gh`` is already authenticated locally, and the operations are simple. This
+module wraps the relevant subcommands behind an async interface so the polling
+loop stays non-blocking.
+
+Each public function returns plain dicts (parsed JSON). Errors raise
+:class:`GhCommandError` carrying stdout/stderr for diagnostics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import shutil
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from deile.orchestration.pipeline.labels import (LABEL_COLORS,
+                                                 LABEL_DESCRIPTIONS,
+                                                 REVIEW_LABELS,
+                                                 WORKFLOW_LABELS,
+                                                 is_batch_label,
+                                                 make_batch_label)
+
+logger = logging.getLogger(__name__)
+
+
+from deile.core.exceptions import DEILEError
+
+
+class GhCommandError(DEILEError):
+    """Raised when the `gh` CLI exits non-zero."""
+
+    def __init__(self, cmd: Sequence[str], returncode: int, stdout: str, stderr: str) -> None:
+        super().__init__(f"gh {' '.join(cmd[1:])} failed ({returncode}): {stderr.strip()[:300]}")
+        self.cmd = list(cmd)
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@dataclass(frozen=True)
+class IssueRef:
+    number: int
+    title: str
+    url: str
+    labels: Tuple[str, ...]
+    body: str = ""
+    state: str = "open"
+
+    @property
+    def batch_id(self) -> Optional[str]:
+        for label in self.labels:
+            if is_batch_label(label):
+                return label[len("~batch:"):]
+        return None
+
+
+@dataclass(frozen=True)
+class PrRef:
+    number: int
+    title: str
+    url: str
+    labels: Tuple[str, ...]
+    head_ref: str = ""
+    base_ref: str = "main"
+    state: str = "open"
+    is_draft: bool = False
+
+    @property
+    def batch_id(self) -> Optional[str]:
+        for label in self.labels:
+            if is_batch_label(label):
+                return label[len("~batch:"):]
+        return None
+
+
+def compute_batch_id(title: str) -> str:
+    """SHA-8 of the trimmed title — matches the format described in #87."""
+    digest = hashlib.sha256(title.strip().encode("utf-8")).hexdigest()
+    return digest[:8]
+
+
+class GitHubClient:
+    """Thin async wrapper around `gh` for the pipeline."""
+
+    def __init__(self, repo: str, *, gh_path: Optional[str] = None) -> None:
+        if "/" not in repo:
+            raise ValueError(f"repo must be 'owner/name', got {repo!r}")
+        self.repo = repo
+        self._gh = gh_path or shutil.which("gh") or "gh"
+
+    # -- low-level subprocess plumbing --------------------------------
+
+    async def _run(self, *args: str, capture_stdout: bool = True) -> Tuple[int, str, str]:
+        cmd = [self._gh, *args]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE if capture_stdout else None,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_b, stderr_b = await proc.communicate()
+        stdout = (stdout_b or b"").decode("utf-8", errors="replace")
+        stderr = (stderr_b or b"").decode("utf-8", errors="replace")
+        return proc.returncode or 0, stdout, stderr
+
+    async def _run_checked(self, *args: str) -> str:
+        rc, out, err = await self._run(*args)
+        if rc != 0:
+            raise GhCommandError(args, rc, out, err)
+        return out
+
+    # -- issues -------------------------------------------------------
+
+    async def list_issues_with_label(self, label: str, *, limit: int = 50) -> List[IssueRef]:
+        """Return open issues having ``label`` (and not having any later-stage workflow label)."""
+        out = await self._run_checked(
+            "issue", "list",
+            "--repo", self.repo,
+            "--state", "open",
+            "--label", label,
+            "--limit", str(limit),
+            "--json", "number,title,url,labels,body,state",
+        )
+        data = json.loads(out or "[]")
+        return [
+            IssueRef(
+                number=item["number"],
+                title=item["title"],
+                url=item["url"],
+                labels=tuple(lab["name"] for lab in item.get("labels", [])),
+                body=item.get("body", "") or "",
+                state=item.get("state", "open"),
+            )
+            for item in data
+        ]
+
+    async def get_issue(self, number: int) -> IssueRef:
+        out = await self._run_checked(
+            "issue", "view", str(number),
+            "--repo", self.repo,
+            "--json", "number,title,url,labels,body,state",
+        )
+        item = json.loads(out)
+        return IssueRef(
+            number=item["number"],
+            title=item["title"],
+            url=item["url"],
+            labels=tuple(lab["name"] for lab in item.get("labels", [])),
+            body=item.get("body", "") or "",
+            state=item.get("state", "open"),
+        )
+
+    # -- pull requests ------------------------------------------------
+
+    async def list_open_prs(self, *, limit: int = 50) -> List[PrRef]:
+        out = await self._run_checked(
+            "pr", "list",
+            "--repo", self.repo,
+            "--state", "open",
+            "--limit", str(limit),
+            "--json", "number,title,url,labels,headRefName,baseRefName,state,isDraft",
+        )
+        data = json.loads(out or "[]")
+        return [
+            PrRef(
+                number=item["number"],
+                title=item["title"],
+                url=item["url"],
+                labels=tuple(lab["name"] for lab in item.get("labels", [])),
+                head_ref=item.get("headRefName", ""),
+                base_ref=item.get("baseRefName", "main"),
+                state=item.get("state", "open"),
+                is_draft=bool(item.get("isDraft", False)),
+            )
+            for item in data
+        ]
+
+    # -- labels -------------------------------------------------------
+
+    async def add_labels(self, kind: str, number: int, labels: Iterable[str]) -> None:
+        labels_list = list(labels)
+        if not labels_list:
+            return
+        await self._run_checked(
+            kind, "edit", str(number),
+            "--repo", self.repo,
+            "--add-label", ",".join(labels_list),
+        )
+
+    async def remove_labels(self, kind: str, number: int, labels: Iterable[str]) -> None:
+        labels_list = list(labels)
+        if not labels_list:
+            return
+        await self._run_checked(
+            kind, "edit", str(number),
+            "--repo", self.repo,
+            "--remove-label", ",".join(labels_list),
+        )
+
+    async def transition_issue(
+        self,
+        number: int,
+        *,
+        from_label: Optional[str],
+        to_label: str,
+    ) -> None:
+        """Atomically swap a workflow label on an issue."""
+        if from_label is not None:
+            await self.remove_labels("issue", number, [from_label])
+        await self.add_labels("issue", number, [to_label])
+
+    async def transition_pr(
+        self,
+        number: int,
+        *,
+        from_label: Optional[str],
+        to_label: str,
+    ) -> None:
+        if from_label is not None:
+            await self.remove_labels("pr", number, [from_label])
+        await self.add_labels("pr", number, [to_label])
+
+    async def claim_with_batch(
+        self,
+        kind: str,
+        number: int,
+        title: str,
+    ) -> Optional[str]:
+        """Try to claim an issue/PR by attaching a batch lock label.
+
+        Returns the batch_id on success, or None if the issue already has a
+        ``~batch:`` label (someone else picked it up).
+        """
+        # Re-read the latest labels — list-then-add is racy across runners but
+        # acceptable for a single-instance pipeline (the typical deployment).
+        if kind == "issue":
+            current = await self.get_issue(number)
+        elif kind == "pr":
+            prs = await self.list_open_prs(limit=200)
+            current = next((p for p in prs if p.number == number), None)
+            if current is None:
+                return None
+        else:
+            raise ValueError(f"kind must be 'issue' or 'pr', got {kind!r}")
+        if current.batch_id is not None:
+            return None
+        batch_id = compute_batch_id(title)
+        await self.add_labels(kind, number, [make_batch_label(batch_id)])
+        return batch_id
+
+    async def ensure_pipeline_labels(self) -> None:
+        """Create all pipeline-managed labels on the repo if they don't exist."""
+        for label in (*WORKFLOW_LABELS, *REVIEW_LABELS):
+            color = LABEL_COLORS.get(label, "ededed")
+            description = LABEL_DESCRIPTIONS.get(label, "Pipeline-managed label")
+            rc, _, _ = await self._run(
+                "label", "create", label,
+                "--repo", self.repo,
+                "--color", color,
+                "--description", description,
+            )
+            # rc != 0 typically means "already exists"; we ignore that case.
+            if rc != 0:
+                logger.debug("label %s already exists or could not be created", label)
+
+    async def comment_on_issue(self, number: int, text: str) -> None:
+        await self._run_checked(
+            "issue", "comment", str(number),
+            "--repo", self.repo,
+            "--body", text,
+        )
+
+    async def comment_on_pr(self, number: int, text: str) -> None:
+        await self._run_checked(
+            "pr", "comment", str(number),
+            "--repo", self.repo,
+            "--body", text,
+        )

--- a/deile/orchestration/pipeline/identity.py
+++ b/deile/orchestration/pipeline/identity.py
@@ -1,0 +1,104 @@
+"""Per-monitor identity for the autonomous pipeline.
+
+The identity ties together everything that must NOT collide between
+parallel monitors:
+
+- ``monitor_id`` — appears in worktree paths, branch names, and ownership labels
+- ``shard_index`` / ``shard_count`` — hash-based sharding so two monitors never
+  compete for the same issue/PR
+
+Single-monitor deployments (no env vars set) default to
+``monitor_id="default"``, ``shard_index=0``, ``shard_count=1`` — equivalent to
+the pre-multi-monitor behaviour. Backwards-compatible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+_MONITOR_ID_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,32}$")
+
+
+class IdentityError(ValueError):
+    """Raised for malformed identity configuration."""
+
+
+@dataclass(frozen=True)
+class MonitorIdentity:
+    """Identifies one autonomous monitor within a deployment."""
+
+    monitor_id: str = "default"
+    shard_index: int = 0
+    shard_count: int = 1
+
+    def __post_init__(self) -> None:
+        if not _MONITOR_ID_RE.match(self.monitor_id):
+            raise IdentityError(
+                f"monitor_id must match {_MONITOR_ID_RE.pattern}, got {self.monitor_id!r}"
+            )
+        if self.shard_count < 1:
+            raise IdentityError(f"shard_count must be >= 1, got {self.shard_count}")
+        if not (0 <= self.shard_index < self.shard_count):
+            raise IdentityError(
+                f"shard_index must be in [0, {self.shard_count}), got {self.shard_index}"
+            )
+
+    @classmethod
+    def from_env(cls, env: Optional[dict] = None) -> "MonitorIdentity":
+        e = env if env is not None else os.environ
+        return cls(
+            monitor_id=e.get("DEILE_PIPELINE_MONITOR_ID", "default"),
+            shard_index=int(e.get("DEILE_PIPELINE_SHARD_INDEX", "0")),
+            shard_count=int(e.get("DEILE_PIPELINE_SHARD_COUNT", "1")),
+        )
+
+    @property
+    def is_default(self) -> bool:
+        """True for the legacy single-monitor configuration."""
+        return (
+            self.monitor_id == "default"
+            and self.shard_count == 1
+            and self.shard_index == 0
+        )
+
+    def owns(self, key: str) -> bool:
+        """Return True if `key` is in this monitor's shard.
+
+        Uses SHA-256 of the key modulo ``shard_count``. Two monitors with
+        consistent shard_count agree deterministically on ownership.
+        """
+        if self.shard_count == 1:
+            return True
+        h = int(hashlib.sha256(key.encode("utf-8")).hexdigest(), 16)
+        return (h % self.shard_count) == self.shard_index
+
+    def branch_prefix(self, action: str = "auto") -> str:
+        """Return the branch prefix this monitor uses (no trailing slash).
+
+        - default identity → ``auto`` (legacy behaviour)
+        - other identities → ``auto/<monitor_id>``
+        """
+        if self.is_default:
+            return action
+        return f"{action}/{self.monitor_id}"
+
+    def worktree_subdir(self) -> Optional[str]:
+        """Return the per-monitor worktree subdirectory, or None for default.
+
+        - default identity → None (worktrees go straight to ``.worktrees/<branch>``)
+        - other identities → ``<monitor_id>`` (worktrees go to ``.worktrees/<monitor_id>/<branch>``)
+        """
+        return None if self.is_default else self.monitor_id
+
+    def ownership_label(self) -> str:
+        """Label that identifies ownership of a claimed issue/PR."""
+        return f"~by:{self.monitor_id}"
+
+    def lockfile_name(self) -> str:
+        """Filename of the PID lock for this monitor instance."""
+        return f".deile-pipeline-{self.monitor_id}.lock"

--- a/deile/orchestration/pipeline/labels.py
+++ b/deile/orchestration/pipeline/labels.py
@@ -1,0 +1,79 @@
+"""Label name constants used as state markers across the autonomous pipeline.
+
+These labels (and their colors / descriptions) are owned by the pipeline. The
+``ensure_pipeline_labels`` helper in :mod:`github_client` creates them on the
+target repository if they do not already exist.
+
+The ``~`` prefix is a deliberate choice: GitHub sorts labels lexicographically,
+and ``~`` is one of the last printable ASCII characters, which keeps pipeline
+labels grouped at the end of the label list (out of the way of project labels
+like ``bug``, ``enhancement``, ``intent``).
+"""
+
+from __future__ import annotations
+
+# Issue workflow ----------------------------------------------------------
+WORKFLOW_NEW = "~workflow:nova"
+WORKFLOW_REVIEWING = "~workflow:em_revisao"
+WORKFLOW_REVIEWED = "~workflow:revisada"
+WORKFLOW_IMPLEMENTING = "~workflow:em_implementacao"
+WORKFLOW_PR = "~workflow:em_pr"
+WORKFLOW_DONE = "~workflow:concluida"
+
+# PR workflow -------------------------------------------------------------
+REVIEW_PENDING = "~review:pendente"
+REVIEW_IN_PROGRESS = "~review:em_andamento"
+REVIEW_CONCLUDED = "~review:concluida"
+
+# Distributed lock --------------------------------------------------------
+BATCH_LABEL_PREFIX = "~batch:"
+
+WORKFLOW_LABELS = (
+    WORKFLOW_NEW,
+    WORKFLOW_REVIEWING,
+    WORKFLOW_REVIEWED,
+    WORKFLOW_IMPLEMENTING,
+    WORKFLOW_PR,
+    WORKFLOW_DONE,
+)
+
+REVIEW_LABELS = (REVIEW_PENDING, REVIEW_IN_PROGRESS, REVIEW_CONCLUDED)
+
+LABEL_COLORS = {
+    WORKFLOW_NEW: "0e8a16",
+    WORKFLOW_REVIEWING: "fbca04",
+    WORKFLOW_REVIEWED: "5319e7",
+    WORKFLOW_IMPLEMENTING: "1d76db",
+    WORKFLOW_PR: "0052cc",
+    WORKFLOW_DONE: "0e8a16",
+    REVIEW_PENDING: "0e8a16",
+    REVIEW_IN_PROGRESS: "fbca04",
+    REVIEW_CONCLUDED: "0e8a16",
+}
+
+LABEL_DESCRIPTIONS = {
+    WORKFLOW_NEW: "Pipeline: issue nova, ainda não revisada",
+    WORKFLOW_REVIEWING: "Pipeline: DEILE revisando (lock)",
+    WORKFLOW_REVIEWED: "Pipeline: revisada, pronta para implementação",
+    WORKFLOW_IMPLEMENTING: "Pipeline: Claude Code implementando (lock)",
+    WORKFLOW_PR: "Pipeline: PR aberta",
+    WORKFLOW_DONE: "Pipeline: concluída",
+    REVIEW_PENDING: "Pipeline: PR aguardando revisão",
+    REVIEW_IN_PROGRESS: "Pipeline: PR em revisão (lock)",
+    REVIEW_CONCLUDED: "Pipeline: PR revisada/mergeada",
+}
+
+
+def is_batch_label(label: str) -> bool:
+    """Return True if `label` is a per-task lock marker (``~batch:<sha>``)."""
+    return label.startswith(BATCH_LABEL_PREFIX)
+
+
+def make_batch_label(batch_id: str) -> str:
+    return f"{BATCH_LABEL_PREFIX}{batch_id}"
+
+
+def batch_id_from_label(label: str) -> str:
+    if not is_batch_label(label):
+        raise ValueError(f"not a batch label: {label!r}")
+    return label[len(BATCH_LABEL_PREFIX):]

--- a/deile/orchestration/pipeline/lockfile.py
+++ b/deile/orchestration/pipeline/lockfile.py
@@ -1,0 +1,99 @@
+"""PID-based lockfile for monitor instance singletons (per host).
+
+Prevents two monitors with the *same* identity running simultaneously on
+the same host (which would corrupt the shared `.worktrees/<monitor_id>/`
+directory + race on schedule files).
+
+Cross-host coordination is not the goal here — that's covered by hash
+sharding (different identities = different shards). This is purely a
+local "did I forget to kill the previous one?" guard.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from deile.core.exceptions import DEILEError
+
+logger = logging.getLogger(__name__)
+
+
+class LockHeldError(DEILEError):
+    """Raised when another live process already holds the lock."""
+
+    def __init__(self, path: Path, holder_pid: int) -> None:
+        super().__init__(
+            f"lock {path} is held by live PID {holder_pid}"
+        )
+        self.path = path
+        self.holder_pid = holder_pid
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if the PID corresponds to a running process."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError as exc:
+        return exc.errno != errno.ESRCH
+
+
+def acquire(path: Path, *, holder_pid: Optional[int] = None) -> Path:
+    """Try to acquire the lock at ``path``.
+
+    Returns the resolved path on success, raises :class:`LockHeldError` if
+    another live PID already holds it. Stale locks (PID dead) are silently
+    overwritten.
+    """
+    pid = holder_pid if holder_pid is not None else os.getpid()
+    path = Path(path).resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if path.exists():
+        try:
+            existing = int(path.read_text().strip() or "0")
+        except (ValueError, OSError):
+            existing = 0
+        if existing > 0 and existing != pid and _pid_alive(existing):
+            raise LockHeldError(path, existing)
+        # Stale or self-owned — fall through to overwrite.
+    path.write_text(f"{pid}\n", encoding="utf-8")
+    return path
+
+
+def release(path: Path, *, holder_pid: Optional[int] = None) -> None:
+    """Release the lock if owned by ``holder_pid`` (default: current PID).
+
+    Best-effort: missing or foreign-owned locks are left alone, never raise.
+    """
+    pid = holder_pid if holder_pid is not None else os.getpid()
+    path = Path(path).resolve()
+    try:
+        if not path.exists():
+            return
+        try:
+            current = int(path.read_text().strip() or "0")
+        except (ValueError, OSError):
+            current = 0
+        if current == pid:
+            path.unlink()
+    except OSError as exc:
+        logger.debug("lock release ignored %s: %s", path, exc)
+
+
+@contextmanager
+def pid_lock(path: Path) -> Iterator[Path]:
+    """Context manager wrapper around :func:`acquire` / :func:`release`."""
+    locked = acquire(path)
+    try:
+        yield locked
+    finally:
+        release(locked)

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -158,9 +158,22 @@ class PipelineMonitor:
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
+        """Start the background polling loop.
+
+        PID locking is enabled when:
+        - ``config.use_pid_lock`` is explicitly set, **or**
+        - the identity is non-default (any named monitor, any sharded deployment).
+
+        The second condition is intentional: a non-default identity implies a
+        multi-monitor deployment where two instances with the same ``monitor_id``
+        on the same host are a guaranteed-bug — they would race on the same
+        worktree sub-directory and schedule file. The lockfile is the last line
+        of defence against operator error.
+        """
         if self._task is not None and not self._task.done():
             return
-        if self.config.use_pid_lock:
+        should_lock = self.config.use_pid_lock or not self.identity.is_default
+        if should_lock:
             lock_path = Path(self.config.base_repo_path) / self.identity.lockfile_name()
             try:
                 self._held_lock = acquire_lock(lock_path)
@@ -400,6 +413,9 @@ class PipelineMonitor:
         batch = await self.github.claim_with_batch("pr", target.number, target.title)
         if batch is None:
             return
+        # Tag ownership so other monitors can identify who claimed this PR —
+        # mirrors the identical pattern in stage 1 for issues.
+        await self.github.add_labels("pr", target.number, [self.identity.ownership_label()])
         await self.notifier.pr_picked_up(target.number, target.title, target.url)
         try:
             await self.github.transition_pr(

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -32,13 +32,17 @@ from deile.orchestration.pipeline.claude_dispatcher import (
 from deile.orchestration.pipeline.github_client import (GhCommandError,
                                                         GitHubClient,
                                                         IssueRef, PrRef)
+from deile.orchestration.pipeline.identity import MonitorIdentity
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
                                                  REVIEW_PENDING, WORKFLOW_NEW,
                                                  WORKFLOW_PR,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING)
+from deile.orchestration.pipeline.lockfile import LockHeldError, acquire as acquire_lock, release as release_lock
 from deile.orchestration.pipeline.notifier import DiscordNotifier
+from deile.orchestration.pipeline.scheduler import (PendingRun, Schedule,
+                                                    ScheduleStore)
 from deile.orchestration.pipeline.worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
@@ -52,11 +56,21 @@ class PipelineConfig:
     base_repo_path: Path
     poll_interval_seconds: int = 60
     main_branch: str = "main"
+    # ``branch_prefix`` is the *legacy* per-instance default. When an
+    # ``identity`` is provided to :class:`PipelineMonitor`, the actual prefix
+    # is derived from ``identity.branch_prefix("auto") + "/issue-"`` so two
+    # monitors don't collide on branch names. ``branch_prefix`` here remains
+    # the fallback for single-monitor (default identity) deployments.
     branch_prefix: str = "auto/issue-"
     notify_user_id: Optional[str] = None
     enable_review: bool = True
     enable_implement: bool = True
     enable_pr_review: bool = True
+    # When True, the monitor acquires a PID lockfile under base_repo_path
+    # named after the identity. Two monitors with the same monitor_id on
+    # the same host will fail to start. Default off because most tests
+    # don't need it; production callers should set True.
+    use_pid_lock: bool = False
 
 
 @dataclass
@@ -66,6 +80,8 @@ class _Stats:
     issues_implemented: int = 0
     prs_reviewed: int = 0
     errors: int = 0
+    catchup_runs: int = 0
+    scheduled_runs: int = 0
 
 
 class PipelineMonitor:
@@ -80,21 +96,58 @@ class PipelineMonitor:
         claude: Optional[ClaudeDispatcher] = None,
         notifier: Optional[DiscordNotifier] = None,
         review_callback: Optional[Callable[[IssueRef], Awaitable[str]]] = None,
+        identity: Optional[MonitorIdentity] = None,
+        schedule_store: Optional[ScheduleStore] = None,
     ) -> None:
         self.config = config
+        self.identity = identity or MonitorIdentity.from_env()
         self.github = github or GitHubClient(config.repo)
         self.worktrees = worktrees or WorktreeManager(
-            config.base_repo_path, main_branch=config.main_branch
+            config.base_repo_path,
+            main_branch=config.main_branch,
+            subdir=self.identity.worktree_subdir(),
         )
         self.claude = claude or ClaudeDispatcher()
         self.notifier = notifier or DiscordNotifier(config.notify_user_id)
-        # `review_callback` lets a host inject DEILE's actual review function.
-        # When None, the monitor performs a no-op "mark as reviewed" pass — the
-        # body of the issue is left as-is (useful in tests / dry runs).
         self._review_cb = review_callback
         self._stats = _Stats()
         self._stop_event = asyncio.Event()
         self._task: Optional[asyncio.Task] = None
+        self._held_lock: Optional[Path] = None
+        # Schedule store — when present, schedule entries drive when each
+        # action fires (instead of the fixed poll interval). On startup the
+        # monitor first drains any catch-up queue (entries whose run time
+        # has already passed), then enters the polling loop where every
+        # tick re-checks for due entries. If no schedule file exists, the
+        # monitor falls back to legacy "every action every poll" behaviour.
+        self.schedule_store = schedule_store or ScheduleStore(
+            config.base_repo_path, monitor_id=self.identity.monitor_id
+        )
+
+    # ------------------------------------------------------------------
+    # identity-aware naming helpers
+    # ------------------------------------------------------------------
+
+    def branch_for_issue(self, issue_number: int) -> str:
+        """Per-monitor branch name for stage 2 implementation."""
+        if self.identity.is_default:
+            return f"{self.config.branch_prefix}{issue_number}"
+        # Per-monitor prefix overrides the legacy config.branch_prefix.
+        return f"{self.identity.branch_prefix('auto')}/issue-{issue_number}"
+
+    def _owns_pr_branch(self, head_ref: str) -> bool:
+        """Return True if the PR's branch was opened by THIS monitor.
+
+        Used to scope stage 3 to PRs the local monitor implemented. Default
+        identity owns any branch starting with ``auto/issue-`` (legacy path).
+        """
+        if not head_ref:
+            return False
+        if self.identity.is_default:
+            # Legacy: claim PRs whose branch matches the legacy prefix and has
+            # no monitor segment.
+            return head_ref.startswith("auto/issue-")
+        return head_ref.startswith(f"{self.identity.branch_prefix('auto')}/")
 
     @property
     def stats(self) -> _Stats:
@@ -107,9 +160,56 @@ class PipelineMonitor:
     async def start(self) -> None:
         if self._task is not None and not self._task.done():
             return
+        if self.config.use_pid_lock:
+            lock_path = Path(self.config.base_repo_path) / self.identity.lockfile_name()
+            try:
+                self._held_lock = acquire_lock(lock_path)
+            except LockHeldError as exc:
+                logger.error(
+                    "another monitor with id=%s is already running (PID %d); refusing start",
+                    self.identity.monitor_id, exc.holder_pid,
+                )
+                raise
         await self.github.ensure_pipeline_labels()
+        await self._catch_up_pending()
         self._stop_event.clear()
-        self._task = asyncio.create_task(self._run_forever(), name="pipeline-monitor")
+        self._task = asyncio.create_task(
+            self._run_forever(), name=f"pipeline-monitor-{self.identity.monitor_id}"
+        )
+
+    async def _catch_up_pending(self) -> None:
+        """On startup, drain any schedule entries whose time already passed."""
+        try:
+            schedule = self.schedule_store.load()
+        except Exception as exc:  # noqa: BLE001 — schedule errors must not block boot
+            logger.warning("schedule load failed; skipping catch-up: %s", exc)
+            return
+        pending = schedule.compute_pending()
+        if not pending:
+            return
+        logger.info(
+            "monitor %s catching up on %d missed runs",
+            self.identity.monitor_id, len(pending),
+        )
+        for run in pending:
+            await self._run_scheduled(run)
+            schedule.mark_run(run)
+            self._stats.catchup_runs += 1
+        try:
+            self.schedule_store.save(schedule)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("could not persist schedule after catch-up: %s", exc)
+
+    async def _run_scheduled(self, run: PendingRun) -> None:
+        """Execute a single scheduled action by name."""
+        if run.action == "review" and self.config.enable_review:
+            await self._review_one_new_issue()
+        elif run.action == "implement" and self.config.enable_implement:
+            await self._implement_one_reviewed_issue()
+        elif run.action == "pr_review" and self.config.enable_pr_review:
+            await self._review_one_open_pr()
+        else:
+            logger.debug("scheduled action %s skipped (disabled or unknown)", run.action)
 
     async def stop(self) -> None:
         self._stop_event.set()
@@ -122,6 +222,9 @@ class PipelineMonitor:
                     await self._task
                 except (asyncio.CancelledError, Exception):  # noqa: BLE001
                     pass
+        if self._held_lock is not None:
+            release_lock(self._held_lock)
+            self._held_lock = None
 
     async def _run_forever(self) -> None:
         while not self._stop_event.is_set():
@@ -145,6 +248,28 @@ class PipelineMonitor:
     async def tick(self) -> None:
         self._stats.ticks += 1
         logger.debug("pipeline tick #%d", self._stats.ticks)
+
+        # When a schedule file exists with at least one entry, the schedule
+        # is authoritative: each tick runs only the actions whose cron
+        # window opened since the previous tick. Without a schedule, fall
+        # back to legacy "every action every tick" behaviour.
+        try:
+            schedule = self.schedule_store.load()
+        except Exception:  # noqa: BLE001
+            schedule = None
+        if schedule and (schedule.recurring or schedule.oneshot):
+            pending = schedule.compute_pending()
+            for run in pending:
+                await self._run_scheduled(run)
+                schedule.mark_run(run)
+                self._stats.scheduled_runs += 1
+            if pending:
+                try:
+                    self.schedule_store.save(schedule)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("could not persist schedule after tick: %s", exc)
+            return
+
         if self.config.enable_review:
             await self._review_one_new_issue()
         if self.config.enable_implement:
@@ -160,12 +285,18 @@ class PipelineMonitor:
         except GhCommandError as exc:
             logger.warning("could not list new issues: %s", exc)
             return
-        target = next((i for i in issues if i.batch_id is None), None)
+        # Shard filter: only consider issues whose hash falls in our shard.
+        target = next(
+            (i for i in issues if i.batch_id is None and self.identity.owns(i.title)),
+            None,
+        )
         if target is None:
             return
         batch = await self.github.claim_with_batch("issue", target.number, target.title)
         if batch is None:
             return
+        # Tag ownership so other monitors can identify who claimed this.
+        await self.github.add_labels("issue", target.number, [self.identity.ownership_label()])
         await self.notifier.issue_picked_up(target.number, target.title, target.url)
         try:
             await self.github.transition_issue(
@@ -195,13 +326,26 @@ class PipelineMonitor:
         except GhCommandError as exc:
             logger.warning("could not list reviewed issues: %s", exc)
             return
+        # Stage 2 only picks up issues this monitor claimed in stage 1
+        # (ownership label) OR — for backwards compat — issues with a batch
+        # lock when running with the default identity.
+        own = self.identity.ownership_label()
         target = next(
-            (i for i in issues if WORKFLOW_PR not in i.labels and i.batch_id is not None),
+            (
+                i for i in issues
+                if WORKFLOW_PR not in i.labels
+                and i.batch_id is not None
+                and (
+                    own in i.labels
+                    if not self.identity.is_default
+                    else self.identity.owns(i.title)
+                )
+            ),
             None,
         )
         if target is None:
             return
-        branch = f"{self.config.branch_prefix}{target.number}"
+        branch = self.branch_for_issue(target.number)
         await self.notifier.implementation_started(target.number, target.title, branch)
         try:
             worktree = await self.worktrees.create_branch_worktree(branch)
@@ -236,6 +380,9 @@ class PipelineMonitor:
         except GhCommandError as exc:
             logger.warning("could not list PRs: %s", exc)
             return
+        # Scope stage 3 to PRs whose head branch belongs to THIS monitor
+        # (so we never review a peer's PR). Default-identity monitors keep
+        # the legacy behaviour: any PR with a matching head_ref or none.
         target = next(
             (
                 pr
@@ -244,6 +391,7 @@ class PipelineMonitor:
                 and REVIEW_CONCLUDED not in pr.labels
                 and REVIEW_IN_PROGRESS not in pr.labels
                 and pr.batch_id is None
+                and self._owns_pr_branch(pr.head_ref)
             ),
             None,
         )

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -1,0 +1,296 @@
+"""1-minute polling loop that drives the autonomous pipeline.
+
+The :class:`PipelineMonitor` ticks every ``poll_interval_seconds`` (default 60s)
+and, on each tick:
+
+1. Checks for issues with label ``~workflow:nova`` *and no ~batch:* — claims
+   the next one, transitions to ``~workflow:em_revisao``, asks DEILE to revise
+   the body, then transitions to ``~workflow:revisada``.
+2. Checks for issues with ``~workflow:revisada`` and no ``~workflow:em_pr`` —
+   claims, sets up a worktree, invokes Claude Code one-shot to implement, and
+   on success transitions the issue to ``~workflow:em_pr``.
+3. Checks for open PRs without ``~review:concluida`` — claims, invokes Claude
+   Code one-shot to review/correct/merge, then marks ``~review:concluida``.
+
+Discord notifications (DiscordNotifier) fire at every transition.
+
+This monitor is single-instance by design: locking via ``~batch:`` labels is a
+best-effort coordination mechanism, not a true distributed lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+from deile.orchestration.pipeline.claude_dispatcher import (
+    ClaudeDispatcher, render_implement_prompt, render_review_prompt)
+from deile.orchestration.pipeline.github_client import (GhCommandError,
+                                                        GitHubClient,
+                                                        IssueRef, PrRef)
+from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
+                                                 REVIEW_IN_PROGRESS,
+                                                 REVIEW_PENDING, WORKFLOW_NEW,
+                                                 WORKFLOW_PR,
+                                                 WORKFLOW_REVIEWED,
+                                                 WORKFLOW_REVIEWING)
+from deile.orchestration.pipeline.notifier import DiscordNotifier
+from deile.orchestration.pipeline.worktree_manager import WorktreeManager
+
+logger = logging.getLogger(__name__)
+
+_PR_URL_RE = re.compile(r"https://github\.com/[^\s\"'<>]+/pull/\d+", re.IGNORECASE)
+
+
+@dataclass
+class PipelineConfig:
+    repo: str
+    base_repo_path: Path
+    poll_interval_seconds: int = 60
+    main_branch: str = "main"
+    branch_prefix: str = "auto/issue-"
+    notify_user_id: Optional[str] = None
+    enable_review: bool = True
+    enable_implement: bool = True
+    enable_pr_review: bool = True
+
+
+@dataclass
+class _Stats:
+    ticks: int = 0
+    issues_reviewed: int = 0
+    issues_implemented: int = 0
+    prs_reviewed: int = 0
+    errors: int = 0
+
+
+class PipelineMonitor:
+    """Async polling driver of the issue → PR → merge pipeline."""
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        *,
+        github: Optional[GitHubClient] = None,
+        worktrees: Optional[WorktreeManager] = None,
+        claude: Optional[ClaudeDispatcher] = None,
+        notifier: Optional[DiscordNotifier] = None,
+        review_callback: Optional[Callable[[IssueRef], Awaitable[str]]] = None,
+    ) -> None:
+        self.config = config
+        self.github = github or GitHubClient(config.repo)
+        self.worktrees = worktrees or WorktreeManager(
+            config.base_repo_path, main_branch=config.main_branch
+        )
+        self.claude = claude or ClaudeDispatcher()
+        self.notifier = notifier or DiscordNotifier(config.notify_user_id)
+        # `review_callback` lets a host inject DEILE's actual review function.
+        # When None, the monitor performs a no-op "mark as reviewed" pass — the
+        # body of the issue is left as-is (useful in tests / dry runs).
+        self._review_cb = review_callback
+        self._stats = _Stats()
+        self._stop_event = asyncio.Event()
+        self._task: Optional[asyncio.Task] = None
+
+    @property
+    def stats(self) -> _Stats:
+        return self._stats
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        await self.github.ensure_pipeline_labels()
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run_forever(), name="pipeline-monitor")
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=5)
+            except asyncio.TimeoutError:
+                self._task.cancel()
+                try:
+                    await self._task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+
+    async def _run_forever(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                await self.tick()
+            except Exception as exc:  # noqa: BLE001 — never let the loop die
+                self._stats.errors += 1
+                logger.exception("pipeline tick crashed: %s", exc)
+                await self.notifier.error("monitor.tick", str(exc))
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=self.config.poll_interval_seconds
+                )
+            except asyncio.TimeoutError:
+                pass
+
+    # ------------------------------------------------------------------
+    # one tick
+    # ------------------------------------------------------------------
+
+    async def tick(self) -> None:
+        self._stats.ticks += 1
+        logger.debug("pipeline tick #%d", self._stats.ticks)
+        if self.config.enable_review:
+            await self._review_one_new_issue()
+        if self.config.enable_implement:
+            await self._implement_one_reviewed_issue()
+        if self.config.enable_pr_review:
+            await self._review_one_open_pr()
+
+    # ----- stage 1: review ------------------------------------------
+
+    async def _review_one_new_issue(self) -> None:
+        try:
+            issues = await self.github.list_issues_with_label(WORKFLOW_NEW, limit=50)
+        except GhCommandError as exc:
+            logger.warning("could not list new issues: %s", exc)
+            return
+        target = next((i for i in issues if i.batch_id is None), None)
+        if target is None:
+            return
+        batch = await self.github.claim_with_batch("issue", target.number, target.title)
+        if batch is None:
+            return
+        await self.notifier.issue_picked_up(target.number, target.title, target.url)
+        try:
+            await self.github.transition_issue(
+                target.number, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING
+            )
+            if self._review_cb is not None:
+                comment = await self._review_cb(target)
+                if comment:
+                    await self.github.comment_on_issue(target.number, comment)
+            await self.github.transition_issue(
+                target.number, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_REVIEWED
+            )
+        except Exception as exc:  # noqa: BLE001 — surface and continue
+            logger.exception("review of #%s failed", target.number)
+            await self.notifier.error(
+                f"review issue #{target.number}", f"{type(exc).__name__}: {exc}"
+            )
+            return
+        self._stats.issues_reviewed += 1
+        await self.notifier.issue_reviewed(target.number, target.title, target.url)
+
+    # ----- stage 2: implement ---------------------------------------
+
+    async def _implement_one_reviewed_issue(self) -> None:
+        try:
+            issues = await self.github.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
+        except GhCommandError as exc:
+            logger.warning("could not list reviewed issues: %s", exc)
+            return
+        target = next(
+            (i for i in issues if WORKFLOW_PR not in i.labels and i.batch_id is not None),
+            None,
+        )
+        if target is None:
+            return
+        branch = f"{self.config.branch_prefix}{target.number}"
+        await self.notifier.implementation_started(target.number, target.title, branch)
+        try:
+            worktree = await self.worktrees.create_branch_worktree(branch)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("worktree setup for #%s failed", target.number)
+            await self.notifier.error(
+                f"worktree #{target.number}", f"{type(exc).__name__}: {exc}"
+            )
+            return
+        prompt = render_implement_prompt(self.config.repo, target.number, target.title, target.body)
+        result = await self.claude.run(prompt, cwd=worktree.path)
+        pr_url = _extract_pr_url(result.stdout)
+        if not result.ok:
+            await self.notifier.error(
+                f"implement #{target.number}", result.stderr.strip()[:1500] or "non-zero exit"
+            )
+            return
+        try:
+            await self.github.transition_issue(
+                target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_PR
+            )
+        except GhCommandError as exc:
+            logger.warning("could not transition issue #%s to em_pr: %s", target.number, exc)
+        self._stats.issues_implemented += 1
+        await self.notifier.implementation_finished(target.number, pr_url)
+
+    # ----- stage 3: review PR ---------------------------------------
+
+    async def _review_one_open_pr(self) -> None:
+        try:
+            prs = await self.github.list_open_prs(limit=50)
+        except GhCommandError as exc:
+            logger.warning("could not list PRs: %s", exc)
+            return
+        target = next(
+            (
+                pr
+                for pr in prs
+                if not pr.is_draft
+                and REVIEW_CONCLUDED not in pr.labels
+                and REVIEW_IN_PROGRESS not in pr.labels
+                and pr.batch_id is None
+            ),
+            None,
+        )
+        if target is None:
+            return
+        batch = await self.github.claim_with_batch("pr", target.number, target.title)
+        if batch is None:
+            return
+        await self.notifier.pr_picked_up(target.number, target.title, target.url)
+        try:
+            await self.github.transition_pr(
+                target.number, from_label=REVIEW_PENDING, to_label=REVIEW_IN_PROGRESS
+            )
+        except GhCommandError:
+            # ~review:pendente may not be set; that's ok.
+            await self.github.add_labels("pr", target.number, [REVIEW_IN_PROGRESS])
+        # The PR was opened on a branch — for the worktree, we just need a
+        # checkout of that branch. Use the same naming convention if the branch
+        # follows it; otherwise fall back to ``main`` and let Claude `gh pr
+        # checkout`.
+        worktree_branch = target.head_ref or f"pr/{target.number}"
+        try:
+            wt = await self.worktrees.create_branch_worktree(worktree_branch)
+        except Exception as exc:  # noqa: BLE001
+            await self.notifier.error(
+                f"PR worktree #{target.number}", f"{type(exc).__name__}: {exc}"
+            )
+            return
+        prompt = render_review_prompt(self.config.repo, target.number, target.title)
+        result = await self.claude.run(prompt, cwd=wt.path)
+        merged = result.ok and "merged" in result.stdout.lower()
+        try:
+            await self.github.transition_pr(
+                target.number, from_label=REVIEW_IN_PROGRESS, to_label=REVIEW_CONCLUDED
+            )
+        except GhCommandError as exc:
+            logger.warning("could not transition PR #%s to concluida: %s", target.number, exc)
+        self._stats.prs_reviewed += 1
+        await self.notifier.pr_reviewed(target.number, target.title, target.url, merged=merged)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _extract_pr_url(text: str) -> Optional[str]:
+    if not text:
+        return None
+    m = _PR_URL_RE.search(text)
+    return m.group(0) if m else None

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -1,0 +1,118 @@
+"""Discord-DM notifier for the autonomous pipeline.
+
+Every meaningful state transition fires a DM to the configured operator
+(``DEILE_PIPELINE_NOTIFY_USER_ID``). The notifier is best-effort — failures
+log a warning but never abort the pipeline.
+
+Wiring
+------
+At runtime we rely on ``deile_bot.bridge.dm_tool.send_discord_dm`` (when the
+deile-bot package is importable; that's the standard local-dev configuration)
+or fall back to the ``deilebot.bridge.dm_tool`` import path for the renamed
+package. Either path uses ``DEILE_BOT_DISCORD_TOKEN`` from the environment.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_DM_FN: Optional[Callable[[str, str], Awaitable[dict]]] = None
+
+
+def _resolve_dm_function() -> Optional[Callable[[str, str], Awaitable[dict]]]:
+    """Pick the best available DM sender.
+
+    Tries the new ``deilebot.bridge.dm_tool`` first (current package name),
+    then falls back to the legacy ``deile_bot.bridge.dm_tool`` for older
+    local installs. Returns None if neither is importable — in that case the
+    notifier silently no-ops.
+    """
+    try:
+        from deilebot.bridge.dm_tool import send_discord_dm  # type: ignore
+        return send_discord_dm
+    except Exception:  # noqa: BLE001 — fall back, log later
+        pass
+    try:
+        from deile_bot.bridge.dm_tool import send_discord_dm  # type: ignore
+        return send_discord_dm
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class DiscordNotifier:
+    """Send pipeline-event notifications via Discord DM."""
+
+    def __init__(
+        self,
+        user_id: Optional[str] = None,
+        *,
+        dm_fn: Optional[Callable[[str, str], Awaitable[dict]]] = None,
+    ) -> None:
+        self.user_id = user_id or os.environ.get("DEILE_PIPELINE_NOTIFY_USER_ID", "")
+        self._dm_fn = dm_fn
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.user_id)
+
+    async def _send(self, text: str) -> None:
+        if not self.enabled:
+            return
+        global _DM_FN
+        fn = self._dm_fn
+        if fn is None:
+            if _DM_FN is None:
+                _DM_FN = _resolve_dm_function()
+            fn = _DM_FN
+        if fn is None:
+            logger.debug("no DM function available; skipping notification")
+            return
+        try:
+            await fn(self.user_id, text)
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning("pipeline DM failed: %s", exc)
+
+    # -- typed event helpers ------------------------------------------
+
+    async def issue_picked_up(self, number: int, title: str, url: str) -> None:
+        await self._send(
+            f"🔍 **Pipeline pegou para revisar** issue #{number}: {title}\n🔗 {url}"
+        )
+
+    async def issue_reviewed(self, number: int, title: str, url: str) -> None:
+        await self._send(
+            f"✏️ **Issue revisada** #{number}: {title}\n🔗 {url}"
+        )
+
+    async def implementation_started(self, number: int, title: str, branch: str) -> None:
+        await self._send(
+            f"🛠️ **Implementação iniciada** para issue #{number}: {title}\n"
+            f"branch: `{branch}`"
+        )
+
+    async def implementation_finished(self, number: int, pr_url: Optional[str]) -> None:
+        if pr_url:
+            await self._send(
+                f"✅ **Implementação concluída** issue #{number}\n🔗 PR: {pr_url}"
+            )
+        else:
+            await self._send(
+                f"⚠️ **Implementação finalizada sem PR** para issue #{number}"
+            )
+
+    async def pr_picked_up(self, number: int, title: str, url: str) -> None:
+        await self._send(
+            f"🔎 **Pipeline pegou para revisar** PR #{number}: {title}\n🔗 {url}"
+        )
+
+    async def pr_reviewed(self, number: int, title: str, url: str, *, merged: bool) -> None:
+        verb = "mergeada" if merged else "revisada"
+        emoji = "🟣" if merged else "✅"
+        await self._send(f"{emoji} **PR #{number} {verb}**: {title}\n🔗 {url}")
+
+    async def error(self, where: str, detail: str) -> None:
+        await self._send(f"⚠️ **Pipeline error** em `{where}`:\n```\n{detail[:1500]}\n```")

--- a/deile/orchestration/pipeline/scheduler.py
+++ b/deile/orchestration/pipeline/scheduler.py
@@ -1,0 +1,345 @@
+"""Per-monitor cron schedule store with catch-up.
+
+The pipeline owns a small YAML file per monitor under ``config/`` of the
+base repo. The file is the authority for *when* each pipeline action
+fires (recurring crons + ad-hoc one-shots).
+
+::
+
+    config/pipeline_schedule_<monitor_id>.yaml
+
+    recurring:
+      - id: review_loop
+        action: review
+        cron: "*/5 * * * *"
+        enabled: true
+        last_run_at: 2026-05-06T01:23:00Z
+
+    oneshot:
+      - id: oneshot-impl-99
+        action: implement
+        target_issue: 99
+        run_at: 2026-05-06T18:00:00Z
+        completed: false
+
+Two-phase semantics on monitor startup:
+
+1. ``compute_pending(now)`` returns every entry whose next scheduled run
+   is ``<= now`` — sorted ascending. These are the "missed" runs to
+   catch up on.
+2. The monitor drains the catch-up queue **sequentially**, then enters
+   the normal poll loop where each tick checks ``compute_pending(now)``
+   again.
+
+Catch-up coalesces by default: N runs missed during downtime → 1 run
+right now, with ``last_run_at`` advanced to *now* so we don't replay
+every minute. Set ``replay_all=True`` on a recurring entry for the rare
+case where every missed slot must run individually.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import yaml
+
+from deile.core.exceptions import DEILEError
+from deile.orchestration.pipeline.cron import CronExpressionError, next_after
+
+logger = logging.getLogger(__name__)
+
+
+VALID_ACTIONS = {"review", "implement", "pr_review"}
+
+
+class ScheduleError(DEILEError):
+    """Raised for invalid schedule configuration or operations."""
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_dt(value) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        s = value.strip().rstrip("Z")
+        try:
+            dt = datetime.fromisoformat(s)
+        except ValueError as exc:
+            raise ScheduleError(f"invalid ISO datetime: {value!r}") from exc
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    raise ScheduleError(f"unsupported datetime value: {value!r}")
+
+
+def _serialize_dt(dt: Optional[datetime]) -> Optional[str]:
+    if dt is None:
+        return None
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class RecurringEntry:
+    """A cron-driven recurring schedule for one pipeline action."""
+
+    id: str
+    action: str
+    cron: str
+    enabled: bool = True
+    last_run_at: Optional[datetime] = None
+    replay_all: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.id or not self.id.replace("_", "").replace("-", "").isalnum():
+            raise ScheduleError(f"invalid id: {self.id!r}")
+        if self.action not in VALID_ACTIONS:
+            raise ScheduleError(
+                f"action must be one of {sorted(VALID_ACTIONS)}, got {self.action!r}"
+            )
+        # Validate cron eagerly.
+        try:
+            next_after(self.cron, _now_utc())
+        except CronExpressionError as exc:
+            raise ScheduleError(f"invalid cron {self.cron!r}: {exc}") from exc
+
+    def next_run_at(self, *, after: Optional[datetime] = None) -> datetime:
+        anchor = after or self.last_run_at or _now_utc()
+        return next_after(self.cron, anchor)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "action": self.action,
+            "cron": self.cron,
+            "enabled": self.enabled,
+            "last_run_at": _serialize_dt(self.last_run_at),
+            "replay_all": self.replay_all,
+        }
+
+
+@dataclass
+class OneshotEntry:
+    """A one-shot schedule for a specific datetime."""
+
+    id: str
+    action: str
+    run_at: datetime
+    target_issue: Optional[int] = None
+    target_pr: Optional[int] = None
+    completed: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ScheduleError("oneshot id required")
+        if self.action not in VALID_ACTIONS:
+            raise ScheduleError(
+                f"action must be one of {sorted(VALID_ACTIONS)}, got {self.action!r}"
+            )
+        if not isinstance(self.run_at, datetime):
+            raise ScheduleError("run_at must be a datetime")
+        if self.run_at.tzinfo is None:
+            self.run_at = self.run_at.replace(tzinfo=timezone.utc)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "action": self.action,
+            "run_at": _serialize_dt(self.run_at),
+            "target_issue": self.target_issue,
+            "target_pr": self.target_pr,
+            "completed": self.completed,
+        }
+
+
+@dataclass
+class PendingRun:
+    """A scheduled action whose time has come (or passed)."""
+
+    when: datetime
+    entry_id: str
+    action: str
+    is_oneshot: bool
+    target_issue: Optional[int] = None
+    target_pr: Optional[int] = None
+
+
+@dataclass
+class Schedule:
+    """All schedule entries for one monitor."""
+
+    recurring: List[RecurringEntry] = field(default_factory=list)
+    oneshot: List[OneshotEntry] = field(default_factory=list)
+
+    # ---- query / mutation ----------------------------------------
+
+    def get_recurring(self, entry_id: str) -> Optional[RecurringEntry]:
+        return next((e for e in self.recurring if e.id == entry_id), None)
+
+    def get_oneshot(self, entry_id: str) -> Optional[OneshotEntry]:
+        return next((e for e in self.oneshot if e.id == entry_id), None)
+
+    def add_recurring(self, entry: RecurringEntry) -> None:
+        if self.get_recurring(entry.id):
+            raise ScheduleError(f"recurring id already exists: {entry.id!r}")
+        self.recurring.append(entry)
+
+    def add_oneshot(self, entry: OneshotEntry) -> None:
+        if self.get_oneshot(entry.id):
+            raise ScheduleError(f"oneshot id already exists: {entry.id!r}")
+        self.oneshot.append(entry)
+
+    def remove(self, entry_id: str) -> bool:
+        before = len(self.recurring) + len(self.oneshot)
+        self.recurring = [e for e in self.recurring if e.id != entry_id]
+        self.oneshot = [e for e in self.oneshot if e.id != entry_id]
+        return (len(self.recurring) + len(self.oneshot)) < before
+
+    # ---- catch-up + tick selection -------------------------------
+
+    def compute_pending(self, now: Optional[datetime] = None) -> List[PendingRun]:
+        """Return all schedule entries whose run time is <= now.
+
+        Sorted by ``when`` ascending (oldest miss first). For coalescing
+        recurring entries, only ONE PendingRun is emitted per entry —
+        the most recent missed slot. With ``replay_all=True``, every
+        missed slot becomes its own PendingRun.
+        """
+        now = now or _now_utc()
+        out: List[PendingRun] = []
+
+        for r in self.recurring:
+            if not r.enabled:
+                continue
+            try:
+                # First fire after last_run_at (or epoch if never).
+                anchor = r.last_run_at or datetime(1970, 1, 1, tzinfo=timezone.utc)
+                next_at = next_after(r.cron, anchor)
+            except CronExpressionError:
+                logger.warning("invalid cron in recurring %s", r.id)
+                continue
+            if next_at > now:
+                continue  # not due yet
+            if not r.replay_all:
+                # Coalesce: collapse N misses to 1, fire at the latest miss.
+                latest = next_at
+                while True:
+                    try:
+                        candidate = next_after(r.cron, latest)
+                    except CronExpressionError:
+                        break
+                    if candidate > now:
+                        break
+                    latest = candidate
+                out.append(PendingRun(
+                    when=latest,
+                    entry_id=r.id,
+                    action=r.action,
+                    is_oneshot=False,
+                ))
+            else:
+                cursor = next_at
+                while cursor <= now:
+                    out.append(PendingRun(
+                        when=cursor,
+                        entry_id=r.id,
+                        action=r.action,
+                        is_oneshot=False,
+                    ))
+                    try:
+                        cursor = next_after(r.cron, cursor)
+                    except CronExpressionError:
+                        break
+
+        for o in self.oneshot:
+            if o.completed or o.run_at > now:
+                continue
+            out.append(PendingRun(
+                when=o.run_at,
+                entry_id=o.id,
+                action=o.action,
+                is_oneshot=True,
+                target_issue=o.target_issue,
+                target_pr=o.target_pr,
+            ))
+
+        out.sort(key=lambda p: p.when)
+        return out
+
+    def mark_run(self, run: PendingRun, *, when: Optional[datetime] = None) -> None:
+        """Update last_run_at / completed after a PendingRun executes."""
+        when = when or _now_utc()
+        if run.is_oneshot:
+            o = self.get_oneshot(run.entry_id)
+            if o is not None:
+                o.completed = True
+        else:
+            r = self.get_recurring(run.entry_id)
+            if r is not None:
+                r.last_run_at = when
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class ScheduleStore:
+    """Load/save :class:`Schedule` to YAML, keyed by monitor_id."""
+
+    def __init__(self, base_repo_path: Path, monitor_id: str = "default") -> None:
+        self.base_repo_path = Path(base_repo_path).resolve()
+        self.monitor_id = monitor_id
+        self.config_dir = self.base_repo_path / "config"
+        self.path = self.config_dir / f"pipeline_schedule_{monitor_id}.yaml"
+
+    def load(self) -> Schedule:
+        """Load the schedule. Returns an empty Schedule if file is missing."""
+        if not self.path.exists():
+            return Schedule()
+        try:
+            data = yaml.safe_load(self.path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            raise ScheduleError(f"could not parse {self.path}: {exc}") from exc
+        recurring = [self._build_recurring(d) for d in (data.get("recurring") or [])]
+        oneshot = [self._build_oneshot(d) for d in (data.get("oneshot") or [])]
+        return Schedule(recurring=recurring, oneshot=oneshot)
+
+    def save(self, schedule: Schedule) -> None:
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        data = {
+            "recurring": [e.to_dict() for e in schedule.recurring],
+            "oneshot": [e.to_dict() for e in schedule.oneshot],
+        }
+        self.path.write_text(
+            yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _build_recurring(d: dict) -> RecurringEntry:
+        return RecurringEntry(
+            id=d["id"],
+            action=d["action"],
+            cron=d["cron"],
+            enabled=bool(d.get("enabled", True)),
+            last_run_at=_parse_dt(d.get("last_run_at")),
+            replay_all=bool(d.get("replay_all", False)),
+        )
+
+    @staticmethod
+    def _build_oneshot(d: dict) -> OneshotEntry:
+        return OneshotEntry(
+            id=d["id"],
+            action=d["action"],
+            run_at=_parse_dt(d["run_at"]),
+            target_issue=d.get("target_issue"),
+            target_pr=d.get("target_pr"),
+            completed=bool(d.get("completed", False)),
+        )

--- a/deile/orchestration/pipeline/worktree_manager.py
+++ b/deile/orchestration/pipeline/worktree_manager.py
@@ -52,15 +52,35 @@ class WorktreeManager:
         Name of the integration branch (default ``main``).
     """
 
-    def __init__(self, base_repo: Path, *, main_branch: str = "main") -> None:
+    def __init__(
+        self,
+        base_repo: Path,
+        *,
+        main_branch: str = "main",
+        subdir: Optional[str] = None,
+    ) -> None:
+        """Initialize worktree manager.
+
+        ``subdir`` namespaces all per-branch worktrees under
+        ``.worktrees/<subdir>/<branch>``. ``.worktrees/main`` (the
+        always-clean clone of main) is shared across subdirs to save disk
+        and keep ``ensure_main`` cheap. Pass ``subdir=monitor_id`` to keep
+        parallel monitors from colliding.
+        """
         self.base_repo = Path(base_repo).resolve()
         if not (self.base_repo / ".git").exists():
             raise WorktreeError(f"{self.base_repo} is not a git repository")
         self.main_branch = main_branch
+        self.subdir = subdir
         self.worktrees_dir = self.base_repo / ".worktrees"
+        if subdir is not None:
+            self.branches_dir = self.worktrees_dir / subdir
+        else:
+            self.branches_dir = self.worktrees_dir
 
     @property
     def main_worktree(self) -> Path:
+        # Shared across subdirs: same clean main clone.
         return self.worktrees_dir / "main"
 
     # ------------------------------------------------------------------
@@ -90,7 +110,7 @@ class WorktreeManager:
         if not branch or branch == self.main_branch:
             raise WorktreeError(f"branch must be a non-main branch name, got {branch!r}")
         await self.ensure_main()
-        target = self.worktrees_dir / branch
+        target = self.branches_dir / branch
         if (target / ".git").exists():
             logger.info("worktree %s already exists; reusing", target)
             return Worktree(path=target, branch=branch, base_repo=self.base_repo)

--- a/deile/orchestration/pipeline/worktree_manager.py
+++ b/deile/orchestration/pipeline/worktree_manager.py
@@ -1,0 +1,163 @@
+"""Manage isolated working copies under ``.worktrees/<branch>``.
+
+The convention codified here (specified by the project owner):
+
+1. Pull ``main`` of the *invoked* repository.
+2. Ensure ``.worktrees/main`` exists as a clean clone of the same repo; pull it.
+3. Copy ``.worktrees/main`` to ``.worktrees/<branch>`` (filesystem copy — *not*
+   ``git worktree add``; the spec is a fresh clone-like layout).
+4. Inside ``<branch>``, create the git branch and let the caller mutate.
+
+This module is consumed by both the autonomous pipeline (when DEILE/Claude pick
+up an issue) and the standalone ``WorktreeTool`` exposed to other tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from deile.core.exceptions import DEILEError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Worktree:
+    """Result of a worktree setup."""
+
+    path: Path
+    branch: str
+    base_repo: Path
+
+
+class WorktreeError(DEILEError):
+    """Raised when worktree setup fails."""
+
+
+class WorktreeManager:
+    """Build per-branch sandboxes under ``.worktrees/`` of ``base_repo``.
+
+    Parameters
+    ----------
+    base_repo:
+        Directory of the source git repository. ``.worktrees/`` is created
+        inside this directory.
+    main_branch:
+        Name of the integration branch (default ``main``).
+    """
+
+    def __init__(self, base_repo: Path, *, main_branch: str = "main") -> None:
+        self.base_repo = Path(base_repo).resolve()
+        if not (self.base_repo / ".git").exists():
+            raise WorktreeError(f"{self.base_repo} is not a git repository")
+        self.main_branch = main_branch
+        self.worktrees_dir = self.base_repo / ".worktrees"
+
+    @property
+    def main_worktree(self) -> Path:
+        return self.worktrees_dir / "main"
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    async def ensure_main(self) -> Path:
+        """Make sure ``.worktrees/main`` exists and is up-to-date.
+
+        On first run this clones the base repo. On subsequent runs it pulls.
+        """
+        self.worktrees_dir.mkdir(parents=True, exist_ok=True)
+        if not (self.main_worktree / ".git").exists():
+            logger.info("cloning %s -> %s", self.base_repo, self.main_worktree)
+            await self._git("clone", str(self.base_repo), str(self.main_worktree))
+        await self._git_in(self.main_worktree, "fetch", "origin")
+        await self._git_in(self.main_worktree, "checkout", self.main_branch)
+        await self._git_in(self.main_worktree, "pull", "origin", self.main_branch)
+        return self.main_worktree
+
+    async def create_branch_worktree(self, branch: str) -> Worktree:
+        """Create ``.worktrees/<branch>`` (filesystem copy of main) + checkout branch.
+
+        If the worktree already exists, this fast-paths and just returns the
+        existing path.
+        """
+        if not branch or branch == self.main_branch:
+            raise WorktreeError(f"branch must be a non-main branch name, got {branch!r}")
+        await self.ensure_main()
+        target = self.worktrees_dir / branch
+        if (target / ".git").exists():
+            logger.info("worktree %s already exists; reusing", target)
+            return Worktree(path=target, branch=branch, base_repo=self.base_repo)
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("copying %s -> %s", self.main_worktree, target)
+        # `cp -r` mirrors the spec literally; shutil.copytree refuses an
+        # existing destination, which we've already ruled out above.
+        await asyncio.to_thread(shutil.copytree, self.main_worktree, target,
+                                symlinks=False, ignore=None)
+
+        # Inside the copy, point origin at the parent base_repo so commits
+        # land back there (and from there get pushed to GitHub by the pipeline).
+        await self._git_in(target, "remote", "set-url", "origin", str(self.base_repo))
+
+        # Create / switch to the feature branch.
+        rc, _, err = await self._git_in_capture(target, "checkout", "-b", branch)
+        if rc != 0:
+            # Branch may already exist locally; try a plain checkout.
+            rc2, _, err2 = await self._git_in_capture(target, "checkout", branch)
+            if rc2 != 0:
+                raise WorktreeError(
+                    f"could not create branch {branch!r} in {target}: {err or err2}"
+                )
+        return Worktree(path=target, branch=branch, base_repo=self.base_repo)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _git(*args: str) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            "git", *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr_b = await proc.communicate()
+        if (proc.returncode or 0) != 0:
+            raise WorktreeError(
+                f"git {' '.join(args)} failed: {stderr_b.decode('utf-8', 'replace').strip()[:300]}"
+            )
+
+    @staticmethod
+    async def _git_in(cwd: Path, *args: str) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            "git", "-C", str(cwd), *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr_b = await proc.communicate()
+        if (proc.returncode or 0) != 0:
+            raise WorktreeError(
+                f"git -C {cwd} {' '.join(args)} failed: "
+                f"{stderr_b.decode('utf-8', 'replace').strip()[:300]}"
+            )
+
+    @staticmethod
+    async def _git_in_capture(cwd: Path, *args: str):
+        proc = await asyncio.create_subprocess_exec(
+            "git", "-C", str(cwd), *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_b, stderr_b = await proc.communicate()
+        return (
+            proc.returncode or 0,
+            stdout_b.decode("utf-8", "replace"),
+            stderr_b.decode("utf-8", "replace"),
+        )

--- a/deile/tests/commands/test_pipeline_schedule_command.py
+++ b/deile/tests/commands/test_pipeline_schedule_command.py
@@ -1,0 +1,285 @@
+"""Unit tests for PipelineScheduleCommand (/pipeline-schedule slash command)."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.commands.builtin.pipeline_schedule_command import (
+    PipelineScheduleCommand,
+    _parse_kv,
+)
+from deile.commands.base import CommandContext, CommandResult
+from deile.tools.base import ToolContext, ToolResult
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _ctx(args: str = "") -> CommandContext:
+    ctx = MagicMock(spec=CommandContext)
+    ctx.args = args
+    ctx.agent = MagicMock()
+    return ctx
+
+
+def _success(data: Any = None, message: str = "ok") -> ToolResult:
+    return ToolResult.success_result(data=data, message=message)
+
+
+def _error(message: str = "fail", error_code: str = "ERR") -> ToolResult:
+    return ToolResult.error_result(message=message, error_code=error_code)
+
+
+# ---------------------------------------------------------------------------
+# _parse_kv unit tests
+# ---------------------------------------------------------------------------
+
+class TestParseKv:
+    def test_single_key(self):
+        assert _parse_kv("id:my_id") == {"id": "my_id"}
+
+    def test_multiple_keys(self):
+        result = _parse_kv("trigger:review cron:*/5 * * * *")
+        assert result["trigger"] == "review"
+        assert result["cron"] == "*/5 * * * *"
+
+    def test_at_key(self):
+        result = _parse_kv("trigger:pr_review at:2026-05-06T18:00:00Z")
+        assert result["trigger"] == "pr_review"
+        assert result["at"] == "2026-05-06T18:00:00Z"
+
+    def test_empty_string(self):
+        assert _parse_kv("") == {}
+
+
+# ---------------------------------------------------------------------------
+# sub-command: list
+# ---------------------------------------------------------------------------
+
+class TestListSubCommand:
+    async def test_list_calls_tool_with_action_list(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={
+                "monitor_id": "default",
+                "recurring": [],
+                "oneshot": [],
+            },
+            message="0 recurring + 0 oneshot entries",
+        )
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx("list"))
+
+        assert result.success
+        assert "default" in result.content
+
+    async def test_list_with_entries_formats_output(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={
+                "monitor_id": "default",
+                "recurring": [{"id": "r1", "action": "review", "cron": "*/5 * * * *", "enabled": True}],
+                "oneshot": [{"id": "o1", "action": "implement", "run_at": "2026-05-06T18:00:00+00:00"}],
+            },
+            message="1 recurring + 1 oneshot entries",
+        )
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx("list"))
+
+        assert result.success
+        assert "r1" in result.content
+        assert "o1" in result.content
+
+
+# ---------------------------------------------------------------------------
+# sub-command: add-recurring
+# ---------------------------------------------------------------------------
+
+class TestAddRecurringSubCommand:
+    async def test_add_recurring_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={"id": "review_loop", "cron": "*/5 * * * *", "action": "review"},
+            message="added recurring",
+        )
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("add-recurring trigger:review cron:*/5 * * * *"))
+
+        assert result.success
+        assert captured[0]["action"] == "add_recurring"
+        assert captured[0]["trigger_action"] == "review"
+        assert captured[0]["cron"] == "*/5 * * * *"
+
+    async def test_add_recurring_missing_args_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("add-recurring trigger:review"))
+        assert not result.success
+        assert "cron" in result.content.lower()
+
+    async def test_add_recurring_missing_trigger_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("add-recurring cron:*/10 * * * *"))
+        assert not result.success
+        assert "trigger" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# sub-command: add-oneshot
+# ---------------------------------------------------------------------------
+
+class TestAddOneshotSubCommand:
+    async def test_add_oneshot_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={"id": "o1", "run_at": "2026-05-06T18:00:00+00:00", "action": "implement"},
+            message="added oneshot",
+        )
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(
+                _ctx("add-oneshot trigger:implement at:2026-05-06T18:00:00Z")
+            )
+
+        assert result.success
+        assert captured[0]["action"] == "add_oneshot"
+        assert captured[0]["trigger_action"] == "implement"
+        assert "2026-05-06" in captured[0]["run_at"]
+
+    async def test_add_oneshot_missing_at_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("add-oneshot trigger:review"))
+        assert not result.success
+        assert "at" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# sub-command: remove
+# ---------------------------------------------------------------------------
+
+class TestRemoveSubCommand:
+    async def test_remove_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(data={"id": "r1"}, message="removed r1")
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("remove id:r1"))
+
+        assert result.success
+        assert captured[0] == {"action": "remove", "id": "r1"}
+
+    async def test_remove_missing_id_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("remove"))
+        assert not result.success
+        assert "id" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# sub-command: enable / disable
+# ---------------------------------------------------------------------------
+
+class TestEnableDisableSubCommand:
+    async def test_enable_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(data={"id": "r1", "enabled": True}, message="r1 enabled")
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("enable id:r1"))
+
+        assert result.success
+        assert captured[0] == {"action": "enable", "id": "r1"}
+
+    async def test_disable_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(data={"id": "r1", "enabled": False}, message="r1 disabled")
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("disable id:r1"))
+
+        assert result.success
+        assert captured[0] == {"action": "disable", "id": "r1"}
+
+    async def test_enable_missing_id_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("enable"))
+        assert not result.success
+        assert "id" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# invalid sub-command
+# ---------------------------------------------------------------------------
+
+class TestInvalidSubCommand:
+    async def test_unknown_subcommand_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("foobar"))
+        assert not result.success
+        assert "unknown" in result.content.lower() or "foobar" in result.content.lower()
+
+    async def test_empty_args_defaults_to_list(self):
+        """No args → list (same as /pipeline default = status)."""
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={"monitor_id": "default", "recurring": [], "oneshot": []},
+            message="0 recurring + 0 oneshot entries",
+        )
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx(""))
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# tool error propagation
+# ---------------------------------------------------------------------------
+
+class TestToolErrorPropagation:
+    async def test_tool_error_becomes_command_error(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _error(message="no entry with id='x'", error_code="NOT_FOUND")
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx("remove id:x"))
+        assert not result.success
+        assert "no entry" in result.content.lower()
+
+    async def test_tool_exception_becomes_command_error(self):
+        cmd = PipelineScheduleCommand()
+
+        async def explode(_ctx):
+            raise RuntimeError("disk full")
+
+        with patch.object(cmd._tool, "execute", side_effect=explode):
+            result = await cmd.execute(_ctx("list"))
+
+        assert not result.success
+        assert "RuntimeError" in result.content or "disk full" in result.content

--- a/deile/tests/cron/test_agent_bridge.py
+++ b/deile/tests/cron/test_agent_bridge.py
@@ -1,0 +1,191 @@
+"""Tests for deile.cron.agent_bridge (intent #86)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deile.cron.agent_bridge import make_fire_callback
+from deile.cron.store import CronEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(entry_id: str = "cron-abc123", prompt: str = "do something") -> CronEntry:
+    """Return a minimal one-shot CronEntry for testing."""
+    return CronEntry(
+        id=entry_id,
+        prompt=prompt,
+        run_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _make_agent_response(content: str) -> MagicMock:
+    """Return a mock AgentResponse-like object."""
+    response = MagicMock()
+    response.content = content
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_happy_path_returns_summary():
+    """Callback returns the response content for a normal successful call."""
+    expected = "Task completed successfully"
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(expected))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert result == expected
+    agent.process_input.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_long_response_truncated_to_default():
+    """Response longer than max_summary_chars (500) is truncated with ellipsis."""
+    long_text = "x" * 600
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(long_text))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert len(result) == 500
+    assert result.endswith("…")
+    assert result[:499] == "x" * 499
+
+
+@pytest.mark.unit
+async def test_custom_max_summary_chars_respected():
+    """Custom max_summary_chars is honoured."""
+    text = "hello world — this is a longer reply"
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(text))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider, max_summary_chars=10)
+    result = await cb(_make_entry())
+
+    assert len(result) == 10
+    assert result.endswith("…")
+
+
+@pytest.mark.unit
+async def test_process_input_raises_returns_error_string():
+    """When agent.process_input raises, callback returns error string, not raises."""
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(side_effect=RuntimeError("LLM timeout"))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert result.startswith("error: RuntimeError:")
+    assert "LLM timeout" in result
+
+
+@pytest.mark.unit
+async def test_agent_provider_raises_returns_error_string():
+    """When agent_provider itself raises, callback returns error string, not raises."""
+    async def failing_provider():
+        raise ConnectionError("DB unreachable")
+
+    cb = make_fire_callback(failing_provider)
+    result = await cb(_make_entry())
+
+    assert result.startswith("error: ConnectionError:")
+    assert "DB unreachable" in result
+
+
+@pytest.mark.unit
+async def test_session_id_includes_entry_id():
+    """process_input is called with session_id that contains entry.id."""
+    entry = _make_entry(entry_id="cron-testentry42")
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response("ok"))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    await cb(entry)
+
+    call_kwargs = agent.process_input.call_args
+    assert call_kwargs.kwargs.get("session_id") == "cron-cron-testentry42"
+
+
+@pytest.mark.unit
+async def test_response_without_content_attribute_uses_str():
+    """Response with no .content attribute falls back to str(response)."""
+
+    class NoContentResponse:
+        def __str__(self) -> str:
+            return "fallback text"
+
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=NoContentResponse())
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    # Should have used str() and not raised
+    assert isinstance(result, str)
+    assert "fallback text" in result
+
+
+@pytest.mark.unit
+async def test_short_response_not_truncated():
+    """Response exactly at max_summary_chars is not truncated."""
+    text = "a" * 500
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(text))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert result == text
+    assert not result.endswith("…")
+
+
+@pytest.mark.unit
+async def test_prompt_forwarded_to_process_input():
+    """entry.prompt is forwarded verbatim as the first positional arg."""
+    prompt = "summarize yesterday's commits"
+    entry = _make_entry(prompt=prompt)
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response("done"))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    await cb(entry)
+
+    call_args = agent.process_input.call_args
+    assert call_args.args[0] == prompt

--- a/deile/tests/cron/test_integration_full.py
+++ b/deile/tests/cron/test_integration_full.py
@@ -1,0 +1,112 @@
+"""End-to-end test: CronStore → CronRunner → make_fire_callback → MockAgent."""
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from deile.cron.store import CronEntry, CronStore
+from deile.cron.runner import CronRunner
+from deile.cron.agent_bridge import make_fire_callback
+
+
+class TestCronEndToEnd:
+    async def test_due_entry_flows_through_bridge_to_agent_and_back(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(
+            id="e1", prompt="run report",
+            run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        ))
+
+        # Mock agent that records calls and returns a known response.
+        agent = MagicMock()
+        response = MagicMock()
+        response.content = "report generated successfully"
+        agent.process_input = AsyncMock(return_value=response)
+
+        async def provider():
+            return agent
+
+        runner = CronRunner(store, fire_callback=make_fire_callback(provider))
+        fired = await runner.tick()
+
+        assert fired == 1
+        # agent saw the prompt + correct session_id
+        agent.process_input.assert_awaited_once()
+        call = agent.process_input.await_args
+        assert "run report" in (call.args[0] if call.args else call.kwargs.get("prompt", ""))
+        # entry was marked fired with the response summary
+        loaded = store.get("e1")
+        assert loaded is not None
+        assert not loaded.enabled  # one-shot disabled
+        assert "report generated" in (loaded.last_result or "")
+
+    async def test_session_id_encodes_entry_id(self, tmp_path):
+        """Bridge passes session_id='cron-{entry.id}' so memory layers can correlate."""
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(
+            id="abc123", prompt="hello",
+            run_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+        ))
+
+        agent = MagicMock()
+        agent.process_input = AsyncMock(return_value=MagicMock(content="ok"))
+
+        runner = CronRunner(store, fire_callback=make_fire_callback(lambda: asyncio.coroutine(lambda: agent)()))
+
+        # Use a direct callback to capture kwargs
+        captured: dict = {}
+
+        async def provider():
+            return agent
+
+        async def recording_cb(entry: CronEntry) -> str:
+            result = await make_fire_callback(provider)(entry)
+            captured["session_id"] = agent.process_input.await_args.kwargs.get("session_id")
+            return result
+
+        runner2 = CronRunner(store, fire_callback=recording_cb)
+        await runner2.tick()
+
+        assert captured.get("session_id") == "cron-abc123"
+
+    async def test_agent_provider_error_does_not_crash_runner(self, tmp_path):
+        """If the agent provider raises, the runner marks the entry fired with error."""
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(
+            id="bad1", prompt="will fail",
+            run_at=datetime.now(timezone.utc) - timedelta(seconds=5),
+        ))
+
+        async def broken_provider():
+            raise RuntimeError("provider down")
+
+        runner = CronRunner(store, fire_callback=make_fire_callback(broken_provider))
+        fired = await runner.tick()
+
+        assert fired == 1  # runner still counts it as fired
+        loaded = store.get("bad1")
+        assert loaded is not None
+        assert "RuntimeError" in (loaded.last_result or "") or "error" in (loaded.last_result or "").lower()
+
+    async def test_summary_truncated_at_max_chars(self, tmp_path):
+        """Long agent responses are truncated to max_summary_chars."""
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(
+            id="long1", prompt="generate",
+            run_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        ))
+
+        agent = MagicMock()
+        long_text = "x" * 600
+        agent.process_input = AsyncMock(return_value=MagicMock(content=long_text))
+
+        async def provider():
+            return agent
+
+        runner = CronRunner(store, fire_callback=make_fire_callback(provider, max_summary_chars=100))
+        await runner.tick()
+
+        loaded = store.get("long1")
+        assert loaded is not None
+        result = loaded.last_result or ""
+        assert len(result) <= 500  # store caps at 1000, bridge at max_summary_chars=100
+        assert result.endswith("…") or len(result) <= 100

--- a/deile/tests/cron/test_runner.py
+++ b/deile/tests/cron/test_runner.py
@@ -1,0 +1,99 @@
+"""Unit tests for CronRunner."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deile.cron.runner import CronRunner
+from deile.cron.store import CronEntry, CronStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CronStore(tmp_path / "cron.db")
+
+
+class TestTick:
+    async def test_tick_no_due_entries(self, store):
+        runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
+        fired = await runner.tick()
+        assert fired == 0
+
+    async def test_tick_fires_due_oneshot(self, store):
+        store.add(CronEntry(id="o1", prompt="hi",
+                            run_at=datetime.now(timezone.utc) - timedelta(minutes=1)))
+        cb = AsyncMock(return_value="result")
+        runner = CronRunner(store, fire_callback=cb)
+        fired = await runner.tick()
+        assert fired == 1
+        cb.assert_awaited_once()
+        loaded = store.get("o1")
+        assert not loaded.enabled
+        assert loaded.last_result == "result"
+
+    async def test_tick_no_callback_skips_gracefully(self, store):
+        store.add(CronEntry(id="o1", prompt="hi",
+                            run_at=datetime.now(timezone.utc) - timedelta(minutes=1)))
+        runner = CronRunner(store)  # no callback
+        fired = await runner.tick()
+        assert fired == 1  # counted as fired (to advance)
+        loaded = store.get("o1")
+        assert "no callback" in (loaded.last_result or "")
+
+    async def test_tick_callback_exception_marks_error(self, store):
+        store.add(CronEntry(id="o1", prompt="hi",
+                            run_at=datetime.now(timezone.utc) - timedelta(minutes=1)))
+
+        async def boom(_e):
+            raise RuntimeError("boom")
+
+        runner = CronRunner(store, fire_callback=boom)
+        await runner.tick()
+        loaded = store.get("o1")
+        assert "error" in (loaded.last_result or "").lower()
+        # one-shot still advanced (disabled) so we don't re-fire forever
+        assert not loaded.enabled
+
+    async def test_tick_dms_result_when_configured(self, store):
+        store.add(CronEntry(id="o1", prompt="hi",
+                            run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+                            notify_user_id="42"))
+
+        dm_calls = []
+
+        async def fake_dm(uid, text):
+            dm_calls.append((uid, text))
+            return {"ok": True}
+
+        runner = CronRunner(
+            store,
+            fire_callback=AsyncMock(return_value="result-text"),
+            notify_dm=fake_dm,
+        )
+        await runner.tick()
+        assert len(dm_calls) == 1
+        assert dm_calls[0][0] == "42"
+        assert "result-text" in dm_calls[0][1]
+
+
+class TestLifecycle:
+    async def test_start_then_stop(self, store):
+        runner = CronRunner(
+            store, fire_callback=AsyncMock(return_value="ok"),
+            poll_interval_seconds=1,
+        )
+        await runner.start()
+        assert runner.is_running
+        await runner.stop()
+        assert not runner.is_running
+
+    async def test_start_idempotent(self, store):
+        runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
+        await runner.start()
+        first_task = runner._task
+        await runner.start()
+        assert runner._task is first_task
+        await runner.stop()

--- a/deile/tests/cron/test_store.py
+++ b/deile/tests/cron/test_store.py
@@ -1,0 +1,148 @@
+"""Unit tests for CronEntry + CronStore (SQLite)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from deile.cron.store import CronEntry, CronStore, CronStoreError, make_id
+
+
+def _utc(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+class TestCronEntryConstruction:
+    def test_recurring_entry(self):
+        e = CronEntry(id="x", prompt="hello", cron="*/5 * * * *")
+        assert e.cron == "*/5 * * * *"
+        assert e.run_at is None
+        assert e.next_fire_at is not None
+        assert not e.is_oneshot
+
+    def test_oneshot_entry(self):
+        e = CronEntry(id="x", prompt="ping", run_at=_utc("2030-01-01T00:00:00"))
+        assert e.is_oneshot
+        assert e.next_fire_at == _utc("2030-01-01T00:00:00")
+
+    def test_naive_run_at_promoted_to_utc(self):
+        e = CronEntry(id="x", prompt="ping",
+                      run_at=datetime(2030, 1, 1, 0, 0))
+        assert e.run_at.tzinfo is not None
+
+    def test_rejects_both_cron_and_run_at(self):
+        with pytest.raises(CronStoreError):
+            CronEntry(id="x", prompt="p", cron="* * * * *",
+                      run_at=_utc("2030-01-01T00:00:00"))
+
+    def test_rejects_neither(self):
+        with pytest.raises(CronStoreError):
+            CronEntry(id="x", prompt="p")
+
+    def test_rejects_empty_prompt(self):
+        with pytest.raises(CronStoreError):
+            CronEntry(id="x", prompt="   ", cron="* * * * *")
+
+    def test_rejects_invalid_cron(self):
+        with pytest.raises(CronStoreError):
+            CronEntry(id="x", prompt="p", cron="not a cron")
+
+
+class TestAdvance:
+    def test_oneshot_disables_after_advance(self):
+        e = CronEntry(id="x", prompt="p", run_at=_utc("2030-01-01T00:00:00"))
+        e.advance()
+        assert not e.enabled
+        assert e.next_fire_at is None
+
+    def test_recurring_advances(self):
+        e = CronEntry(id="x", prompt="p", cron="*/5 * * * *",
+                      last_fired_at=_utc("2026-05-06T00:00:00"))
+        first = e.next_fire_at
+        e.advance(after=_utc("2026-05-06T00:10:00"))
+        assert e.next_fire_at > first
+
+
+class TestCronStore:
+    def test_add_and_get(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        e = CronEntry(id="r1", prompt="hello", cron="*/5 * * * *")
+        store.add(e)
+        loaded = store.get("r1")
+        assert loaded is not None
+        assert loaded.prompt == "hello"
+        assert loaded.cron == "*/5 * * * *"
+
+    def test_add_rejects_duplicate(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(id="r1", prompt="p", cron="*/5 * * * *"))
+        with pytest.raises(CronStoreError):
+            store.add(CronEntry(id="r1", prompt="p2", cron="*/10 * * * *"))
+
+    def test_get_missing_returns_none(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        assert store.get("nope") is None
+
+    def test_remove(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(id="r1", prompt="p", cron="*/5 * * * *"))
+        assert store.remove("r1")
+        assert not store.remove("r1")  # already gone
+        assert store.get("r1") is None
+
+    def test_set_enabled(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(id="r1", prompt="p", cron="*/5 * * * *"))
+        assert store.set_enabled("r1", False)
+        loaded = store.get("r1")
+        assert not loaded.enabled
+
+    def test_list_only_enabled(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(id="r1", prompt="a", cron="*/5 * * * *"))
+        store.add(CronEntry(id="r2", prompt="b", cron="*/10 * * * *"))
+        store.set_enabled("r2", False)
+        all_e = store.list_all(only_enabled=False)
+        only_on = store.list_all(only_enabled=True)
+        assert len(all_e) == 2
+        assert len(only_on) == 1
+        assert only_on[0].id == "r1"
+
+    def test_list_due(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        # one-shot in the past → due
+        store.add(CronEntry(id="o1", prompt="p",
+                            run_at=datetime.now(timezone.utc) - timedelta(minutes=1)))
+        # one-shot in the future → not due
+        store.add(CronEntry(id="o2", prompt="p",
+                            run_at=datetime.now(timezone.utc) + timedelta(hours=1)))
+        due = store.list_due()
+        assert [e.id for e in due] == ["o1"]
+
+    def test_mark_fired_oneshot_disables(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(id="o1", prompt="p",
+                            run_at=datetime.now(timezone.utc) - timedelta(minutes=1)))
+        store.mark_fired("o1", result="ok")
+        loaded = store.get("o1")
+        assert not loaded.enabled
+        assert loaded.next_fire_at is None
+        assert loaded.last_result == "ok"
+
+    def test_mark_fired_recurring_advances(self, tmp_path):
+        store = CronStore(tmp_path / "cron.db")
+        store.add(CronEntry(id="r1", prompt="p", cron="*/5 * * * *"))
+        before = store.get("r1").next_fire_at
+        store.mark_fired("r1", when=datetime.now(timezone.utc) + timedelta(hours=1))
+        after = store.get("r1").next_fire_at
+        assert after > before
+
+
+class TestMakeId:
+    def test_unique(self):
+        ids = {make_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_prefix(self):
+        assert make_id().startswith("cron-")

--- a/deile/tests/cron/test_store_stress.py
+++ b/deile/tests/cron/test_store_stress.py
@@ -1,0 +1,181 @@
+"""Stress / performance tests for CronStore.
+
+Validates latency under bulk reads and thread-safety under concurrent writes.
+These tests use threading (not asyncio) because CronStore is synchronous/
+thread-safe by design.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from deile.cron.store import CronEntry, CronStore, make_id
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc_past(minutes: int = 5) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(minutes=minutes)
+
+
+def _utc_future(hours: int = 1) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(hours=hours)
+
+
+def _make_recurring(store_id: str, n: int) -> CronEntry:
+    return CronEntry(id=store_id, prompt=f"prompt {n}", cron="*/5 * * * *")
+
+
+def _make_oneshot_due(store_id: str, n: int) -> CronEntry:
+    return CronEntry(id=store_id, prompt=f"oneshot {n}", run_at=_utc_past(minutes=10))
+
+
+def _make_oneshot_future(store_id: str, n: int) -> CronEntry:
+    return CronEntry(id=store_id, prompt=f"future {n}", run_at=_utc_future())
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.perf
+class TestStorePerformance:
+
+    def test_list_due_with_100_entries_is_fast(self, tmp_path):
+        """list_due() with 100 entries completes in under 100 ms."""
+        db = CronStore(tmp_path / "stress.db")
+
+        # 50 due entries (past) + 50 future entries
+        for i in range(50):
+            db.add(_make_oneshot_due(make_id(), i))
+        for i in range(50):
+            db.add(_make_oneshot_future(make_id(), i))
+
+        start = time.perf_counter()
+        due = db.list_due()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert len(due) == 50
+        assert elapsed_ms < 100, f"list_due() took {elapsed_ms:.1f}ms (limit 100ms)"
+
+    def test_concurrent_writes_no_corruption(self, tmp_path):
+        """10 threads each adding 10 entries produces exactly 100 rows, no duplicates."""
+        db = CronStore(tmp_path / "concurrent.db")
+        errors: List[Exception] = []
+
+        def add_entries():
+            try:
+                for _ in range(10):
+                    db.add(CronEntry(id=make_id(), prompt="concurrent", cron="*/1 * * * *"))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=add_entries) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Threads raised exceptions: {errors}"
+        all_entries = db.list_all()
+        assert len(all_entries) == 100, f"Expected 100 entries, got {len(all_entries)}"
+        # All IDs must be unique.
+        ids = [e.id for e in all_entries]
+        assert len(ids) == len(set(ids)), "Duplicate IDs detected"
+
+    def test_concurrent_read_during_writes(self, tmp_path):
+        """list_all() does not raise or return corrupt data while writes occur."""
+        db = CronStore(tmp_path / "read_write.db")
+        stop_event = threading.Event()
+        read_errors: List[Exception] = []
+        write_errors: List[Exception] = []
+
+        def writer():
+            while not stop_event.is_set():
+                try:
+                    db.add(CronEntry(id=make_id(), prompt="write", cron="*/1 * * * *"))
+                    time.sleep(0.005)
+                except Exception as exc:  # noqa: BLE001
+                    write_errors.append(exc)
+
+        def reader():
+            while not stop_event.is_set():
+                try:
+                    entries = db.list_all()
+                    # Basic sanity: every returned entry must have a non-empty id
+                    for e in entries:
+                        assert e.id, "Entry with empty id returned from list_all"
+                    time.sleep(0.003)
+                except Exception as exc:  # noqa: BLE001
+                    read_errors.append(exc)
+
+        writer_thread = threading.Thread(target=writer, daemon=True)
+        reader_thread = threading.Thread(target=reader, daemon=True)
+        writer_thread.start()
+        reader_thread.start()
+
+        time.sleep(0.5)
+        stop_event.set()
+        writer_thread.join(timeout=2)
+        reader_thread.join(timeout=2)
+
+        assert not read_errors, f"Reader raised: {read_errors}"
+        assert not write_errors, f"Writer raised: {write_errors}"
+
+    def test_list_due_returns_only_enabled_entries(self, tmp_path):
+        """Disabled entries are excluded from list_due()."""
+        db = CronStore(tmp_path / "enabled.db")
+        entry_id = make_id()
+        db.add(_make_oneshot_due(entry_id, 0))
+
+        # Disable it immediately.
+        db.set_enabled(entry_id, False)
+
+        due = db.list_due()
+        assert all(e.id != entry_id for e in due), "Disabled entry appeared in list_due"
+
+    def test_mark_fired_advances_recurring_and_disables_oneshot(self, tmp_path):
+        """mark_fired() moves next_fire_at forward (recurring) or disables (one-shot)."""
+        db = CronStore(tmp_path / "fired.db")
+
+        rec_id = make_id()
+        db.add(CronEntry(id=rec_id, prompt="recur", cron="*/5 * * * *"))
+        old_next = db.get(rec_id).next_fire_at
+        # Advance anchor well past next cron boundary so next_fire_at actually moves.
+        fired_at = old_next + timedelta(minutes=6)
+        db.mark_fired(rec_id, when=fired_at)
+        new_next = db.get(rec_id).next_fire_at
+        assert new_next > old_next, "Recurring next_fire_at should advance after firing"
+
+        os_id = make_id()
+        db.add(CronEntry(id=os_id, prompt="oneshot", run_at=_utc_past(minutes=1)))
+        db.mark_fired(os_id)
+        entry = db.get(os_id)
+        assert not entry.enabled, "One-shot should be disabled after mark_fired"
+
+    def test_list_all_returns_all_including_disabled(self, tmp_path):
+        """list_all() without only_enabled returns disabled entries too."""
+        db = CronStore(tmp_path / "all.db")
+        ids = [make_id() for _ in range(5)]
+        for e_id in ids:
+            db.add(CronEntry(id=e_id, prompt="p", cron="*/5 * * * *"))
+
+        # Disable 2 of them
+        db.set_enabled(ids[0], False)
+        db.set_enabled(ids[1], False)
+
+        all_entries = db.list_all(only_enabled=False)
+        assert len(all_entries) == 5
+
+        enabled_only = db.list_all(only_enabled=True)
+        assert len(enabled_only) == 3

--- a/deile/tests/cron/test_tools.py
+++ b/deile/tests/cron/test_tools.py
@@ -1,0 +1,189 @@
+"""Unit tests for CronCreateTool / CronListTool / CronDeleteTool."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from deile.tools.base import ToolContext, ToolStatus
+from deile.tools.cron_create_tool import CronCreateTool
+from deile.tools.cron_delete_tool import CronDeleteTool
+from deile.tools.cron_list_tool import CronListTool
+
+
+@pytest.fixture
+def cron_db(tmp_path, monkeypatch):
+    """Point all cron tools at an isolated SQLite under tmp_path."""
+    db_path = tmp_path / "cron.db"
+    monkeypatch.setenv("DEILE_CRON_DB_PATH", str(db_path))
+    return db_path
+
+
+def _ctx(**args) -> ToolContext:
+    return ToolContext(user_input="", parsed_args=args)
+
+
+# ---------------------------------------------------------------------------
+# Schema sanity (catches the "type: null" regression we shipped on PipelineTool)
+# ---------------------------------------------------------------------------
+
+class TestToolSchemas:
+    @pytest.mark.parametrize("cls", [CronCreateTool, CronListTool, CronDeleteTool])
+    def test_parameters_are_object_schema(self, cls):
+        schema = cls()._schema
+        assert schema.parameters["type"] == "object"
+        assert "properties" in schema.parameters
+        # Round-trip through to_openai_function.
+        fn = schema.to_openai_function()
+        assert fn["function"]["parameters"]["type"] == "object"
+
+
+# ---------------------------------------------------------------------------
+# CronCreateTool
+# ---------------------------------------------------------------------------
+
+class TestCronCreate:
+    async def test_create_recurring(self, cron_db):
+        tool = CronCreateTool()
+        r = await tool.execute(_ctx(prompt="say hi", cron="*/5 * * * *"))
+        assert r.status == ToolStatus.SUCCESS
+        assert r.data["id"].startswith("cron-")
+        assert r.data["is_oneshot"] is False
+        assert r.data["next_fire_at"] is not None
+
+    async def test_create_oneshot(self, cron_db):
+        tool = CronCreateTool()
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        r = await tool.execute(_ctx(prompt="run report", run_at=future))
+        assert r.status == ToolStatus.SUCCESS
+        assert r.data["is_oneshot"] is True
+
+    async def test_missing_prompt(self, cron_db):
+        tool = CronCreateTool()
+        r = await tool.execute(_ctx(cron="*/5 * * * *"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "MISSING_PROMPT"
+
+    async def test_both_cron_and_run_at_rejected(self, cron_db):
+        tool = CronCreateTool()
+        r = await tool.execute(_ctx(prompt="x", cron="* * * * *",
+                                    run_at="2030-01-01T00:00:00Z"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "INVALID_SCHEDULE"
+
+    async def test_neither_cron_nor_run_at_rejected(self, cron_db):
+        tool = CronCreateTool()
+        r = await tool.execute(_ctx(prompt="x"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "INVALID_SCHEDULE"
+
+    async def test_invalid_run_at(self, cron_db):
+        tool = CronCreateTool()
+        r = await tool.execute(_ctx(prompt="x", run_at="banana"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "INVALID_DATETIME"
+
+    async def test_invalid_cron(self, cron_db):
+        tool = CronCreateTool()
+        r = await tool.execute(_ctx(prompt="x", cron="not a cron"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "CRON_STORE"
+
+    async def test_explicit_id_used(self, cron_db):
+        tool = CronCreateTool()
+        r = await tool.execute(_ctx(prompt="x", cron="*/5 * * * *", id="my-id"))
+        assert r.data["id"] == "my-id"
+
+    async def test_duplicate_id_rejected(self, cron_db):
+        tool = CronCreateTool()
+        await tool.execute(_ctx(prompt="x", cron="*/5 * * * *", id="dup"))
+        r = await tool.execute(_ctx(prompt="y", cron="*/10 * * * *", id="dup"))
+        assert r.status == ToolStatus.ERROR
+
+
+# ---------------------------------------------------------------------------
+# CronListTool
+# ---------------------------------------------------------------------------
+
+class TestCronList:
+    async def test_empty(self, cron_db):
+        r = await CronListTool().execute(_ctx())
+        assert r.status == ToolStatus.SUCCESS
+        assert r.data["count"] == 0
+
+    async def test_lists_added(self, cron_db):
+        await CronCreateTool().execute(_ctx(prompt="a", cron="*/5 * * * *"))
+        await CronCreateTool().execute(_ctx(prompt="b", cron="*/10 * * * *"))
+        r = await CronListTool().execute(_ctx())
+        assert r.data["count"] == 2
+
+    async def test_filter_by_creator(self, cron_db):
+        await CronCreateTool().execute(_ctx(
+            prompt="a", cron="*/5 * * * *", created_by="discord:1"
+        ))
+        await CronCreateTool().execute(_ctx(
+            prompt="b", cron="*/10 * * * *", created_by="discord:2"
+        ))
+        r = await CronListTool().execute(_ctx(created_by="discord:2"))
+        assert r.data["count"] == 1
+        assert r.data["entries"][0]["prompt"] == "b"
+
+    async def test_only_enabled(self, cron_db):
+        # Add two, disable one, request only_enabled.
+        c1 = await CronCreateTool().execute(_ctx(
+            prompt="a", cron="*/5 * * * *", id="r1",
+        ))
+        await CronCreateTool().execute(_ctx(
+            prompt="b", cron="*/10 * * * *", id="r2",
+        ))
+        await CronDeleteTool().execute(_ctx(id="r2", disable_only=True))
+        r = await CronListTool().execute(_ctx(only_enabled=True))
+        assert r.data["count"] == 1
+        assert r.data["entries"][0]["id"] == "r1"
+
+
+# ---------------------------------------------------------------------------
+# CronDeleteTool
+# ---------------------------------------------------------------------------
+
+class TestCronDelete:
+    async def test_delete_existing(self, cron_db):
+        await CronCreateTool().execute(_ctx(prompt="x", cron="*/5 * * * *", id="r1"))
+        r = await CronDeleteTool().execute(_ctx(id="r1"))
+        assert r.status == ToolStatus.SUCCESS
+        assert r.data["action"] == "removed"
+        # gone
+        listing = await CronListTool().execute(_ctx())
+        assert listing.data["count"] == 0
+
+    async def test_disable_preserves_entry(self, cron_db):
+        await CronCreateTool().execute(_ctx(prompt="x", cron="*/5 * * * *", id="r1"))
+        r = await CronDeleteTool().execute(_ctx(id="r1", disable_only=True))
+        assert r.data["action"] == "disabled"
+        listing = await CronListTool().execute(_ctx())
+        assert listing.data["count"] == 1
+        assert listing.data["entries"][0]["enabled"] is False
+
+    async def test_missing_id(self, cron_db):
+        r = await CronDeleteTool().execute(_ctx())
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "MISSING_ID"
+
+    async def test_unknown_id(self, cron_db):
+        r = await CronDeleteTool().execute(_ctx(id="nope"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Auto-discover registration
+# ---------------------------------------------------------------------------
+
+class TestAutoDiscover:
+    def test_three_tools_registered(self):
+        from deile.tools.registry import ToolRegistry
+        r = ToolRegistry()
+        r.auto_discover()
+        for name in ("cron_create", "cron_list", "cron_delete"):
+            assert name in r._tools, f"{name} not auto-registered"

--- a/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
+++ b/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
@@ -1,0 +1,90 @@
+"""Unit tests for ClaudeDispatcher — uses real subprocess via /bin/sh stub."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import (
+    ClaudeDispatcher, render_implement_prompt, render_review_prompt)
+
+
+@pytest.fixture
+def fake_claude(tmp_path: Path) -> Path:
+    """Make a tiny shell script that mimics `claude -p "prompt"`."""
+    script = tmp_path / "fake-claude"
+    script.write_text(
+        "#!/bin/sh\n"
+        # echo back the prompt for stdout assertions
+        "shift\n"  # drop -p
+        'echo "$@"\n'
+        "exit 0\n"
+    )
+    script.chmod(0o755)
+    return script
+
+
+class TestRunBasic:
+    async def test_returns_ok_on_success(self, fake_claude, tmp_path):
+        d = ClaudeDispatcher(claude_path=str(fake_claude), timeout_seconds=10)
+        result = await d.run("hello world", cwd=tmp_path)
+        assert result.ok
+        assert result.returncode == 0
+        assert "hello world" in result.stdout
+
+    async def test_rejects_empty_prompt(self, fake_claude, tmp_path):
+        d = ClaudeDispatcher(claude_path=str(fake_claude))
+        with pytest.raises(ValueError):
+            await d.run("", cwd=tmp_path)
+
+    async def test_rejects_missing_cwd(self, fake_claude, tmp_path):
+        d = ClaudeDispatcher(claude_path=str(fake_claude))
+        with pytest.raises(FileNotFoundError):
+            await d.run("foo", cwd=tmp_path / "does_not_exist")
+
+
+class TestRunFailure:
+    async def test_returncode_propagated_on_nonzero(self, tmp_path):
+        failing = tmp_path / "fail-claude"
+        failing.write_text("#!/bin/sh\necho boom 1>&2\nexit 7\n")
+        failing.chmod(0o755)
+        d = ClaudeDispatcher(claude_path=str(failing))
+        result = await d.run("anything", cwd=tmp_path)
+        assert not result.ok
+        assert result.returncode == 7
+        assert "boom" in result.stderr
+
+
+class TestTimeout:
+    async def test_timeout_terminates(self, tmp_path):
+        slow = tmp_path / "slow-claude"
+        slow.write_text("#!/bin/sh\nsleep 30\n")
+        slow.chmod(0o755)
+        d = ClaudeDispatcher(claude_path=str(slow), timeout_seconds=1)
+        result = await d.run("anything", cwd=tmp_path)
+        assert not result.ok
+        assert result.returncode == 124
+
+
+class TestPrompts:
+    def test_implement_prompt_includes_repo_and_number(self):
+        prompt = render_implement_prompt("foo/bar", 42, "title", "body")
+        assert "foo/bar" in prompt
+        assert "#42" in prompt
+        assert "title" in prompt
+        assert "body" in prompt
+
+    def test_implement_prompt_truncates_long_body(self):
+        body = "@" * 10000
+        prompt = render_implement_prompt("foo/bar", 1, "t", body)
+        # The '@' marker isolates the body: the template contains none.
+        assert prompt.count("@") == 6000
+
+    def test_review_prompt_includes_repo_and_number(self):
+        prompt = render_review_prompt("foo/bar", 17, "PR title")
+        assert "foo/bar" in prompt
+        assert "#17" in prompt
+        assert "PR title" in prompt

--- a/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
+++ b/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
@@ -88,3 +88,53 @@ class TestPrompts:
         assert "foo/bar" in prompt
         assert "#17" in prompt
         assert "PR title" in prompt
+
+
+class TestSubscriptionAuthStripping:
+    """Verify ANTHROPIC_API_KEY is stripped from subprocess env by default."""
+
+    def test_build_env_strips_api_key_by_default(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        monkeypatch.setenv("PATH", "/bin")
+        d = ClaudeDispatcher()
+        env = d._build_env(None)
+        assert env is not None
+        assert "ANTHROPIC_API_KEY" not in env
+        assert env.get("PATH") == "/bin"  # other vars preserved
+
+    def test_build_env_strips_all_anthropic_auth_vars(self, monkeypatch):
+        for k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BEARER_TOKEN"):
+            monkeypatch.setenv(k, "secret")
+        d = ClaudeDispatcher()
+        env = d._build_env(None)
+        for k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BEARER_TOKEN"):
+            assert k not in env
+
+    def test_build_env_inherits_when_subscription_disabled(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        d = ClaudeDispatcher(prefer_subscription_auth=False)
+        env = d._build_env(None)
+        # None means "inherit parent env" — claude will see the API key.
+        assert env is None
+
+    def test_build_env_explicit_override_wins(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        d = ClaudeDispatcher()  # subscription mode by default
+        # Caller passes an explicit env — we don't second-guess them.
+        env = d._build_env({"X": "1", "ANTHROPIC_API_KEY": "explicit-key"})
+        assert env == {"X": "1", "ANTHROPIC_API_KEY": "explicit-key"}
+
+    async def test_run_uses_stripped_env(self, monkeypatch, fake_claude, tmp_path):
+        # Echo the env back so we can assert what claude actually saw.
+        echoer = tmp_path / "echo-env"
+        echoer.write_text(
+            "#!/bin/sh\n"
+            "echo \"key=${ANTHROPIC_API_KEY:-UNSET}\"\n"
+            "exit 0\n"
+        )
+        echoer.chmod(0o755)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-leak")
+        d = ClaudeDispatcher(claude_path=str(echoer), timeout_seconds=10)
+        result = await d.run("anything", cwd=tmp_path)
+        assert "key=UNSET" in result.stdout, \
+            f"expected ANTHROPIC_API_KEY to be stripped; got: {result.stdout!r}"

--- a/deile/tests/orchestration/pipeline/test_concurrency.py
+++ b/deile/tests/orchestration/pipeline/test_concurrency.py
@@ -1,0 +1,155 @@
+"""Tests for multi-monitor concurrency safety and identity-based partitioning.
+
+Validates that parallel monitors with distinct identities:
+- partition the issue space without overlap (sharding)
+- produce distinct branch names and worktree subdirs
+- correctly express ownership via labels
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.orchestration.pipeline.identity import IdentityError, MonitorIdentity
+
+
+class TestParallelMonitorSafety:
+
+    # ------------------------------------------------------------------
+    # Sharding correctness
+    # ------------------------------------------------------------------
+
+    def test_sharding_partitions_titles(self):
+        """For shard_count=2, every title is owned by exactly one monitor."""
+        id_a = MonitorIdentity(monitor_id="a", shard_index=0, shard_count=2)
+        id_b = MonitorIdentity(monitor_id="b", shard_index=1, shard_count=2)
+
+        titles = [f"issue title number {i}" for i in range(100)]
+        for title in titles:
+            owns_a = id_a.owns(title)
+            owns_b = id_b.owns(title)
+            # Exactly one shard must own each title.
+            assert owns_a != owns_b, (
+                f"Both or neither shard owns {title!r}: a={owns_a}, b={owns_b}"
+            )
+
+    def test_sharding_partitions_across_three_shards(self):
+        """For shard_count=3, exactly one of three monitors owns each title."""
+        monitors = [
+            MonitorIdentity(monitor_id=f"m{i}", shard_index=i, shard_count=3)
+            for i in range(3)
+        ]
+        for i in range(200):
+            title = f"title-{i}"
+            owners = [m for m in monitors if m.owns(title)]
+            assert len(owners) == 1, (
+                f"Expected exactly 1 owner for {title!r}, got {len(owners)}"
+            )
+
+    def test_default_identity_owns_all(self):
+        """With shard_count=1 (default), owns() always returns True."""
+        identity = MonitorIdentity()
+        titles = ["any title", "", "unicode: 日本語", "a" * 256]
+        for title in titles:
+            assert identity.owns(title), f"Default identity should own {title!r}"
+
+    def test_ownership_is_deterministic(self):
+        """Same (shard_index, shard_count, title) always produces the same result."""
+        id_x = MonitorIdentity(monitor_id="x", shard_index=0, shard_count=4)
+        title = "deterministic test title"
+        results = [id_x.owns(title) for _ in range(100)]
+        assert len(set(results)) == 1, "owns() is non-deterministic"
+
+    # ------------------------------------------------------------------
+    # Branch / worktree namespacing
+    # ------------------------------------------------------------------
+
+    def test_different_monitors_get_different_branches_for_same_issue(self):
+        """Two named monitors produce different branch names for issue #42."""
+        id_a = MonitorIdentity(monitor_id="a")
+        id_b = MonitorIdentity(monitor_id="b")
+
+        # branch_for_issue logic mirrors monitor.py's branch_for_issue()
+        def branch_for_issue(identity: MonitorIdentity, issue_number: int) -> str:
+            if identity.is_default:
+                return f"auto/issue-{issue_number}"
+            return f"{identity.branch_prefix('auto')}/issue-{issue_number}"
+
+        branch_a = branch_for_issue(id_a, 42)
+        branch_b = branch_for_issue(id_b, 42)
+
+        assert branch_a != branch_b
+        assert "a" in branch_a
+        assert "b" in branch_b
+
+    def test_default_identity_branch_uses_legacy_prefix(self):
+        identity = MonitorIdentity()
+        assert identity.branch_prefix("auto") == "auto"
+
+    def test_named_identity_branch_includes_monitor_id(self):
+        identity = MonitorIdentity(monitor_id="worker-1")
+        assert identity.branch_prefix("auto") == "auto/worker-1"
+
+    def test_different_monitors_get_different_worktree_subdirs(self):
+        """Named monitors return distinct non-None worktree subdirs."""
+        id_a = MonitorIdentity(monitor_id="monitor-alpha")
+        id_b = MonitorIdentity(monitor_id="monitor-beta")
+
+        subdir_a = id_a.worktree_subdir()
+        subdir_b = id_b.worktree_subdir()
+
+        assert subdir_a is not None
+        assert subdir_b is not None
+        assert subdir_a != subdir_b
+
+    def test_default_identity_worktree_subdir_is_none(self):
+        """Default identity uses no per-monitor subdirectory (legacy path)."""
+        identity = MonitorIdentity()
+        assert identity.worktree_subdir() is None
+
+    # ------------------------------------------------------------------
+    # Ownership labels
+    # ------------------------------------------------------------------
+
+    def test_ownership_label_unique_per_id(self):
+        """Different monitor IDs produce different ownership labels."""
+        identity1 = MonitorIdentity(monitor_id="alpha")
+        identity2 = MonitorIdentity(monitor_id="beta")
+        assert identity1.ownership_label() != identity2.ownership_label()
+
+    def test_ownership_label_format(self):
+        """Ownership label follows the ~by:<id> convention."""
+        identity = MonitorIdentity(monitor_id="my-worker")
+        assert identity.ownership_label() == "~by:my-worker"
+
+    def test_default_identity_ownership_label(self):
+        """Default identity produces ~by:default."""
+        identity = MonitorIdentity()
+        assert identity.ownership_label() == "~by:default"
+
+    # ------------------------------------------------------------------
+    # Identity validation
+    # ------------------------------------------------------------------
+
+    def test_invalid_monitor_id_raises(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(monitor_id="bad/id")
+
+    def test_invalid_shard_count_raises(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(shard_count=0)
+
+    def test_shard_index_out_of_range_raises(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(shard_index=2, shard_count=2)
+
+    def test_valid_boundary_identity(self):
+        """shard_index == shard_count-1 is valid."""
+        identity = MonitorIdentity(monitor_id="last", shard_index=1, shard_count=2)
+        assert identity.shard_index == 1
+
+    def test_is_default_requires_all_defaults(self):
+        """is_default is False even when only one parameter differs."""
+        assert MonitorIdentity().is_default
+        assert not MonitorIdentity(monitor_id="x").is_default
+        assert not MonitorIdentity(shard_index=0, shard_count=2).is_default

--- a/deile/tests/orchestration/pipeline/test_cron.py
+++ b/deile/tests/orchestration/pipeline/test_cron.py
@@ -1,0 +1,105 @@
+"""Unit tests for the tiny cron evaluator."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from deile.orchestration.pipeline.cron import (CronExpressionError, matches,
+                                               next_after, parse,
+                                               previous_or_equal)
+
+
+class TestParse:
+    def test_star(self):
+        m, h, dom, mon, dow = parse("* * * * *")
+        assert m == list(range(60))
+        assert h == list(range(24))
+        assert dom == list(range(1, 32))
+        assert mon == list(range(1, 13))
+        assert dow == list(range(7))
+
+    def test_step(self):
+        m, *_ = parse("*/5 * * * *")
+        assert m == [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]
+
+    def test_range(self):
+        _, h, *_ = parse("0 9-17 * * *")
+        assert h == list(range(9, 18))
+
+    def test_list(self):
+        _, h, *_ = parse("0 8,12,18 * * *")
+        assert h == [8, 12, 18]
+
+    def test_predefined_daily(self):
+        m, h, dom, mon, dow = parse("@daily")
+        assert m == [0]
+        assert h == [0]
+
+    def test_invalid_field_count(self):
+        with pytest.raises(CronExpressionError):
+            parse("* * * *")
+
+    def test_out_of_range(self):
+        with pytest.raises(CronExpressionError):
+            parse("99 * * * *")
+
+    def test_invalid_step_zero(self):
+        with pytest.raises(CronExpressionError):
+            parse("*/0 * * * *")
+
+
+class TestMatches:
+    def _dt(self, s: str) -> datetime:
+        return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+    def test_every_5_minutes_match(self):
+        assert matches("*/5 * * * *", self._dt("2026-05-06T01:00:00"))
+        assert matches("*/5 * * * *", self._dt("2026-05-06T01:05:00"))
+
+    def test_every_5_minutes_no_match(self):
+        assert not matches("*/5 * * * *", self._dt("2026-05-06T01:03:00"))
+
+    def test_specific_hour(self):
+        assert matches("0 14 * * *", self._dt("2026-05-06T14:00:00"))
+        assert not matches("0 14 * * *", self._dt("2026-05-06T14:05:00"))
+
+    def test_weekday_only(self):
+        # 2026-05-06 is Wed (weekday 2 → cron dow 3)
+        assert matches("0 9 * * 1-5", self._dt("2026-05-06T09:00:00"))
+        # 2026-05-09 is Sat (weekday 5 → cron dow 6)
+        assert not matches("0 9 * * 1-5", self._dt("2026-05-09T09:00:00"))
+
+
+class TestNextAfter:
+    def _dt(self, s: str) -> datetime:
+        return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+    def test_strictly_after(self):
+        nxt = next_after("*/5 * * * *", self._dt("2026-05-06T01:00:00"))
+        # Strictly AFTER 01:00 → 01:05
+        assert nxt == self._dt("2026-05-06T01:05:00")
+
+    def test_handles_day_rollover(self):
+        nxt = next_after("0 0 * * *", self._dt("2026-05-06T23:30:00"))
+        assert nxt == self._dt("2026-05-07T00:00:00")
+
+    def test_naive_datetime_assumed_utc(self):
+        # Should not raise.
+        nxt = next_after("*/10 * * * *", datetime(2026, 5, 6, 1, 0, 0))
+        assert nxt.tzinfo is not None
+
+
+class TestPreviousOrEqual:
+    def _dt(self, s: str) -> datetime:
+        return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+    def test_returns_self_when_match(self):
+        assert previous_or_equal("*/5 * * * *", self._dt("2026-05-06T01:05:00")) == \
+               self._dt("2026-05-06T01:05:00")
+
+    def test_searches_backwards(self):
+        # 01:03 is not a match for */5; previous match is 01:00
+        assert previous_or_equal("*/5 * * * *", self._dt("2026-05-06T01:03:00")) == \
+               self._dt("2026-05-06T01:00:00")

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -1,0 +1,173 @@
+"""Unit tests for GitHubClient — mocks the `gh` subprocess."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.github_client import (GhCommandError,
+                                                        GitHubClient,
+                                                        IssueRef, PrRef,
+                                                        compute_batch_id)
+from deile.orchestration.pipeline.labels import (REVIEW_PENDING, WORKFLOW_NEW,
+                                                 WORKFLOW_REVIEWED,
+                                                 WORKFLOW_REVIEWING)
+
+
+class TestComputeBatchId:
+    def test_deterministic(self):
+        assert compute_batch_id("hello") == compute_batch_id("hello")
+
+    def test_changes_with_title(self):
+        assert compute_batch_id("a") != compute_batch_id("b")
+
+    def test_strips_whitespace(self):
+        assert compute_batch_id("  hello  ") == compute_batch_id("hello")
+
+    def test_returns_8_hex_chars(self):
+        bid = compute_batch_id("anything")
+        assert len(bid) == 8
+        int(bid, 16)
+
+
+class TestGitHubClientCtor:
+    def test_rejects_invalid_repo(self):
+        with pytest.raises(ValueError):
+            GitHubClient("just-a-name")
+
+    def test_accepts_owner_slash_name(self):
+        client = GitHubClient("owner/name")
+        assert client.repo == "owner/name"
+
+
+class TestListIssues:
+    async def test_list_issues_with_label_parses_json(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 1,
+                "title": "primeira",
+                "url": "https://github.com/owner/name/issues/1",
+                "labels": [{"name": WORKFLOW_NEW}],
+                "body": "corpo",
+                "state": "open",
+            },
+            {
+                "number": 2,
+                "title": "segunda",
+                "url": "https://github.com/owner/name/issues/2",
+                "labels": [{"name": WORKFLOW_NEW}, {"name": "~batch:abcd1234"}],
+                "body": "outro corpo",
+                "state": "open",
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            issues = await client.list_issues_with_label(WORKFLOW_NEW)
+        assert len(issues) == 2
+        assert issues[0].number == 1
+        assert issues[0].batch_id is None
+        assert issues[1].batch_id == "abcd1234"
+
+    async def test_list_issues_returns_empty_on_empty_output(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
+            issues = await client.list_issues_with_label(WORKFLOW_NEW)
+        assert issues == []
+
+
+class TestGetIssue:
+    async def test_get_issue_parses_single_object(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps({
+            "number": 9,
+            "title": "test",
+            "url": "https://github.com/owner/name/issues/9",
+            "labels": [{"name": WORKFLOW_REVIEWED}],
+            "body": "",
+            "state": "open",
+        })
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            issue = await client.get_issue(9)
+        assert issue.number == 9
+        assert WORKFLOW_REVIEWED in issue.labels
+
+
+class TestTransitions:
+    async def test_transition_issue_swaps_labels(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+            await client.transition_issue(7, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING)
+        # Two calls: remove + add
+        assert run.call_count == 2
+        remove_call = run.call_args_list[0].args
+        add_call = run.call_args_list[1].args
+        assert "--remove-label" in remove_call
+        assert WORKFLOW_NEW in remove_call
+        assert "--add-label" in add_call
+        assert WORKFLOW_REVIEWING in add_call
+
+    async def test_transition_skips_remove_when_from_label_none(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+            await client.transition_pr(7, from_label=None, to_label=REVIEW_PENDING)
+        assert run.call_count == 1
+
+
+class TestClaimWithBatch:
+    async def test_claim_returns_batch_id_when_unclaimed(self):
+        client = GitHubClient("owner/name")
+        unclaimed = IssueRef(
+            number=5,
+            title="claim me",
+            url="x",
+            labels=(WORKFLOW_NEW,),
+        )
+        with patch.object(client, "get_issue", new=AsyncMock(return_value=unclaimed)), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
+            bid = await client.claim_with_batch("issue", 5, "claim me")
+        assert bid == compute_batch_id("claim me")
+
+    async def test_claim_returns_none_when_already_claimed(self):
+        client = GitHubClient("owner/name")
+        claimed = IssueRef(
+            number=5,
+            title="claim me",
+            url="x",
+            labels=(WORKFLOW_NEW, "~batch:dead0000"),
+        )
+        with patch.object(client, "get_issue", new=AsyncMock(return_value=claimed)):
+            bid = await client.claim_with_batch("issue", 5, "claim me")
+        assert bid is None
+
+    async def test_claim_pr_uses_pr_list(self):
+        client = GitHubClient("owner/name")
+        pr = PrRef(number=7, title="t", url="u", labels=(REVIEW_PENDING,))
+        with patch.object(client, "list_open_prs", new=AsyncMock(return_value=[pr])), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
+            bid = await client.claim_with_batch("pr", 7, "t")
+        assert bid is not None
+
+    async def test_claim_rejects_invalid_kind(self):
+        client = GitHubClient("owner/name")
+        with pytest.raises(ValueError):
+            await client.claim_with_batch("comment", 1, "x")
+
+
+class TestEnsureLabels:
+    async def test_creates_all_labels_idempotent(self):
+        client = GitHubClient("owner/name")
+        # `_run` returns rc=0 first call, rc=1 thereafter (already exists).
+        rcs = iter([(0, "", ""), (1, "", "exists"), (1, "", ""), (1, "", ""),
+                    (1, "", ""), (1, "", ""), (1, "", ""), (1, "", ""), (1, "", "")])
+        with patch.object(client, "_run", new=AsyncMock(side_effect=lambda *a: next(rcs))):
+            # Should not raise, regardless of existing/missing.
+            await client.ensure_pipeline_labels()
+
+
+class TestGhCommandError:
+    def test_error_carries_metadata(self):
+        err = GhCommandError(("gh", "issue", "list"), 2, "out", "err msg")
+        assert err.returncode == 2
+        assert "err msg" in str(err)

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -171,3 +171,33 @@ class TestGhCommandError:
         err = GhCommandError(("gh", "issue", "list"), 2, "out", "err msg")
         assert err.returncode == 2
         assert "err msg" in str(err)
+
+
+class TestEnsureLabelOnClaim:
+    """The batch lock label must be created on-demand by claim_with_batch."""
+
+    async def test_claim_creates_batch_label_before_adding(self):
+        from unittest.mock import AsyncMock, patch
+        client = GitHubClient("owner/name")
+        unclaimed = IssueRef(
+            number=42, title="brand new", url="x", labels=(WORKFLOW_NEW,),
+        )
+        calls = []
+
+        async def fake_run(*args):
+            calls.append(args)
+            return (0, "", "")
+
+        async def fake_run_checked(*args):
+            calls.append(args)
+            return ""
+
+        with patch.object(client, "get_issue", new=AsyncMock(return_value=unclaimed)), \
+             patch.object(client, "_run", side_effect=fake_run), \
+             patch.object(client, "_run_checked", side_effect=fake_run_checked):
+            bid = await client.claim_with_batch("issue", 42, "brand new")
+
+        assert bid is not None
+        # The first call must be `label create ~batch:<bid>` via _run
+        assert calls[0][0] == "label" and calls[0][1] == "create"
+        assert calls[0][2].startswith("~batch:")

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -201,3 +201,44 @@ class TestEnsureLabelOnClaim:
         # The first call must be `label create ~batch:<bid>` via _run
         assert calls[0][0] == "label" and calls[0][1] == "create"
         assert calls[0][2].startswith("~batch:")
+
+    async def test_claim_pr_creates_batch_label_before_adding(self):
+        """For PRs, _ensure_label must be called BEFORE add_labels — same
+        contract as for issues (tested above).  This test verifies call order
+        using a spy that records every invocation."""
+        client = GitHubClient("owner/name")
+        unclaimed_pr = PrRef(
+            number=11, title="pr title", url="u", labels=(REVIEW_PENDING,),
+            head_ref="auto/issue-11",
+        )
+        calls = []
+
+        async def fake_run(*args):
+            calls.append(("_run", *args))
+            return (0, "", "")
+
+        async def fake_run_checked(*args):
+            calls.append(("_run_checked", *args))
+            return ""
+
+        with patch.object(client, "list_open_prs", new=AsyncMock(return_value=[unclaimed_pr])), \
+             patch.object(client, "_run", side_effect=fake_run), \
+             patch.object(client, "_run_checked", side_effect=fake_run_checked):
+            bid = await client.claim_with_batch("pr", 11, "pr title")
+
+        assert bid is not None
+
+        # Locate the _ensure_label call (label create) and the add_labels call.
+        ensure_idx = next(
+            (i for i, c in enumerate(calls) if c[0] == "_run" and "label" in c and "create" in c),
+            None,
+        )
+        add_idx = next(
+            (i for i, c in enumerate(calls) if c[0] == "_run_checked" and "edit" in c),
+            None,
+        )
+        assert ensure_idx is not None, f"_ensure_label not called; calls={calls}"
+        assert add_idx is not None, f"add_labels not called; calls={calls}"
+        assert ensure_idx < add_idx, (
+            f"_ensure_label (idx={ensure_idx}) must precede add_labels (idx={add_idx})"
+        )

--- a/deile/tests/orchestration/pipeline/test_identity.py
+++ b/deile/tests/orchestration/pipeline/test_identity.py
@@ -1,0 +1,99 @@
+"""Unit tests for MonitorIdentity."""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.orchestration.pipeline.identity import (IdentityError,
+                                                    MonitorIdentity)
+
+
+class TestConstruction:
+    def test_default(self):
+        i = MonitorIdentity()
+        assert i.monitor_id == "default"
+        assert i.shard_index == 0
+        assert i.shard_count == 1
+        assert i.is_default
+
+    def test_custom(self):
+        i = MonitorIdentity(monitor_id="m-alfa", shard_index=0, shard_count=2)
+        assert not i.is_default
+        assert i.shard_count == 2
+
+    def test_invalid_monitor_id_chars(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(monitor_id="bad/id")
+
+    def test_invalid_monitor_id_empty(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(monitor_id="")
+
+    def test_invalid_shard_index_out_of_range(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(monitor_id="m", shard_index=2, shard_count=2)
+
+    def test_invalid_shard_count_zero(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(monitor_id="m", shard_count=0)
+
+
+class TestFromEnv:
+    def test_defaults_when_no_env(self, monkeypatch):
+        for k in ("DEILE_PIPELINE_MONITOR_ID", "DEILE_PIPELINE_SHARD_INDEX",
+                  "DEILE_PIPELINE_SHARD_COUNT"):
+            monkeypatch.delenv(k, raising=False)
+        i = MonitorIdentity.from_env()
+        assert i.is_default
+
+    def test_reads_env_vars(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_MONITOR_ID", "m-beta")
+        monkeypatch.setenv("DEILE_PIPELINE_SHARD_INDEX", "1")
+        monkeypatch.setenv("DEILE_PIPELINE_SHARD_COUNT", "3")
+        i = MonitorIdentity.from_env()
+        assert i.monitor_id == "m-beta"
+        assert i.shard_index == 1
+        assert i.shard_count == 3
+
+
+class TestSharding:
+    def test_owns_everything_when_count_one(self):
+        i = MonitorIdentity()
+        assert i.owns("any title")
+        assert i.owns("another")
+
+    def test_two_shards_partition_keys(self):
+        a = MonitorIdentity(monitor_id="a", shard_index=0, shard_count=2)
+        b = MonitorIdentity(monitor_id="b", shard_index=1, shard_count=2)
+        # For each key, exactly one shard owns it.
+        for key in ("issue 1", "issue 2", "feature X", "bug Y"):
+            assert a.owns(key) ^ b.owns(key), f"{key!r} ownership not partitioned"
+
+    def test_owns_is_deterministic(self):
+        i = MonitorIdentity(monitor_id="m", shard_index=0, shard_count=4)
+        assert i.owns("hello") == i.owns("hello")
+
+
+class TestNamespacing:
+    def test_default_branch_prefix_is_legacy(self):
+        i = MonitorIdentity()
+        assert i.branch_prefix("auto") == "auto"
+
+    def test_custom_branch_prefix_includes_id(self):
+        i = MonitorIdentity(monitor_id="m-alfa")
+        assert i.branch_prefix("auto") == "auto/m-alfa"
+
+    def test_default_worktree_subdir_is_none(self):
+        assert MonitorIdentity().worktree_subdir() is None
+
+    def test_custom_worktree_subdir_is_id(self):
+        i = MonitorIdentity(monitor_id="m-alfa")
+        assert i.worktree_subdir() == "m-alfa"
+
+    def test_ownership_label_format(self):
+        i = MonitorIdentity(monitor_id="m-alfa")
+        assert i.ownership_label() == "~by:m-alfa"
+
+    def test_lockfile_name_includes_id(self):
+        i = MonitorIdentity(monitor_id="m-alfa")
+        assert i.lockfile_name() == ".deile-pipeline-m-alfa.lock"

--- a/deile/tests/orchestration/pipeline/test_labels.py
+++ b/deile/tests/orchestration/pipeline/test_labels.py
@@ -1,0 +1,56 @@
+"""Unit tests for label name constants and helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.orchestration.pipeline.labels import (BATCH_LABEL_PREFIX,
+                                                 LABEL_COLORS,
+                                                 LABEL_DESCRIPTIONS,
+                                                 REVIEW_CONCLUDED,
+                                                 REVIEW_LABELS,
+                                                 REVIEW_PENDING,
+                                                 WORKFLOW_LABELS, WORKFLOW_NEW,
+                                                 batch_id_from_label,
+                                                 is_batch_label,
+                                                 make_batch_label)
+
+
+class TestLabelConstants:
+    def test_workflow_labels_use_tilde_prefix(self):
+        for label in WORKFLOW_LABELS:
+            assert label.startswith("~workflow:")
+
+    def test_review_labels_use_tilde_prefix(self):
+        for label in REVIEW_LABELS:
+            assert label.startswith("~review:")
+
+    def test_batch_prefix(self):
+        assert BATCH_LABEL_PREFIX == "~batch:"
+
+    def test_every_label_has_color_and_description(self):
+        for label in (*WORKFLOW_LABELS, *REVIEW_LABELS):
+            assert label in LABEL_COLORS
+            assert label in LABEL_DESCRIPTIONS
+            # Colors are 6-digit hex (no #).
+            assert len(LABEL_COLORS[label]) == 6
+            int(LABEL_COLORS[label], 16)
+
+
+class TestBatchHelpers:
+    def test_make_batch_label_uses_prefix(self):
+        assert make_batch_label("abc12345") == "~batch:abc12345"
+
+    def test_is_batch_label_true_for_prefixed(self):
+        assert is_batch_label("~batch:abc12345")
+
+    def test_is_batch_label_false_for_workflow(self):
+        assert not is_batch_label(WORKFLOW_NEW)
+        assert not is_batch_label(REVIEW_PENDING)
+
+    def test_batch_id_from_label_extracts_id(self):
+        assert batch_id_from_label("~batch:f00dcafe") == "f00dcafe"
+
+    def test_batch_id_from_label_rejects_non_batch(self):
+        with pytest.raises(ValueError):
+            batch_id_from_label(WORKFLOW_NEW)

--- a/deile/tests/orchestration/pipeline/test_lockfile.py
+++ b/deile/tests/orchestration/pipeline/test_lockfile.py
@@ -1,0 +1,76 @@
+"""Unit tests for PID lockfile."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from deile.orchestration.pipeline.lockfile import (LockHeldError, _pid_alive,
+                                                    acquire, pid_lock, release)
+
+
+class TestPidAlive:
+    def test_self_is_alive(self):
+        assert _pid_alive(os.getpid())
+
+    def test_huge_pid_not_alive(self):
+        assert not _pid_alive(2**31 - 1)
+
+    def test_zero_or_negative_not_alive(self):
+        assert not _pid_alive(0)
+        assert not _pid_alive(-1)
+
+
+class TestAcquireRelease:
+    def test_acquire_creates_file_with_pid(self, tmp_path):
+        path = tmp_path / "x.lock"
+        acquire(path)
+        assert path.exists()
+        assert path.read_text().strip() == str(os.getpid())
+
+    def test_acquire_replaces_stale_pid(self, tmp_path):
+        path = tmp_path / "x.lock"
+        path.write_text("999999\n")  # almost certainly dead
+        acquire(path)
+        assert path.read_text().strip() == str(os.getpid())
+
+    def test_acquire_raises_when_live_pid_holds(self, tmp_path):
+        path = tmp_path / "x.lock"
+        # Write our own current PID, then try to acquire as a different PID.
+        path.write_text(f"{os.getpid()}\n")
+        with pytest.raises(LockHeldError) as exc:
+            acquire(path, holder_pid=os.getpid() + 1)
+        assert exc.value.holder_pid == os.getpid()
+
+    def test_release_removes_self_owned_lock(self, tmp_path):
+        path = tmp_path / "x.lock"
+        acquire(path)
+        release(path)
+        assert not path.exists()
+
+    def test_release_leaves_foreign_lock(self, tmp_path):
+        path = tmp_path / "x.lock"
+        path.write_text(f"{os.getpid()}\n")
+        release(path, holder_pid=os.getpid() + 1)  # not us
+        assert path.exists()
+
+    def test_release_missing_is_noop(self, tmp_path):
+        # Should not raise.
+        release(tmp_path / "missing.lock")
+
+
+class TestPidLockContextManager:
+    def test_acquires_and_releases(self, tmp_path):
+        path = tmp_path / "x.lock"
+        with pid_lock(path) as p:
+            assert p.exists()
+        assert not path.exists()
+
+    def test_releases_on_exception(self, tmp_path):
+        path = tmp_path / "x.lock"
+        with pytest.raises(RuntimeError):
+            with pid_lock(path):
+                assert path.exists()
+                raise RuntimeError("boom")
+        assert not path.exists()

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -226,3 +226,60 @@ class TestLifecycle:
         await monitor.stop()
         assert monitor.stats.ticks >= 1
         monitor.github.ensure_pipeline_labels.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Multi-monitor identity-aware tests
+# ---------------------------------------------------------------------------
+
+from deile.orchestration.pipeline.identity import MonitorIdentity
+
+
+class TestIdentityAwareSelection:
+    async def test_default_identity_picks_any_issue(self, tmp_path):
+        new_issue = IssueRef(number=1, title="t", url="u", labels=(WORKFLOW_NEW,))
+        monitor, notifier = _make_monitor(issues_new=[new_issue])
+        # default identity (shard_count=1) → owns everything
+        await monitor.tick()
+        notifier.issue_picked_up.assert_called_once()
+
+    async def test_sharded_identity_skips_other_shard(self, tmp_path):
+        # Pick a title that hashes to shard 1 (we'll make monitor be shard 0).
+        # Iterate to find one.
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+        a = MonitorIdentity(monitor_id="a", shard_index=0, shard_count=2)
+        # Find a title that shard 0 does NOT own.
+        title = None
+        for i in range(1, 100):
+            cand = f"some title {i}"
+            if not a.owns(cand):
+                title = cand
+                break
+        assert title is not None, "could not find unowned title"
+        new_issue = IssueRef(number=1, title=title, url="u", labels=(WORKFLOW_NEW,))
+        monitor, notifier = _make_monitor(issues_new=[new_issue])
+        monitor.identity = a
+        await monitor.tick()
+        notifier.issue_picked_up.assert_not_called()
+
+    async def test_branch_for_issue_uses_default_prefix(self):
+        monitor, _ = _make_monitor()
+        # default identity → legacy prefix
+        assert monitor.branch_for_issue(42) == "auto/issue-42"
+
+    async def test_branch_for_issue_uses_namespaced_prefix(self):
+        monitor, _ = _make_monitor()
+        monitor.identity = MonitorIdentity(monitor_id="m-alfa")
+        assert monitor.branch_for_issue(42) == "auto/m-alfa/issue-42"
+
+    async def test_pr_ownership_default_matches_legacy_prefix(self):
+        monitor, _ = _make_monitor()
+        assert monitor._owns_pr_branch("auto/issue-42")
+        assert not monitor._owns_pr_branch("feat/something-else")
+
+    async def test_pr_ownership_namespaced(self):
+        monitor, _ = _make_monitor()
+        monitor.identity = MonitorIdentity(monitor_id="m-alfa")
+        assert monitor._owns_pr_branch("auto/m-alfa/issue-1")
+        assert not monitor._owns_pr_branch("auto/m-beta/issue-1")
+        assert not monitor._owns_pr_branch("auto/issue-1")  # legacy prefix not ours

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -283,3 +283,110 @@ class TestIdentityAwareSelection:
         assert monitor._owns_pr_branch("auto/m-alfa/issue-1")
         assert not monitor._owns_pr_branch("auto/m-beta/issue-1")
         assert not monitor._owns_pr_branch("auto/issue-1")  # legacy prefix not ours
+
+
+# ---------------------------------------------------------------------------
+# PID lock auto-enable for non-default identity
+# ---------------------------------------------------------------------------
+
+def _make_minimal_monitor(
+    tmp_path,
+    *,
+    identity,
+    use_pid_lock: bool = False,
+):
+    """Build a PipelineMonitor with all I/O mocked, using ``tmp_path`` as repo."""
+    from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+    from deile.orchestration.pipeline.worktree_manager import Worktree
+
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=tmp_path,
+        use_pid_lock=use_pid_lock,
+        poll_interval_seconds=60,
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(return_value=[])
+    github.list_open_prs = AsyncMock(return_value=[])
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(path=tmp_path / ".wt", branch="x", base_repo=tmp_path)
+    )
+
+    notifier = MagicMock()
+    for attr in ("issue_picked_up", "issue_reviewed", "implementation_started",
+                 "implementation_finished", "pr_picked_up", "pr_reviewed", "error"):
+        setattr(notifier, attr, AsyncMock())
+
+    schedule_store = MagicMock()
+    schedule_store.load = MagicMock(return_value=MagicMock(
+        recurring=[], oneshot=[], compute_pending=MagicMock(return_value=[])
+    ))
+
+    return PipelineMonitor(
+        cfg,
+        github=github,
+        worktrees=worktrees,
+        notifier=notifier,
+        identity=identity,
+        schedule_store=schedule_store,
+    )
+
+
+class TestPidLockAutoEnable:
+    async def test_non_default_identity_creates_lockfile(self, tmp_path):
+        """A non-default identity must acquire a PID lock even when
+        config.use_pid_lock is False (multi-monitor guard)."""
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+
+        identity = MonitorIdentity(monitor_id="gamma")
+        monitor = _make_minimal_monitor(tmp_path, identity=identity, use_pid_lock=False)
+        try:
+            await monitor.start()
+            # After start(), the lockfile must exist under base_repo_path.
+            lock_path = tmp_path / identity.lockfile_name()
+            assert lock_path.exists(), f"expected lockfile at {lock_path}"
+        finally:
+            await monitor.stop()
+
+    async def test_default_identity_no_pid_lock_flag_skips_lockfile(self, tmp_path):
+        """Default identity with use_pid_lock=False must NOT create a lockfile."""
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+
+        identity = MonitorIdentity()  # default
+        monitor = _make_minimal_monitor(tmp_path, identity=identity, use_pid_lock=False)
+        try:
+            await monitor.start()
+            # No lockfile should be created for the default identity without flag.
+            lock_path = tmp_path / identity.lockfile_name()
+            assert not lock_path.exists(), f"unexpected lockfile at {lock_path}"
+        finally:
+            await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# Ownership label stamped on claimed PRs
+# ---------------------------------------------------------------------------
+
+class TestPrOwnershipLabel:
+    async def test_claimed_pr_gets_ownership_label(self):
+        """After a PR is claimed in stage 3, the monitor's ownership label must
+        be stamped on the PR — mirroring stage 1 issue behaviour."""
+        pr = PrRef(
+            number=77, title="my pr", url="https://x/pull/77",
+            labels=(REVIEW_PENDING,), head_ref="auto/issue-5",
+        )
+        monitor, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        await monitor.tick()
+
+        # ownership label must have been added
+        ownership = monitor.identity.ownership_label()
+        add_labels_calls = monitor.github.add_labels.call_args_list
+        ownership_calls = [c for c in add_labels_calls if ownership in (c.args[2] if c.args else [])]
+        assert ownership_calls, (
+            f"expected add_labels call with {ownership!r}; calls were: {add_labels_calls}"
+        )

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -1,0 +1,228 @@
+"""Unit tests for PipelineMonitor — uses mocked GitHub/Claude/Worktree/Notifier."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import IssueRef, PrRef
+from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
+                                                 REVIEW_IN_PROGRESS,
+                                                 REVIEW_PENDING, WORKFLOW_NEW,
+                                                 WORKFLOW_PR,
+                                                 WORKFLOW_REVIEWED)
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor,
+                                                  _extract_pr_url)
+from deile.orchestration.pipeline.worktree_manager import Worktree
+
+
+def _make_monitor(
+    *,
+    issues_new: Optional[List[IssueRef]] = None,
+    issues_reviewed: Optional[List[IssueRef]] = None,
+    prs: Optional[List[PrRef]] = None,
+    claude_stdout: str = "",
+    claude_rc: int = 0,
+    review_callback=None,
+) -> Tuple[PipelineMonitor, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(side_effect=lambda label, **_: {
+        WORKFLOW_NEW: list(issues_new or []),
+        WORKFLOW_REVIEWED: list(issues_reviewed or []),
+    }.get(label, []))
+    github.list_open_prs = AsyncMock(return_value=list(prs or []))
+    github.claim_with_batch = AsyncMock(return_value="abc12345")
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(path=Path("/tmp/fake/.worktrees/x"),
+                              branch="x", base_repo=Path("/tmp/fake"))
+    )
+
+    claude = MagicMock()
+    claude.run = AsyncMock(return_value=ClaudeRunResult(
+        returncode=claude_rc,
+        stdout=claude_stdout,
+        stderr="",
+        duration_seconds=0.1,
+        cmd=("claude", "-p", "x"),
+    ))
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up", "issue_reviewed", "implementation_started",
+        "implementation_finished", "pr_picked_up", "pr_reviewed", "error",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    monitor = PipelineMonitor(
+        cfg, github=github, worktrees=worktrees, claude=claude, notifier=notifier,
+        review_callback=review_callback,
+    )
+    return monitor, notifier
+
+
+class TestExtractPrUrl:
+    def test_extracts_pr_url(self):
+        assert _extract_pr_url("see https://github.com/o/r/pull/9") == \
+            "https://github.com/o/r/pull/9"
+
+    def test_returns_none_when_no_url(self):
+        assert _extract_pr_url("nothing here") is None
+
+    def test_handles_empty_string(self):
+        assert _extract_pr_url("") is None
+
+
+class TestStage1Review:
+    async def test_no_new_issues_no_op(self):
+        monitor, notifier = _make_monitor(issues_new=[])
+        await monitor.tick()
+        notifier.issue_picked_up.assert_not_called()
+
+    async def test_picks_up_first_unclaimed_issue(self):
+        new_issue = IssueRef(number=1, title="t", url="u", labels=(WORKFLOW_NEW,))
+        monitor, notifier = _make_monitor(issues_new=[new_issue])
+        await monitor.tick()
+        notifier.issue_picked_up.assert_called_once()
+        notifier.issue_reviewed.assert_called_once()
+        assert monitor.stats.issues_reviewed == 1
+
+    async def test_skips_already_claimed(self):
+        claimed = IssueRef(
+            number=1, title="t", url="u",
+            labels=(WORKFLOW_NEW, "~batch:dead0000"),
+        )
+        monitor, notifier = _make_monitor(issues_new=[claimed])
+        await monitor.tick()
+        notifier.issue_picked_up.assert_not_called()
+
+    async def test_review_callback_invoked(self):
+        new_issue = IssueRef(number=1, title="t", url="u", labels=(WORKFLOW_NEW,))
+        called: List[IssueRef] = []
+
+        async def cb(i):
+            called.append(i)
+            return "review comment"
+
+        monitor, notifier = _make_monitor(issues_new=[new_issue], review_callback=cb)
+        await monitor.tick()
+        assert called and called[0].number == 1
+        monitor.github.comment_on_issue.assert_called_once_with(1, "review comment")
+
+
+class TestStage2Implement:
+    async def test_implements_reviewed_with_batch(self):
+        rev = IssueRef(
+            number=2, title="impl me", url="u",
+            labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
+        )
+        monitor, notifier = _make_monitor(
+            issues_reviewed=[rev],
+            claude_stdout="Done. https://github.com/owner/name/pull/3",
+        )
+        # Disable stage 1 and 3 to focus on stage 2.
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_finished.assert_called_once()
+        # PR URL extracted from stdout
+        args, kwargs = notifier.implementation_finished.call_args
+        assert args[1] == "https://github.com/owner/name/pull/3"
+        assert monitor.stats.issues_implemented == 1
+
+    async def test_skips_reviewed_without_batch(self):
+        rev = IssueRef(
+            number=2, title="t", url="u",
+            labels=(WORKFLOW_REVIEWED,),  # no batch claim
+        )
+        monitor, notifier = _make_monitor(issues_reviewed=[rev])
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        notifier.implementation_started.assert_not_called()
+
+    async def test_claude_failure_emits_error(self):
+        rev = IssueRef(
+            number=2, title="t", url="u",
+            labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
+        )
+        monitor, notifier = _make_monitor(
+            issues_reviewed=[rev],
+            claude_rc=2,
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        notifier.error.assert_called_once()
+        notifier.implementation_finished.assert_not_called()
+
+
+class TestStage3PrReview:
+    async def test_picks_up_unclaimed_open_pr(self):
+        pr = PrRef(number=10, title="prt", url="https://x/pull/10",
+                   labels=(REVIEW_PENDING,), head_ref="auto/issue-2")
+        monitor, notifier = _make_monitor(prs=[pr], claude_stdout="merged.")
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        await monitor.tick()
+        notifier.pr_picked_up.assert_called_once()
+        notifier.pr_reviewed.assert_called_once()
+        assert monitor.stats.prs_reviewed == 1
+
+    async def test_skips_drafts(self):
+        pr = PrRef(number=10, title="t", url="u", labels=(),
+                   head_ref="x", is_draft=True)
+        monitor, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        await monitor.tick()
+        notifier.pr_picked_up.assert_not_called()
+
+    async def test_skips_concluded_prs(self):
+        pr = PrRef(number=10, title="t", url="u",
+                   labels=(REVIEW_CONCLUDED,), head_ref="x")
+        monitor, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        await monitor.tick()
+        notifier.pr_picked_up.assert_not_called()
+
+    async def test_skips_in_progress_prs(self):
+        pr = PrRef(number=10, title="t", url="u",
+                   labels=(REVIEW_IN_PROGRESS,), head_ref="x")
+        monitor, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        await monitor.tick()
+        notifier.pr_picked_up.assert_not_called()
+
+
+class TestLifecycle:
+    async def test_start_then_stop_runs_at_least_one_tick(self):
+        monitor, notifier = _make_monitor()
+        monitor.config.poll_interval_seconds = 1
+        await monitor.start()
+        # Allow the first tick to fire.
+        import asyncio
+        await asyncio.sleep(0.05)
+        await monitor.stop()
+        assert monitor.stats.ticks >= 1
+        monitor.github.ensure_pipeline_labels.assert_called_once()

--- a/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
+++ b/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
@@ -1,0 +1,291 @@
+"""Integration tests for PipelineMonitor + ScheduleStore scheduling logic.
+
+Validates:
+- schedule-driven ticks only run due actions
+- fallback to legacy "all every tick" when no schedule exists
+- catch-up on startup drains missed runs in chronological order
+- one-shot entries fire once and are marked completed
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import IssueRef, PrRef
+from deile.orchestration.pipeline.labels import (
+    WORKFLOW_NEW,
+    WORKFLOW_REVIEWED,
+    WORKFLOW_PR,
+    REVIEW_PENDING,
+    REVIEW_IN_PROGRESS,
+    REVIEW_CONCLUDED,
+)
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+from deile.orchestration.pipeline.scheduler import (
+    OneshotEntry,
+    RecurringEntry,
+    Schedule,
+    ScheduleStore,
+)
+from deile.orchestration.pipeline.worktree_manager import Worktree
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_BATCH_ID = "deadbeef"
+
+
+def _utc(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+def _make_monitor_sched(
+    tmp_path: Path,
+    *,
+    issues_new: Optional[List[IssueRef]] = None,
+    issues_reviewed: Optional[List[IssueRef]] = None,
+    prs: Optional[List[PrRef]] = None,
+    claude_stdout: str = "",
+    claude_rc: int = 0,
+    schedule_store: Optional[ScheduleStore] = None,
+) -> Tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/repo",
+        base_repo_path=tmp_path,
+        notify_user_id=None,
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: {
+            WORKFLOW_NEW: list(issues_new or []),
+            WORKFLOW_REVIEWED: list(issues_reviewed or []),
+        }.get(label, [])
+    )
+    github.list_open_prs = AsyncMock(return_value=list(prs or []))
+    github.claim_with_batch = AsyncMock(return_value=_BATCH_ID)
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(
+            path=tmp_path / ".worktrees" / "x",
+            branch="x",
+            base_repo=tmp_path,
+        )
+    )
+
+    claude = MagicMock()
+    claude.run = AsyncMock(
+        return_value=ClaudeRunResult(
+            returncode=claude_rc,
+            stdout=claude_stdout,
+            stderr="",
+            duration_seconds=0.1,
+            cmd=("claude", "-p", "x"),
+        )
+    )
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up",
+        "issue_reviewed",
+        "implementation_started",
+        "implementation_finished",
+        "pr_picked_up",
+        "pr_reviewed",
+        "error",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    monitor = PipelineMonitor(
+        cfg,
+        github=github,
+        worktrees=worktrees,
+        claude=claude,
+        notifier=notifier,
+        schedule_store=schedule_store,
+    )
+    return monitor, github, notifier
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorScheduleIntegration:
+    async def test_tick_with_schedule_runs_only_due_actions(self, tmp_path):
+        """A schedule with a due 'review' entry and a future 'implement' entry
+        should invoke the review path but NOT the implement path."""
+        issue_nova = IssueRef(
+            number=1, title="sched issue", url="u", labels=(WORKFLOW_NEW,)
+        )
+
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        # review: due (last_run_at = 2 hours ago)
+        s.add_recurring(
+            RecurringEntry(
+                id="rev-loop",
+                action="review",
+                cron="*/5 * * * *",
+                last_run_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            )
+        )
+        # implement: NOT due (last_run_at = just now → next fire is in the future)
+        s.add_recurring(
+            RecurringEntry(
+                id="impl-loop",
+                action="implement",
+                cron="*/5 * * * *",
+                last_run_at=datetime.now(timezone.utc),
+            )
+        )
+        store.save(s)
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            schedule_store=store,
+        )
+        await monitor.tick()
+
+        # review path fired
+        notifier.issue_picked_up.assert_called_once()
+        # implement path did NOT fire (no implementation_started)
+        notifier.implementation_started.assert_not_called()
+
+    async def test_tick_without_schedule_falls_back_to_legacy(self, tmp_path):
+        """When no schedule file exists, all enabled stages run every tick."""
+        issue_nova = IssueRef(
+            number=2, title="legacy issue", url="u", labels=(WORKFLOW_NEW,)
+        )
+        # Store with no file on disk (empty schedule)
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        # Do NOT call store.save() — keep file missing → load() returns Schedule()
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            schedule_store=store,
+        )
+        await monitor.tick()
+
+        # Stage 1 must have run (legacy fallback)
+        notifier.issue_picked_up.assert_called_once()
+
+    async def test_catchup_drains_pending_on_start(self, tmp_path):
+        """On start(), catch-up drains all due entries in chronological order
+        and stats.catchup_runs reflects the count."""
+        now = datetime.now(timezone.utc)
+
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        # 3 one-shot entries, all in the past (oldest first)
+        for i, minutes_ago in enumerate([30, 20, 10]):
+            s.add_oneshot(
+                OneshotEntry(
+                    id=f"oneshot-{i}",
+                    action="review",
+                    run_at=now - timedelta(minutes=minutes_ago),
+                )
+            )
+        store.save(s)
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            schedule_store=store,
+        )
+        # start() calls _catch_up_pending() before the poll loop
+        await monitor.start()
+        await monitor.stop()
+
+        assert monitor.stats.catchup_runs == 3
+
+    async def test_oneshot_marked_completed_after_fire(self, tmp_path):
+        """A one-shot entry transitions to completed=True after it fires,
+        and a subsequent tick does NOT re-fire it."""
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        past = datetime.now(timezone.utc) - timedelta(minutes=5)
+        s.add_oneshot(
+            OneshotEntry(id="os-review", action="review", run_at=past)
+        )
+        store.save(s)
+
+        issue_nova = IssueRef(
+            number=3, title="oneshot issue", url="u", labels=(WORKFLOW_NEW,)
+        )
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            schedule_store=store,
+        )
+
+        # First tick — oneshot should fire
+        await monitor.tick()
+        assert monitor.stats.scheduled_runs == 1
+
+        # Second tick — oneshot is now completed=True, should NOT fire again
+        notifier.issue_picked_up.reset_mock()
+        await monitor.tick()
+        notifier.issue_picked_up.assert_not_called()
+
+    async def test_schedule_with_multiple_due_entries_runs_all(self, tmp_path):
+        """When both 'review' and 'implement' are due, both run on the same tick."""
+        issue_nova = IssueRef(
+            number=4, title="multi-stage", url="u", labels=(WORKFLOW_NEW,)
+        )
+        issue_reviewed = IssueRef(
+            number=5,
+            title="ready",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}"),
+        )
+
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        long_ago = datetime.now(timezone.utc) - timedelta(hours=2)
+        s.add_recurring(
+            RecurringEntry(
+                id="rev",
+                action="review",
+                cron="*/5 * * * *",
+                last_run_at=long_ago,
+            )
+        )
+        s.add_recurring(
+            RecurringEntry(
+                id="impl",
+                action="implement",
+                cron="*/5 * * * *",
+                last_run_at=long_ago,
+            )
+        )
+        store.save(s)
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            issues_reviewed=[issue_reviewed],
+            claude_stdout="https://github.com/owner/repo/pull/99",
+            schedule_store=store,
+        )
+        await monitor.tick()
+
+        assert monitor.stats.scheduled_runs >= 2
+        notifier.issue_picked_up.assert_called_once()
+        notifier.implementation_started.assert_called_once()

--- a/deile/tests/orchestration/pipeline/test_notifier.py
+++ b/deile/tests/orchestration/pipeline/test_notifier.py
@@ -1,0 +1,85 @@
+"""Unit tests for DiscordNotifier."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deile.orchestration.pipeline.notifier import DiscordNotifier
+
+
+class TestNotifierEnabled:
+    def test_disabled_when_no_user_id(self, monkeypatch):
+        monkeypatch.delenv("DEILE_PIPELINE_NOTIFY_USER_ID", raising=False)
+        n = DiscordNotifier()
+        assert not n.enabled
+
+    def test_enabled_with_user_id(self):
+        n = DiscordNotifier(user_id="123")
+        assert n.enabled
+
+    def test_user_id_from_env(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_NOTIFY_USER_ID", "42")
+        n = DiscordNotifier()
+        assert n.user_id == "42"
+
+
+class TestNotifierEvents:
+    async def test_disabled_notifier_noops(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+            return {"ok": True}
+
+        n = DiscordNotifier(user_id="", dm_fn=fake_dm)
+        await n.issue_picked_up(1, "t", "u")
+        assert sent == []
+
+    async def test_issue_picked_up_sends_dm(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.issue_picked_up(7, "title", "https://x")
+        assert len(sent) == 1
+        assert sent[0][0] == "42"
+        assert "#7" in sent[0][1]
+        assert "title" in sent[0][1]
+
+    async def test_pr_reviewed_distinguishes_merged(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append(text)
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.pr_reviewed(1, "t", "u", merged=True)
+        await n.pr_reviewed(2, "t", "u", merged=False)
+        assert "mergeada" in sent[0]
+        assert "🟣" in sent[0]
+        assert "revisada" in sent[1]
+        assert "✅" in sent[1]
+
+    async def test_implementation_finished_handles_missing_pr(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append(text)
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.implementation_finished(1, None)
+        await n.implementation_finished(1, "https://github.com/x/y/pull/1")
+        assert "sem PR" in sent[0]
+        assert "https://github.com/x/y/pull/1" in sent[1]
+
+    async def test_dm_failure_swallowed(self):
+        async def failing_dm(uid, text):
+            raise RuntimeError("network")
+
+        n = DiscordNotifier(user_id="42", dm_fn=failing_dm)
+        # Must not raise.
+        await n.issue_picked_up(1, "t", "u")

--- a/deile/tests/orchestration/pipeline/test_pipeline_integration.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_integration.py
@@ -1,0 +1,328 @@
+"""Integration tests for the full stage 1 → 2 → 3 pipeline flow.
+
+Uses mocked GitHub, Claude, and Worktree collaborators (same style as
+test_monitor.py) but exercises multi-stage baton passing and label
+transition ordering end-to-end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import IssueRef, PrRef
+from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.orchestration.pipeline.labels import (
+    REVIEW_CONCLUDED,
+    REVIEW_IN_PROGRESS,
+    REVIEW_PENDING,
+    WORKFLOW_NEW,
+    WORKFLOW_PR,
+    WORKFLOW_REVIEWED,
+    WORKFLOW_REVIEWING,
+)
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+from deile.orchestration.pipeline.worktree_manager import Worktree
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_BATCH_ID = "abc12345"
+_PR_URL = "https://github.com/owner/name/pull/55"
+
+
+def _make_monitor_full(
+    *,
+    issues_new: Optional[List[IssueRef]] = None,
+    issues_reviewed: Optional[List[IssueRef]] = None,
+    prs: Optional[List[PrRef]] = None,
+    claude_stdout: str = "",
+    claude_rc: int = 0,
+    review_callback=None,
+    identity: Optional[MonitorIdentity] = None,
+) -> Tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: {
+            WORKFLOW_NEW: list(issues_new or []),
+            WORKFLOW_REVIEWED: list(issues_reviewed or []),
+        }.get(label, [])
+    )
+    github.list_open_prs = AsyncMock(return_value=list(prs or []))
+    github.claim_with_batch = AsyncMock(return_value=_BATCH_ID)
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(
+            path=Path("/tmp/fake/.worktrees/x"),
+            branch="x",
+            base_repo=Path("/tmp/fake"),
+        )
+    )
+
+    claude = MagicMock()
+    claude.run = AsyncMock(
+        return_value=ClaudeRunResult(
+            returncode=claude_rc,
+            stdout=claude_stdout,
+            stderr="",
+            duration_seconds=0.1,
+            cmd=("claude", "-p", "x"),
+        )
+    )
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up",
+        "issue_reviewed",
+        "implementation_started",
+        "implementation_finished",
+        "pr_picked_up",
+        "pr_reviewed",
+        "error",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    monitor = PipelineMonitor(
+        cfg,
+        github=github,
+        worktrees=worktrees,
+        claude=claude,
+        notifier=notifier,
+        review_callback=review_callback,
+        identity=identity,
+    )
+    return monitor, github, notifier
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestStageIntegration:
+    async def test_full_flow_issue_to_pr_review(self):
+        """Three separate ticks: stage 1, then stage 2, then stage 3.
+
+        The first tick picks up a ~workflow:nova issue and transitions it to
+        ~workflow:revisada. The second tick picks up the reviewed issue and
+        transitions it to ~workflow:em_pr (Claude returns PR URL in stdout).
+        The third tick reviews the open PR and transitions it to
+        ~review:concluida.
+        """
+        issue_nova = IssueRef(
+            number=10,
+            title="feat: new feature",
+            url="https://github.com/owner/name/issues/10",
+            labels=(WORKFLOW_NEW,),
+            body="Please implement X",
+        )
+        issue_reviewed = IssueRef(
+            number=10,
+            title="feat: new feature",
+            url="https://github.com/owner/name/issues/10",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:default"),
+            body="Please implement X",
+        )
+        pr_open = PrRef(
+            number=55,
+            title="auto: issue-10",
+            url=_PR_URL,
+            labels=(REVIEW_PENDING,),
+            head_ref="auto/issue-10",
+        )
+
+        # -- Tick 1: stage 1 only -----------------------------------------
+        monitor, github, notifier = _make_monitor_full(issues_new=[issue_nova])
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+
+        notifier.issue_picked_up.assert_called_once()
+        notifier.issue_reviewed.assert_called_once()
+        assert monitor.stats.issues_reviewed == 1
+
+        # Transition calls: nova→em_revisao then em_revisao→revisada
+        transition_calls = github.transition_issue.call_args_list
+        assert len(transition_calls) == 2
+        assert transition_calls[0] == call(
+            10, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING
+        )
+        assert transition_calls[1] == call(
+            10, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_REVIEWED
+        )
+
+        # -- Tick 2: stage 2 only -----------------------------------------
+        monitor2, github2, notifier2 = _make_monitor_full(
+            issues_reviewed=[issue_reviewed],
+            claude_stdout=f"Done! See {_PR_URL}",
+        )
+        monitor2.config.enable_review = False
+        monitor2.config.enable_pr_review = False
+        await monitor2.tick()
+
+        notifier2.implementation_started.assert_called_once()
+        notifier2.implementation_finished.assert_called_once()
+        args, _ = notifier2.implementation_finished.call_args
+        assert args[1] == _PR_URL
+        assert monitor2.stats.issues_implemented == 1
+
+        # Transition: revisada → em_pr
+        github2.transition_issue.assert_called_once_with(
+            10, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_PR
+        )
+
+        # -- Tick 3: stage 3 only -----------------------------------------
+        monitor3, github3, notifier3 = _make_monitor_full(
+            prs=[pr_open],
+            claude_stdout="All good, merged the PR.",
+        )
+        monitor3.config.enable_review = False
+        monitor3.config.enable_implement = False
+        await monitor3.tick()
+
+        notifier3.pr_picked_up.assert_called_once()
+        notifier3.pr_reviewed.assert_called_once()
+        assert monitor3.stats.prs_reviewed == 1
+
+        # Transition: em_andamento → concluida
+        github3.transition_pr.assert_called_with(
+            55, from_label=REVIEW_IN_PROGRESS, to_label=REVIEW_CONCLUDED
+        )
+
+    async def test_stage1_passes_baton_to_stage2(self):
+        """After stage 1 review, the issue carries ~workflow:revisada + ~by:<id>."""
+        issue_nova = IssueRef(
+            number=7,
+            title="fix: regression",
+            url="u",
+            labels=(WORKFLOW_NEW,),
+        )
+        monitor, github, notifier = _make_monitor_full(issues_new=[issue_nova])
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        # Ownership label is added so stage 2 knows who claimed it.
+        add_labels_calls = github.add_labels.call_args_list
+        owned = any(
+            "~by:default" in str(c)
+            for c in add_labels_calls
+        )
+        assert owned, f"~by:default not added; add_labels calls: {add_labels_calls}"
+
+        # Workflow transition: nova → revisada (via em_revisao)
+        transitions = github.transition_issue.call_args_list
+        actions = [(c[1]["from_label"], c[1]["to_label"]) for c in transitions]
+        assert (WORKFLOW_NEW, WORKFLOW_REVIEWING) in actions
+        assert (WORKFLOW_REVIEWING, WORKFLOW_REVIEWED) in actions
+
+    async def test_stage2_only_picks_own_claimed(self):
+        """Stage 2 with default identity only picks issues labelled ~by:default."""
+        issue_mine = IssueRef(
+            number=1,
+            title="mine",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:default"),
+        )
+        issue_other = IssueRef(
+            number=2,
+            title="not mine",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:m-other"),
+        )
+        # Default identity: is_default=True → uses owns(title) which returns True
+        # for shard_count=1 but ALSO checks ownership_label. Let's verify the
+        # other monitor's issue is NOT picked when identity is non-default.
+        identity_a = MonitorIdentity(monitor_id="worker-a")
+        monitor, github, notifier = _make_monitor_full(
+            issues_reviewed=[issue_mine, issue_other],
+            claude_stdout=f"Done! {_PR_URL}",
+            identity=identity_a,
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        # worker-a only owns issues with ~by:worker-a — neither issue qualifies
+        notifier.implementation_started.assert_not_called()
+
+    async def test_stage2_picks_its_own_ownership_label(self):
+        """Stage 2 picks issue labelled ~by:<its-own-id>."""
+        identity_a = MonitorIdentity(monitor_id="worker-a")
+        issue_owned = IssueRef(
+            number=3,
+            title="owned by worker-a",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:worker-a"),
+        )
+        monitor, github, notifier = _make_monitor_full(
+            issues_reviewed=[issue_owned],
+            claude_stdout=f"Implemented. {_PR_URL}",
+            identity=identity_a,
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_finished.assert_called_once()
+
+    async def test_stage3_does_not_pick_peer_branch(self):
+        """Stage 3 on monitor 'a' skips PRs from monitor 'b'."""
+        identity_a = MonitorIdentity(monitor_id="a")
+        pr_from_b = PrRef(
+            number=20,
+            title="b's PR",
+            url="https://github.com/o/r/pull/20",
+            labels=(REVIEW_PENDING,),
+            head_ref="auto/b/issue-5",
+        )
+        monitor, github, notifier = _make_monitor_full(
+            prs=[pr_from_b],
+            identity=identity_a,
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+
+        await monitor.tick()
+
+        notifier.pr_picked_up.assert_not_called()
+
+    async def test_notifier_fires_on_every_transition(self):
+        """All notifier events are emitted at the right stages."""
+        issue_nova = IssueRef(
+            number=5,
+            title="feat: notifier check",
+            url="u",
+            labels=(WORKFLOW_NEW,),
+        )
+        monitor, github, notifier = _make_monitor_full(issues_new=[issue_nova])
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        notifier.issue_picked_up.assert_called_once_with(5, "feat: notifier check", "u")
+        notifier.issue_reviewed.assert_called_once_with(5, "feat: notifier check", "u")
+        notifier.error.assert_not_called()

--- a/deile/tests/orchestration/pipeline/test_pipeline_schedule_tool.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_schedule_tool.py
@@ -1,0 +1,142 @@
+"""Unit tests for PipelineScheduleTool."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from deile.tools.base import ToolContext, ToolStatus
+from deile.tools.pipeline_schedule_tool import PipelineScheduleTool
+
+
+@pytest.fixture
+def tmp_repo(tmp_path: Path, monkeypatch) -> Path:
+    """Create a minimal git repo + deile.py marker so _resolve_base_path picks it."""
+    subprocess.run(["git", "init", str(tmp_path)], check=True,
+                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (tmp_path / "deile.py").write_text("# marker\n")
+    monkeypatch.setenv("DEILE_PIPELINE_BASE_PATH", str(tmp_path))
+    return tmp_path
+
+
+def _ctx(**args) -> ToolContext:
+    return ToolContext(user_input="", parsed_args=args)
+
+
+class TestList:
+    async def test_list_empty(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        result = await tool.execute(_ctx(action="list"))
+        assert result.status == ToolStatus.SUCCESS
+        assert result.data["recurring"] == []
+        assert result.data["oneshot"] == []
+
+
+class TestAddRecurring:
+    async def test_add_then_list(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        r = await tool.execute(_ctx(
+            action="add_recurring", trigger_action="review",
+            cron="*/5 * * * *", id="r1",
+        ))
+        assert r.status == ToolStatus.SUCCESS
+        listing = await tool.execute(_ctx(action="list"))
+        assert len(listing.data["recurring"]) == 1
+        assert listing.data["recurring"][0]["cron"] == "*/5 * * * *"
+
+    async def test_missing_args(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        r = await tool.execute(_ctx(action="add_recurring"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "MISSING_ARGS"
+
+    async def test_invalid_cron(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        r = await tool.execute(_ctx(
+            action="add_recurring", trigger_action="review",
+            cron="totally invalid", id="r1",
+        ))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "SCHEDULE_ERROR"
+
+
+class TestAddOneshot:
+    async def test_add_oneshot_with_target_issue(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        r = await tool.execute(_ctx(
+            action="add_oneshot", trigger_action="implement",
+            run_at="2026-05-06T18:00:00Z", target_issue=99,
+        ))
+        assert r.status == ToolStatus.SUCCESS
+        # auto-generated id
+        assert r.data["id"].startswith("oneshot-implement-")
+
+    async def test_invalid_run_at(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        r = await tool.execute(_ctx(
+            action="add_oneshot", trigger_action="implement",
+            run_at="not a date",
+        ))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "INVALID_DATETIME"
+
+
+class TestRemove:
+    async def test_remove_existing(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        await tool.execute(_ctx(
+            action="add_recurring", trigger_action="review",
+            cron="*/5 * * * *", id="r1",
+        ))
+        r = await tool.execute(_ctx(action="remove", id="r1"))
+        assert r.status == ToolStatus.SUCCESS
+
+    async def test_remove_missing(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        r = await tool.execute(_ctx(action="remove", id="nope"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "NOT_FOUND"
+
+
+class TestEnableDisable:
+    async def test_disable_then_enable(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        await tool.execute(_ctx(
+            action="add_recurring", trigger_action="review",
+            cron="*/5 * * * *", id="r1",
+        ))
+        r = await tool.execute(_ctx(action="disable", id="r1"))
+        assert r.status == ToolStatus.SUCCESS and r.data["enabled"] is False
+        r = await tool.execute(_ctx(action="enable", id="r1"))
+        assert r.status == ToolStatus.SUCCESS and r.data["enabled"] is True
+
+
+class TestPerMonitorIsolation:
+    async def test_two_monitors_use_separate_files(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        await tool.execute(_ctx(
+            action="add_recurring", trigger_action="review",
+            cron="*/5 * * * *", id="alfa-loop", monitor_id="m-alfa",
+        ))
+        await tool.execute(_ctx(
+            action="add_recurring", trigger_action="implement",
+            cron="*/2 * * * *", id="beta-loop", monitor_id="m-beta",
+        ))
+        # Each monitor sees only its own entries.
+        list_alfa = await tool.execute(_ctx(action="list", monitor_id="m-alfa"))
+        list_beta = await tool.execute(_ctx(action="list", monitor_id="m-beta"))
+        assert [r["id"] for r in list_alfa.data["recurring"]] == ["alfa-loop"]
+        assert [r["id"] for r in list_beta.data["recurring"]] == ["beta-loop"]
+        # Files exist separately.
+        assert (tmp_repo / "config" / "pipeline_schedule_m-alfa.yaml").exists()
+        assert (tmp_repo / "config" / "pipeline_schedule_m-beta.yaml").exists()
+
+
+class TestInvalidAction:
+    async def test_unknown_action(self, tmp_repo):
+        tool = PipelineScheduleTool()
+        r = await tool.execute(_ctx(action="nope"))
+        assert r.status == ToolStatus.ERROR
+        assert r.metadata["error_code"] == "INVALID_ACTION"

--- a/deile/tests/orchestration/pipeline/test_pipeline_tool.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_tool.py
@@ -1,0 +1,182 @@
+"""Unit tests for PipelineTool — LLM-callable pipeline interface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+from deile.tools.base import ToolContext, ToolStatus
+from deile.tools.pipeline_tool import PipelineTool
+
+
+def _make_context(action: str, agent=None) -> ToolContext:
+    ctx = ToolContext(user_input="", parsed_args={"action": action})
+    if agent is not None:
+        ctx.session_data["agent"] = agent
+    return ctx
+
+
+def _make_monitor() -> PipelineMonitor:
+    cfg = PipelineConfig(repo="o/n", base_repo_path=Path("/tmp"))
+    # Inject mocks for github + worktrees so PipelineMonitor.__init__ doesn't
+    # validate /tmp as a git repo.
+    monitor = PipelineMonitor(cfg, github=MagicMock(), worktrees=MagicMock())
+    monitor.start = AsyncMock()
+    monitor.stop = AsyncMock()
+    monitor.tick = AsyncMock()
+    return monitor
+
+
+class TestPipelineToolSchema:
+    def test_schema_metadata(self):
+        tool = PipelineTool()
+        assert tool.name == "pipeline"
+        assert tool.category == "system"
+        assert "start" in tool.description.lower()
+        schema = tool._schema
+        assert "action" in schema.parameters
+        assert "start" in schema.parameters["action"]["enum"]
+        assert "stop" in schema.parameters["action"]["enum"]
+        assert "status" in schema.parameters["action"]["enum"]
+        assert "tick" in schema.parameters["action"]["enum"]
+
+
+class TestPipelineToolActions:
+    async def test_invalid_action_returns_error(self):
+        tool = PipelineTool()
+        ctx = _make_context("nope")
+        result = await tool.execute(ctx)
+        assert result.status == ToolStatus.ERROR
+        assert "INVALID_ACTION" in result.metadata.get("error_code", "")
+
+    async def test_start_calls_monitor_start(self):
+        tool = PipelineTool()
+        agent = MagicMock()
+        agent.pipeline_monitor = _make_monitor()
+        ctx = _make_context("start", agent=agent)
+        result = await tool.execute(ctx)
+        assert result.status == ToolStatus.SUCCESS
+        agent.pipeline_monitor.start.assert_awaited_once()
+        assert result.data["running"] is True
+
+    async def test_stop_calls_monitor_stop(self):
+        tool = PipelineTool()
+        agent = MagicMock()
+        agent.pipeline_monitor = _make_monitor()
+        ctx = _make_context("stop", agent=agent)
+        result = await tool.execute(ctx)
+        assert result.status == ToolStatus.SUCCESS
+        agent.pipeline_monitor.stop.assert_awaited_once()
+        assert result.data["running"] is False
+
+    async def test_tick_calls_monitor_tick_and_returns_stats(self):
+        tool = PipelineTool()
+        agent = MagicMock()
+        agent.pipeline_monitor = _make_monitor()
+        ctx = _make_context("tick", agent=agent)
+        result = await tool.execute(ctx)
+        assert result.status == ToolStatus.SUCCESS
+        agent.pipeline_monitor.tick.assert_awaited_once()
+        assert "ticks" in result.data
+        assert "errors" in result.data
+
+    async def test_status_default_action_when_args_missing(self):
+        tool = PipelineTool()
+        agent = MagicMock()
+        agent.pipeline_monitor = _make_monitor()
+        ctx = ToolContext(user_input="", parsed_args={})
+        ctx.session_data["agent"] = agent
+        result = await tool.execute(ctx)
+        # Default action is "status" (idempotent, never starts/stops the monitor).
+        assert result.status == ToolStatus.SUCCESS
+        agent.pipeline_monitor.start.assert_not_called()
+        agent.pipeline_monitor.stop.assert_not_called()
+        assert "running" in result.data
+
+    async def test_status_returns_running_flag(self):
+        tool = PipelineTool()
+        agent = MagicMock()
+        monitor = _make_monitor()
+        # Simulate a running task.
+        monitor._task = MagicMock()
+        monitor._task.done.return_value = False
+        agent.pipeline_monitor = monitor
+        ctx = _make_context("status", agent=agent)
+        result = await tool.execute(ctx)
+        assert result.data["running"] is True
+
+    async def test_status_running_false_when_task_done(self):
+        tool = PipelineTool()
+        agent = MagicMock()
+        monitor = _make_monitor()
+        monitor._task = MagicMock()
+        monitor._task.done.return_value = True
+        agent.pipeline_monitor = monitor
+        ctx = _make_context("status", agent=agent)
+        result = await tool.execute(ctx)
+        assert result.data["running"] is False
+
+
+class TestPipelineToolMonitorReuse:
+    async def test_reuses_agent_pipeline_monitor(self):
+        tool = PipelineTool()
+        existing = _make_monitor()
+        agent = MagicMock()
+        agent.pipeline_monitor = existing
+        ctx = _make_context("status", agent=agent)
+        await tool.execute(ctx)
+        # The same instance was reused — no new monitor was attached to the agent.
+        assert agent.pipeline_monitor is existing
+
+    async def test_creates_monitor_when_agent_has_none(self, monkeypatch, tmp_path):
+        # The fresh-monitor path goes through WorktreeManager which validates
+        # that base_repo_path is a real git repo. Initialize one.
+        import subprocess
+        subprocess.run(["git", "init", str(tmp_path)], check=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        monkeypatch.setenv("DEILE_PIPELINE_BASE_PATH", str(tmp_path))
+        tool = PipelineTool()
+        agent = MagicMock(spec=["pipeline_monitor"])
+        agent.pipeline_monitor = None
+        ctx = _make_context("status", agent=agent)
+        result = await tool.execute(ctx)
+        assert result.status == ToolStatus.SUCCESS
+        # The tool tried to attach a fresh monitor to the agent.
+        assert agent.pipeline_monitor is not None
+
+    async def test_works_without_agent(self, monkeypatch, tmp_path):
+        import subprocess
+        subprocess.run(["git", "init", str(tmp_path)], check=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        monkeypatch.setenv("DEILE_PIPELINE_BASE_PATH", str(tmp_path))
+        tool = PipelineTool()
+        ctx = _make_context("status")  # no agent
+        result = await tool.execute(ctx)
+        assert result.status == ToolStatus.SUCCESS
+
+
+class TestPipelineToolFailureHandling:
+    async def test_monitor_exception_returns_error_result(self):
+        tool = PipelineTool()
+        agent = MagicMock()
+        monitor = _make_monitor()
+        monitor.tick = AsyncMock(side_effect=RuntimeError("kaboom"))
+        agent.pipeline_monitor = monitor
+        ctx = _make_context("tick", agent=agent)
+        result = await tool.execute(ctx)
+        assert result.status == ToolStatus.ERROR
+        assert "kaboom" in result.message
+        assert result.metadata.get("error_code") == "PIPELINE_OP_FAILED"
+
+
+class TestAutoDiscover:
+    def test_pipeline_tool_in_default_packages(self):
+        from deile.tools.registry import ToolRegistry
+        # Construct a registry and inspect the default discovery list.
+        # We don't actually import; just check the constant.
+        import inspect
+        src = inspect.getsource(ToolRegistry.auto_discover)
+        assert "deile.tools.pipeline_tool" in src

--- a/deile/tests/orchestration/pipeline/test_pipeline_tool.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_tool.py
@@ -37,11 +37,18 @@ class TestPipelineToolSchema:
         assert tool.category == "system"
         assert "start" in tool.description.lower()
         schema = tool._schema
-        assert "action" in schema.parameters
-        assert "start" in schema.parameters["action"]["enum"]
-        assert "stop" in schema.parameters["action"]["enum"]
-        assert "status" in schema.parameters["action"]["enum"]
-        assert "tick" in schema.parameters["action"]["enum"]
+        # JSON Schema: parameters MUST be a wrapped object schema for the
+        # OpenAI/Anthropic/Gemini function-calling APIs.
+        assert schema.parameters["type"] == "object"
+        properties = schema.parameters["properties"]
+        assert "action" in properties
+        assert "start" in properties["action"]["enum"]
+        assert "stop" in properties["action"]["enum"]
+        assert "status" in properties["action"]["enum"]
+        assert "tick" in properties["action"]["enum"]
+        # And the ToolSchema serializes correctly for OpenAI function calling.
+        fn = schema.to_openai_function()
+        assert fn["function"]["parameters"]["type"] == "object"
 
 
 class TestPipelineToolActions:

--- a/deile/tests/orchestration/pipeline/test_scheduler.py
+++ b/deile/tests/orchestration/pipeline/test_scheduler.py
@@ -72,10 +72,15 @@ class TestComputePending:
 
     def test_recurring_not_due_yet(self):
         s = Schedule()
-        # cron fires every 5 min; last_run_at is 2 min ago → next is 3 min from now
+        # `0 0 1 1 *` = once a year on Jan 1 00:00. With last_run_at set to
+        # the most recent Jan 1, the next run is far in the future regardless
+        # of when this test runs.
+        now = datetime.now(timezone.utc)
+        last_jan_1 = datetime(now.year if now.month > 1 or now.day > 1 else now.year - 1,
+                              1, 1, 0, 0, tzinfo=timezone.utc)
         s.add_recurring(RecurringEntry(
-            id="r1", action="review", cron="*/5 * * * *",
-            last_run_at=datetime.now(timezone.utc) - timedelta(minutes=2),
+            id="r1", action="review", cron="0 0 1 1 *",
+            last_run_at=last_jan_1,
         ))
         assert s.compute_pending() == []
 

--- a/deile/tests/orchestration/pipeline/test_scheduler.py
+++ b/deile/tests/orchestration/pipeline/test_scheduler.py
@@ -1,0 +1,196 @@
+"""Unit tests for ScheduleStore + Schedule + catch-up."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from deile.orchestration.pipeline.scheduler import (OneshotEntry, PendingRun,
+                                                     RecurringEntry, Schedule,
+                                                     ScheduleError,
+                                                     ScheduleStore)
+
+
+def _utc(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+class TestRecurringEntry:
+    def test_valid_construction(self):
+        e = RecurringEntry(id="r1", action="review", cron="*/5 * * * *")
+        assert e.enabled
+        assert e.replay_all is False
+
+    def test_invalid_action(self):
+        with pytest.raises(ScheduleError):
+            RecurringEntry(id="r1", action="bad", cron="* * * * *")
+
+    def test_invalid_cron(self):
+        with pytest.raises(ScheduleError):
+            RecurringEntry(id="r1", action="review", cron="not a cron")
+
+    def test_invalid_id(self):
+        with pytest.raises(ScheduleError):
+            RecurringEntry(id="bad/id", action="review", cron="* * * * *")
+
+
+class TestOneshotEntry:
+    def test_valid_construction(self):
+        e = OneshotEntry(id="o1", action="implement", run_at=_utc("2026-05-06T18:00:00"))
+        assert not e.completed
+
+    def test_naive_run_at_treated_as_utc(self):
+        e = OneshotEntry(id="o1", action="implement",
+                         run_at=datetime(2026, 5, 6, 18, 0, 0))
+        assert e.run_at.tzinfo is not None
+
+    def test_invalid_action(self):
+        with pytest.raises(ScheduleError):
+            OneshotEntry(id="o1", action="bad", run_at=_utc("2026-05-06T18:00:00"))
+
+
+class TestSchedule:
+    def test_add_recurring_rejects_duplicate_id(self):
+        s = Schedule()
+        s.add_recurring(RecurringEntry(id="r1", action="review", cron="* * * * *"))
+        with pytest.raises(ScheduleError):
+            s.add_recurring(RecurringEntry(id="r1", action="implement", cron="* * * * *"))
+
+    def test_remove_returns_true_when_found(self):
+        s = Schedule()
+        s.add_recurring(RecurringEntry(id="r1", action="review", cron="* * * * *"))
+        assert s.remove("r1")
+        assert not s.remove("r1")  # already removed
+
+
+class TestComputePending:
+    def test_no_pending_when_empty(self):
+        s = Schedule()
+        assert s.compute_pending() == []
+
+    def test_recurring_not_due_yet(self):
+        s = Schedule()
+        # cron fires every 5 min; last_run_at is 2 min ago → next is 3 min from now
+        s.add_recurring(RecurringEntry(
+            id="r1", action="review", cron="*/5 * * * *",
+            last_run_at=datetime.now(timezone.utc) - timedelta(minutes=2),
+        ))
+        assert s.compute_pending() == []
+
+    def test_recurring_coalesced_to_single_run(self):
+        # last_run_at = 1 hour ago. Cron */5 → 12 misses. Default coalesces to 1.
+        long_ago = datetime.now(timezone.utc) - timedelta(hours=1)
+        s = Schedule()
+        s.add_recurring(RecurringEntry(
+            id="r1", action="review", cron="*/5 * * * *",
+            last_run_at=long_ago,
+        ))
+        pending = s.compute_pending()
+        assert len(pending) == 1
+        assert pending[0].entry_id == "r1"
+        assert pending[0].action == "review"
+
+    def test_recurring_replay_all_emits_each(self):
+        long_ago = datetime.now(timezone.utc) - timedelta(minutes=20)
+        s = Schedule()
+        s.add_recurring(RecurringEntry(
+            id="r1", action="review", cron="*/5 * * * *",
+            last_run_at=long_ago, replay_all=True,
+        ))
+        pending = s.compute_pending()
+        # 4 missed slots in 20 minutes (5, 10, 15, 20)
+        assert len(pending) >= 3
+
+    def test_disabled_recurring_skipped(self):
+        long_ago = datetime.now(timezone.utc) - timedelta(hours=1)
+        s = Schedule()
+        s.add_recurring(RecurringEntry(
+            id="r1", action="review", cron="*/5 * * * *",
+            last_run_at=long_ago, enabled=False,
+        ))
+        assert s.compute_pending() == []
+
+    def test_oneshot_due(self):
+        past = datetime.now(timezone.utc) - timedelta(minutes=5)
+        s = Schedule()
+        s.add_oneshot(OneshotEntry(id="o1", action="implement", run_at=past, target_issue=99))
+        pending = s.compute_pending()
+        assert len(pending) == 1
+        assert pending[0].is_oneshot
+        assert pending[0].target_issue == 99
+
+    def test_oneshot_not_yet_due(self):
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        s = Schedule()
+        s.add_oneshot(OneshotEntry(id="o1", action="implement", run_at=future))
+        assert s.compute_pending() == []
+
+    def test_completed_oneshot_skipped(self):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        s = Schedule()
+        s.add_oneshot(OneshotEntry(id="o1", action="implement", run_at=past, completed=True))
+        assert s.compute_pending() == []
+
+    def test_pending_sorted_chronologically(self):
+        now = datetime.now(timezone.utc)
+        s = Schedule()
+        s.add_oneshot(OneshotEntry(id="late", action="review",
+                                   run_at=now - timedelta(minutes=1)))
+        s.add_oneshot(OneshotEntry(id="early", action="review",
+                                   run_at=now - timedelta(minutes=10)))
+        pending = s.compute_pending()
+        assert [p.entry_id for p in pending] == ["early", "late"]
+
+
+class TestMarkRun:
+    def test_mark_recurring_advances_last_run(self):
+        s = Schedule()
+        s.add_recurring(RecurringEntry(id="r1", action="review", cron="*/5 * * * *"))
+        when = datetime.now(timezone.utc)
+        run = PendingRun(when=when, entry_id="r1", action="review", is_oneshot=False)
+        s.mark_run(run, when=when)
+        assert s.get_recurring("r1").last_run_at == when
+
+    def test_mark_oneshot_completes(self):
+        s = Schedule()
+        s.add_oneshot(OneshotEntry(
+            id="o1", action="implement",
+            run_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        ))
+        run = PendingRun(when=datetime.now(timezone.utc), entry_id="o1",
+                         action="implement", is_oneshot=True)
+        s.mark_run(run)
+        assert s.get_oneshot("o1").completed
+
+
+class TestScheduleStore:
+    def test_load_returns_empty_when_missing(self, tmp_path):
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = store.load()
+        assert s.recurring == [] and s.oneshot == []
+
+    def test_save_and_reload_roundtrips(self, tmp_path):
+        store = ScheduleStore(tmp_path, monitor_id="m-alfa")
+        s = Schedule()
+        s.add_recurring(RecurringEntry(id="r1", action="review", cron="*/5 * * * *"))
+        s.add_oneshot(OneshotEntry(
+            id="o1", action="implement",
+            run_at=_utc("2026-05-06T18:00:00"), target_issue=99,
+        ))
+        store.save(s)
+        assert store.path.exists()
+        assert store.path.name == "pipeline_schedule_m-alfa.yaml"
+        # Roundtrip
+        s2 = store.load()
+        assert len(s2.recurring) == 1
+        assert s2.recurring[0].id == "r1"
+        assert len(s2.oneshot) == 1
+        assert s2.oneshot[0].target_issue == 99
+
+    def test_save_creates_config_dir(self, tmp_path):
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        assert not (tmp_path / "config").exists()
+        store.save(Schedule())
+        assert (tmp_path / "config").is_dir()

--- a/deile/tests/orchestration/pipeline/test_worktree_manager.py
+++ b/deile/tests/orchestration/pipeline/test_worktree_manager.py
@@ -1,0 +1,103 @@
+"""Unit tests for WorktreeManager — uses real git in tmp_path."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from deile.orchestration.pipeline.worktree_manager import (Worktree,
+                                                            WorktreeError,
+                                                            WorktreeManager)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo with one commit on main."""
+    repo = tmp_path / "fake-repo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("# fake\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+class TestWorktreeManagerCtor:
+    def test_rejects_non_repo(self, tmp_path):
+        with pytest.raises(WorktreeError):
+            WorktreeManager(tmp_path)
+
+    def test_accepts_repo(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        assert wm.base_repo == fake_repo.resolve()
+        assert wm.worktrees_dir == fake_repo.resolve() / ".worktrees"
+
+
+class TestEnsureMain:
+    async def test_clones_main_on_first_run(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        path = await wm.ensure_main()
+        assert path.exists()
+        assert (path / ".git").exists()
+        assert (path / "README.md").exists()
+
+    async def test_idempotent(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        p1 = await wm.ensure_main()
+        p2 = await wm.ensure_main()
+        assert p1 == p2
+
+
+class TestCreateBranchWorktree:
+    async def test_rejects_main_branch(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        with pytest.raises(WorktreeError):
+            await wm.create_branch_worktree("main")
+
+    async def test_rejects_empty_branch(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        with pytest.raises(WorktreeError):
+            await wm.create_branch_worktree("")
+
+    async def test_creates_branch_copy(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        wt = await wm.create_branch_worktree("feat/x")
+        assert isinstance(wt, Worktree)
+        assert wt.branch == "feat/x"
+        assert (wt.path / ".git").exists()
+        assert (wt.path / "README.md").exists()
+        # Verify branch is checked out.
+        out = subprocess.check_output(["git", "-C", str(wt.path), "branch", "--show-current"])
+        assert out.strip() == b"feat/x"
+
+    async def test_idempotent_reuses_existing(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        wt1 = await wm.create_branch_worktree("feat/y")
+        # Simulate user-edited file in the worktree.
+        (wt1.path / "marker.txt").write_text("preserved\n")
+        wt2 = await wm.create_branch_worktree("feat/y")
+        assert wt1.path == wt2.path
+        assert (wt2.path / "marker.txt").exists(), "existing worktree must not be wiped"
+
+    async def test_remote_origin_points_back_to_base_repo(self, fake_repo):
+        wm = WorktreeManager(fake_repo)
+        wt = await wm.create_branch_worktree("feat/origin-check")
+        out = subprocess.check_output(
+            ["git", "-C", str(wt.path), "remote", "get-url", "origin"]
+        )
+        assert out.strip().decode() == str(fake_repo.resolve())

--- a/deile/tests/tools/test_worktree_tool.py
+++ b/deile/tests/tools/test_worktree_tool.py
@@ -1,0 +1,305 @@
+"""Tests for WorktreeTool.
+
+Design notes
+------------
+- No real git operations: WorktreeManager is monkeypatched / replaced with an
+  AsyncMock at the class level so tests stay fast and hermetic.
+- Schema regression: ``test_schema_is_json_schema_object`` mirrors the guard
+  introduced after commit 5815725 — it checks both the raw ``parameters`` dict
+  and the serialised ``to_openai_function()`` output.
+- ``asyncio_mode = auto`` in pytest.ini — no ``@pytest.mark.asyncio`` needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.tools.base import ToolContext, ToolStatus
+from deile.tools.worktree_tool import WorktreeTool, _resolve_base_path
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(**kwargs) -> ToolContext:
+    return ToolContext(user_input="", parsed_args=kwargs, session_data={})
+
+
+def _fake_worktree(path: str = "/repo/.worktrees/feat/my-branch", branch: str = "my-branch"):
+    wt = MagicMock()
+    wt.path = Path(path)
+    wt.branch = branch
+    wt.base_repo = Path("/repo")
+    return wt
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema validity — the regression guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_schema_is_json_schema_object():
+    """parameters must be a JSON Schema object, not a raw property dict.
+
+    Regression guard for the bug caught in commit 5815725: passing a raw
+    ``{"action": {...}}`` dict instead of
+    ``{"type": "object", "properties": {"action": {...}}}`` silently broke
+    all providers that validate the schema.
+    """
+    tool = WorktreeTool()
+    params = tool._schema.parameters
+    assert params["type"] == "object", (
+        "parameters must have top-level 'type': 'object'"
+    )
+    assert "properties" in params, "parameters must contain 'properties'"
+    assert "action" in params["properties"]
+
+
+@pytest.mark.unit
+def test_to_openai_function_parameters_type_is_object():
+    """to_openai_function() must emit 'type': 'object' in parameters."""
+    tool = WorktreeTool()
+    oai = tool.schema.to_openai_function()
+    assert oai["function"]["parameters"]["type"] == "object"
+
+
+# ---------------------------------------------------------------------------
+# 2. Invalid action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_invalid_action_returns_error():
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="fly"))
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "INVALID_ACTION"
+
+
+@pytest.mark.unit
+async def test_empty_action_returns_error():
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action=""))
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "INVALID_ACTION"
+
+
+# ---------------------------------------------------------------------------
+# 3. ensure_main happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_ensure_main_happy_path(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    mock_mgr = AsyncMock()
+    mock_mgr.ensure_main = AsyncMock(return_value=tmp_path / ".worktrees" / "main")
+
+    tool = WorktreeTool()
+    with patch(
+        "deile.tools.worktree_tool.WorktreeManager", return_value=mock_mgr
+    ):
+        result = await tool.execute(_ctx(action="ensure_main", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.SUCCESS
+    assert "path" in result.data
+    mock_mgr.ensure_main.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 4. create happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_create_happy_path(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    wt = _fake_worktree(str(tmp_path / ".worktrees" / "feat" / "my-branch"), "my-branch")
+    mock_mgr = AsyncMock()
+    mock_mgr.create_branch_worktree = AsyncMock(return_value=wt)
+
+    tool = WorktreeTool()
+    with patch(
+        "deile.tools.worktree_tool.WorktreeManager", return_value=mock_mgr
+    ):
+        result = await tool.execute(
+            _ctx(action="create", branch="my-branch", subdir="feat", base_path=str(tmp_path))
+        )
+
+    assert result.status == ToolStatus.SUCCESS
+    assert result.data["branch"] == "my-branch"
+    assert "path" in result.data
+    mock_mgr.create_branch_worktree.assert_awaited_once_with("my-branch")
+
+
+@pytest.mark.unit
+async def test_create_missing_branch_returns_error(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="create", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "MISSING_BRANCH"
+
+
+# ---------------------------------------------------------------------------
+# 5. list happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_list_returns_worktrees(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+    # Create fake worktree directories
+    wt_dir = tmp_path / ".worktrees" / "feat" / "branch-a"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").mkdir()
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="list", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.SUCCESS
+    assert isinstance(result.data["worktrees"], list)
+    assert len(result.data["worktrees"]) == 1
+    assert result.data["worktrees"][0]["branch"] == "branch-a"
+
+
+@pytest.mark.unit
+async def test_list_no_worktrees_dir(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="list", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.SUCCESS
+    assert result.data["worktrees"] == []
+
+
+# ---------------------------------------------------------------------------
+# 6. remove happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_remove_happy_path(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+    branch_dir = tmp_path / ".worktrees" / "my-branch"
+    branch_dir.mkdir(parents=True)
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="my-branch", base_path=str(tmp_path))
+    )
+
+    assert result.status == ToolStatus.SUCCESS
+    assert not branch_dir.exists()
+
+
+@pytest.mark.unit
+async def test_remove_missing_branch_returns_error(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="remove", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "MISSING_BRANCH"
+
+
+# ---------------------------------------------------------------------------
+# 7. remove safety: refuse to remove 'main'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+async def test_remove_refuses_main(tmp_path):
+    """The shared clean main clone must never be removed."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+    main_dir = tmp_path / ".worktrees" / "main"
+    main_dir.mkdir(parents=True)
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="main", base_path=str(tmp_path))
+    )
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "REMOVE_PROTECTED"
+    # Directory must still exist.
+    assert main_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# 8. remove non-existent path returns NOT_FOUND
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_remove_nonexistent_returns_not_found(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="ghost-branch", base_path=str(tmp_path))
+    )
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# 9. Auto-discover registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_registered_by_auto_discover():
+    from deile.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+    reg.auto_discover()
+    assert reg.get("worktree") is not None
+
+
+# ---------------------------------------------------------------------------
+# 10. _resolve_base_path utility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolve_base_path_uses_override(tmp_path):
+    result = _resolve_base_path(str(tmp_path))
+    assert result == tmp_path.resolve()
+
+
+@pytest.mark.unit
+def test_resolve_base_path_uses_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEILE_PIPELINE_BASE_PATH", str(tmp_path))
+    result = _resolve_base_path()
+    assert result == tmp_path.resolve()
+
+
+@pytest.mark.unit
+def test_resolve_base_path_override_beats_env(tmp_path, monkeypatch, tmp_path_factory):
+    other = tmp_path_factory.mktemp("other")
+    monkeypatch.setenv("DEILE_PIPELINE_BASE_PATH", str(other))
+    result = _resolve_base_path(str(tmp_path))
+    assert result == tmp_path.resolve()

--- a/deile/tools/cron_create_tool.py
+++ b/deile/tools/cron_create_tool.py
@@ -1,0 +1,176 @@
+"""CronCreateTool — schedule a natural-language prompt for future execution.
+
+Implements the create half of intent #86. Pass either ``cron`` (recurring)
+or ``run_at`` (one-shot UTC datetime). The prompt is whatever the user
+asked DEILE to do — it gets fed back into a fresh agent turn when the
+schedule fires.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from deile.cron.store import CronEntry, CronStore, CronStoreError, make_id
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolSchema)
+
+
+def _resolve_db_path() -> Path:
+    raw = os.environ.get("DEILE_CRON_DB_PATH")
+    if raw:
+        return Path(raw).resolve()
+    base = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if base:
+        return Path(base).resolve() / "data" / "cron.db"
+    return Path.cwd() / "data" / "cron.db"
+
+
+def _get_store() -> CronStore:
+    return CronStore(_resolve_db_path())
+
+
+class CronCreateTool(Tool):
+    """Schedule a prompt for future execution (recurring cron OR one-shot)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="cron_create",
+                description=(
+                    "Schedule a natural-language prompt to be executed by DEILE "
+                    "at a future time. Provide EITHER `cron` (5-field expression "
+                    "for recurring tasks, e.g. '0 9 * * 1' = Mondays at 09:00 UTC) "
+                    "OR `run_at` (ISO-8601 UTC datetime for one-shot, e.g. "
+                    "'2026-05-06T18:00:00Z'). When the schedule fires, the prompt "
+                    "is fed back into a fresh DEILE turn. Set `notify_user_id` to "
+                    "DM the result to a Discord user."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "description": (
+                                "The natural-language instruction DEILE will "
+                                "execute when the schedule fires. Should be "
+                                "self-contained (no missing context)."
+                            ),
+                        },
+                        "cron": {
+                            "type": "string",
+                            "description": (
+                                "5-field cron expression in UTC. Use for "
+                                "recurring tasks. Mutually exclusive with run_at."
+                            ),
+                        },
+                        "run_at": {
+                            "type": "string",
+                            "description": (
+                                "ISO-8601 UTC datetime. Use for one-shot. "
+                                "Mutually exclusive with cron."
+                            ),
+                        },
+                        "id": {
+                            "type": "string",
+                            "description": "Custom id (auto-generated if omitted).",
+                        },
+                        "notify_user_id": {
+                            "type": "string",
+                            "description": (
+                                "Discord snowflake to DM the result to when "
+                                "the schedule fires."
+                            ),
+                        },
+                        "created_by": {
+                            "type": "string",
+                            "description": (
+                                "Identifier of the user who scheduled this "
+                                "(e.g. 'discord:1234'). Optional but useful "
+                                "for audit."
+                            ),
+                        },
+                    },
+                    "required": ["prompt"],
+                },
+                required=["prompt"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return "cron_create"
+
+    @property
+    def description(self) -> str:
+        return self._schema.description if self._schema else ""
+
+    @property
+    def category(self) -> str:
+        return ToolCategory.SYSTEM.value
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        args = context.parsed_args or {}
+        prompt = (args.get("prompt") or "").strip()
+        cron = args.get("cron")
+        run_at_str = args.get("run_at")
+
+        if not prompt:
+            return ToolResult.error_result(
+                message="prompt is required and must be non-empty",
+                error_code="MISSING_PROMPT",
+            )
+        if bool(cron) == bool(run_at_str):
+            return ToolResult.error_result(
+                message="provide EITHER cron OR run_at, not both",
+                error_code="INVALID_SCHEDULE",
+            )
+
+        run_at: Optional[datetime] = None
+        if run_at_str:
+            try:
+                run_at = datetime.fromisoformat(str(run_at_str).rstrip("Z"))
+            except ValueError as exc:
+                return ToolResult.error_result(
+                    message=f"invalid run_at: {run_at_str!r}",
+                    error=exc, error_code="INVALID_DATETIME",
+                )
+            if run_at.tzinfo is None:
+                run_at = run_at.replace(tzinfo=timezone.utc)
+
+        try:
+            entry = CronEntry(
+                id=str(args.get("id") or make_id()),
+                prompt=prompt,
+                cron=cron,
+                run_at=run_at,
+                created_by=args.get("created_by"),
+                notify_user_id=args.get("notify_user_id"),
+            )
+            store = _get_store()
+            store.add(entry)
+        except CronStoreError as exc:
+            return ToolResult.error_result(
+                message=str(exc), error=exc, error_code="CRON_STORE",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult.error_result(
+                message=f"{type(exc).__name__}: {exc}",
+                error=exc, error_code="UNEXPECTED",
+            )
+
+        return ToolResult.success_result(
+            data={
+                "id": entry.id,
+                "next_fire_at": entry.next_fire_at.isoformat() if entry.next_fire_at else None,
+                "is_oneshot": entry.is_oneshot,
+            },
+            message=(
+                f"agendado {entry.id!r} — próxima execução em "
+                f"{entry.next_fire_at.isoformat() if entry.next_fire_at else 'never'}"
+            ),
+        )

--- a/deile/tools/cron_delete_tool.py
+++ b/deile/tools/cron_delete_tool.py
@@ -1,0 +1,102 @@
+"""CronDeleteTool — remove or disable a scheduled prompt (intent #86)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from deile.cron.store import CronStore
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolSchema)
+
+
+def _resolve_db_path() -> Path:
+    raw = os.environ.get("DEILE_CRON_DB_PATH")
+    if raw:
+        return Path(raw).resolve()
+    base = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if base:
+        return Path(base).resolve() / "data" / "cron.db"
+    return Path.cwd() / "data" / "cron.db"
+
+
+class CronDeleteTool(Tool):
+    """Remove or disable a scheduled prompt by id."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="cron_delete",
+                description=(
+                    "Remove a scheduled prompt by id (or just disable it with "
+                    "`disable_only=true` to keep its history). The id comes "
+                    "from cron_create's response or cron_list."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "Entry id to remove/disable.",
+                        },
+                        "disable_only": {
+                            "type": "boolean",
+                            "description": (
+                                "If true, set enabled=false instead of "
+                                "deleting (preserves last_result for audit)."
+                            ),
+                        },
+                    },
+                    "required": ["id"],
+                },
+                required=["id"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return "cron_delete"
+
+    @property
+    def description(self) -> str:
+        return self._schema.description if self._schema else ""
+
+    @property
+    def category(self) -> str:
+        return ToolCategory.SYSTEM.value
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        args = context.parsed_args or {}
+        entry_id = (args.get("id") or "").strip()
+        disable_only = bool(args.get("disable_only", False))
+
+        if not entry_id:
+            return ToolResult.error_result(
+                message="id is required", error_code="MISSING_ID",
+            )
+
+        try:
+            store = CronStore(_resolve_db_path())
+            if disable_only:
+                ok = store.set_enabled(entry_id, False)
+                action_label = "disabled"
+            else:
+                ok = store.remove(entry_id)
+                action_label = "removed"
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult.error_result(
+                message=f"{type(exc).__name__}: {exc}",
+                error=exc, error_code="UNEXPECTED",
+            )
+
+        if not ok:
+            return ToolResult.error_result(
+                message=f"no entry with id={entry_id!r}",
+                error_code="NOT_FOUND",
+            )
+        return ToolResult.success_result(
+            data={"id": entry_id, "action": action_label},
+            message=f"{action_label} {entry_id!r}",
+        )

--- a/deile/tools/cron_list_tool.py
+++ b/deile/tools/cron_list_tool.py
@@ -1,0 +1,102 @@
+"""CronListTool — list scheduled prompts (intent #86)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from deile.cron.store import CronStore
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolSchema)
+
+
+def _resolve_db_path() -> Path:
+    raw = os.environ.get("DEILE_CRON_DB_PATH")
+    if raw:
+        return Path(raw).resolve()
+    base = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if base:
+        return Path(base).resolve() / "data" / "cron.db"
+    return Path.cwd() / "data" / "cron.db"
+
+
+class CronListTool(Tool):
+    """List scheduled prompts (recurring + one-shot)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="cron_list",
+                description=(
+                    "List all scheduled prompts (recurring crons + one-shots). "
+                    "Use this to answer 'what's scheduled?' / 'what tasks are "
+                    "pending?'. Set `only_enabled=true` to skip disabled "
+                    "entries. Set `created_by` to filter by who scheduled."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "only_enabled": {
+                            "type": "boolean",
+                            "description": "If true, omit disabled / completed entries.",
+                        },
+                        "created_by": {
+                            "type": "string",
+                            "description": "Filter by creator id (e.g. 'discord:1234').",
+                        },
+                    },
+                    "required": [],
+                },
+                security_level=SecurityLevel.SAFE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return "cron_list"
+
+    @property
+    def description(self) -> str:
+        return self._schema.description if self._schema else ""
+
+    @property
+    def category(self) -> str:
+        return ToolCategory.SYSTEM.value
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        args = context.parsed_args or {}
+        only_enabled = bool(args.get("only_enabled", False))
+        creator = args.get("created_by")
+        try:
+            store = CronStore(_resolve_db_path())
+            entries = store.list_all(only_enabled=only_enabled)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult.error_result(
+                message=f"could not list cron entries: {exc}",
+                error=exc, error_code="LIST_FAILED",
+            )
+
+        if creator:
+            entries = [e for e in entries if e.created_by == creator]
+
+        out = [
+            {
+                "id": e.id,
+                "prompt": e.prompt,
+                "cron": e.cron,
+                "run_at": e.run_at.isoformat() if e.run_at else None,
+                "next_fire_at": e.next_fire_at.isoformat() if e.next_fire_at else None,
+                "last_fired_at": e.last_fired_at.isoformat() if e.last_fired_at else None,
+                "enabled": e.enabled,
+                "is_oneshot": e.is_oneshot,
+                "created_by": e.created_by,
+                "notify_user_id": e.notify_user_id,
+                "last_result": e.last_result,
+            }
+            for e in entries
+        ]
+        return ToolResult.success_result(
+            data={"entries": out, "count": len(out)},
+            message=f"{len(out)} entries scheduled",
+        )

--- a/deile/tools/pipeline_schedule_tool.py
+++ b/deile/tools/pipeline_schedule_tool.py
@@ -1,0 +1,253 @@
+"""PipelineScheduleTool — LLM-callable schedule editor for the pipeline.
+
+Lets DEILE answer requests like:
+
+- "agenda implementação da issue #99 pra hoje 18h"
+- "muda o intervalo de review pra cada 10 minutos"
+- "lista os agendamentos"
+- "remove o oneshot 99"
+
+The tool delegates to :class:`ScheduleStore` and persists changes to
+``config/pipeline_schedule_<monitor_id>.yaml``. Edits take effect on
+the next monitor tick.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.orchestration.pipeline.scheduler import (OneshotEntry,
+                                                    RecurringEntry,
+                                                    ScheduleError,
+                                                    ScheduleStore)
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolSchema)
+
+
+def _resolve_base_path() -> Path:
+    raw = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if raw:
+        return Path(raw).resolve()
+    cwd = Path.cwd()
+    for ancestor in (cwd, *cwd.parents):
+        if (ancestor / ".git").is_dir() and (ancestor / "deile.py").is_file():
+            return ancestor
+    return cwd
+
+
+class PipelineScheduleTool(Tool):
+    """List/add/remove pipeline schedule entries (recurring crons + oneshots)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="pipeline_schedule",
+                description=(
+                    "Manage the autonomous pipeline schedule (cron-based "
+                    "recurring entries + ad-hoc oneshots). Use action='list' "
+                    "to see all entries, action='add_recurring' for cron "
+                    "schedules, action='add_oneshot' for one-time runs at a "
+                    "specific UTC datetime, action='remove' to delete by id, "
+                    "action='enable'/'disable' to toggle a recurring entry."
+                ),
+                parameters={
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "add_recurring", "add_oneshot",
+                                 "remove", "enable", "disable"],
+                        "description": "Operation to perform.",
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": (
+                            "Entry id (required for remove/enable/disable; "
+                            "auto-generated if omitted on add_*)."
+                        ),
+                    },
+                    "trigger_action": {
+                        "type": "string",
+                        "enum": ["review", "implement", "pr_review"],
+                        "description": "Pipeline action this entry fires.",
+                    },
+                    "cron": {
+                        "type": "string",
+                        "description": "5-field cron expression (e.g. '*/5 * * * *').",
+                    },
+                    "run_at": {
+                        "type": "string",
+                        "description": (
+                            "ISO-8601 UTC datetime for oneshot (e.g. "
+                            "'2026-05-06T18:00:00Z')."
+                        ),
+                    },
+                    "target_issue": {
+                        "type": "integer",
+                        "description": "Issue number for oneshot (optional context).",
+                    },
+                    "target_pr": {
+                        "type": "integer",
+                        "description": "PR number for oneshot (optional context).",
+                    },
+                    "monitor_id": {
+                        "type": "string",
+                        "description": (
+                            "Monitor whose schedule to edit (defaults to env "
+                            "DEILE_PIPELINE_MONITOR_ID or 'default')."
+                        ),
+                    },
+                },
+                required=["action"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return "pipeline_schedule"
+
+    @property
+    def description(self) -> str:
+        return self._schema.description if self._schema else ""
+
+    @property
+    def category(self) -> str:
+        return ToolCategory.SYSTEM.value
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        args = context.parsed_args or {}
+        action = (args.get("action") or "").strip().lower()
+
+        identity = MonitorIdentity(
+            monitor_id=args.get("monitor_id")
+            or os.environ.get("DEILE_PIPELINE_MONITOR_ID", "default"),
+        )
+        store = ScheduleStore(_resolve_base_path(), monitor_id=identity.monitor_id)
+
+        try:
+            schedule = store.load()
+        except ScheduleError as exc:
+            return ToolResult.error_result(
+                message=f"could not load schedule: {exc}",
+                error=exc, error_code="SCHEDULE_LOAD",
+            )
+
+        try:
+            if action == "list":
+                return ToolResult.success_result(
+                    data={
+                        "monitor_id": identity.monitor_id,
+                        "recurring": [e.to_dict() for e in schedule.recurring],
+                        "oneshot": [e.to_dict() for e in schedule.oneshot],
+                    },
+                    message=(
+                        f"{len(schedule.recurring)} recurring + "
+                        f"{len(schedule.oneshot)} oneshot entries"
+                    ),
+                )
+
+            if action == "add_recurring":
+                trigger = args.get("trigger_action")
+                cron = args.get("cron")
+                if not trigger or not cron:
+                    return ToolResult.error_result(
+                        message="add_recurring requires 'trigger_action' and 'cron'",
+                        error_code="MISSING_ARGS",
+                    )
+                entry_id = args.get("id") or f"{trigger}_loop"
+                schedule.add_recurring(RecurringEntry(
+                    id=entry_id, action=trigger, cron=cron, enabled=True,
+                ))
+                store.save(schedule)
+                return ToolResult.success_result(
+                    data={"id": entry_id, "cron": cron, "action": trigger},
+                    message=f"added recurring {entry_id!r} ({trigger} @ {cron})",
+                )
+
+            if action == "add_oneshot":
+                trigger = args.get("trigger_action")
+                run_at_str = args.get("run_at")
+                if not trigger or not run_at_str:
+                    return ToolResult.error_result(
+                        message="add_oneshot requires 'trigger_action' and 'run_at'",
+                        error_code="MISSING_ARGS",
+                    )
+                try:
+                    run_at = datetime.fromisoformat(run_at_str.rstrip("Z"))
+                except ValueError as exc:
+                    return ToolResult.error_result(
+                        message=f"invalid run_at: {run_at_str!r}",
+                        error=exc, error_code="INVALID_DATETIME",
+                    )
+                if run_at.tzinfo is None:
+                    run_at = run_at.replace(tzinfo=timezone.utc)
+                entry_id = (
+                    args.get("id")
+                    or f"oneshot-{trigger}-{int(run_at.timestamp())}"
+                )
+                schedule.add_oneshot(OneshotEntry(
+                    id=entry_id, action=trigger, run_at=run_at,
+                    target_issue=args.get("target_issue"),
+                    target_pr=args.get("target_pr"),
+                ))
+                store.save(schedule)
+                return ToolResult.success_result(
+                    data={
+                        "id": entry_id,
+                        "run_at": run_at.isoformat(),
+                        "action": trigger,
+                    },
+                    message=f"added oneshot {entry_id!r} ({trigger} at {run_at.isoformat()})",
+                )
+
+            if action == "remove":
+                entry_id = args.get("id")
+                if not entry_id:
+                    return ToolResult.error_result(
+                        message="remove requires 'id'", error_code="MISSING_ARGS",
+                    )
+                if not schedule.remove(entry_id):
+                    return ToolResult.error_result(
+                        message=f"no entry with id={entry_id!r}",
+                        error_code="NOT_FOUND",
+                    )
+                store.save(schedule)
+                return ToolResult.success_result(
+                    data={"id": entry_id}, message=f"removed {entry_id!r}",
+                )
+
+            if action in ("enable", "disable"):
+                entry_id = args.get("id")
+                if not entry_id:
+                    return ToolResult.error_result(
+                        message=f"{action} requires 'id'", error_code="MISSING_ARGS",
+                    )
+                entry = schedule.get_recurring(entry_id)
+                if entry is None:
+                    return ToolResult.error_result(
+                        message=f"no recurring entry with id={entry_id!r}",
+                        error_code="NOT_FOUND",
+                    )
+                entry.enabled = (action == "enable")
+                store.save(schedule)
+                return ToolResult.success_result(
+                    data={"id": entry_id, "enabled": entry.enabled},
+                    message=f"{entry_id} {'enabled' if entry.enabled else 'disabled'}",
+                )
+
+            return ToolResult.error_result(
+                message=f"unknown action: {action!r}", error_code="INVALID_ACTION",
+            )
+        except ScheduleError as exc:
+            return ToolResult.error_result(
+                message=str(exc), error=exc, error_code="SCHEDULE_ERROR",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult.error_result(
+                message=f"{type(exc).__name__}: {exc}",
+                error=exc, error_code="UNEXPECTED",
+            )

--- a/deile/tools/pipeline_schedule_tool.py
+++ b/deile/tools/pipeline_schedule_tool.py
@@ -55,50 +55,54 @@ class PipelineScheduleTool(Tool):
                     "action='enable'/'disable' to toggle a recurring entry."
                 ),
                 parameters={
-                    "action": {
-                        "type": "string",
-                        "enum": ["list", "add_recurring", "add_oneshot",
-                                 "remove", "enable", "disable"],
-                        "description": "Operation to perform.",
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["list", "add_recurring", "add_oneshot",
+                                     "remove", "enable", "disable"],
+                            "description": "Operation to perform.",
+                        },
+                        "id": {
+                            "type": "string",
+                            "description": (
+                                "Entry id (required for remove/enable/disable; "
+                                "auto-generated if omitted on add_*)."
+                            ),
+                        },
+                        "trigger_action": {
+                            "type": "string",
+                            "enum": ["review", "implement", "pr_review"],
+                            "description": "Pipeline action this entry fires.",
+                        },
+                        "cron": {
+                            "type": "string",
+                            "description": "5-field cron expression (e.g. '*/5 * * * *').",
+                        },
+                        "run_at": {
+                            "type": "string",
+                            "description": (
+                                "ISO-8601 UTC datetime for oneshot (e.g. "
+                                "'2026-05-06T18:00:00Z')."
+                            ),
+                        },
+                        "target_issue": {
+                            "type": "integer",
+                            "description": "Issue number for oneshot (optional context).",
+                        },
+                        "target_pr": {
+                            "type": "integer",
+                            "description": "PR number for oneshot (optional context).",
+                        },
+                        "monitor_id": {
+                            "type": "string",
+                            "description": (
+                                "Monitor whose schedule to edit (defaults to env "
+                                "DEILE_PIPELINE_MONITOR_ID or 'default')."
+                            ),
+                        },
                     },
-                    "id": {
-                        "type": "string",
-                        "description": (
-                            "Entry id (required for remove/enable/disable; "
-                            "auto-generated if omitted on add_*)."
-                        ),
-                    },
-                    "trigger_action": {
-                        "type": "string",
-                        "enum": ["review", "implement", "pr_review"],
-                        "description": "Pipeline action this entry fires.",
-                    },
-                    "cron": {
-                        "type": "string",
-                        "description": "5-field cron expression (e.g. '*/5 * * * *').",
-                    },
-                    "run_at": {
-                        "type": "string",
-                        "description": (
-                            "ISO-8601 UTC datetime for oneshot (e.g. "
-                            "'2026-05-06T18:00:00Z')."
-                        ),
-                    },
-                    "target_issue": {
-                        "type": "integer",
-                        "description": "Issue number for oneshot (optional context).",
-                    },
-                    "target_pr": {
-                        "type": "integer",
-                        "description": "PR number for oneshot (optional context).",
-                    },
-                    "monitor_id": {
-                        "type": "string",
-                        "description": (
-                            "Monitor whose schedule to edit (defaults to env "
-                            "DEILE_PIPELINE_MONITOR_ID or 'default')."
-                        ),
-                    },
+                    "required": ["action"],
                 },
                 required=["action"],
                 security_level=SecurityLevel.MODERATE,

--- a/deile/tools/pipeline_tool.py
+++ b/deile/tools/pipeline_tool.py
@@ -56,11 +56,15 @@ class PipelineTool(Tool):
                     "synchronous tick (debug)."
                 ),
                 parameters={
-                    "action": {
-                        "type": "string",
-                        "enum": ["start", "stop", "status", "tick"],
-                        "description": "Pipeline operation to perform.",
-                    }
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["start", "stop", "status", "tick"],
+                            "description": "Pipeline operation to perform.",
+                        },
+                    },
+                    "required": ["action"],
                 },
                 required=["action"],
                 security_level=SecurityLevel.MODERATE,

--- a/deile/tools/pipeline_tool.py
+++ b/deile/tools/pipeline_tool.py
@@ -1,0 +1,167 @@
+"""PipelineTool — LLM-callable interface to the autonomous pipeline.
+
+Sibling to the ``/pipeline`` slash command (``deile/commands/builtin/pipeline_command.py``)
+but registered as a Tool so the LLM can invoke it from natural language
+(e.g. user via Discord: "verifica o status do pipeline pra mim" → DEILE
+chooses to call this tool with action='status').
+
+Both surfaces share the same :class:`PipelineMonitor` instance held on the
+agent (``agent.pipeline_monitor``) — invoking the tool and then the slash
+command in the same session sees consistent state.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolSchema)
+
+
+_DEFAULT_REPO = "elimarcavalli/deile"
+
+
+def _resolve_repo() -> str:
+    return os.environ.get("DEILE_PIPELINE_REPO", _DEFAULT_REPO)
+
+
+def _resolve_base_path() -> Path:
+    raw = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if raw:
+        return Path(raw).resolve()
+    cwd = Path.cwd()
+    for ancestor in (cwd, *cwd.parents):
+        if (ancestor / ".git").is_dir() and (ancestor / "deile.py").is_file():
+            return ancestor
+    return cwd
+
+
+class PipelineTool(Tool):
+    """Start/stop/inspect the autonomous DEILE-bot → DEILE → Claude Code pipeline."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="pipeline",
+                description=(
+                    "Control the autonomous pipeline that polls GitHub issues/PRs and "
+                    "delegates to Claude Code one-shot for implementation/review. "
+                    "Use action='start' to begin the 1-minute polling loop, "
+                    "action='stop' to halt it, action='status' for ticks/reviewed/"
+                    "implemented/PRs/errors counters, action='tick' to force a single "
+                    "synchronous tick (debug)."
+                ),
+                parameters={
+                    "action": {
+                        "type": "string",
+                        "enum": ["start", "stop", "status", "tick"],
+                        "description": "Pipeline operation to perform.",
+                    }
+                },
+                required=["action"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return "pipeline"
+
+    @property
+    def description(self) -> str:
+        return self._schema.description if self._schema else ""
+
+    @property
+    def category(self) -> str:
+        return ToolCategory.SYSTEM.value
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        action = (context.parsed_args.get("action") or "status").strip().lower()
+        if action not in {"start", "stop", "status", "tick"}:
+            return ToolResult.error_result(
+                message=f"action must be one of start|stop|status|tick, got {action!r}",
+                error_code="INVALID_ACTION",
+            )
+
+        agent = context.session_data.get("agent") or context.extra.get("agent")
+        monitor = self._get_or_create_monitor(agent)
+
+        try:
+            if action == "start":
+                await monitor.start()
+                msg = (
+                    f"pipeline iniciado (repo={monitor.config.repo}, "
+                    f"interval={monitor.config.poll_interval_seconds}s)"
+                )
+                return ToolResult.success_result(
+                    data={"running": True, "repo": monitor.config.repo},
+                    message=msg,
+                )
+            if action == "stop":
+                await monitor.stop()
+                return ToolResult.success_result(
+                    data={"running": False}, message="pipeline parado"
+                )
+            if action == "tick":
+                await monitor.tick()
+                return ToolResult.success_result(
+                    data=self._stats_dict(monitor),
+                    message="single tick executed",
+                )
+            # status (default)
+            running = self._is_running(monitor)
+            return ToolResult.success_result(
+                data={"running": running, **self._stats_dict(monitor)},
+                message=(
+                    f"pipeline {'rodando' if running else 'parado'} | "
+                    f"repo={monitor.config.repo}"
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — surface any failure to the LLM
+            return ToolResult.error_result(
+                message=f"pipeline {action} failed: {type(exc).__name__}: {exc}",
+                error=exc,
+                error_code="PIPELINE_OP_FAILED",
+            )
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_or_create_monitor(agent: Optional[Any]) -> PipelineMonitor:
+        if agent is not None and getattr(agent, "pipeline_monitor", None) is not None:
+            return agent.pipeline_monitor
+        cfg = PipelineConfig(
+            repo=_resolve_repo(),
+            base_repo_path=_resolve_base_path(),
+            notify_user_id=os.environ.get("DEILE_PIPELINE_NOTIFY_USER_ID"),
+        )
+        monitor = PipelineMonitor(cfg)
+        if agent is not None:
+            try:
+                agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
+            except Exception:
+                pass
+        return monitor
+
+    @staticmethod
+    def _is_running(monitor: PipelineMonitor) -> bool:
+        task = getattr(monitor, "_task", None)
+        return task is not None and not task.done()
+
+    @staticmethod
+    def _stats_dict(monitor: PipelineMonitor) -> dict:
+        s = monitor.stats
+        return {
+            "ticks": s.ticks,
+            "issues_reviewed": s.issues_reviewed,
+            "issues_implemented": s.issues_implemented,
+            "prs_reviewed": s.prs_reviewed,
+            "errors": s.errors,
+        }

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -297,6 +297,7 @@ class ToolRegistry:
                 'deile.tools.cron_create_tool',
                 'deile.tools.cron_list_tool',
                 'deile.tools.cron_delete_tool',
+                'deile.tools.worktree_tool',
             ]
 
         discovered_count = 0

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -292,6 +292,7 @@ class ToolRegistry:
                 'deile.tools.bash_tool',
                 'deile.tools.slash_command_executor',
                 'deile.tools.vision_tool',
+                'deile.tools.pipeline_tool',
             ]
 
         discovered_count = 0

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -293,6 +293,7 @@ class ToolRegistry:
                 'deile.tools.slash_command_executor',
                 'deile.tools.vision_tool',
                 'deile.tools.pipeline_tool',
+                'deile.tools.pipeline_schedule_tool',
             ]
 
         discovered_count = 0

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -294,6 +294,9 @@ class ToolRegistry:
                 'deile.tools.vision_tool',
                 'deile.tools.pipeline_tool',
                 'deile.tools.pipeline_schedule_tool',
+                'deile.tools.cron_create_tool',
+                'deile.tools.cron_list_tool',
+                'deile.tools.cron_delete_tool',
             ]
 
         discovered_count = 0

--- a/deile/tools/worktree_tool.py
+++ b/deile/tools/worktree_tool.py
@@ -1,0 +1,273 @@
+"""WorktreeTool — LLM-callable interface to worktree management.
+
+Exposes :class:`WorktreeManager` (``deile/orchestration/pipeline/worktree_manager.py``)
+to the LLM so users can create, list and remove branch worktrees without
+dropping to the shell.
+
+Actions
+-------
+ensure_main
+    Ensure ``.worktrees/main`` exists and is up-to-date. Returns the path.
+create
+    Create a per-branch worktree under ``.worktrees/<subdir>/<branch>`` (or
+    ``.worktrees/<branch>`` when *subdir* is omitted). Returns the path + branch.
+list
+    List all entries discovered under ``.worktrees/``. Returns an array of
+    ``{path, branch, base_repo}`` objects.
+remove
+    Remove ``.worktrees/<subdir>/<branch>`` (or ``.worktrees/<branch>``) after
+    safety checks. Uses ``shutil.rmtree``.
+
+Schema note
+-----------
+``parameters`` is a **JSON Schema object** (``{"type": "object", "properties": {…},
+"required": […]}``) — *not* a raw dict.  The regression test
+``test_schema_is_json_schema_object`` explicitly guards this shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+from deile.orchestration.pipeline.worktree_manager import (WorktreeError,
+                                                           WorktreeManager)
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolSchema)
+
+logger = logging.getLogger(__name__)
+
+_PROTECTED_SUBDIRS = {"main"}  # worktrees that must never be removed
+
+
+def _resolve_base_path(override: Optional[str] = None) -> Path:
+    """Return the base repository path.
+
+    Priority: explicit *override* arg > ``DEILE_PIPELINE_BASE_PATH`` env var >
+    auto-detect by walking CWD ancestors looking for ``.git`` + ``deile.py``.
+    """
+    if override:
+        return Path(override).resolve()
+    raw = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if raw:
+        return Path(raw).resolve()
+    cwd = Path.cwd()
+    for ancestor in (cwd, *cwd.parents):
+        if (ancestor / ".git").is_dir() and (ancestor / "deile.py").is_file():
+            return ancestor
+    return cwd
+
+
+class WorktreeTool(Tool):
+    """Create, list and remove branch worktrees via the LLM."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="worktree",
+                description=(
+                    "Manage isolated branch worktrees under .worktrees/. "
+                    "Use action='ensure_main' to initialise or refresh the shared clean "
+                    "main clone; action='create' to set up a new branch sandbox; "
+                    "action='list' to see existing worktrees; action='remove' to delete "
+                    "a branch worktree (safety-checked — cannot remove main)."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["ensure_main", "create", "list", "remove"],
+                            "description": "Worktree operation to perform.",
+                        },
+                        "branch": {
+                            "type": "string",
+                            "description": (
+                                "Branch name. Required for 'create' and 'remove'."
+                            ),
+                        },
+                        "subdir": {
+                            "type": "string",
+                            "description": (
+                                "Optional namespace subdirectory under .worktrees/ "
+                                "(e.g. 'agents', 'feat'). Defaults to no subdirectory."
+                            ),
+                        },
+                        "base_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to the base git repository. "
+                                "Defaults to auto-detected repo root."
+                            ),
+                        },
+                    },
+                    "required": ["action"],
+                },
+                required=["action"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return "worktree"
+
+    @property
+    def description(self) -> str:
+        return self._schema.description if self._schema else ""
+
+    @property
+    def category(self) -> str:
+        return ToolCategory.SYSTEM.value
+
+    async def execute(self, context: ToolContext) -> ToolResult:  # noqa: C901
+        action = (context.parsed_args.get("action") or "").strip().lower()
+        valid_actions = {"ensure_main", "create", "list", "remove"}
+        if action not in valid_actions:
+            return ToolResult.error_result(
+                message=(
+                    f"action must be one of {sorted(valid_actions)!r}, got {action!r}"
+                ),
+                error_code="INVALID_ACTION",
+            )
+
+        base_path_raw: Optional[str] = context.parsed_args.get("base_path")
+        branch: Optional[str] = context.parsed_args.get("branch")
+        subdir: Optional[str] = context.parsed_args.get("subdir") or None
+
+        try:
+            base_path = _resolve_base_path(base_path_raw)
+
+            if action == "ensure_main":
+                return await self._ensure_main(base_path, subdir)
+
+            if action == "create":
+                if not branch:
+                    return ToolResult.error_result(
+                        message="'branch' is required for action='create'",
+                        error_code="MISSING_BRANCH",
+                    )
+                return await self._create(base_path, branch, subdir)
+
+            if action == "list":
+                return await self._list(base_path)
+
+            if action == "remove":
+                if not branch:
+                    return ToolResult.error_result(
+                        message="'branch' is required for action='remove'",
+                        error_code="MISSING_BRANCH",
+                    )
+                return await self._remove(base_path, branch, subdir)
+
+        except WorktreeError as exc:
+            return ToolResult.error_result(
+                message=str(exc),
+                error=exc,
+                error_code="WORKTREE_ERROR",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("worktree %s failed: %s", action, exc, exc_info=True)
+            return ToolResult.error_result(
+                message=f"worktree {action} failed: {type(exc).__name__}: {exc}",
+                error=exc,
+                error_code="WORKTREE_OP_FAILED",
+            )
+
+        # Unreachable — all branches return above.  Satisfies type-checker.
+        return ToolResult.error_result(  # pragma: no cover
+            message="internal error: unhandled action",
+            error_code="INTERNAL",
+        )
+
+    # ------------------------------------------------------------------
+    # private action helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _ensure_main(base_path: Path, subdir: Optional[str]) -> ToolResult:
+        mgr = WorktreeManager(base_path, subdir=subdir)
+        path = await mgr.ensure_main()
+        return ToolResult.success_result(
+            data={"path": str(path)},
+            message=f"main worktree ready at {path}",
+        )
+
+    @staticmethod
+    async def _create(
+        base_path: Path, branch: str, subdir: Optional[str]
+    ) -> ToolResult:
+        mgr = WorktreeManager(base_path, subdir=subdir)
+        wt = await mgr.create_branch_worktree(branch)
+        return ToolResult.success_result(
+            data={
+                "path": str(wt.path),
+                "branch": wt.branch,
+                "base_repo": str(wt.base_repo),
+            },
+            message=f"worktree for {branch!r} ready at {wt.path}",
+        )
+
+    @staticmethod
+    async def _list(base_path: Path) -> ToolResult:
+        """Scan ``.worktrees/`` and return entries that look like git repos."""
+        worktrees_dir = base_path / ".worktrees"
+        if not worktrees_dir.is_dir():
+            return ToolResult.success_result(
+                data={"worktrees": []},
+                message="no .worktrees/ directory found",
+            )
+
+        entries = []
+        for item in sorted(worktrees_dir.rglob("*")):
+            if item.is_dir() and (item / ".git").exists():
+                entries.append(
+                    {
+                        "path": str(item),
+                        "branch": item.name,
+                        "base_repo": str(base_path),
+                    }
+                )
+
+        return ToolResult.success_result(
+            data={"worktrees": entries},
+            message=f"found {len(entries)} worktree(s)",
+        )
+
+    @staticmethod
+    async def _remove(
+        base_path: Path, branch: str, subdir: Optional[str]
+    ) -> ToolResult:
+        """Remove a branch worktree after safety checks."""
+        # Safety: refuse to remove the shared clean main clone.
+        if branch in _PROTECTED_SUBDIRS:
+            return ToolResult.error_result(
+                message=(
+                    f"cannot remove protected worktree {branch!r} — "
+                    "it is the shared clean main clone used by all pipelines"
+                ),
+                error_code="REMOVE_PROTECTED",
+            )
+
+        worktrees_dir = base_path / ".worktrees"
+        if subdir:
+            target = worktrees_dir / subdir / branch
+        else:
+            target = worktrees_dir / branch
+
+        if not target.exists():
+            return ToolResult.error_result(
+                message=f"worktree path does not exist: {target}",
+                error_code="NOT_FOUND",
+            )
+
+        await asyncio.to_thread(shutil.rmtree, str(target))
+        return ToolResult.success_result(
+            data={"removed": str(target)},
+            message=f"removed worktree at {target}",
+        )

--- a/docs/2026-05-06_PIPELINE-AUTONOMO.md
+++ b/docs/2026-05-06_PIPELINE-AUTONOMO.md
@@ -1,0 +1,497 @@
+# Pipeline Autônomo de Issues/PRs + Cron Genérico
+
+> **Intents de origem:** [#87](https://github.com/elimarcavalli/deile/issues/87) (pipeline autônomo) e [#86](https://github.com/elimarcavalli/deile/issues/86) (agendador de prompts)
+>
+> **Versão:** V1 — implementação inicial completa
+>
+> **Decisões arquiteturais relacionadas:** #18, #19, #20 — ver `docs/system_design/DECISOES.md`
+
+---
+
+## 1. Overview
+
+O DEILE adquiriu a capacidade de **operar autonomamente sobre o repositório GitHub**, sem intervenção humana por mensagem. Quando um operador abre uma issue com o label `~workflow:nova`, o pipeline:
+
+1. Revisa o corpo da issue com DEILE e a transita para `~workflow:revisada`.
+2. Cria um worktree isolado, invoca `claude -p <prompt>` (Claude Code one-shot) para implementar, e abre uma PR.
+3. Invoca Claude Code na PR para revisar, corrigir e dar merge.
+
+Complementarmente, o **cron genérico** (intent #86) permite que qualquer usuário (ex.: via Discord) agende prompts naturais — "rodar X toda segunda às 9h" ou "executar Y amanhã às 18h" — que o `CronRunner` dispara como novas turns do agente DEILE.
+
+**Problema resolvido:** eliminar o ciclo manual de "usuário pede, DEILE implementa, usuário abre PR, usuário pede revisão". O pipeline automatiza o loop completo; o cron permite agendamento assíncrono de qualquer instrução.
+
+---
+
+## 2. Architectural Decisions
+
+### Patterns escolhidos
+
+| Pattern | Aplicação |
+|---|---|
+| Polling loop async | `PipelineMonitor._run_forever` usa `asyncio.wait_for` com timeout para poll a cada `poll_interval_seconds` sem threads |
+| Strategy de autenticação | `ClaudeDispatcher.prefer_subscription_auth` isola a decisão de qual key usar em um único ponto |
+| Hash sharding | `MonitorIdentity.owns(key)` distribui issues/PRs entre instâncias sem coordenador — ver Decisão #18 |
+| Separação de stores | `ScheduleStore` (YAML) para pipeline scheduler; `CronStore` (SQLite) para cron genérico — ver Decisão #19 |
+| Tool + Command dual surface | Cada funcionalidade exposta tanto como `Tool` (LLM pode invocar) quanto como `/command` (operador pode usar diretamente no REPL) |
+
+### Trade-offs
+
+| Aspecto | Escolha | Alternativa descartada |
+|---|---|---|
+| Coordenação entre monitores | Labels GitHub (`~batch:<sha>`) como lock otimista | Lock distribuído (Redis, etcd) — dependência operacional pesada para uso local |
+| Scheduler do pipeline | YAML por monitor | SQLite compartilhado — YAML é legível/editável manualmente; SQLite seria melhor para N>10 monitores |
+| Cron genérico | SQLite | YAML — SQLite suporta escrita concorrente com threading lock; YAML corromperia em acesso paralelo |
+| Invocação de Claude Code | subprocess `claude -p` | API direta (anthropic SDK) — Claude Code CLI tem CLAUDE.md e contexto de repositório por design |
+
+### Async/await
+
+- `PipelineMonitor.start/stop/tick` são `async` e usam `asyncio.create_task` para o loop
+- `ClaudeDispatcher.run` usa `asyncio.create_subprocess_exec` + `asyncio.wait_for` para timeout
+- `CronRunner.tick/_fire` são `async`; `CronStore` é síncrono (SQLite) mas protegido com `threading.Lock` para ser seguro em contexto multithread-over-asyncio
+
+### Segurança
+
+- `ClaudeDispatcher` strip de `ANTHROPIC_API_KEY` por default — ver Decisão #20
+- Labels `~batch:<sha>` com SHA de 8 chars evitam colisões de claim entre monitores
+- `PIDLockFile` (`lockfile.py`) impede dois monitores com o mesmo `monitor_id` no mesmo host
+
+---
+
+## 3. Component Architecture
+
+### Core Components
+
+| Módulo | Responsabilidade |
+|---|---|
+| `orchestration/pipeline/monitor.py` | `PipelineMonitor` — driver do loop; orquestra os 3 estágios; mantém `_Stats` |
+| `orchestration/pipeline/github_client.py` | `GitHubClient` — wrapper de `gh issue list/view/label`, `gh pr list/label/merge` |
+| `orchestration/pipeline/worktree_manager.py` | `WorktreeManager` — cria/remove `.worktrees/<branch>` via `git worktree add` |
+| `orchestration/pipeline/claude_dispatcher.py` | `ClaudeDispatcher` — subprocess `claude -p <prompt>`, timeout, strip de keys |
+| `orchestration/pipeline/notifier.py` | `DiscordNotifier` — DMs de notificação em cada transição de estado |
+| `orchestration/pipeline/identity.py` | `MonitorIdentity` — `monitor_id`, `shard_index/count`, `owns(key)`, branch prefix |
+| `orchestration/pipeline/lockfile.py` | `acquire/release` — PID lock em arquivo |
+| `orchestration/pipeline/scheduler.py` | `ScheduleStore`, `Schedule`, `RecurringEntry`, `OneshotEntry`, `compute_pending` |
+| `orchestration/pipeline/cron.py` | `next_after(expr, anchor)` — parser de expressões cron 5-field |
+| `orchestration/pipeline/labels.py` | Constantes de labels; `is_batch_label`, `make_batch_label` |
+| `cron/store.py` | `CronStore` (SQLite), `CronEntry`, `make_id` |
+| `cron/runner.py` | `CronRunner` — poll loop 30s, `fire_callback`, DM de resultado |
+
+### Tools registradas
+
+| Tool | Módulo | Categoria | SecurityLevel |
+|---|---|---|---|
+| `pipeline` | `tools/pipeline_tool.py` | SYSTEM | MODERATE |
+| `pipeline_schedule` | `tools/pipeline_schedule_tool.py` | SYSTEM | MODERATE |
+| `cron_create` | `tools/cron_create_tool.py` | SYSTEM | MODERATE |
+| `cron_list` | `tools/cron_list_tool.py` | SYSTEM | SAFE |
+| `cron_delete` | `tools/cron_delete_tool.py` | SYSTEM | MODERATE |
+
+### Comandos slash
+
+| Comando | Módulo |
+|---|---|
+| `/pipeline` | `commands/builtin/pipeline_command.py` |
+
+### Storage
+
+| Artefato | Caminho | Formato |
+|---|---|---|
+| Schedule do pipeline (por monitor) | `config/pipeline_schedule_<monitor_id>.yaml` | YAML |
+| CronStore | `data/cron.db` (ou `DEILE_CRON_DB_PATH`) | SQLite |
+| Worktrees | `.worktrees/<branch>` (ou `.worktrees/<monitor_id>/<branch>`) | git worktree |
+
+---
+
+## 4. Implementation Details
+
+```
+PipelineMonitor
+├── config: PipelineConfig
+│   ├── repo: str
+│   ├── base_repo_path: Path
+│   ├── poll_interval_seconds: int (default 60)
+│   ├── main_branch: str (default "main")
+│   ├── branch_prefix: str (default "auto/issue-")
+│   ├── notify_user_id: Optional[str]
+│   ├── enable_review/implement/pr_review: bool
+│   └── use_pid_lock: bool
+├── identity: MonitorIdentity
+│   ├── monitor_id: str
+│   ├── shard_index: int
+│   ├── shard_count: int
+│   ├── owns(key: str) -> bool  # SHA-256 % shard_count
+│   └── branch_prefix(action) -> str
+├── stats: _Stats
+│   ├── ticks, issues_reviewed, issues_implemented
+│   ├── prs_reviewed, errors, catchup_runs, scheduled_runs
+├── async start() → acquires PID lock → catch_up_pending → create_task(_run_forever)
+├── async stop() → set stop_event → wait task → release lock
+├── async tick() → check schedule → run pending or run all stages
+├── Stage 1: _review_one_new_issue()
+│   ├── list issues with ~workflow:nova
+│   ├── identity.owns(issue.title) filter + shard
+│   ├── claim_with_batch → add ownership label
+│   └── transition nova → em_revisao → revisada
+├── Stage 2: _implement_one_reviewed_issue()
+│   ├── list issues with ~workflow:revisada owned by this monitor
+│   ├── WorktreeManager.create_branch_worktree(branch)
+│   ├── ClaudeDispatcher.run(implement_prompt, cwd=worktree)
+│   └── transition revisada → em_pr
+└── Stage 3: _review_one_open_pr()
+    ├── list open PRs not draft, no ~review:concluida, owned branch
+    ├── claim_with_batch → transition pendente → em_andamento
+    ├── ClaudeDispatcher.run(review_prompt, cwd=worktree)
+    └── transition em_andamento → concluida
+
+CronRunner
+├── store: CronStore
+├── fire_callback: async (CronEntry) -> str
+├── poll_interval_seconds: int (default 30)
+├── notify_dm: Optional[async (user_id, msg) -> dict]
+├── async start() → create_task(_run_forever)
+├── async tick() → store.list_due() → _fire(entry) for each
+└── async _fire(entry)
+    ├── await fire_callback(entry)
+    ├── store.mark_fired(entry.id, result=summary)
+    └── notify_dm if entry.notify_user_id
+```
+
+---
+
+## 5. API Specification
+
+### PipelineMonitor
+
+| Method | Parameters | Return | Async | Notes |
+|---|---|---|---|---|
+| `start()` | — | `None` | Yes | Idempotente; levanta `LockHeldError` se PID lock já ocupado |
+| `stop()` | — | `None` | Yes | Wait 5s, cancela se timeout |
+| `tick()` | — | `None` | Yes | Um ciclo completo dos 3 estágios (ou entradas de schedule) |
+| `stats` | — | `_Stats` | No (property) | Contadores acumulativos |
+
+### ClaudeDispatcher
+
+| Method | Parameters | Return | Async | Notes |
+|---|---|---|---|---|
+| `run(prompt, cwd, env=None, extra_args=())` | `str`, `Path` | `ClaudeRunResult` | Yes | Timeout default 1800s |
+
+### CronStore
+
+| Method | Parameters | Return | Notes |
+|---|---|---|---|
+| `add(entry)` | `CronEntry` | `None` | Lança `CronStoreError` se id já existe |
+| `list_all(only_enabled=False)` | `bool` | `List[CronEntry]` | Order by next_fire_at |
+| `list_due(now=None)` | `datetime` | `List[CronEntry]` | enabled=1 AND next_fire_at <= now |
+| `mark_fired(id, when=None, result=None)` | `str`, `datetime`, `str` | `None` | Avança next_fire_at ou desabilita one-shot |
+| `remove(id)` | `str` | `bool` | True se linha deletada |
+| `set_enabled(id, enabled)` | `str`, `bool` | `bool` | True se linha atualizada |
+
+### ScheduleStore
+
+| Method | Parameters | Return | Notes |
+|---|---|---|---|
+| `load()` | — | `Schedule` | Retorna `Schedule()` vazio se arquivo ausente |
+| `save(schedule)` | `Schedule` | `None` | Cria `config/` se necessário |
+
+### Schedule
+
+| Method | Parameters | Return | Notes |
+|---|---|---|---|
+| `compute_pending(now=None)` | `datetime` | `List[PendingRun]` | Coalesça misseds por padrão; `replay_all=True` replica cada slot |
+| `mark_run(run, when=None)` | `PendingRun` | `None` | Atualiza last_run_at (recurring) ou completed (oneshot) |
+
+---
+
+## 6. Configuration Schema
+
+### `config/pipeline_schedule_<monitor_id>.yaml`
+
+```yaml
+recurring:
+  - id: review_loop           # str, alphanum + _- obrigatório
+    action: review            # review | implement | pr_review
+    cron: "*/5 * * * *"       # 5-field cron expression em UTC
+    enabled: true             # false congela a entrada sem deletar
+    last_run_at: null         # ISO-8601 UTC; null = nunca rodou
+    replay_all: false         # true = replay cada slot missed no downtime
+
+oneshot:
+  - id: oneshot-impl-99
+    action: implement
+    target_issue: 99          # contexto; não modifica o pipeline hoje
+    run_at: "2026-05-06T18:00:00Z"
+    completed: false
+```
+
+### `CronEntry` (SQLite)
+
+```
+id TEXT PRIMARY KEY
+prompt TEXT NOT NULL
+cron TEXT                    -- NULL para one-shot
+run_at TEXT                  -- NULL para recorrente
+next_fire_at TEXT            -- ISO-8601 UTC; index para list_due
+last_fired_at TEXT
+created_by TEXT              -- e.g. "discord:1234567890"
+notify_user_id TEXT          -- Discord snowflake para DM de resultado
+enabled INTEGER NOT NULL DEFAULT 1
+created_at TEXT NOT NULL
+last_result TEXT             -- resumo da última execução (max 1000 chars)
+```
+
+### Variáveis de ambiente
+
+Ver seção "Pipeline + Cron — variáveis de ambiente" em `docs/system_design/09-CONFIGURACAO.md`.
+
+---
+
+## 7. Security Implementation
+
+| Aspecto | Implementação |
+|---|---|
+| Key isolation | `ClaudeDispatcher` strip de `ANTHROPIC_API_KEY` (Decisão #20) — o subprocess `claude` usa assinatura do operador |
+| PID lock | `lockfile.py` impede dois monitores com mesmo `monitor_id` no mesmo host; levanta `LockHeldError` com PID do holder |
+| Label-based optimistic lock | `~batch:<sha8>` adicionado atomicamente via GitHub API antes de processar; se outro monitor já adicionou, o claim falha silenciosamente |
+| Worktree isolation | Cada issue/PR tem seu próprio worktree; Claude Code opera num subdiretório isolado sem acesso ao repo raiz |
+| Prompt injection | Os prompts (`IMPLEMENT_PROMPT_TEMPLATE`, `REVIEW_PROMPT_TEMPLATE`) truncam o issue body em 6000 chars; não injetam conteúdo não-sanitizado em flags de shell |
+| Tool SecurityLevel | Todas as tools de pipeline/cron classificadas como `MODERATE` (exceto `cron_list`: `SAFE`); passam por `ApprovalSystem` se configurado |
+| Sem PII no cron | `created_by` e `notify_user_id` são opcionais; a decisão de logar esses campos cabe ao operador |
+
+---
+
+## 8. Testing Strategy
+
+### Unit Tests
+
+```python
+# deile/tests/orchestration/pipeline/
+async def test_pipeline_monitor_tick_dispatches_stage1():
+    github = MockGitHubClient(issues=[IssueRef(number=1, labels=[WORKFLOW_NEW])])
+    monitor = PipelineMonitor(config, github=github)
+    await monitor.tick()
+    assert monitor.stats.issues_reviewed == 1
+
+async def test_cron_store_add_and_list_due():
+    store = CronStore(Path(tmp_path) / "cron.db")
+    entry = CronEntry(id="x", prompt="test", cron="* * * * *")
+    store.add(entry)
+    due = store.list_due(now=datetime.now(timezone.utc) + timedelta(minutes=2))
+    assert len(due) == 1
+
+async def test_monitor_identity_shard():
+    id1 = MonitorIdentity(monitor_id="a", shard_index=0, shard_count=2)
+    id2 = MonitorIdentity(monitor_id="b", shard_index=1, shard_count=2)
+    # every key is owned by exactly one monitor
+    keys = ["issue-1", "issue-2", "issue-3", "issue-4"]
+    for k in keys:
+        assert id1.owns(k) != id2.owns(k)
+```
+
+### Integration Tests
+
+| Cenário | Cobertura |
+|---|---|
+| Pipeline tick end-to-end (mocked `gh`) | Todos os 3 estágios; transições de label corretas |
+| `CronRunner.tick` com fire_callback | Entry marked_fired após disparo; one-shot desabilitado |
+| `PipelineScheduleTool` add_recurring + list | Persistência YAML roundtrip |
+| `CronCreateTool` + `CronListTool` + `CronDeleteTool` | CRUD completo via tool interface |
+| Sharding: 2 monitors com shard_count=2 | Particionamento sem sobreposição |
+
+### Segurança
+
+| Cenário | Verificação |
+|---|---|
+| Monitor sem PID lock / lock já ocupado | `LockHeldError` levantado com PID correto |
+| `CronEntry` com `cron` e `run_at` ao mesmo tempo | `CronStoreError` levantado em `__post_init__` |
+| Prompt vazio em `cron_create` | `ToolResult.error_result("MISSING_PROMPT")` |
+| `MonitorIdentity` com `shard_index >= shard_count` | `IdentityError` |
+
+---
+
+## 9. Usage Examples
+
+### CLI (REPL)
+
+```
+# Iniciar o pipeline
+/pipeline start
+
+# Verificar status
+/pipeline status
+
+# Forçar um tick para depuração
+/pipeline tick
+
+# Parar
+/pipeline stop
+```
+
+### Agendamento via LLM (ex.: Discord → DEILE)
+
+```
+Usuário: "Revise as issues novas a cada 5 minutos"
+DEILE invoca: pipeline_schedule(action="add_recurring",
+              trigger_action="review", cron="*/5 * * * *")
+
+Usuário: "Implemente a issue 99 amanhã às 18h"
+DEILE invoca: pipeline_schedule(action="add_oneshot",
+              trigger_action="implement", run_at="2026-05-07T18:00:00Z",
+              target_issue=99)
+
+Usuário: "Agende um relatório de custos toda segunda às 9h"
+DEILE invoca: cron_create(prompt="Gere um relatório de custo das últimas
+              24h e envie via DM", cron="0 9 * * 1",
+              notify_user_id="1234567890")
+```
+
+### Programático (bootstrap do daemon)
+
+```python
+# No deilebot / daemon startup
+from deile.orchestration.pipeline.monitor import PipelineMonitor, PipelineConfig
+from deile.cron.store import CronStore
+from deile.cron.runner import CronRunner
+
+config = PipelineConfig(
+    repo=os.environ["DEILE_PIPELINE_REPO"],
+    base_repo_path=Path(os.environ["DEILE_PIPELINE_BASE_PATH"]),
+    notify_user_id=os.environ.get("DEILE_PIPELINE_NOTIFY_USER_ID"),
+    use_pid_lock=True,
+)
+monitor = PipelineMonitor(config)
+await monitor.start()   # dispara o loop
+
+cron_store = CronStore(Path("data/cron.db"))
+cron_runner = CronRunner(
+    cron_store,
+    fire_callback=my_agent_fire,  # async (entry) -> str
+    notify_dm=my_discord_dm,      # async (user_id, msg) -> dict
+)
+await cron_runner.start()
+```
+
+---
+
+## 10. Performance Characteristics
+
+| Aspecto | Característica |
+|---|---|
+| Poll interval | 60s por padrão; configurável em `PipelineConfig.poll_interval_seconds` |
+| Cron runner poll | 30s por padrão; configurável em `CronRunner.poll_interval_seconds` |
+| Claude Code timeout | 1800s (30 min) por invocação; configurável em `ClaudeDispatcher.timeout_seconds` |
+| GitHub API | Cada tick faz no máximo 3 chamadas de listagem + N operações de label (N ≤ 3 por issue/PR) |
+| Worktrees | Criados em disco; removidos manualmente (worktree cleanup não é automático — ver § Rollback) |
+| `CronStore.list_due` | `O(log N)` via índice `(enabled, next_fire_at)` |
+| Schedule YAML | Parse a cada tick; aceitável para schedules com < 100 entradas |
+| Concorrência | Um monitor por identidade por host; shards rodam em processos/máquinas separadas |
+
+---
+
+## 11. Monitoring & Observability
+
+### Logs
+
+| Logger | Eventos |
+|---|---|
+| `deile.orchestration.pipeline.monitor` | Tick #{n}, stage transitions, errors |
+| `deile.orchestration.pipeline.claude_dispatcher` | `invoking Claude Code: ... in <cwd>` |
+| `deile.orchestration.pipeline.github_client` | gh CLI calls + stderr |
+| `deile.orchestration.pipeline.notifier` | DM sent / DM failed |
+| `deile.cron.runner` | Entry fired / fire failed |
+
+### Métricas (via `PipelineMonitor.stats`)
+
+| Contador | Significado |
+|---|---|
+| `ticks` | Total de ticks executados desde start |
+| `issues_reviewed` | Issues que passaram pelo estágio 1 com sucesso |
+| `issues_implemented` | Issues que passaram pelo estágio 2 com sucesso |
+| `prs_reviewed` | PRs que passaram pelo estágio 3 com sucesso |
+| `errors` | Ticks que levantaram exceção não-esperada |
+| `catchup_runs` | Runs de catch-up executados no startup |
+| `scheduled_runs` | Runs de schedule executados em ticks normais |
+
+### Discord DMs
+
+`DiscordNotifier` envia DM para `DEILE_PIPELINE_NOTIFY_USER_ID` nos seguintes eventos:
+- Issue picked up (nome + URL)
+- Issue reviewed
+- Implementation started (branch name)
+- Implementation finished (PR URL)
+- PR picked up
+- PR reviewed (merged: true/false)
+- Error (stage name + mensagem truncada em 1500 chars)
+
+---
+
+## 12. Migration & Deployment
+
+### Backwards-compat
+
+- **Monitor único (sem env vars):** comportamento idêntico ao pré-#87. `MonitorIdentity.is_default=True`, branch prefix `auto/issue-`, worktrees em `.worktrees/<branch>`.
+- **Sem `config/pipeline_schedule_<id>.yaml`:** monitor cai para modo legacy "todas as ações a cada tick".
+- **Sem `DEILE_CRON_DB_PATH`:** CronStore criado em `data/cron.db`; diretório auto-criado.
+- **Tools não registradas automaticamente:** `pipeline_tool`, `pipeline_schedule_tool`, `cron_*` requerem registro explícito via `register_tool(...)`. O `auto_discover()` existente não os cobre — o daemon/bootstrap deve registrá-los.
+
+### Deploy de múltiplos monitores
+
+```bash
+# Monitor 0 de 2
+DEILE_PIPELINE_MONITOR_ID=monitor-0 \
+DEILE_PIPELINE_SHARD_INDEX=0 \
+DEILE_PIPELINE_SHARD_COUNT=2 \
+python3 deile.py
+
+# Monitor 1 de 2 (outra máquina ou outro processo)
+DEILE_PIPELINE_MONITOR_ID=monitor-1 \
+DEILE_PIPELINE_SHARD_INDEX=1 \
+DEILE_PIPELINE_SHARD_COUNT=2 \
+python3 deile.py
+```
+
+### Autostart via deilebot
+
+Configurar no `config/deilebot.yaml`:
+```yaml
+# (seção a ser definida no deilebot)
+pipeline:
+  autostart: true   # equivalente a DEILE_PIPELINE_AUTOSTART=1
+cron:
+  autostart: true   # equivalente a DEILE_CRON_AUTOSTART=1
+```
+
+Ou via env vars no daemon:
+```
+DEILE_PIPELINE_AUTOSTART=1
+DEILE_CRON_AUTOSTART=1
+```
+
+---
+
+## 13. Troubleshooting Guide
+
+| Problema | Diagnóstico | Solução |
+|---|---|---|
+| Monitor não inicia | Log `another monitor with id=X is already running` | Matar o processo holder (PID no log) ou usar `monitor_id` diferente |
+| Issue não é claimed | `batch_id` já presente ou `identity.owns()` retorna False | Verificar `DEILE_PIPELINE_SHARD_*`; inspecionar labels da issue via `gh issue view` |
+| `claude -p` timeout | Log `claude -p timed out after 1800s` | Issue/PR muito complexo; aumentar `ClaudeDispatcher.timeout_seconds` |
+| PR não aberta após implementação | `_extract_pr_url` não encontrou URL no stdout | Claude Code não abriu PR; inspecionar logs do subprocess em `result.stderr` |
+| Worktrees acumulando em disco | Não há cleanup automático | Rodar `git worktree prune` + `git worktree list` manualmente na raiz do repo |
+| `CronStore` falha ao abrir | `data/` não existe ou sem permissão | Verificar `DEILE_CRON_DB_PATH`; criar diretório manualmente |
+| Entry cron nunca dispara | `enabled=0` ou `next_fire_at` no passado sem advance | Usar `cron_list` tool para inspecionar; `cron_delete` + `cron_create` para re-agendar |
+| DMs não chegam | `DEILE_PIPELINE_NOTIFY_USER_ID` não configurado ou `deilebot` offline | Verificar env var; checar log do notifier |
+
+---
+
+## 14. Future Considerations
+
+| Aspecto | Nota |
+|---|---|
+| Cleanup automático de worktrees | `WorktreeManager` poderia listar e remover worktrees de branches já mergeadas |
+| Retry com backoff | `ClaudeDispatcher` atualmente não retenta; um resultado `ok=False` encerra o estágio sem retry |
+| Dashboard de pipeline | Stats em `PipelineMonitor.stats` são efêmeros (em memória); persistir em SQLite permitiria queries históricas |
+| Cron com suporte a timezones | `CronStore` e `next_after` operam em UTC; UI de Discord pode querer aceitar "às 9h BRT" e converter |
+| `CronRunner` multi-host | Sem lock distribuído, dois runners no mesmo `CronStore` disparariam a mesma entry; adicionar `~batch:`-style locking no SQLite |
+| `replay_all` no cron genérico | `CronEntry` não tem `replay_all`; se o runner ficar offline por horas, ele coalesce o catchup (fire uma vez) |
+| Scheduler do pipeline em SQLite | Para N > ~20 monitores ou schedules dinâmicos, migrar de YAML para SQLite por consistência |
+| Débito técnico | `PluginSandbox` em issue #54 poderia isolar o Claude Code subprocess em vez de rodar com mesmo usuário |

--- a/docs/system_design/00-VISAO-GERAL.md
+++ b/docs/system_design/00-VISAO-GERAL.md
@@ -86,6 +86,9 @@
 | 15 | Streaming-first: `process_input_stream` é o caminho default da CLI | V1 | Fluxo (05) |
 | 16 | Two-flag flag de fallback `use_legacy_gemini_only` em `model_providers.yaml` | V1 | Integrações LLM (07) |
 | 17 | Separação `deile`/`deilebot` + protocolo HTTP local (Bearer, 127.0.0.1) para a flecha reversa `agente → bot` | V1 | Arquitetura (02), Componentes (04), Segurança (08) |
+| 18 | Hash sharding para execução paralela de monitores (`MonitorIdentity` + `shard_index/shard_count`) | V1 | Princípios (03), Arquitetura (02) |
+| 19 | Cron genérico separado do scheduler do pipeline (`CronStore` SQLite + `CronRunner` vs `ScheduleStore` YAML) | V1 | Componentes (04) |
+| 20 | Strip de `ANTHROPIC_API_KEY` no subprocess do Claude Code (`ClaudeDispatcher.prefer_subscription_auth`) | V1 | Segurança (08) |
 
 ## Estado dos pilares
 

--- a/docs/system_design/02-ARQUITETURA.md
+++ b/docs/system_design/02-ARQUITETURA.md
@@ -52,6 +52,8 @@
 | `commands/` | Slash commands, `CommandRegistry`, builtins em `deile/commands/builtin/` |
 | `parsers/` | Pipeline de parsing: comando, arquivo, diff, parser inteligente; `ParserRegistry` |
 | `orchestration/` | `PlanManager`, `WorkflowExecutor`, `TaskManager`, `SQLiteTaskManager`, `ApprovalSystem`, `ArtifactManager`, `RunManager` |
+| `orchestration/pipeline/` | Pipeline autônomo de issues/PRs: `PipelineMonitor` (loop de polling, 3 estágios), `GitHubClient` (wrapper de `gh` CLI), `WorktreeManager`, `ClaudeDispatcher` (`claude -p` subprocess), `DiscordNotifier`, `MonitorIdentity` (sharding hash-based), `LockFile` (PID lock), `ScheduleStore`/`Schedule`/`RecurringEntry`/`OneshotEntry` (scheduler YAML por monitor), `cron.py` (parser de expressões 5-field) |
+| `cron/` | Agendador genérico de prompts: `CronStore` (SQLite, `data/cron.db`), `CronEntry` (recurring + one-shot), `CronRunner` (poll loop 30s, dispara `fire_callback`) |
 | `memory/` | `MemoryManager` + 4 camadas (`WorkingMemory`, `EpisodicMemory`, `SemanticMemory`, `ProceduralMemory`) + `MemoryConsolidator` |
 | `security/` | `PermissionManager`, `AuditLogger`, `SecretsScanner` |
 | `personas/` | `BasePersona`, `BaseAutonomousPersona`, `PersonaManager`, `PersonaLoader`, `instruction_loader`, `builder`, `context`, `library/` (YAMLs), `instructions/` (MDs), `memory/integration.py` |

--- a/docs/system_design/04-MODELO-COMPONENTES.md
+++ b/docs/system_design/04-MODELO-COMPONENTES.md
@@ -35,7 +35,20 @@
 | Auto-discovery | `auto_discover(package_names=None)` | Cobre por padrão: `file_tools`, `execution_tools`, `search_tool`, `bash_tool`, `slash_command_executor`. Após o conjunto-padrão, chama `register_messaging_tools()` (registra 7 tools `messaging.discord_*` quando `deilebot` está instalado **e** `DEILE_BOT_ENDPOINT`/`AUTH_TOKEN` configurados) |
 | Demais módulos | `git_tool`, `http_tool`, `lint_tool`, `archive_tool`, `process_tool`, `secrets_tool`, `tokenizer_tool` | Precisam de registro explícito ou descoberta passando o nome do módulo |
 | Tools de mensageria | `deile/tools/messaging/` | Categoria `MESSAGING`. Cada tool herda `MessagingTool` (`_base.py`), que centraliza permission/audit/approval e mapeia erros do `BotControlClient` para `ToolResult.error_result(error_code=...)` tipados |
+| Tools de pipeline/cron | `deile/tools/pipeline_tool.py`, `pipeline_schedule_tool.py`, `cron_create_tool.py`, `cron_list_tool.py`, `cron_delete_tool.py` | Categoria `SYSTEM`. Descritas abaixo. Precisam de registro explícito |
 | Conversores para LLMs | `get_anthropic_tools(...)`, `get_openai_functions(...)`, `get_gemini_functions(...)` | Geram declarações nativas para function calling |
+
+#### Tools do pipeline autônomo (intent #87 e #86)
+
+As cinco tools abaixo expõem o pipeline e o agendador para o LLM, permitindo que o DEILE as invoque quando o usuário pede em linguagem natural (ex: via Discord).
+
+| Tool | Arquivo | Propósito |
+|---|---|---|
+| `pipeline` | `pipeline_tool.py` | Controla o `PipelineMonitor`: start/stop/status/tick. Serve intent "inicie / pare / verifique o pipeline" |
+| `pipeline_schedule` | `pipeline_schedule_tool.py` | CRUD de entradas no `ScheduleStore` (YAML por monitor): lista, add_recurring, add_oneshot, remove, enable, disable. Serve intent "agende revisão de issue a cada 5 minutos" |
+| `cron_create` | `cron_create_tool.py` | Agenda um prompt natural para execução futura no `CronStore` (SQLite). Serve intent "execute isso todo dia às 9h" ou "execute isso uma vez amanhã às 18h" |
+| `cron_list` | `cron_list_tool.py` | Lista entradas do `CronStore` com filtros. Serve intent "o que está agendado?" / "quais tarefas pendentes?" |
+| `cron_delete` | `cron_delete_tool.py` | Remove ou desabilita uma entrada do `CronStore` por id. Serve intent "cancele o cron X" |
 
 ## Commands (Slash)
 
@@ -58,6 +71,13 @@
 | Despacho | Para comandos parseados pelo `CommandParser` |
 | Variante adicional | `StaticCommandRegistry` (registro classe-a-classe) |
 | Configuração estendida | `deile/config/commands.yaml` |
+
+#### Comandos slash do pipeline (intent #87)
+
+| Comando | Arquivo | Propósito |
+|---|---|---|
+| `/pipeline` | `pipeline_command.py` | `start \| stop \| status \| tick` — controla o `PipelineMonitor` diretamente da CLI. Idempotente: `start` duas vezes é no-op. Guarda a instância em `agent.pipeline_monitor` |
+| `/pipeline-schedule` | (se existir `pipeline_schedule_command.py`) | Alias de linha de comando para as mesmas operações de `pipeline_schedule` tool; útil para operação manual no REPL sem passar pelo LLM |
 
 ## Parsers
 

--- a/docs/system_design/09-CONFIGURACAO.md
+++ b/docs/system_design/09-CONFIGURACAO.md
@@ -101,6 +101,24 @@ pip install deile[bot]              # instala deilebot (apenas httpx + pydantic)
 
 O daemon em si vive em `elimarcavalli/deilebot` e tem extras próprios (`discord`, `telegram`, etc.). Ver `deilebot/pyproject.toml`.
 
+### Pipeline + Cron — variáveis de ambiente
+
+> Todas opcionais. Ausentes, o pipeline e o cron simplesmente não iniciam automaticamente.
+
+| Variável | Uso | Default |
+|---|---|---|
+| `DEILE_PIPELINE_REPO` | Repositório GitHub alvo no formato `owner/repo` | `elimarcavalli/deile` |
+| `DEILE_PIPELINE_BASE_PATH` | Caminho absoluto da raiz do repositório onde `.worktrees/` será criado | Detectado automaticamente (busca ancestral com `.git` + `deile.py`) |
+| `DEILE_PIPELINE_NOTIFY_USER_ID` | Discord snowflake para DMs de notificação de transições de estado | nenhum |
+| `DEILE_PIPELINE_MONITOR_ID` | Identificador único deste monitor (1-32 chars `[a-zA-Z0-9_-]`); aparece em branch names, labels e worktree paths | `default` |
+| `DEILE_PIPELINE_SHARD_INDEX` | Índice do shard neste monitor (int, `[0, SHARD_COUNT)`) | `0` |
+| `DEILE_PIPELINE_SHARD_COUNT` | Total de shards no deploy (int `>= 1`); define quantas issues/PRs cada monitor atende por hash | `1` |
+| `DEILE_PIPELINE_AUTOSTART` | Se `1`, o daemon `deilebot` inicia o `PipelineMonitor` automaticamente no boot | não setado |
+| `DEILE_CRON_AUTOSTART` | Se `1`, o daemon `deilebot` inicia o `CronRunner` automaticamente no boot | não setado |
+| `DEILE_CRON_DB_PATH` | Caminho absoluto do SQLite do `CronStore` | `<DEILE_PIPELINE_BASE_PATH>/data/cron.db` ou `<cwd>/data/cron.db` |
+
+> O `pipeline_tool.py` e o `pipeline_command.py` leem essas variáveis diretamente via `os.environ` (pois são componentes de borda — não domínio); isso está alinhado com a regra "adapters podem ler env, core não pode".
+
 ## Hot-reload
 
 | Componente | Como funciona |

--- a/docs/system_design/DECISOES.md
+++ b/docs/system_design/DECISOES.md
@@ -219,6 +219,42 @@
 
 ---
 
+## Decisão #18 — Hash sharding para execução paralela de monitores
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 |
+| Pilar dono | 03-Princípios, 02-Arquitetura |
+| Decisão | Cada instância do `PipelineMonitor` tem uma identidade (`MonitorIdentity`) composta por `monitor_id`, `shard_index` e `shard_count`. O método `owns(key)` computa `SHA-256(key) % shard_count == shard_index` para decidir se aquela instância deve processar um dado issue/PR. Dois monitores com `shard_count=2` e `shard_index=0,1` dividem o trabalho de forma determinística e sem comunicação entre si. A identidade padrão (`monitor_id=default`, `shard_count=1`) mantém comportamento backwards-compatible de monitor único |
+| Evidência | `deile/orchestration/pipeline/identity.py:MonitorIdentity.owns`, `monitor.py:_review_one_new_issue` |
+| Motivação | Permitir escalar o pipeline horizontalmente (N máquinas ou N processos) sem um coordenador central, sem banco de dados compartilhado e sem mudança de protocolo com o GitHub. O `~batch:` label garante que dois monitors não processem a mesma issue simultaneamente |
+
+---
+
+## Decisão #19 — Cron genérico separado do scheduler do pipeline
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 |
+| Pilar dono | 04-Componentes |
+| Decisão | Existem dois mecanismos de agendamento com propósitos distintos: (a) `ScheduleStore` / `Schedule` / `RecurringEntry` / `OneshotEntry` em `orchestration/pipeline/scheduler.py` — YAML por monitor, controla *quando* cada estágio do pipeline dispara (review/implement/pr_review); (b) `CronStore` / `CronEntry` / `CronRunner` em `cron/` — SQLite global, agenda *prompts naturais* do usuário para execução futura em uma turn do agente. Os dois são independentes: o pipeline scheduler determina atividade do monitor; o cron runner dispara texto arbitrário que o usuário queira agendar |
+| Evidência | `deile/orchestration/pipeline/scheduler.py`, `deile/cron/store.py`, `deile/cron/runner.py` |
+| Motivação | Misturar os dois num único mecanismo forçaria o cron a conhecer semântica de pipeline (review/implement/pr_review) e impediria que o cron fosse usado para tarefas não relacionadas ao pipeline. A separação mantém responsabilidades únicas (SRP) |
+
+---
+
+## Decisão #20 — Strip de `ANTHROPIC_API_KEY` no subprocess do Claude Code
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 |
+| Pilar dono | 08-Segurança |
+| Decisão | `ClaudeDispatcher` tem flag `prefer_subscription_auth=True` (default). Quando ativa, o env passado ao subprocess `claude -p <prompt>` tem `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` e `ANTHROPIC_BEARER_TOKEN` removidos. O subprocess `claude` cai então para autenticação por assinatura Claude Pro/Max do operador |
+| Evidência | `deile/orchestration/pipeline/claude_dispatcher.py:ClaudeDispatcher._build_env`, atributo `_STRIP_KEYS` |
+| Motivação | O agente DEILE tipicamente roda com uma `ANTHROPIC_API_KEY` de API (paga por token). O Claude Code usado para implementação no pipeline deve faturar contra a assinatura do operador, não contra a mesma key do DEILE. Sem o strip, os subprocessos consumiriam tokens da key do DEILE, gerando custo inesperado e potencialmente excedendo o budget |
+
+---
+
 ## Como adicionar uma nova decisão
 
 | # | Passo |


### PR DESCRIPTION
## Summary

Implements the 3-agent autonomous pipeline specified in #87: ideas submitted via Discord (`/ideia` in [elimarcavalli/deile-bot#6](https://github.com/elimarcavalli/deilebot/pull/6)) become INTENT issues, which DEILE picks up, reviews, hands off to Claude Code one-shot for implementation, opens a PR, and reviews/merges — all autonomously, with Discord-DM notifications to the operator at every state transition.

## What's new

### `deile/orchestration/pipeline/` — new package

| Module | Responsibility |
|---|---|
| `labels.py` | Pipeline label constants (`~workflow:*`, `~review:*`, `~batch:<sha8>`) + helpers |
| `github_client.py` | Async `gh` CLI wrapper (issues/PRs/labels, batch-claim distributed lock, idempotent label bootstrap) |
| `worktree_manager.py` | The owner-specified `.worktrees/<branch>` convention (clone → copy → branch) |
| `claude_dispatcher.py` | Async `claude -p "<prompt>"` runner with timeout + canonical implement/review prompts |
| `notifier.py` | Discord-DM notifier (resolves `deilebot.bridge.dm_tool` → `deile_bot.bridge.dm_tool` → no-op) |
| `monitor.py` | `PipelineMonitor` — 1-minute polling loop driving all three stages |

### `/pipeline` command

`/pipeline {start|stop|status|tick}` registered in builtin commands. Config via env:

- `DEILE_PIPELINE_REPO` (default `elimarcavalli/deile`)
- `DEILE_PIPELINE_BASE_PATH` (auto-detected)
- `DEILE_PIPELINE_NOTIFY_USER_ID` (Discord snowflake; opt-in DM)

## Pipeline stages (per tick, ~60s)

1. **Stage 1 — review**: claim first `~workflow:nova` issue with no batch lock → `em_revisao` → optional `review_callback` (host agent fills gaps) → `~workflow:revisada`. DM at start + end.
2. **Stage 2 — implement**: claim first batch-claimed `~workflow:revisada` issue → spin up `.worktrees/auto/issue-N` → `claude -p "<implement prompt>"` → on success, `~workflow:em_pr` and extract PR URL from stdout. DM at start + finish (with PR URL).
3. **Stage 3 — review PR**: claim first non-draft, non-concluded open PR → spin up `.worktrees/<head_ref>` → `claude -p "<review prompt>"` → `~review:em_andamento` → `~review:concluida`. DM at start + finish (distinguishes merged vs reviewed).

The `~batch:<sha8>` label acts as a distributed lock keyed on the issue/PR title hash, preventing two ticks (or workers) from doubling up.

## Test plan

- [x] **66 new unit tests** in `deile/tests/orchestration/pipeline/`, all green:
  - `test_labels.py` (9), `test_github_client.py` (16), `test_worktree_manager.py` (9 — real `git` in `tmp_path`), `test_claude_dispatcher.py` (8 — `/bin/sh` stubs for success/failure/timeout), `test_notifier.py` (8), `test_monitor.py` (16 — all 3 stages with mocked deps + lifecycle).
- [x] No regressions in DEILE: `1000 passed, 12 skipped` (excluding 2 pre-existing collection errors in `deile/tests/integrations/bot/test_client.py` and `tests/tools/messaging/test_e2e_against_fake_daemon.py` due to missing `deilebot_client` module).
- [ ] **End-to-end live run**: deile-bot updated → user sends `/ideia` → DEILE creates issue → pipeline polls, reviews, hands to Claude Code → PR opened → pipeline reviews PR → merge. Will be exercised against this very PR's branch as the integration test (see #87 acceptance criteria).

## Pre-existing failures (not addressed)

- `deile/tests/tools/messaging/test_discord_pin_message.py::test_pin_message_not_found_returns_typed_error`
- `deile/tests/tools/messaging/test_discord_react.py::test_facade_error_mapped`

Both fail on `main` with `TypeError: Exception() takes no keyword arguments` (unrelated to this PR — confirmed by running on the main worktree).

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)