### PR TITLE
feat(pipeline): production hardening — PID lock auto, PR batch fix, /pipeline-schedule slash command

### DIFF
--- a/deile/commands/builtin/__init__.py
+++ b/deile/commands/builtin/__init__.py
@@ -27,6 +27,7 @@ from .logs_command import LogsCommand
 from .memory_command import MemoryCommand
 from .welcome_command import WelcomeCommand
 from .pipeline_command import PipelineCommand
+from .pipeline_schedule_command import PipelineScheduleCommand
 
 __all__ = [
     "HelpCommand",
@@ -52,4 +53,5 @@ __all__ = [
     "MemoryCommand",
     "WelcomeCommand",
     "PipelineCommand",
+    "PipelineScheduleCommand",
 ]

--- a/deile/commands/builtin/pipeline_schedule_command.py
+++ b/deile/commands/builtin/pipeline_schedule_command.py
@@ -1,0 +1,208 @@
+"""``/pipeline-schedule`` command — manage the autonomous pipeline schedule.
+
+Usage:
+    /pipeline-schedule list
+        List all recurring and oneshot schedule entries.
+
+    /pipeline-schedule add-recurring trigger:<action> cron:<expr>
+        Add a cron-driven recurring entry.
+        trigger: one of ``review``, ``implement``, ``pr_review``
+        cron: 5-field cron expression, e.g. ``*/5 * * * *``
+
+    /pipeline-schedule add-oneshot trigger:<action> at:<iso>
+        Add a one-time run at a specific UTC datetime.
+        at: ISO-8601 UTC, e.g. ``2026-05-06T18:00:00Z``
+
+    /pipeline-schedule remove id:<entry_id>
+        Delete a recurring or oneshot entry.
+
+    /pipeline-schedule enable id:<entry_id>
+    /pipeline-schedule disable id:<entry_id>
+        Toggle a recurring entry on or off.
+
+The command delegates to :class:`PipelineScheduleTool` for all mutations so
+that validation and persistence logic stay in one place (the tool).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+from deile.commands.base import CommandContext, CommandResult, DirectCommand
+from deile.config.manager import CommandConfig
+from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.tools.base import ToolContext
+from deile.tools.pipeline_schedule_tool import PipelineScheduleTool
+
+logger = logging.getLogger(__name__)
+
+# Pre-compiled lookahead for the start of a new key:value pair.
+# A new key is a word boundary followed by ``word_chars:``.
+_KEY_START_RE = re.compile(r"\s+\w[\w-]*:")
+
+
+def _parse_kv(text: str) -> Dict[str, str]:
+    """Parse a ``key:value key2:val2 …`` string into a dict.
+
+    Handles multi-word values (e.g. ``cron:*/5 * * * *``) and values with
+    colons (e.g. ``at:2026-05-06T18:00:00Z``) by consuming everything up to
+    the next ``<space>key:`` boundary or end-of-string.
+
+    Algorithm: split on boundaries where a space is followed by a ``word:``
+    pattern, then parse each segment as ``key:rest-of-line``.
+    """
+    result: Dict[str, str] = {}
+    # Insert sentinels so the pattern can split cleanly.
+    # Replace "  key:" boundaries with a null-byte separator.
+    normalised = _KEY_START_RE.sub(lambda m: "\x00" + m.group(0).lstrip(), text.strip())
+    for segment in normalised.split("\x00"):
+        segment = segment.strip()
+        if not segment:
+            continue
+        colon = segment.find(":")
+        if colon <= 0:
+            continue
+        key = segment[:colon].strip()
+        value = segment[colon + 1:].strip()
+        if key:
+            result[key] = value
+    return result
+
+
+class PipelineScheduleCommand(DirectCommand):
+    """``/pipeline-schedule {list|add-recurring|add-oneshot|remove|enable|disable}``."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            CommandConfig(
+                name="pipeline-schedule",
+                description=(
+                    "Gerencia o schedule do pipeline autônomo "
+                    "(list|add-recurring|add-oneshot|remove|enable|disable)"
+                ),
+                action="pipeline-schedule",
+            )
+        )
+        self.category = "orchestration"
+        self._tool = PipelineScheduleTool()
+
+    async def execute(self, context: CommandContext) -> CommandResult:
+        raw = (context.args or "").strip()
+        parts = raw.split(None, 1)
+        sub = parts[0].lower() if parts else "list"
+        rest = parts[1] if len(parts) > 1 else ""
+
+        tool_args: Dict[str, Any] = {}
+
+        if sub == "list":
+            tool_args = {"action": "list"}
+
+        elif sub == "add-recurring":
+            kv = _parse_kv(rest)
+            trigger = kv.get("trigger")
+            cron = kv.get("cron")
+            if not trigger or not cron:
+                return CommandResult.error_result(
+                    "add-recurring requires trigger:<action> and cron:<expr>\n"
+                    "Example: /pipeline-schedule add-recurring trigger:review cron:*/5 * * * *"
+                )
+            tool_args = {
+                "action": "add_recurring",
+                "trigger_action": trigger,
+                "cron": cron,
+            }
+            if "id" in kv:
+                tool_args["id"] = kv["id"]
+
+        elif sub == "add-oneshot":
+            kv = _parse_kv(rest)
+            trigger = kv.get("trigger")
+            at = kv.get("at")
+            if not trigger or not at:
+                return CommandResult.error_result(
+                    "add-oneshot requires trigger:<action> and at:<iso-datetime>\n"
+                    "Example: /pipeline-schedule add-oneshot trigger:review at:2026-05-06T18:00:00Z"
+                )
+            tool_args = {
+                "action": "add_oneshot",
+                "trigger_action": trigger,
+                "run_at": at,
+            }
+            if "id" in kv:
+                tool_args["id"] = kv["id"]
+
+        elif sub == "remove":
+            kv = _parse_kv(rest)
+            entry_id = kv.get("id")
+            if not entry_id:
+                return CommandResult.error_result(
+                    "remove requires id:<entry_id>\n"
+                    "Example: /pipeline-schedule remove id:review_loop"
+                )
+            tool_args = {"action": "remove", "id": entry_id}
+
+        elif sub in ("enable", "disable"):
+            kv = _parse_kv(rest)
+            entry_id = kv.get("id")
+            if not entry_id:
+                return CommandResult.error_result(
+                    f"{sub} requires id:<entry_id>\n"
+                    f"Example: /pipeline-schedule {sub} id:review_loop"
+                )
+            tool_args = {"action": sub, "id": entry_id}
+
+        else:
+            return CommandResult.error_result(
+                f"Unknown sub-command: {sub!r}\n"
+                "Valid sub-commands: list, add-recurring, add-oneshot, remove, enable, disable"
+            )
+
+        try:
+            tool_ctx = ToolContext(user_input=raw, parsed_args=tool_args)
+            result = await self._tool.execute(tool_ctx)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("pipeline-schedule tool error: %s", exc, exc_info=True)
+            return CommandResult.error_result(
+                f"{type(exc).__name__}: {exc}", error=exc
+            )
+
+        if not result.is_success:
+            return CommandResult.error_result(result.message or "tool returned error")
+
+        return CommandResult(
+            success=True,
+            content=_format_result(sub, result.data, result.message),
+        )
+
+
+# ---------------------------------------------------------------------------
+# display helpers
+# ---------------------------------------------------------------------------
+
+def _format_result(sub: str, data: Any, message: Optional[str]) -> str:
+    if sub == "list":
+        if not data:
+            return message or "no schedule data"
+        recurring = data.get("recurring", [])
+        oneshot = data.get("oneshot", [])
+        lines = [f"Monitor: {data.get('monitor_id', '?')}"]
+        if recurring:
+            lines.append("\nRecurring:")
+            for e in recurring:
+                status = "on" if e.get("enabled", True) else "off"
+                lines.append(
+                    f"  [{status}] {e['id']}  {e['action']}  @  {e['cron']}"
+                )
+        if oneshot:
+            lines.append("\nOneshot:")
+            for e in oneshot:
+                lines.append(
+                    f"  {e['id']}  {e['action']}  at  {e.get('run_at', '?')}"
+                )
+        if not recurring and not oneshot:
+            lines.append("  (empty)")
+        return "\n".join(lines)
+
+    return message or str(data)

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -158,9 +158,22 @@ class PipelineMonitor:
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
+        """Start the background polling loop.
+
+        PID locking is enabled when:
+        - ``config.use_pid_lock`` is explicitly set, **or**
+        - the identity is non-default (any named monitor, any sharded deployment).
+
+        The second condition is intentional: a non-default identity implies a
+        multi-monitor deployment where two instances with the same ``monitor_id``
+        on the same host are a guaranteed-bug — they would race on the same
+        worktree sub-directory and schedule file. The lockfile is the last line
+        of defence against operator error.
+        """
         if self._task is not None and not self._task.done():
             return
-        if self.config.use_pid_lock:
+        should_lock = self.config.use_pid_lock or not self.identity.is_default
+        if should_lock:
             lock_path = Path(self.config.base_repo_path) / self.identity.lockfile_name()
             try:
                 self._held_lock = acquire_lock(lock_path)
@@ -400,6 +413,9 @@ class PipelineMonitor:
         batch = await self.github.claim_with_batch("pr", target.number, target.title)
         if batch is None:
             return
+        # Tag ownership so other monitors can identify who claimed this PR —
+        # mirrors the identical pattern in stage 1 for issues.
+        await self.github.add_labels("pr", target.number, [self.identity.ownership_label()])
         await self.notifier.pr_picked_up(target.number, target.title, target.url)
         try:
             await self.github.transition_pr(

--- a/deile/tests/commands/test_pipeline_schedule_command.py
+++ b/deile/tests/commands/test_pipeline_schedule_command.py
@@ -1,0 +1,285 @@
+"""Unit tests for PipelineScheduleCommand (/pipeline-schedule slash command)."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.commands.builtin.pipeline_schedule_command import (
+    PipelineScheduleCommand,
+    _parse_kv,
+)
+from deile.commands.base import CommandContext, CommandResult
+from deile.tools.base import ToolContext, ToolResult
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _ctx(args: str = "") -> CommandContext:
+    ctx = MagicMock(spec=CommandContext)
+    ctx.args = args
+    ctx.agent = MagicMock()
+    return ctx
+
+
+def _success(data: Any = None, message: str = "ok") -> ToolResult:
+    return ToolResult.success_result(data=data, message=message)
+
+
+def _error(message: str = "fail", error_code: str = "ERR") -> ToolResult:
+    return ToolResult.error_result(message=message, error_code=error_code)
+
+
+# ---------------------------------------------------------------------------
+# _parse_kv unit tests
+# ---------------------------------------------------------------------------
+
+class TestParseKv:
+    def test_single_key(self):
+        assert _parse_kv("id:my_id") == {"id": "my_id"}
+
+    def test_multiple_keys(self):
+        result = _parse_kv("trigger:review cron:*/5 * * * *")
+        assert result["trigger"] == "review"
+        assert result["cron"] == "*/5 * * * *"
+
+    def test_at_key(self):
+        result = _parse_kv("trigger:pr_review at:2026-05-06T18:00:00Z")
+        assert result["trigger"] == "pr_review"
+        assert result["at"] == "2026-05-06T18:00:00Z"
+
+    def test_empty_string(self):
+        assert _parse_kv("") == {}
+
+
+# ---------------------------------------------------------------------------
+# sub-command: list
+# ---------------------------------------------------------------------------
+
+class TestListSubCommand:
+    async def test_list_calls_tool_with_action_list(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={
+                "monitor_id": "default",
+                "recurring": [],
+                "oneshot": [],
+            },
+            message="0 recurring + 0 oneshot entries",
+        )
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx("list"))
+
+        assert result.success
+        assert "default" in result.content
+
+    async def test_list_with_entries_formats_output(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={
+                "monitor_id": "default",
+                "recurring": [{"id": "r1", "action": "review", "cron": "*/5 * * * *", "enabled": True}],
+                "oneshot": [{"id": "o1", "action": "implement", "run_at": "2026-05-06T18:00:00+00:00"}],
+            },
+            message="1 recurring + 1 oneshot entries",
+        )
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx("list"))
+
+        assert result.success
+        assert "r1" in result.content
+        assert "o1" in result.content
+
+
+# ---------------------------------------------------------------------------
+# sub-command: add-recurring
+# ---------------------------------------------------------------------------
+
+class TestAddRecurringSubCommand:
+    async def test_add_recurring_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={"id": "review_loop", "cron": "*/5 * * * *", "action": "review"},
+            message="added recurring",
+        )
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("add-recurring trigger:review cron:*/5 * * * *"))
+
+        assert result.success
+        assert captured[0]["action"] == "add_recurring"
+        assert captured[0]["trigger_action"] == "review"
+        assert captured[0]["cron"] == "*/5 * * * *"
+
+    async def test_add_recurring_missing_args_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("add-recurring trigger:review"))
+        assert not result.success
+        assert "cron" in result.content.lower()
+
+    async def test_add_recurring_missing_trigger_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("add-recurring cron:*/10 * * * *"))
+        assert not result.success
+        assert "trigger" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# sub-command: add-oneshot
+# ---------------------------------------------------------------------------
+
+class TestAddOneshotSubCommand:
+    async def test_add_oneshot_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={"id": "o1", "run_at": "2026-05-06T18:00:00+00:00", "action": "implement"},
+            message="added oneshot",
+        )
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(
+                _ctx("add-oneshot trigger:implement at:2026-05-06T18:00:00Z")
+            )
+
+        assert result.success
+        assert captured[0]["action"] == "add_oneshot"
+        assert captured[0]["trigger_action"] == "implement"
+        assert "2026-05-06" in captured[0]["run_at"]
+
+    async def test_add_oneshot_missing_at_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("add-oneshot trigger:review"))
+        assert not result.success
+        assert "at" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# sub-command: remove
+# ---------------------------------------------------------------------------
+
+class TestRemoveSubCommand:
+    async def test_remove_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(data={"id": "r1"}, message="removed r1")
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("remove id:r1"))
+
+        assert result.success
+        assert captured[0] == {"action": "remove", "id": "r1"}
+
+    async def test_remove_missing_id_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("remove"))
+        assert not result.success
+        assert "id" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# sub-command: enable / disable
+# ---------------------------------------------------------------------------
+
+class TestEnableDisableSubCommand:
+    async def test_enable_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(data={"id": "r1", "enabled": True}, message="r1 enabled")
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("enable id:r1"))
+
+        assert result.success
+        assert captured[0] == {"action": "enable", "id": "r1"}
+
+    async def test_disable_delegates_to_tool(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(data={"id": "r1", "enabled": False}, message="r1 disabled")
+        captured: list[dict] = []
+
+        async def fake_execute(ctx: ToolContext) -> ToolResult:
+            captured.append(dict(ctx.parsed_args))
+            return tool_result
+
+        with patch.object(cmd._tool, "execute", side_effect=fake_execute):
+            result = await cmd.execute(_ctx("disable id:r1"))
+
+        assert result.success
+        assert captured[0] == {"action": "disable", "id": "r1"}
+
+    async def test_enable_missing_id_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("enable"))
+        assert not result.success
+        assert "id" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# invalid sub-command
+# ---------------------------------------------------------------------------
+
+class TestInvalidSubCommand:
+    async def test_unknown_subcommand_returns_error(self):
+        cmd = PipelineScheduleCommand()
+        result = await cmd.execute(_ctx("foobar"))
+        assert not result.success
+        assert "unknown" in result.content.lower() or "foobar" in result.content.lower()
+
+    async def test_empty_args_defaults_to_list(self):
+        """No args → list (same as /pipeline default = status)."""
+        cmd = PipelineScheduleCommand()
+        tool_result = _success(
+            data={"monitor_id": "default", "recurring": [], "oneshot": []},
+            message="0 recurring + 0 oneshot entries",
+        )
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx(""))
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# tool error propagation
+# ---------------------------------------------------------------------------
+
+class TestToolErrorPropagation:
+    async def test_tool_error_becomes_command_error(self):
+        cmd = PipelineScheduleCommand()
+        tool_result = _error(message="no entry with id='x'", error_code="NOT_FOUND")
+        with patch.object(cmd._tool, "execute", new=AsyncMock(return_value=tool_result)):
+            result = await cmd.execute(_ctx("remove id:x"))
+        assert not result.success
+        assert "no entry" in result.content.lower()
+
+    async def test_tool_exception_becomes_command_error(self):
+        cmd = PipelineScheduleCommand()
+
+        async def explode(_ctx):
+            raise RuntimeError("disk full")
+
+        with patch.object(cmd._tool, "execute", side_effect=explode):
+            result = await cmd.execute(_ctx("list"))
+
+        assert not result.success
+        assert "RuntimeError" in result.content or "disk full" in result.content

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -201,3 +201,44 @@ class TestEnsureLabelOnClaim:
         # The first call must be `label create ~batch:<bid>` via _run
         assert calls[0][0] == "label" and calls[0][1] == "create"
         assert calls[0][2].startswith("~batch:")
+
+    async def test_claim_pr_creates_batch_label_before_adding(self):
+        """For PRs, _ensure_label must be called BEFORE add_labels — same
+        contract as for issues (tested above).  This test verifies call order
+        using a spy that records every invocation."""
+        client = GitHubClient("owner/name")
+        unclaimed_pr = PrRef(
+            number=11, title="pr title", url="u", labels=(REVIEW_PENDING,),
+            head_ref="auto/issue-11",
+        )
+        calls = []
+
+        async def fake_run(*args):
+            calls.append(("_run", *args))
+            return (0, "", "")
+
+        async def fake_run_checked(*args):
+            calls.append(("_run_checked", *args))
+            return ""
+
+        with patch.object(client, "list_open_prs", new=AsyncMock(return_value=[unclaimed_pr])), \
+             patch.object(client, "_run", side_effect=fake_run), \
+             patch.object(client, "_run_checked", side_effect=fake_run_checked):
+            bid = await client.claim_with_batch("pr", 11, "pr title")
+
+        assert bid is not None
+
+        # Locate the _ensure_label call (label create) and the add_labels call.
+        ensure_idx = next(
+            (i for i, c in enumerate(calls) if c[0] == "_run" and "label" in c and "create" in c),
+            None,
+        )
+        add_idx = next(
+            (i for i, c in enumerate(calls) if c[0] == "_run_checked" and "edit" in c),
+            None,
+        )
+        assert ensure_idx is not None, f"_ensure_label not called; calls={calls}"
+        assert add_idx is not None, f"add_labels not called; calls={calls}"
+        assert ensure_idx < add_idx, (
+            f"_ensure_label (idx={ensure_idx}) must precede add_labels (idx={add_idx})"
+        )

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -283,3 +283,110 @@ class TestIdentityAwareSelection:
         assert monitor._owns_pr_branch("auto/m-alfa/issue-1")
         assert not monitor._owns_pr_branch("auto/m-beta/issue-1")
         assert not monitor._owns_pr_branch("auto/issue-1")  # legacy prefix not ours
+
+
+# ---------------------------------------------------------------------------
+# PID lock auto-enable for non-default identity
+# ---------------------------------------------------------------------------
+
+def _make_minimal_monitor(
+    tmp_path,
+    *,
+    identity,
+    use_pid_lock: bool = False,
+):
+    """Build a PipelineMonitor with all I/O mocked, using ``tmp_path`` as repo."""
+    from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+    from deile.orchestration.pipeline.worktree_manager import Worktree
+
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=tmp_path,
+        use_pid_lock=use_pid_lock,
+        poll_interval_seconds=60,
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(return_value=[])
+    github.list_open_prs = AsyncMock(return_value=[])
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(path=tmp_path / ".wt", branch="x", base_repo=tmp_path)
+    )
+
+    notifier = MagicMock()
+    for attr in ("issue_picked_up", "issue_reviewed", "implementation_started",
+                 "implementation_finished", "pr_picked_up", "pr_reviewed", "error"):
+        setattr(notifier, attr, AsyncMock())
+
+    schedule_store = MagicMock()
+    schedule_store.load = MagicMock(return_value=MagicMock(
+        recurring=[], oneshot=[], compute_pending=MagicMock(return_value=[])
+    ))
+
+    return PipelineMonitor(
+        cfg,
+        github=github,
+        worktrees=worktrees,
+        notifier=notifier,
+        identity=identity,
+        schedule_store=schedule_store,
+    )
+
+
+class TestPidLockAutoEnable:
+    async def test_non_default_identity_creates_lockfile(self, tmp_path):
+        """A non-default identity must acquire a PID lock even when
+        config.use_pid_lock is False (multi-monitor guard)."""
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+
+        identity = MonitorIdentity(monitor_id="gamma")
+        monitor = _make_minimal_monitor(tmp_path, identity=identity, use_pid_lock=False)
+        try:
+            await monitor.start()
+            # After start(), the lockfile must exist under base_repo_path.
+            lock_path = tmp_path / identity.lockfile_name()
+            assert lock_path.exists(), f"expected lockfile at {lock_path}"
+        finally:
+            await monitor.stop()
+
+    async def test_default_identity_no_pid_lock_flag_skips_lockfile(self, tmp_path):
+        """Default identity with use_pid_lock=False must NOT create a lockfile."""
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+
+        identity = MonitorIdentity()  # default
+        monitor = _make_minimal_monitor(tmp_path, identity=identity, use_pid_lock=False)
+        try:
+            await monitor.start()
+            # No lockfile should be created for the default identity without flag.
+            lock_path = tmp_path / identity.lockfile_name()
+            assert not lock_path.exists(), f"unexpected lockfile at {lock_path}"
+        finally:
+            await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# Ownership label stamped on claimed PRs
+# ---------------------------------------------------------------------------
+
+class TestPrOwnershipLabel:
+    async def test_claimed_pr_gets_ownership_label(self):
+        """After a PR is claimed in stage 3, the monitor's ownership label must
+        be stamped on the PR — mirroring stage 1 issue behaviour."""
+        pr = PrRef(
+            number=77, title="my pr", url="https://x/pull/77",
+            labels=(REVIEW_PENDING,), head_ref="auto/issue-5",
+        )
+        monitor, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        await monitor.tick()
+
+        # ownership label must have been added
+        ownership = monitor.identity.ownership_label()
+        add_labels_calls = monitor.github.add_labels.call_args_list
+        ownership_calls = [c for c in add_labels_calls if ownership in (c.args[2] if c.args else [])]
+        assert ownership_calls, (
+            f"expected add_labels call with {ownership!r}; calls were: {add_labels_calls}"
+        )


### PR DESCRIPTION
## Summary

- **PID lock auto-enable** (`monitor.py::start`): non-default identity implies multi-monitor deployment; lock is now acquired automatically regardless of `use_pid_lock` flag, preventing two monitors with the same `monitor_id` from racing on the same worktree + schedule file on the same host.
- **PR ownership stamping** (`monitor.py::_review_one_open_pr`): after a PR is claimed via `claim_with_batch`, the monitor's `~by:<monitor_id>` ownership label is now applied — mirroring the identical pattern already in stage 1 for issues.
- **PR batch label call-order** (`test_github_client.py`): added explicit test asserting `_ensure_label` is called before `add_labels` for the PR path in `claim_with_batch` (issue path was already tested; this closes the gap).
- **`/pipeline-schedule` slash command** (`pipeline_schedule_command.py`): new `DirectCommand` with sub-actions `list`, `add-recurring`, `add-oneshot`, `remove`, `enable`, `disable`. Delegates all mutations to `PipelineScheduleTool` — no logic duplication.

## Test plan

- [ ] `python3 -m pytest deile/tests/orchestration/pipeline/ deile/tests/commands/ -q --no-cov` → **194 passed, 0 failed**
- [ ] Existing 170 pipeline tests unchanged — confirmed in CI
- [ ] New tests added:
  - `TestPidLockAutoEnable` (2 tests): lockfile created for non-default identity; skipped for default identity without flag
  - `TestPrOwnershipLabel` (1 test): ownership label stamped on claimed PR
  - `TestEnsureLabelOnClaim::test_claim_pr_creates_batch_label_before_adding` (1 test): call-order spy
  - `test_pipeline_schedule_command.py` (20 tests): full sub-command coverage including error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)