### PR TITLE
feat(cron): agent bridge — fire_callback for natural-language scheduled prompts

### DIFF
--- a/deile/cron/agent_bridge.py
+++ b/deile/cron/agent_bridge.py
@@ -1,0 +1,116 @@
+"""Cron → Agent bridge for intent #86 (autonomous pipeline).
+
+This module closes the loop between the CronRunner and the DEILE agent:
+the CronRunner fires a scheduled entry by calling a ``FireCallback``; this
+module provides ``make_fire_callback``, which manufactures that callback
+from a lazy ``agent_provider`` factory.
+
+Integration point
+-----------------
+CronRunner receives a ``fire_callback: FireCallback`` at construction time.
+Callers that bootstrap the full agent stack should wire it like this::
+
+    from deile.cron.agent_bridge import make_fire_callback
+
+    async def agent_provider():
+        return my_deile_agent  # DeileAgent instance
+
+    runner = CronRunner(store, fire_callback=make_fire_callback(agent_provider))
+
+Design notes
+------------
+- ``agent_provider`` is a **lazy async factory** so the bridge does not
+  require the agent to be initialised at module import time.  The provider
+  is called once per ``tick``; callers may cache the agent themselves or
+  return a freshly-built one — both are valid patterns.
+- All exceptions are caught and converted to a human-readable error string
+  so the runner can persist a ``last_result`` without raising.  The runner
+  itself already guards its outer loop, but defence-in-depth here prevents
+  a single bad entry from surfacing an unhandled exception.
+- The ``session_id`` format ``"cron-{entry.id}"`` deliberately encodes the
+  entry id so agent memory layers can correlate turns across recurring fires.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+from deile.cron.store import CronEntry
+from deile.cron.runner import FireCallback
+
+logger = logging.getLogger(__name__)
+
+AgentProvider = Callable[[], Awaitable[Any]]
+
+
+def make_fire_callback(
+    agent_provider: AgentProvider,
+    *,
+    max_summary_chars: int = 500,
+) -> FireCallback:
+    """Return a :data:`FireCallback` that routes a :class:`CronEntry` through DEILE.
+
+    Parameters
+    ----------
+    agent_provider:
+        Async factory that returns a :class:`~deile.core.agent.DeileAgent`
+        (or any object with ``async process_input(prompt, session_id=...)``).
+        Called on every fire so the caller controls caching / lifecycle.
+    max_summary_chars:
+        Maximum length of the returned summary string.  Longer responses
+        are truncated with an ellipsis.  Defaults to 500.
+
+    Returns
+    -------
+    FireCallback
+        An ``async (entry: CronEntry) -> str`` callable ready to pass to
+        :class:`~deile.cron.runner.CronRunner`.
+    """
+
+    async def _fire(entry: CronEntry) -> str:
+        try:
+            agent = await agent_provider()
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "cron agent_provider failed for entry %s: %s",
+                entry.id,
+                exc,
+                exc_info=True,
+            )
+            return f"error: {type(exc).__name__}: {exc}"
+
+        try:
+            response = await agent.process_input(
+                entry.prompt,
+                session_id=f"cron-{entry.id}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "cron agent.process_input failed for entry %s: %s",
+                entry.id,
+                exc,
+                exc_info=True,
+            )
+            return f"error: {type(exc).__name__}: {exc}"
+
+        # Extract text: prefer .content attribute (AgentResponse), fall back
+        # to str() for duck-typed responses.
+        try:
+            text = response.content if hasattr(response, "content") else str(response)
+        except Exception:  # noqa: BLE001
+            text = ""
+
+        if not text:
+            text = str(response) if response is not None else ""
+
+        summary = text[:max_summary_chars]
+        if len(text) > max_summary_chars:
+            summary = summary[: max_summary_chars - 1] + "…"
+
+        logger.debug(
+            "cron entry %s fired; summary length=%d", entry.id, len(summary)
+        )
+        return summary
+
+    return _fire

--- a/deile/tests/cron/test_agent_bridge.py
+++ b/deile/tests/cron/test_agent_bridge.py
@@ -1,0 +1,191 @@
+"""Tests for deile.cron.agent_bridge (intent #86)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deile.cron.agent_bridge import make_fire_callback
+from deile.cron.store import CronEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(entry_id: str = "cron-abc123", prompt: str = "do something") -> CronEntry:
+    """Return a minimal one-shot CronEntry for testing."""
+    return CronEntry(
+        id=entry_id,
+        prompt=prompt,
+        run_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _make_agent_response(content: str) -> MagicMock:
+    """Return a mock AgentResponse-like object."""
+    response = MagicMock()
+    response.content = content
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_happy_path_returns_summary():
+    """Callback returns the response content for a normal successful call."""
+    expected = "Task completed successfully"
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(expected))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert result == expected
+    agent.process_input.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_long_response_truncated_to_default():
+    """Response longer than max_summary_chars (500) is truncated with ellipsis."""
+    long_text = "x" * 600
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(long_text))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert len(result) == 500
+    assert result.endswith("…")
+    assert result[:499] == "x" * 499
+
+
+@pytest.mark.unit
+async def test_custom_max_summary_chars_respected():
+    """Custom max_summary_chars is honoured."""
+    text = "hello world — this is a longer reply"
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(text))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider, max_summary_chars=10)
+    result = await cb(_make_entry())
+
+    assert len(result) == 10
+    assert result.endswith("…")
+
+
+@pytest.mark.unit
+async def test_process_input_raises_returns_error_string():
+    """When agent.process_input raises, callback returns error string, not raises."""
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(side_effect=RuntimeError("LLM timeout"))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert result.startswith("error: RuntimeError:")
+    assert "LLM timeout" in result
+
+
+@pytest.mark.unit
+async def test_agent_provider_raises_returns_error_string():
+    """When agent_provider itself raises, callback returns error string, not raises."""
+    async def failing_provider():
+        raise ConnectionError("DB unreachable")
+
+    cb = make_fire_callback(failing_provider)
+    result = await cb(_make_entry())
+
+    assert result.startswith("error: ConnectionError:")
+    assert "DB unreachable" in result
+
+
+@pytest.mark.unit
+async def test_session_id_includes_entry_id():
+    """process_input is called with session_id that contains entry.id."""
+    entry = _make_entry(entry_id="cron-testentry42")
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response("ok"))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    await cb(entry)
+
+    call_kwargs = agent.process_input.call_args
+    assert call_kwargs.kwargs.get("session_id") == "cron-cron-testentry42"
+
+
+@pytest.mark.unit
+async def test_response_without_content_attribute_uses_str():
+    """Response with no .content attribute falls back to str(response)."""
+
+    class NoContentResponse:
+        def __str__(self) -> str:
+            return "fallback text"
+
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=NoContentResponse())
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    # Should have used str() and not raised
+    assert isinstance(result, str)
+    assert "fallback text" in result
+
+
+@pytest.mark.unit
+async def test_short_response_not_truncated():
+    """Response exactly at max_summary_chars is not truncated."""
+    text = "a" * 500
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response(text))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    result = await cb(_make_entry())
+
+    assert result == text
+    assert not result.endswith("…")
+
+
+@pytest.mark.unit
+async def test_prompt_forwarded_to_process_input():
+    """entry.prompt is forwarded verbatim as the first positional arg."""
+    prompt = "summarize yesterday's commits"
+    entry = _make_entry(prompt=prompt)
+    agent = AsyncMock()
+    agent.process_input = AsyncMock(return_value=_make_agent_response("done"))
+
+    async def provider():
+        return agent
+
+    cb = make_fire_callback(provider)
+    await cb(entry)
+
+    call_args = agent.process_input.call_args
+    assert call_args.args[0] == prompt


### PR DESCRIPTION
## Summary

- Adds `deile/cron/agent_bridge.py` with `make_fire_callback(agent_provider, *, max_summary_chars)` — the missing glue between `CronRunner` and the DEILE agent (closes the intent #86 autonomous-pipeline loop).
- The factory accepts a lazy async `agent_provider` (never instantiated at import time), calls `agent.process_input(entry.prompt, session_id=f"cron-{entry.id}")`, extracts `response.content` (falling back to `str(response)`), truncates to `max_summary_chars` (default 500), and returns the summary string the runner persists as `last_result`.
- All exceptions from provider or agent are caught and returned as `"error: <Type>: <msg>"` so no entry can crash the runner loop.
- Adds `deile/tests/cron/test_agent_bridge.py` with 9 unit tests covering: happy path, truncation at default and custom limits, error containment for both `agent_provider` and `process_input` failures, `session_id` format, no-`content`-attribute fallback, exact-length non-truncation, and prompt forwarding.

## Test plan

- [x] `python3 -m pytest deile/tests/cron/test_agent_bridge.py -v --no-cov` → 9/9 passed
- [x] `python3 -m pytest deile/tests/cron/ deile/tests/orchestration/pipeline/ -q --no-cov` → 227/227 passed
- [ ] Wire `make_fire_callback` into the full bootstrap path (CronRunner init) — follow-up in intent #86 scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)