### PR TITLE
feat(common): add slug() helper in text_utils

### DIFF
--- a/deile/common/text_utils.py
+++ b/deile/common/text_utils.py
@@ -1,0 +1,19 @@
+"""Text manipulation helpers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+def slug(text: str) -> str:
+    """Convert text to a URL-friendly slug.
+
+    Lowercases, strips accents, replaces non-alphanumeric runs with a single
+    hyphen, and trims leading/trailing hyphens.
+    """
+    normalized = unicodedata.normalize("NFKD", text)
+    ascii_only = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    lowered = ascii_only.lower()
+    hyphenated = re.sub(r"[^a-z0-9]+", "-", lowered)
+    return hyphenated.strip("-")

--- a/deile/tests/common/test_text_utils.py
+++ b/deile/tests/common/test_text_utils.py
@@ -1,0 +1,19 @@
+"""Tests for deile.common.text_utils."""
+
+import pytest
+
+from deile.common.text_utils import slug
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("Olá Mundo!", "ola-mundo"),
+        ("  espaços  ", "espacos"),
+        ("a/b/c", "a-b-c"),
+        ("---", ""),
+        ("Açaí 100%!!", "acai-100"),
+    ],
+)
+def test_slug(raw, expected):
+    assert slug(raw) == expected


### PR DESCRIPTION
## Summary
- Adds `slug(text: str) -> str` in `deile/common/text_utils.py` — lowercase, NFKD-stripped diacritics, non-alphanumeric runs collapsed to a single hyphen, trimmed.
- Adds `deile/tests/common/test_text_utils.py` covering the cases listed in the issue.

## Test plan
- [x] `python3 -m pytest deile/tests/common/test_text_utils.py -v` — 5/5 pass.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)