### PR TITLE
feat(tools): WorktreeTool — LLM-callable worktree management

### DIFF
--- a/deile/tests/tools/test_worktree_tool.py
+++ b/deile/tests/tools/test_worktree_tool.py
@@ -1,0 +1,305 @@
+"""Tests for WorktreeTool.
+
+Design notes
+------------
+- No real git operations: WorktreeManager is monkeypatched / replaced with an
+  AsyncMock at the class level so tests stay fast and hermetic.
+- Schema regression: ``test_schema_is_json_schema_object`` mirrors the guard
+  introduced after commit 5815725 — it checks both the raw ``parameters`` dict
+  and the serialised ``to_openai_function()`` output.
+- ``asyncio_mode = auto`` in pytest.ini — no ``@pytest.mark.asyncio`` needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.tools.base import ToolContext, ToolStatus
+from deile.tools.worktree_tool import WorktreeTool, _resolve_base_path
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(**kwargs) -> ToolContext:
+    return ToolContext(user_input="", parsed_args=kwargs, session_data={})
+
+
+def _fake_worktree(path: str = "/repo/.worktrees/feat/my-branch", branch: str = "my-branch"):
+    wt = MagicMock()
+    wt.path = Path(path)
+    wt.branch = branch
+    wt.base_repo = Path("/repo")
+    return wt
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema validity — the regression guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_schema_is_json_schema_object():
+    """parameters must be a JSON Schema object, not a raw property dict.
+
+    Regression guard for the bug caught in commit 5815725: passing a raw
+    ``{"action": {...}}`` dict instead of
+    ``{"type": "object", "properties": {"action": {...}}}`` silently broke
+    all providers that validate the schema.
+    """
+    tool = WorktreeTool()
+    params = tool._schema.parameters
+    assert params["type"] == "object", (
+        "parameters must have top-level 'type': 'object'"
+    )
+    assert "properties" in params, "parameters must contain 'properties'"
+    assert "action" in params["properties"]
+
+
+@pytest.mark.unit
+def test_to_openai_function_parameters_type_is_object():
+    """to_openai_function() must emit 'type': 'object' in parameters."""
+    tool = WorktreeTool()
+    oai = tool.schema.to_openai_function()
+    assert oai["function"]["parameters"]["type"] == "object"
+
+
+# ---------------------------------------------------------------------------
+# 2. Invalid action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_invalid_action_returns_error():
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="fly"))
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "INVALID_ACTION"
+
+
+@pytest.mark.unit
+async def test_empty_action_returns_error():
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action=""))
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "INVALID_ACTION"
+
+
+# ---------------------------------------------------------------------------
+# 3. ensure_main happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_ensure_main_happy_path(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    mock_mgr = AsyncMock()
+    mock_mgr.ensure_main = AsyncMock(return_value=tmp_path / ".worktrees" / "main")
+
+    tool = WorktreeTool()
+    with patch(
+        "deile.tools.worktree_tool.WorktreeManager", return_value=mock_mgr
+    ):
+        result = await tool.execute(_ctx(action="ensure_main", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.SUCCESS
+    assert "path" in result.data
+    mock_mgr.ensure_main.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 4. create happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_create_happy_path(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    wt = _fake_worktree(str(tmp_path / ".worktrees" / "feat" / "my-branch"), "my-branch")
+    mock_mgr = AsyncMock()
+    mock_mgr.create_branch_worktree = AsyncMock(return_value=wt)
+
+    tool = WorktreeTool()
+    with patch(
+        "deile.tools.worktree_tool.WorktreeManager", return_value=mock_mgr
+    ):
+        result = await tool.execute(
+            _ctx(action="create", branch="my-branch", subdir="feat", base_path=str(tmp_path))
+        )
+
+    assert result.status == ToolStatus.SUCCESS
+    assert result.data["branch"] == "my-branch"
+    assert "path" in result.data
+    mock_mgr.create_branch_worktree.assert_awaited_once_with("my-branch")
+
+
+@pytest.mark.unit
+async def test_create_missing_branch_returns_error(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="create", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "MISSING_BRANCH"
+
+
+# ---------------------------------------------------------------------------
+# 5. list happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_list_returns_worktrees(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+    # Create fake worktree directories
+    wt_dir = tmp_path / ".worktrees" / "feat" / "branch-a"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").mkdir()
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="list", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.SUCCESS
+    assert isinstance(result.data["worktrees"], list)
+    assert len(result.data["worktrees"]) == 1
+    assert result.data["worktrees"][0]["branch"] == "branch-a"
+
+
+@pytest.mark.unit
+async def test_list_no_worktrees_dir(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="list", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.SUCCESS
+    assert result.data["worktrees"] == []
+
+
+# ---------------------------------------------------------------------------
+# 6. remove happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_remove_happy_path(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+    branch_dir = tmp_path / ".worktrees" / "my-branch"
+    branch_dir.mkdir(parents=True)
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="my-branch", base_path=str(tmp_path))
+    )
+
+    assert result.status == ToolStatus.SUCCESS
+    assert not branch_dir.exists()
+
+
+@pytest.mark.unit
+async def test_remove_missing_branch_returns_error(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(_ctx(action="remove", base_path=str(tmp_path)))
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "MISSING_BRANCH"
+
+
+# ---------------------------------------------------------------------------
+# 7. remove safety: refuse to remove 'main'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+async def test_remove_refuses_main(tmp_path):
+    """The shared clean main clone must never be removed."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+    main_dir = tmp_path / ".worktrees" / "main"
+    main_dir.mkdir(parents=True)
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="main", base_path=str(tmp_path))
+    )
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "REMOVE_PROTECTED"
+    # Directory must still exist.
+    assert main_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# 8. remove non-existent path returns NOT_FOUND
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_remove_nonexistent_returns_not_found(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "deile.py").write_text("")
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="ghost-branch", base_path=str(tmp_path))
+    )
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# 9. Auto-discover registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_registered_by_auto_discover():
+    from deile.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+    reg.auto_discover()
+    assert reg.get("worktree") is not None
+
+
+# ---------------------------------------------------------------------------
+# 10. _resolve_base_path utility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolve_base_path_uses_override(tmp_path):
+    result = _resolve_base_path(str(tmp_path))
+    assert result == tmp_path.resolve()
+
+
+@pytest.mark.unit
+def test_resolve_base_path_uses_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEILE_PIPELINE_BASE_PATH", str(tmp_path))
+    result = _resolve_base_path()
+    assert result == tmp_path.resolve()
+
+
+@pytest.mark.unit
+def test_resolve_base_path_override_beats_env(tmp_path, monkeypatch, tmp_path_factory):
+    other = tmp_path_factory.mktemp("other")
+    monkeypatch.setenv("DEILE_PIPELINE_BASE_PATH", str(other))
+    result = _resolve_base_path(str(tmp_path))
+    assert result == tmp_path.resolve()

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -297,6 +297,7 @@ class ToolRegistry:
                 'deile.tools.cron_create_tool',
                 'deile.tools.cron_list_tool',
                 'deile.tools.cron_delete_tool',
+                'deile.tools.worktree_tool',
             ]
 
         discovered_count = 0

--- a/deile/tools/worktree_tool.py
+++ b/deile/tools/worktree_tool.py
@@ -1,0 +1,273 @@
+"""WorktreeTool — LLM-callable interface to worktree management.
+
+Exposes :class:`WorktreeManager` (``deile/orchestration/pipeline/worktree_manager.py``)
+to the LLM so users can create, list and remove branch worktrees without
+dropping to the shell.
+
+Actions
+-------
+ensure_main
+    Ensure ``.worktrees/main`` exists and is up-to-date. Returns the path.
+create
+    Create a per-branch worktree under ``.worktrees/<subdir>/<branch>`` (or
+    ``.worktrees/<branch>`` when *subdir* is omitted). Returns the path + branch.
+list
+    List all entries discovered under ``.worktrees/``. Returns an array of
+    ``{path, branch, base_repo}`` objects.
+remove
+    Remove ``.worktrees/<subdir>/<branch>`` (or ``.worktrees/<branch>``) after
+    safety checks. Uses ``shutil.rmtree``.
+
+Schema note
+-----------
+``parameters`` is a **JSON Schema object** (``{"type": "object", "properties": {…},
+"required": […]}``) — *not* a raw dict.  The regression test
+``test_schema_is_json_schema_object`` explicitly guards this shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+from deile.orchestration.pipeline.worktree_manager import (WorktreeError,
+                                                           WorktreeManager)
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolSchema)
+
+logger = logging.getLogger(__name__)
+
+_PROTECTED_SUBDIRS = {"main"}  # worktrees that must never be removed
+
+
+def _resolve_base_path(override: Optional[str] = None) -> Path:
+    """Return the base repository path.
+
+    Priority: explicit *override* arg > ``DEILE_PIPELINE_BASE_PATH`` env var >
+    auto-detect by walking CWD ancestors looking for ``.git`` + ``deile.py``.
+    """
+    if override:
+        return Path(override).resolve()
+    raw = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if raw:
+        return Path(raw).resolve()
+    cwd = Path.cwd()
+    for ancestor in (cwd, *cwd.parents):
+        if (ancestor / ".git").is_dir() and (ancestor / "deile.py").is_file():
+            return ancestor
+    return cwd
+
+
+class WorktreeTool(Tool):
+    """Create, list and remove branch worktrees via the LLM."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="worktree",
+                description=(
+                    "Manage isolated branch worktrees under .worktrees/. "
+                    "Use action='ensure_main' to initialise or refresh the shared clean "
+                    "main clone; action='create' to set up a new branch sandbox; "
+                    "action='list' to see existing worktrees; action='remove' to delete "
+                    "a branch worktree (safety-checked — cannot remove main)."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["ensure_main", "create", "list", "remove"],
+                            "description": "Worktree operation to perform.",
+                        },
+                        "branch": {
+                            "type": "string",
+                            "description": (
+                                "Branch name. Required for 'create' and 'remove'."
+                            ),
+                        },
+                        "subdir": {
+                            "type": "string",
+                            "description": (
+                                "Optional namespace subdirectory under .worktrees/ "
+                                "(e.g. 'agents', 'feat'). Defaults to no subdirectory."
+                            ),
+                        },
+                        "base_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to the base git repository. "
+                                "Defaults to auto-detected repo root."
+                            ),
+                        },
+                    },
+                    "required": ["action"],
+                },
+                required=["action"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+
+    @property
+    def name(self) -> str:
+        return "worktree"
+
+    @property
+    def description(self) -> str:
+        return self._schema.description if self._schema else ""
+
+    @property
+    def category(self) -> str:
+        return ToolCategory.SYSTEM.value
+
+    async def execute(self, context: ToolContext) -> ToolResult:  # noqa: C901
+        action = (context.parsed_args.get("action") or "").strip().lower()
+        valid_actions = {"ensure_main", "create", "list", "remove"}
+        if action not in valid_actions:
+            return ToolResult.error_result(
+                message=(
+                    f"action must be one of {sorted(valid_actions)!r}, got {action!r}"
+                ),
+                error_code="INVALID_ACTION",
+            )
+
+        base_path_raw: Optional[str] = context.parsed_args.get("base_path")
+        branch: Optional[str] = context.parsed_args.get("branch")
+        subdir: Optional[str] = context.parsed_args.get("subdir") or None
+
+        try:
+            base_path = _resolve_base_path(base_path_raw)
+
+            if action == "ensure_main":
+                return await self._ensure_main(base_path, subdir)
+
+            if action == "create":
+                if not branch:
+                    return ToolResult.error_result(
+                        message="'branch' is required for action='create'",
+                        error_code="MISSING_BRANCH",
+                    )
+                return await self._create(base_path, branch, subdir)
+
+            if action == "list":
+                return await self._list(base_path)
+
+            if action == "remove":
+                if not branch:
+                    return ToolResult.error_result(
+                        message="'branch' is required for action='remove'",
+                        error_code="MISSING_BRANCH",
+                    )
+                return await self._remove(base_path, branch, subdir)
+
+        except WorktreeError as exc:
+            return ToolResult.error_result(
+                message=str(exc),
+                error=exc,
+                error_code="WORKTREE_ERROR",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("worktree %s failed: %s", action, exc, exc_info=True)
+            return ToolResult.error_result(
+                message=f"worktree {action} failed: {type(exc).__name__}: {exc}",
+                error=exc,
+                error_code="WORKTREE_OP_FAILED",
+            )
+
+        # Unreachable — all branches return above.  Satisfies type-checker.
+        return ToolResult.error_result(  # pragma: no cover
+            message="internal error: unhandled action",
+            error_code="INTERNAL",
+        )
+
+    # ------------------------------------------------------------------
+    # private action helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _ensure_main(base_path: Path, subdir: Optional[str]) -> ToolResult:
+        mgr = WorktreeManager(base_path, subdir=subdir)
+        path = await mgr.ensure_main()
+        return ToolResult.success_result(
+            data={"path": str(path)},
+            message=f"main worktree ready at {path}",
+        )
+
+    @staticmethod
+    async def _create(
+        base_path: Path, branch: str, subdir: Optional[str]
+    ) -> ToolResult:
+        mgr = WorktreeManager(base_path, subdir=subdir)
+        wt = await mgr.create_branch_worktree(branch)
+        return ToolResult.success_result(
+            data={
+                "path": str(wt.path),
+                "branch": wt.branch,
+                "base_repo": str(wt.base_repo),
+            },
+            message=f"worktree for {branch!r} ready at {wt.path}",
+        )
+
+    @staticmethod
+    async def _list(base_path: Path) -> ToolResult:
+        """Scan ``.worktrees/`` and return entries that look like git repos."""
+        worktrees_dir = base_path / ".worktrees"
+        if not worktrees_dir.is_dir():
+            return ToolResult.success_result(
+                data={"worktrees": []},
+                message="no .worktrees/ directory found",
+            )
+
+        entries = []
+        for item in sorted(worktrees_dir.rglob("*")):
+            if item.is_dir() and (item / ".git").exists():
+                entries.append(
+                    {
+                        "path": str(item),
+                        "branch": item.name,
+                        "base_repo": str(base_path),
+                    }
+                )
+
+        return ToolResult.success_result(
+            data={"worktrees": entries},
+            message=f"found {len(entries)} worktree(s)",
+        )
+
+    @staticmethod
+    async def _remove(
+        base_path: Path, branch: str, subdir: Optional[str]
+    ) -> ToolResult:
+        """Remove a branch worktree after safety checks."""
+        # Safety: refuse to remove the shared clean main clone.
+        if branch in _PROTECTED_SUBDIRS:
+            return ToolResult.error_result(
+                message=(
+                    f"cannot remove protected worktree {branch!r} — "
+                    "it is the shared clean main clone used by all pipelines"
+                ),
+                error_code="REMOVE_PROTECTED",
+            )
+
+        worktrees_dir = base_path / ".worktrees"
+        if subdir:
+            target = worktrees_dir / subdir / branch
+        else:
+            target = worktrees_dir / branch
+
+        if not target.exists():
+            return ToolResult.error_result(
+                message=f"worktree path does not exist: {target}",
+                error_code="NOT_FOUND",
+            )
+
+        await asyncio.to_thread(shutil.rmtree, str(target))
+        return ToolResult.success_result(
+            data={"removed": str(target)},
+            message=f"removed worktree at {target}",
+        )


### PR DESCRIPTION
## Summary

- Adds `deile/tools/worktree_tool.py` — a `ToolSchema`-based `Tool` that exposes `WorktreeManager` to the LLM via four actions: `ensure_main`, `create`, `list`, `remove`
- Registers `deile.tools.worktree_tool` in `ToolRegistry.auto_discover` defaults (after `cron_delete_tool`)
- Schema `parameters` uses the mandatory `{"type": "object", "properties": {...}}` JSON Schema wrapper — the regression guard that was violated in commit 5815725

## Actions

| Action | Description |
|---|---|
| `ensure_main` | Initialise / refresh `.worktrees/main` (the shared clean clone) |
| `create` | Create `.worktrees/<subdir>/<branch>` via `WorktreeManager.create_branch_worktree` |
| `list` | Scan `.worktrees/` and return array of `{path, branch, base_repo}` |
| `remove` | `shutil.rmtree` a branch worktree — refuses `main` with `REMOVE_PROTECTED` |

## Test plan

- [x] 17 tests in `deile/tests/tools/test_worktree_tool.py` — 100% pass, no real git ops
- [x] `test_schema_is_json_schema_object` + `test_to_openai_function_parameters_type_is_object` — schema regression guards
- [x] Happy path for each action (WorktreeManager mocked)
- [x] `INVALID_ACTION` for unknown / empty action
- [x] `MISSING_BRANCH` for create/remove without branch arg
- [x] `REMOVE_PROTECTED` when attempting to remove `main`
- [x] `NOT_FOUND` when removing non-existent worktree
- [x] `test_registered_by_auto_discover` — ToolRegistry integration
- [x] `_resolve_base_path` utility — override / env-var / precedence
- [x] 276 / 278 pre-existing tests still pass (2 pre-existing failures in messaging tests unrelated to this PR — `TypeError: Exception() takes no keyword arguments` on Python 3.14, present on base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)