### PR TITLE
test(pipeline,cron): integration + concurrency + stress tests

### DIFF
--- a/deile/tests/cron/test_store_stress.py
+++ b/deile/tests/cron/test_store_stress.py
@@ -1,0 +1,181 @@
+"""Stress / performance tests for CronStore.
+
+Validates latency under bulk reads and thread-safety under concurrent writes.
+These tests use threading (not asyncio) because CronStore is synchronous/
+thread-safe by design.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from deile.cron.store import CronEntry, CronStore, make_id
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc_past(minutes: int = 5) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(minutes=minutes)
+
+
+def _utc_future(hours: int = 1) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(hours=hours)
+
+
+def _make_recurring(store_id: str, n: int) -> CronEntry:
+    return CronEntry(id=store_id, prompt=f"prompt {n}", cron="*/5 * * * *")
+
+
+def _make_oneshot_due(store_id: str, n: int) -> CronEntry:
+    return CronEntry(id=store_id, prompt=f"oneshot {n}", run_at=_utc_past(minutes=10))
+
+
+def _make_oneshot_future(store_id: str, n: int) -> CronEntry:
+    return CronEntry(id=store_id, prompt=f"future {n}", run_at=_utc_future())
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.perf
+class TestStorePerformance:
+
+    def test_list_due_with_100_entries_is_fast(self, tmp_path):
+        """list_due() with 100 entries completes in under 100 ms."""
+        db = CronStore(tmp_path / "stress.db")
+
+        # 50 due entries (past) + 50 future entries
+        for i in range(50):
+            db.add(_make_oneshot_due(make_id(), i))
+        for i in range(50):
+            db.add(_make_oneshot_future(make_id(), i))
+
+        start = time.perf_counter()
+        due = db.list_due()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert len(due) == 50
+        assert elapsed_ms < 100, f"list_due() took {elapsed_ms:.1f}ms (limit 100ms)"
+
+    def test_concurrent_writes_no_corruption(self, tmp_path):
+        """10 threads each adding 10 entries produces exactly 100 rows, no duplicates."""
+        db = CronStore(tmp_path / "concurrent.db")
+        errors: List[Exception] = []
+
+        def add_entries():
+            try:
+                for _ in range(10):
+                    db.add(CronEntry(id=make_id(), prompt="concurrent", cron="*/1 * * * *"))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=add_entries) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Threads raised exceptions: {errors}"
+        all_entries = db.list_all()
+        assert len(all_entries) == 100, f"Expected 100 entries, got {len(all_entries)}"
+        # All IDs must be unique.
+        ids = [e.id for e in all_entries]
+        assert len(ids) == len(set(ids)), "Duplicate IDs detected"
+
+    def test_concurrent_read_during_writes(self, tmp_path):
+        """list_all() does not raise or return corrupt data while writes occur."""
+        db = CronStore(tmp_path / "read_write.db")
+        stop_event = threading.Event()
+        read_errors: List[Exception] = []
+        write_errors: List[Exception] = []
+
+        def writer():
+            while not stop_event.is_set():
+                try:
+                    db.add(CronEntry(id=make_id(), prompt="write", cron="*/1 * * * *"))
+                    time.sleep(0.005)
+                except Exception as exc:  # noqa: BLE001
+                    write_errors.append(exc)
+
+        def reader():
+            while not stop_event.is_set():
+                try:
+                    entries = db.list_all()
+                    # Basic sanity: every returned entry must have a non-empty id
+                    for e in entries:
+                        assert e.id, "Entry with empty id returned from list_all"
+                    time.sleep(0.003)
+                except Exception as exc:  # noqa: BLE001
+                    read_errors.append(exc)
+
+        writer_thread = threading.Thread(target=writer, daemon=True)
+        reader_thread = threading.Thread(target=reader, daemon=True)
+        writer_thread.start()
+        reader_thread.start()
+
+        time.sleep(0.5)
+        stop_event.set()
+        writer_thread.join(timeout=2)
+        reader_thread.join(timeout=2)
+
+        assert not read_errors, f"Reader raised: {read_errors}"
+        assert not write_errors, f"Writer raised: {write_errors}"
+
+    def test_list_due_returns_only_enabled_entries(self, tmp_path):
+        """Disabled entries are excluded from list_due()."""
+        db = CronStore(tmp_path / "enabled.db")
+        entry_id = make_id()
+        db.add(_make_oneshot_due(entry_id, 0))
+
+        # Disable it immediately.
+        db.set_enabled(entry_id, False)
+
+        due = db.list_due()
+        assert all(e.id != entry_id for e in due), "Disabled entry appeared in list_due"
+
+    def test_mark_fired_advances_recurring_and_disables_oneshot(self, tmp_path):
+        """mark_fired() moves next_fire_at forward (recurring) or disables (one-shot)."""
+        db = CronStore(tmp_path / "fired.db")
+
+        rec_id = make_id()
+        db.add(CronEntry(id=rec_id, prompt="recur", cron="*/5 * * * *"))
+        old_next = db.get(rec_id).next_fire_at
+        # Advance anchor well past next cron boundary so next_fire_at actually moves.
+        fired_at = old_next + timedelta(minutes=6)
+        db.mark_fired(rec_id, when=fired_at)
+        new_next = db.get(rec_id).next_fire_at
+        assert new_next > old_next, "Recurring next_fire_at should advance after firing"
+
+        os_id = make_id()
+        db.add(CronEntry(id=os_id, prompt="oneshot", run_at=_utc_past(minutes=1)))
+        db.mark_fired(os_id)
+        entry = db.get(os_id)
+        assert not entry.enabled, "One-shot should be disabled after mark_fired"
+
+    def test_list_all_returns_all_including_disabled(self, tmp_path):
+        """list_all() without only_enabled returns disabled entries too."""
+        db = CronStore(tmp_path / "all.db")
+        ids = [make_id() for _ in range(5)]
+        for e_id in ids:
+            db.add(CronEntry(id=e_id, prompt="p", cron="*/5 * * * *"))
+
+        # Disable 2 of them
+        db.set_enabled(ids[0], False)
+        db.set_enabled(ids[1], False)
+
+        all_entries = db.list_all(only_enabled=False)
+        assert len(all_entries) == 5
+
+        enabled_only = db.list_all(only_enabled=True)
+        assert len(enabled_only) == 3

--- a/deile/tests/orchestration/pipeline/test_concurrency.py
+++ b/deile/tests/orchestration/pipeline/test_concurrency.py
@@ -1,0 +1,155 @@
+"""Tests for multi-monitor concurrency safety and identity-based partitioning.
+
+Validates that parallel monitors with distinct identities:
+- partition the issue space without overlap (sharding)
+- produce distinct branch names and worktree subdirs
+- correctly express ownership via labels
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.orchestration.pipeline.identity import IdentityError, MonitorIdentity
+
+
+class TestParallelMonitorSafety:
+
+    # ------------------------------------------------------------------
+    # Sharding correctness
+    # ------------------------------------------------------------------
+
+    def test_sharding_partitions_titles(self):
+        """For shard_count=2, every title is owned by exactly one monitor."""
+        id_a = MonitorIdentity(monitor_id="a", shard_index=0, shard_count=2)
+        id_b = MonitorIdentity(monitor_id="b", shard_index=1, shard_count=2)
+
+        titles = [f"issue title number {i}" for i in range(100)]
+        for title in titles:
+            owns_a = id_a.owns(title)
+            owns_b = id_b.owns(title)
+            # Exactly one shard must own each title.
+            assert owns_a != owns_b, (
+                f"Both or neither shard owns {title!r}: a={owns_a}, b={owns_b}"
+            )
+
+    def test_sharding_partitions_across_three_shards(self):
+        """For shard_count=3, exactly one of three monitors owns each title."""
+        monitors = [
+            MonitorIdentity(monitor_id=f"m{i}", shard_index=i, shard_count=3)
+            for i in range(3)
+        ]
+        for i in range(200):
+            title = f"title-{i}"
+            owners = [m for m in monitors if m.owns(title)]
+            assert len(owners) == 1, (
+                f"Expected exactly 1 owner for {title!r}, got {len(owners)}"
+            )
+
+    def test_default_identity_owns_all(self):
+        """With shard_count=1 (default), owns() always returns True."""
+        identity = MonitorIdentity()
+        titles = ["any title", "", "unicode: 日本語", "a" * 256]
+        for title in titles:
+            assert identity.owns(title), f"Default identity should own {title!r}"
+
+    def test_ownership_is_deterministic(self):
+        """Same (shard_index, shard_count, title) always produces the same result."""
+        id_x = MonitorIdentity(monitor_id="x", shard_index=0, shard_count=4)
+        title = "deterministic test title"
+        results = [id_x.owns(title) for _ in range(100)]
+        assert len(set(results)) == 1, "owns() is non-deterministic"
+
+    # ------------------------------------------------------------------
+    # Branch / worktree namespacing
+    # ------------------------------------------------------------------
+
+    def test_different_monitors_get_different_branches_for_same_issue(self):
+        """Two named monitors produce different branch names for issue #42."""
+        id_a = MonitorIdentity(monitor_id="a")
+        id_b = MonitorIdentity(monitor_id="b")
+
+        # branch_for_issue logic mirrors monitor.py's branch_for_issue()
+        def branch_for_issue(identity: MonitorIdentity, issue_number: int) -> str:
+            if identity.is_default:
+                return f"auto/issue-{issue_number}"
+            return f"{identity.branch_prefix('auto')}/issue-{issue_number}"
+
+        branch_a = branch_for_issue(id_a, 42)
+        branch_b = branch_for_issue(id_b, 42)
+
+        assert branch_a != branch_b
+        assert "a" in branch_a
+        assert "b" in branch_b
+
+    def test_default_identity_branch_uses_legacy_prefix(self):
+        identity = MonitorIdentity()
+        assert identity.branch_prefix("auto") == "auto"
+
+    def test_named_identity_branch_includes_monitor_id(self):
+        identity = MonitorIdentity(monitor_id="worker-1")
+        assert identity.branch_prefix("auto") == "auto/worker-1"
+
+    def test_different_monitors_get_different_worktree_subdirs(self):
+        """Named monitors return distinct non-None worktree subdirs."""
+        id_a = MonitorIdentity(monitor_id="monitor-alpha")
+        id_b = MonitorIdentity(monitor_id="monitor-beta")
+
+        subdir_a = id_a.worktree_subdir()
+        subdir_b = id_b.worktree_subdir()
+
+        assert subdir_a is not None
+        assert subdir_b is not None
+        assert subdir_a != subdir_b
+
+    def test_default_identity_worktree_subdir_is_none(self):
+        """Default identity uses no per-monitor subdirectory (legacy path)."""
+        identity = MonitorIdentity()
+        assert identity.worktree_subdir() is None
+
+    # ------------------------------------------------------------------
+    # Ownership labels
+    # ------------------------------------------------------------------
+
+    def test_ownership_label_unique_per_id(self):
+        """Different monitor IDs produce different ownership labels."""
+        identity1 = MonitorIdentity(monitor_id="alpha")
+        identity2 = MonitorIdentity(monitor_id="beta")
+        assert identity1.ownership_label() != identity2.ownership_label()
+
+    def test_ownership_label_format(self):
+        """Ownership label follows the ~by:<id> convention."""
+        identity = MonitorIdentity(monitor_id="my-worker")
+        assert identity.ownership_label() == "~by:my-worker"
+
+    def test_default_identity_ownership_label(self):
+        """Default identity produces ~by:default."""
+        identity = MonitorIdentity()
+        assert identity.ownership_label() == "~by:default"
+
+    # ------------------------------------------------------------------
+    # Identity validation
+    # ------------------------------------------------------------------
+
+    def test_invalid_monitor_id_raises(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(monitor_id="bad/id")
+
+    def test_invalid_shard_count_raises(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(shard_count=0)
+
+    def test_shard_index_out_of_range_raises(self):
+        with pytest.raises(IdentityError):
+            MonitorIdentity(shard_index=2, shard_count=2)
+
+    def test_valid_boundary_identity(self):
+        """shard_index == shard_count-1 is valid."""
+        identity = MonitorIdentity(monitor_id="last", shard_index=1, shard_count=2)
+        assert identity.shard_index == 1
+
+    def test_is_default_requires_all_defaults(self):
+        """is_default is False even when only one parameter differs."""
+        assert MonitorIdentity().is_default
+        assert not MonitorIdentity(monitor_id="x").is_default
+        assert not MonitorIdentity(shard_index=0, shard_count=2).is_default

--- a/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
+++ b/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
@@ -1,0 +1,291 @@
+"""Integration tests for PipelineMonitor + ScheduleStore scheduling logic.
+
+Validates:
+- schedule-driven ticks only run due actions
+- fallback to legacy "all every tick" when no schedule exists
+- catch-up on startup drains missed runs in chronological order
+- one-shot entries fire once and are marked completed
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import IssueRef, PrRef
+from deile.orchestration.pipeline.labels import (
+    WORKFLOW_NEW,
+    WORKFLOW_REVIEWED,
+    WORKFLOW_PR,
+    REVIEW_PENDING,
+    REVIEW_IN_PROGRESS,
+    REVIEW_CONCLUDED,
+)
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+from deile.orchestration.pipeline.scheduler import (
+    OneshotEntry,
+    RecurringEntry,
+    Schedule,
+    ScheduleStore,
+)
+from deile.orchestration.pipeline.worktree_manager import Worktree
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_BATCH_ID = "deadbeef"
+
+
+def _utc(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+def _make_monitor_sched(
+    tmp_path: Path,
+    *,
+    issues_new: Optional[List[IssueRef]] = None,
+    issues_reviewed: Optional[List[IssueRef]] = None,
+    prs: Optional[List[PrRef]] = None,
+    claude_stdout: str = "",
+    claude_rc: int = 0,
+    schedule_store: Optional[ScheduleStore] = None,
+) -> Tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/repo",
+        base_repo_path=tmp_path,
+        notify_user_id=None,
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: {
+            WORKFLOW_NEW: list(issues_new or []),
+            WORKFLOW_REVIEWED: list(issues_reviewed or []),
+        }.get(label, [])
+    )
+    github.list_open_prs = AsyncMock(return_value=list(prs or []))
+    github.claim_with_batch = AsyncMock(return_value=_BATCH_ID)
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(
+            path=tmp_path / ".worktrees" / "x",
+            branch="x",
+            base_repo=tmp_path,
+        )
+    )
+
+    claude = MagicMock()
+    claude.run = AsyncMock(
+        return_value=ClaudeRunResult(
+            returncode=claude_rc,
+            stdout=claude_stdout,
+            stderr="",
+            duration_seconds=0.1,
+            cmd=("claude", "-p", "x"),
+        )
+    )
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up",
+        "issue_reviewed",
+        "implementation_started",
+        "implementation_finished",
+        "pr_picked_up",
+        "pr_reviewed",
+        "error",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    monitor = PipelineMonitor(
+        cfg,
+        github=github,
+        worktrees=worktrees,
+        claude=claude,
+        notifier=notifier,
+        schedule_store=schedule_store,
+    )
+    return monitor, github, notifier
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorScheduleIntegration:
+    async def test_tick_with_schedule_runs_only_due_actions(self, tmp_path):
+        """A schedule with a due 'review' entry and a future 'implement' entry
+        should invoke the review path but NOT the implement path."""
+        issue_nova = IssueRef(
+            number=1, title="sched issue", url="u", labels=(WORKFLOW_NEW,)
+        )
+
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        # review: due (last_run_at = 2 hours ago)
+        s.add_recurring(
+            RecurringEntry(
+                id="rev-loop",
+                action="review",
+                cron="*/5 * * * *",
+                last_run_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            )
+        )
+        # implement: NOT due (last_run_at = just now → next fire is in the future)
+        s.add_recurring(
+            RecurringEntry(
+                id="impl-loop",
+                action="implement",
+                cron="*/5 * * * *",
+                last_run_at=datetime.now(timezone.utc),
+            )
+        )
+        store.save(s)
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            schedule_store=store,
+        )
+        await monitor.tick()
+
+        # review path fired
+        notifier.issue_picked_up.assert_called_once()
+        # implement path did NOT fire (no implementation_started)
+        notifier.implementation_started.assert_not_called()
+
+    async def test_tick_without_schedule_falls_back_to_legacy(self, tmp_path):
+        """When no schedule file exists, all enabled stages run every tick."""
+        issue_nova = IssueRef(
+            number=2, title="legacy issue", url="u", labels=(WORKFLOW_NEW,)
+        )
+        # Store with no file on disk (empty schedule)
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        # Do NOT call store.save() — keep file missing → load() returns Schedule()
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            schedule_store=store,
+        )
+        await monitor.tick()
+
+        # Stage 1 must have run (legacy fallback)
+        notifier.issue_picked_up.assert_called_once()
+
+    async def test_catchup_drains_pending_on_start(self, tmp_path):
+        """On start(), catch-up drains all due entries in chronological order
+        and stats.catchup_runs reflects the count."""
+        now = datetime.now(timezone.utc)
+
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        # 3 one-shot entries, all in the past (oldest first)
+        for i, minutes_ago in enumerate([30, 20, 10]):
+            s.add_oneshot(
+                OneshotEntry(
+                    id=f"oneshot-{i}",
+                    action="review",
+                    run_at=now - timedelta(minutes=minutes_ago),
+                )
+            )
+        store.save(s)
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            schedule_store=store,
+        )
+        # start() calls _catch_up_pending() before the poll loop
+        await monitor.start()
+        await monitor.stop()
+
+        assert monitor.stats.catchup_runs == 3
+
+    async def test_oneshot_marked_completed_after_fire(self, tmp_path):
+        """A one-shot entry transitions to completed=True after it fires,
+        and a subsequent tick does NOT re-fire it."""
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        past = datetime.now(timezone.utc) - timedelta(minutes=5)
+        s.add_oneshot(
+            OneshotEntry(id="os-review", action="review", run_at=past)
+        )
+        store.save(s)
+
+        issue_nova = IssueRef(
+            number=3, title="oneshot issue", url="u", labels=(WORKFLOW_NEW,)
+        )
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            schedule_store=store,
+        )
+
+        # First tick — oneshot should fire
+        await monitor.tick()
+        assert monitor.stats.scheduled_runs == 1
+
+        # Second tick — oneshot is now completed=True, should NOT fire again
+        notifier.issue_picked_up.reset_mock()
+        await monitor.tick()
+        notifier.issue_picked_up.assert_not_called()
+
+    async def test_schedule_with_multiple_due_entries_runs_all(self, tmp_path):
+        """When both 'review' and 'implement' are due, both run on the same tick."""
+        issue_nova = IssueRef(
+            number=4, title="multi-stage", url="u", labels=(WORKFLOW_NEW,)
+        )
+        issue_reviewed = IssueRef(
+            number=5,
+            title="ready",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}"),
+        )
+
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        long_ago = datetime.now(timezone.utc) - timedelta(hours=2)
+        s.add_recurring(
+            RecurringEntry(
+                id="rev",
+                action="review",
+                cron="*/5 * * * *",
+                last_run_at=long_ago,
+            )
+        )
+        s.add_recurring(
+            RecurringEntry(
+                id="impl",
+                action="implement",
+                cron="*/5 * * * *",
+                last_run_at=long_ago,
+            )
+        )
+        store.save(s)
+
+        monitor, github, notifier = _make_monitor_sched(
+            tmp_path,
+            issues_new=[issue_nova],
+            issues_reviewed=[issue_reviewed],
+            claude_stdout="https://github.com/owner/repo/pull/99",
+            schedule_store=store,
+        )
+        await monitor.tick()
+
+        assert monitor.stats.scheduled_runs >= 2
+        notifier.issue_picked_up.assert_called_once()
+        notifier.implementation_started.assert_called_once()

--- a/deile/tests/orchestration/pipeline/test_pipeline_integration.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_integration.py
@@ -1,0 +1,328 @@
+"""Integration tests for the full stage 1 → 2 → 3 pipeline flow.
+
+Uses mocked GitHub, Claude, and Worktree collaborators (same style as
+test_monitor.py) but exercises multi-stage baton passing and label
+transition ordering end-to-end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import IssueRef, PrRef
+from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.orchestration.pipeline.labels import (
+    REVIEW_CONCLUDED,
+    REVIEW_IN_PROGRESS,
+    REVIEW_PENDING,
+    WORKFLOW_NEW,
+    WORKFLOW_PR,
+    WORKFLOW_REVIEWED,
+    WORKFLOW_REVIEWING,
+)
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+from deile.orchestration.pipeline.worktree_manager import Worktree
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_BATCH_ID = "abc12345"
+_PR_URL = "https://github.com/owner/name/pull/55"
+
+
+def _make_monitor_full(
+    *,
+    issues_new: Optional[List[IssueRef]] = None,
+    issues_reviewed: Optional[List[IssueRef]] = None,
+    prs: Optional[List[PrRef]] = None,
+    claude_stdout: str = "",
+    claude_rc: int = 0,
+    review_callback=None,
+    identity: Optional[MonitorIdentity] = None,
+) -> Tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: {
+            WORKFLOW_NEW: list(issues_new or []),
+            WORKFLOW_REVIEWED: list(issues_reviewed or []),
+        }.get(label, [])
+    )
+    github.list_open_prs = AsyncMock(return_value=list(prs or []))
+    github.claim_with_batch = AsyncMock(return_value=_BATCH_ID)
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(
+            path=Path("/tmp/fake/.worktrees/x"),
+            branch="x",
+            base_repo=Path("/tmp/fake"),
+        )
+    )
+
+    claude = MagicMock()
+    claude.run = AsyncMock(
+        return_value=ClaudeRunResult(
+            returncode=claude_rc,
+            stdout=claude_stdout,
+            stderr="",
+            duration_seconds=0.1,
+            cmd=("claude", "-p", "x"),
+        )
+    )
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up",
+        "issue_reviewed",
+        "implementation_started",
+        "implementation_finished",
+        "pr_picked_up",
+        "pr_reviewed",
+        "error",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    monitor = PipelineMonitor(
+        cfg,
+        github=github,
+        worktrees=worktrees,
+        claude=claude,
+        notifier=notifier,
+        review_callback=review_callback,
+        identity=identity,
+    )
+    return monitor, github, notifier
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestStageIntegration:
+    async def test_full_flow_issue_to_pr_review(self):
+        """Three separate ticks: stage 1, then stage 2, then stage 3.
+
+        The first tick picks up a ~workflow:nova issue and transitions it to
+        ~workflow:revisada. The second tick picks up the reviewed issue and
+        transitions it to ~workflow:em_pr (Claude returns PR URL in stdout).
+        The third tick reviews the open PR and transitions it to
+        ~review:concluida.
+        """
+        issue_nova = IssueRef(
+            number=10,
+            title="feat: new feature",
+            url="https://github.com/owner/name/issues/10",
+            labels=(WORKFLOW_NEW,),
+            body="Please implement X",
+        )
+        issue_reviewed = IssueRef(
+            number=10,
+            title="feat: new feature",
+            url="https://github.com/owner/name/issues/10",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:default"),
+            body="Please implement X",
+        )
+        pr_open = PrRef(
+            number=55,
+            title="auto: issue-10",
+            url=_PR_URL,
+            labels=(REVIEW_PENDING,),
+            head_ref="auto/issue-10",
+        )
+
+        # -- Tick 1: stage 1 only -----------------------------------------
+        monitor, github, notifier = _make_monitor_full(issues_new=[issue_nova])
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+
+        notifier.issue_picked_up.assert_called_once()
+        notifier.issue_reviewed.assert_called_once()
+        assert monitor.stats.issues_reviewed == 1
+
+        # Transition calls: nova→em_revisao then em_revisao→revisada
+        transition_calls = github.transition_issue.call_args_list
+        assert len(transition_calls) == 2
+        assert transition_calls[0] == call(
+            10, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING
+        )
+        assert transition_calls[1] == call(
+            10, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_REVIEWED
+        )
+
+        # -- Tick 2: stage 2 only -----------------------------------------
+        monitor2, github2, notifier2 = _make_monitor_full(
+            issues_reviewed=[issue_reviewed],
+            claude_stdout=f"Done! See {_PR_URL}",
+        )
+        monitor2.config.enable_review = False
+        monitor2.config.enable_pr_review = False
+        await monitor2.tick()
+
+        notifier2.implementation_started.assert_called_once()
+        notifier2.implementation_finished.assert_called_once()
+        args, _ = notifier2.implementation_finished.call_args
+        assert args[1] == _PR_URL
+        assert monitor2.stats.issues_implemented == 1
+
+        # Transition: revisada → em_pr
+        github2.transition_issue.assert_called_once_with(
+            10, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_PR
+        )
+
+        # -- Tick 3: stage 3 only -----------------------------------------
+        monitor3, github3, notifier3 = _make_monitor_full(
+            prs=[pr_open],
+            claude_stdout="All good, merged the PR.",
+        )
+        monitor3.config.enable_review = False
+        monitor3.config.enable_implement = False
+        await monitor3.tick()
+
+        notifier3.pr_picked_up.assert_called_once()
+        notifier3.pr_reviewed.assert_called_once()
+        assert monitor3.stats.prs_reviewed == 1
+
+        # Transition: em_andamento → concluida
+        github3.transition_pr.assert_called_with(
+            55, from_label=REVIEW_IN_PROGRESS, to_label=REVIEW_CONCLUDED
+        )
+
+    async def test_stage1_passes_baton_to_stage2(self):
+        """After stage 1 review, the issue carries ~workflow:revisada + ~by:<id>."""
+        issue_nova = IssueRef(
+            number=7,
+            title="fix: regression",
+            url="u",
+            labels=(WORKFLOW_NEW,),
+        )
+        monitor, github, notifier = _make_monitor_full(issues_new=[issue_nova])
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        # Ownership label is added so stage 2 knows who claimed it.
+        add_labels_calls = github.add_labels.call_args_list
+        owned = any(
+            "~by:default" in str(c)
+            for c in add_labels_calls
+        )
+        assert owned, f"~by:default not added; add_labels calls: {add_labels_calls}"
+
+        # Workflow transition: nova → revisada (via em_revisao)
+        transitions = github.transition_issue.call_args_list
+        actions = [(c[1]["from_label"], c[1]["to_label"]) for c in transitions]
+        assert (WORKFLOW_NEW, WORKFLOW_REVIEWING) in actions
+        assert (WORKFLOW_REVIEWING, WORKFLOW_REVIEWED) in actions
+
+    async def test_stage2_only_picks_own_claimed(self):
+        """Stage 2 with default identity only picks issues labelled ~by:default."""
+        issue_mine = IssueRef(
+            number=1,
+            title="mine",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:default"),
+        )
+        issue_other = IssueRef(
+            number=2,
+            title="not mine",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:m-other"),
+        )
+        # Default identity: is_default=True → uses owns(title) which returns True
+        # for shard_count=1 but ALSO checks ownership_label. Let's verify the
+        # other monitor's issue is NOT picked when identity is non-default.
+        identity_a = MonitorIdentity(monitor_id="worker-a")
+        monitor, github, notifier = _make_monitor_full(
+            issues_reviewed=[issue_mine, issue_other],
+            claude_stdout=f"Done! {_PR_URL}",
+            identity=identity_a,
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        # worker-a only owns issues with ~by:worker-a — neither issue qualifies
+        notifier.implementation_started.assert_not_called()
+
+    async def test_stage2_picks_its_own_ownership_label(self):
+        """Stage 2 picks issue labelled ~by:<its-own-id>."""
+        identity_a = MonitorIdentity(monitor_id="worker-a")
+        issue_owned = IssueRef(
+            number=3,
+            title="owned by worker-a",
+            url="u",
+            labels=(WORKFLOW_REVIEWED, f"~batch:{_BATCH_ID}", "~by:worker-a"),
+        )
+        monitor, github, notifier = _make_monitor_full(
+            issues_reviewed=[issue_owned],
+            claude_stdout=f"Implemented. {_PR_URL}",
+            identity=identity_a,
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_finished.assert_called_once()
+
+    async def test_stage3_does_not_pick_peer_branch(self):
+        """Stage 3 on monitor 'a' skips PRs from monitor 'b'."""
+        identity_a = MonitorIdentity(monitor_id="a")
+        pr_from_b = PrRef(
+            number=20,
+            title="b's PR",
+            url="https://github.com/o/r/pull/20",
+            labels=(REVIEW_PENDING,),
+            head_ref="auto/b/issue-5",
+        )
+        monitor, github, notifier = _make_monitor_full(
+            prs=[pr_from_b],
+            identity=identity_a,
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+
+        await monitor.tick()
+
+        notifier.pr_picked_up.assert_not_called()
+
+    async def test_notifier_fires_on_every_transition(self):
+        """All notifier events are emitted at the right stages."""
+        issue_nova = IssueRef(
+            number=5,
+            title="feat: notifier check",
+            url="u",
+            labels=(WORKFLOW_NEW,),
+        )
+        monitor, github, notifier = _make_monitor_full(issues_new=[issue_nova])
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+
+        await monitor.tick()
+
+        notifier.issue_picked_up.assert_called_once_with(5, "feat: notifier check", "u")
+        notifier.issue_reviewed.assert_called_once_with(5, "feat: notifier check", "u")
+        notifier.error.assert_not_called()


### PR DESCRIPTION
## Summary

- **34 new tests** across 4 files covering integration, concurrency, and stress scenarios that complement the existing 218 unit tests
- `test_pipeline_integration.py` — full stage 1→2→3 label-transition flow, baton passing, peer-ownership scoping, notifier event ordering
- `test_monitor_with_schedule.py` — schedule-driven ticks run only due actions; legacy fallback when no schedule file; catch-up drains pending in chronological order; one-shot entries complete after firing
- `test_concurrency.py` — hash-based sharding partitions 100+ titles with no overlap across 2-shard and 3-shard configs; distinct branch names, worktree subdirs, and ownership labels per monitor identity; identity validation
- `test_store_stress.py` — `list_due()` with 100 entries under 100 ms; 10-thread concurrent writes produce exactly 100 unique rows; concurrent reads during writes raise no exceptions; `mark_fired()` semantics for recurring and one-shot entries

## Test plan

- [x] All 34 new tests pass (`pytest ... -v --no-cov`)
- [x] Full pipeline + cron suite: 252 passed, no regressions
- [x] No production files modified — only new test files added

🤖 Generated with [Claude Code](https://claude.com/claude-code)