### PR TITLE
refactor(pipeline,cron): centralize timeouts, truncations and default repo constant

### DIFF
--- a/PR89-ACC.md
+++ b/PR89-ACC.md
@@ -1,0 +1,102 @@
+⏺ 🏁 **Entrega completa — resumo + aprovação**
+
+## Trabalho de cada agente
+
+### 🅰️  ALPHA — Bridge cron↔agente — [PR #93](https://github.com/elimarcavalli/deile/pull/93)
+
+- `deile/cron/agent_bridge.py` — `make_fire_callback(agent_provider, max_summary_chars=500)` (factory lazy + truncamento + swallow de exceção)
+- 9 testes cobrindo happy/truncate/erro-no-provider/erro-no-process_input/session_id/sem-.content
+- **Veredito:** APROVO — pequeno, focado, swallow-de-exceção exatamente como CronRunner espera.
+
+---
+
+### 🅱️  BETA — daemon do deile-bot — [PR #7](https://github.com/elimarcavalli/deilebot/pull/7)
+
+- `deilebot/cli.py` com 2 blocos opt-in: `DEILE_CRON_AUTOSTART=1` e `DEILE_PIPELINE_AUTOSTART=1` (ambos com try/except — bot não quebra se imports faltarem)
+- Cog novo `cron_cog.py` com `/agendar`, `/agendamentos`, `/cancelar` (parser `_parse_quando` aceita ISO ou cron)
+- 16 testes novos, 65/65 da suite Discord verde
+- **Veredito:** APROVO — boa defesa (lazy import + try/except), parser inteligente, mocks limpos. Em repo separado, fica aguardando review humana.
+
+---
+
+### 🅶 GAMMA — hardening do pipeline — [PR #96](https://github.com/elimarcavalli/deile/pull/96)
+
+- PID lock auto-enable quando `identity != default` (com docstring explicando o porquê)
+- Stamp de `~by:<monitor_id>` em PR claimed (mirror do stage 1)
+- Teste novo cravando ordem `_ensure_label → add_labels` no claim de PR
+- `/pipeline-schedule` slash command com parser `_parse_kv` que respeita espaços em cron e `:` em ISO
+- 20 testes novos no `test_pipeline_schedule_command.py`
+- **Veredito:** APROVO — todas as 3 lacunas SHOULD endereçadas, parser robusto.
+
+---
+
+### 🅳 DELTA — WorktreeTool LLM-callable — [PR #94](https://github.com/elimarcavalli/deile/pull/94)
+
+- Stamp de `~by:<monitor_id>` em PR claimed (mirror do stage 1)
+- Teste novo cravando ordem `_ensure_label → add_labels` no claim de PR
+- `/pipeline-schedule` slash command com parser `_parse_kv` que respeita espaços em cron e `:` em ISO
+- 20 testes novos no `test_pipeline_schedule_command.py`
+- **Veredito:** APROVO — todas as 3 lacunas SHOULD endereçadas, parser robusto.
+
+---
+
+### 🅳 DELTA — WorktreeTool LLM-callable — [PR #94](https://github.com/elimarcavalli/deile/pull/94)
+
+- `deile/tools/worktree_tool.py` com 4 actions: `ensure_main`, `create`, `list`, `remove`
+- Safety check: recusa remover `.worktrees/main`
+- Schema com wrapper `{"type":"object","properties":...}` correto + teste de regressão
+- 17 testes novos
+- **Veredito:** APROVO — schema-regression-test impede o bug de type:null voltar; safety check preventiva.
+
+---
+
+### 🅴 EPSILON — testes profundos — [PR #95](https://github.com/elimarcavalli/deile/pull/95)
+
+- `test_pipeline_integration.py` (6) — stage 1→2→3 ponta-a-ponta com label transitions verdadeiras
+- `test_monitor_with_schedule.py` (5) — schedule-driven + catchup + oneshot
+- `test_concurrency.py` (17) — sharding partitions 100 títulos sem overlap, branches/subdirs/labels distintos
+- `test_store_stress.py` (6) — `list_due()` <100ms com 100 entries, 10 threads concorrentes sem corruption
+- **Total:** 34 testes novos
+- **Veredito:** APROVO — cobre exatamente os 4 cenários que você levantou (paralelismo, conflito, schedule, performance).
+
+---
+
+### 🅵 ZETA — documentação — [PR #97](https://github.com/elimarcavalli/deile/pull/97)
+
+- 4 pilares atualizados (02, 04, 09, 00)
+- Decisões #18/#19/#20 detalhadas em `DECISOES.md`
+- `docs/2026-05-06_PIPELINE-AUTONOMO.md` (~700 linhas, 14 seções)
+- `README.md` com seção "Pipeline autônomo"
+- `config/deilebot.example.yaml` com env vars comentadas
+- **Veredito:** APROVO — segue o padrão do pilar 13, sem código alterado, índice em 00 mantido como single source of truth.
+
+---
+
+### 🅾️  OMEGA — integração final — commit `3ba2b87`
+
+- 5/5 merges bem-sucedidos, 1 conflito resolvido (test files pré-existentes — apenas re-stage, zero perda)
+- Teste deferred adicionado: `test_integration_full.py` (`CronStore → Runner → Bridge → MockAgent` ponta-a-ponta)
+- Suite final: 1239 passed, 12 skipped, 2 failures pré-existentes (Python 3.14 Exception() takes no kwargs em `test_discord_pin_message` e `test_discord_react` — não introduzidas pela wave)
+- Smoke: `python3 deile.py` → SMOKE_OK limpo
+- Schema audit: 17 tools, 100% válidas
+- E2E live: tick contra GitHub real, errors=0
+- [PR #89 — comentário de integração final](https://github.com/elimarcavalli/deile/pull/89#issuecomment-4384871875)
+- **Veredito:** APROVO — honesto sobre os 2 failures pré-existentes, não escondeu problemas, integração limpa.
+
+---
+
+## 📋 Aprovação geral
+
+**APROVO TUDO.**  
+Branch `feat/pipeline-autonomo-87` está em estado de merge-ready no remote  
+(`github/feat/pipeline-autonomo-87 @ 3ba2b87`).
+
+### O que está pronto
+
+- ✅ Pipeline autônomo (#87): stages 1+2+3 com sharding multi-monitor, lockfile, worktree namespacing
+- ✅ Cron genérico (#86): tools + storage SQLite + runner + bridge para o agent
+- ✅ Bot daemon: opt-in autostart de pipeline + cron, novos slash commands
+- ✅ Tools LLM-callable: pipeline, pipeline_schedule, cron_create/list/delete, worktree
+- ✅ Slash commands: `/pipeline`, `/pipeline-schedule`, `/agendar`, `/agendamentos`, `/cancelar`
+- ✅ Documentação completa em system_design + feature doc
+- ✅ 1239 testes verdes, 0 regressão introduzida pela wave

--- a/PR89-ACCEPTED.md
+++ b/PR89-ACCEPTED.md
@@ -1,0 +1,106 @@
+⏳ 🏁 **Entrega completa — resumo + aprovação**
+
+## Trabalho de cada agente
+
+### 🅰️  ALPHA — Bridge cron↔agente — [PR #93](https://github.com/elimarcavalli/deile/pull/93)
+
+- `deile/cron/agent_bridge.py` — `make_fire_callback(agent_provider, max_summary_chars=500)` (factory lazy + truncamento + swallow de exceção)
+- 9 testes cobrindo happy/truncate/erro-no-provider/erro-no-process_input/session_id/sem-.content
+- **Veredito:** APROVO — pequeno, focado, swallow-de-exceção exatamente como CronRunner espera.
+
+---
+
+### 🅱️  BETA — daemon do deile-bot — [PR #7](https://github.com/elimarcavalli/deilebot/pull/7)
+
+- `deilebot/cli.py` com 2 blocos opt-in: `DEILE_CRON_AUTOSTART=1` e `DEILE_PIPELINE_AUTOSTART=1` (ambos com try/except — bot não quebra se imports faltarem)
+- Cog novo `cron_cog.py` com `/agendar`, `/agendamentos`, `/cancelar` (parser `_parse_quando` aceita ISO ou cron)
+- 16 testes novos, 65/65 da suite Discord verde
+- **Veredito:** APROVO — boa defesa (lazy import + try/except), parser inteligente, mocks limpos. Em repo separado, fica aguardando review humana.
+
+---
+
+### 🅶 GAMMA — hardening do pipeline — [PR #96](https://github.com/elimarcavalli/deile/pull/96)
+
+- PID lock auto-enable quando `identity != default` (com docstring explicando o porquê)
+- Stamp de `~by:<monitor_id>` em PR claimed (mirror do stage 1)
+- Teste novo cravando ordem `_ensure_label → add_labels` no claim de PR
+- `/pipeline-schedule` slash command com parser `_parse_kv` que respeita espaços em cron e `:` em ISO
+- 20 testes novos no `test_pipeline_schedule_command.py`
+- **Veredito:** APROVO — todas as 3 lacunas SHOULD endereçadas, parser robusto.
+
+---
+
+### 🅳 DELTA — WorktreeTool LLM-callable — [PR #94](https://github.com/elimarcavalli/deile/pull/94)
+
+- Stamp de `~by:<monitor_id>` em PR claimed (mirror do stage 1)
+- Teste novo cravando ordem `_ensure_label → add_labels` no claim de PR
+- `/pipeline-schedule` slash command com parser `_parse_kv` que respeita espaços em cron e `:` em ISO
+- 20 testes novos no `test_pipeline_schedule_command.py`
+- **Veredito:** APROVO — todas as 3 lacunas SHOULD endereçadas, parser robusto.
+
+---
+
+### 🅳 DELTA — WorktreeTool LLM-callable — [PR #94](https://github.com/elimarcavalli/deile/pull/94)
+
+- `deile/tools/worktree_tool.py` com 4 actions: `ensure_main`, `create`, `list`, `remove`
+- Safety check: recusa remover `.worktrees/main`
+- Schema com wrapper `{"type":"object","properties":...}` correto + teste de regressão
+- 17 testes novos
+- **Veredito:** APROVO — schema-regression-test impede o bug de type:null voltar; safety check preventiva.
+
+---
+
+### 🅴 EPSILON — testes profundos — [PR #95](https://github.com/elimarcavalli/deile/pull/95)
+
+- `test_pipeline_integration.py` (6) — stage 1→2→3 ponta-a-ponta com label transitions verdadeiras
+- `test_monitor_with_schedule.py` (5) — schedule-driven + catchup + oneshot
+- `test_concurrency.py` (17) — sharding partitions 100 títulos sem overlap, branches/subdirs/labels distintos
+- `test_store_stress.py` (6) — `list_due()` <100ms com 100 entries, 10 threads concorrentes sem corruption
+- **Total:** 34 testes novos
+- **Veredito:** APROVO — cobre exatamente os 4 cenários que você levantou (paralelismo, conflito, schedule, performance).
+
+---
+
+### 🅵 ZETA — documentação — [PR #97](https://github.com/elimarcavalli/deile/pull/97)
+
+- 4 pilares atualizados (02, 04, 09, 00)
+- Decisões #18/#19/#20 detalhadas em `DECISOES.md`
+- `docs/2026-05-06_PIPELINE-AUTONOMO.md` (~700 linhas, 14 seções)
+- `README.md` com seção "Pipeline autônomo"
+- `config/deilebot.example.yaml` com env vars comentadas
+- **Veredito:** APROVO — segue o padrão do pilar 13, sem código alterado, índice em 00 mantido como single source of truth.
+
+---
+
+### 🅾️  OMEGA — integração final — commit `3ba2b87`
+
+- 5/5 merges bem-sucedidos, 1 conflito resolvido (test files pré-existentes — apenas re-stage, zero perda)
+- Teste deferred adicionado: `test_integration_full.py` (`CronStore → Runner → Bridge → MockAgent` ponta-a-ponta)
+- Suite final: 1239 passed, 12 skipped, 2 failures pré-existentes (Python 3.14 Exception() takes no kwargs em `test_discord_pin_message` e `test_discord_react` — não introduzidas pela wave)
+- Smoke: `python3 deile.py` → SMOKE_OK limpo
+- Schema audit: 17 tools, 100% válidas
+- E2E live: tick contra GitHub real, errors=0
+- [PR #89 — comentário de integração final](https://github.com/elimarcavalli/deile/pull/89#issuecomment-4384871875)
+- **Veredito:** APROVO — honesto sobre os 2 failures pré-existentes, não escondeu problemas, integração limpa.
+
+---
+
+## 📋 Aprovação geral
+
+**APROVO TUDO.**  
+Branch `feat/pipeline-autonomo-87` está em estado de merge-ready no remote  
+(`github/feat/pipeline-autonomo-87 @ 3ba2b87`).
+
+### O que está pronto
+
+- ✅ Pipeline autônomo (#87): stages 1+2+3 com sharding multi-monitor, lockfile, worktree namespacing
+- ✅ Cron genérico (#86): tools + storage SQLite + runner + bridge para o agent
+- ✅ Bot daemon: opt-in autostart de pipeline + cron, novos slash commands
+- ✅ Tools LLM-callable: pipeline, pipeline_schedule, cron_create/list/delete, worktree
+- ✅ Slash commands: `/pipeline`, `/pipeline-schedule`, `/agendar`, `/agendamentos`, `/cancelar`
+- ✅ Documentação completa em system_design + feature doc
+- ✅ 1239 testes verdes, 0 regressão introduzida pela wave
+
+---
+
+By [@DEILE 1.0](mailto:deile@deile.info)

--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -18,15 +18,13 @@ from typing import Optional
 
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
 from deile.config.manager import CommandConfig
+from deile.orchestration.pipeline.constants import PIPELINE_DEFAULT_REPO
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
 
 
-_DEFAULT_REPO = "elimarcavalli/deile"
-
-
 def _resolve_repo() -> str:
-    return os.environ.get("DEILE_PIPELINE_REPO", _DEFAULT_REPO)
+    return os.environ.get("DEILE_PIPELINE_REPO", PIPELINE_DEFAULT_REPO)
 
 
 def _resolve_base_path() -> Path:
@@ -55,7 +53,8 @@ class PipelineCommand(DirectCommand):
         self.category = "orchestration"
 
     async def execute(self, context: CommandContext) -> CommandResult:
-        sub = (context.args.strip().split(" ", 1) + [""])[0].lower() or "status"
+        parts = context.args.strip().split(None, 1)
+        sub = parts[0].lower() if parts else "status"
         agent = context.agent
         monitor: Optional[PipelineMonitor] = getattr(agent, "pipeline_monitor", None)
 
@@ -93,7 +92,7 @@ class PipelineCommand(DirectCommand):
             )
         # default: status
         s = monitor.stats
-        running = monitor._task is not None and not monitor._task.done()  # type: ignore[union-attr]
+        running = monitor.is_running
         return CommandResult(
             success=True,
             content=(

--- a/deile/cron/__init__.py
+++ b/deile/cron/__init__.py
@@ -14,6 +14,6 @@ The three LLM-callable tools (CronCreate / CronList / CronDelete) live
 under ``deile/tools/`` for registry auto-discovery.
 """
 
-from deile.cron.store import CronEntry, CronStore
+from deile.cron.store import CronEntry, CronStore, resolve_db_path
 
-__all__ = ["CronEntry", "CronStore"]
+__all__ = ["CronEntry", "CronStore", "resolve_db_path"]

--- a/deile/cron/constants.py
+++ b/deile/cron/constants.py
@@ -1,0 +1,24 @@
+"""Central constants for the cron subsystem.
+
+Deployment-tunable values are backed by env vars.  Truncation limits are
+pure Python constants.
+"""
+from __future__ import annotations
+
+import os
+
+# ── CronRunner ────────────────────────────────────────────────────────────
+#: Default polling cadence for :class:`CronRunner`.
+CRON_POLL_INTERVAL_SECONDS: int = int(os.environ.get("DEILE_CRON_POLL_INTERVAL", "30"))
+#: Seconds ``stop()`` waits for the loop task before cancelling it.
+CRON_STOP_TIMEOUT_SECONDS: int = 5
+
+# ── CronStore / result storage ────────────────────────────────────────────
+#: Max chars persisted in ``last_result`` and error strings.
+CRON_RESULT_MAX_CHARS: int = 500
+
+# ── Discord DM notifications ──────────────────────────────────────────────
+#: Max chars of ``entry.prompt`` shown in the notification DM.
+CRON_DM_PROMPT_MAX_CHARS: int = 300
+#: Max chars of the result summary shown in the notification DM.
+CRON_DM_RESULT_MAX_CHARS: int = 1500

--- a/deile/cron/runner.py
+++ b/deile/cron/runner.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Awaitable, Callable, Optional
 
+from deile.cron.constants import (CRON_DM_PROMPT_MAX_CHARS, CRON_DM_RESULT_MAX_CHARS,
+                                  CRON_POLL_INTERVAL_SECONDS, CRON_RESULT_MAX_CHARS,
+                                  CRON_STOP_TIMEOUT_SECONDS)
 from deile.cron.store import CronEntry, CronStore
 
 logger = logging.getLogger(__name__)
@@ -44,7 +46,7 @@ class CronRunner:
         store: CronStore,
         *,
         fire_callback: Optional[FireCallback] = None,
-        poll_interval_seconds: int = 30,
+        poll_interval_seconds: int = CRON_POLL_INTERVAL_SECONDS,
         notify_dm: Optional[Callable[[str, str], Awaitable[dict]]] = None,
     ) -> None:
         self.store = store
@@ -73,7 +75,7 @@ class CronRunner:
         self._stop_event.set()
         if self._task is not None:
             try:
-                await asyncio.wait_for(self._task, timeout=5)
+                await asyncio.wait_for(self._task, timeout=CRON_STOP_TIMEOUT_SECONDS)
             except asyncio.TimeoutError:
                 self._task.cancel()
                 try:
@@ -99,7 +101,7 @@ class CronRunner:
                 # Even on error, mark fired so we don't loop on a poison entry.
                 self.store.mark_fired(
                     entry.id, when=datetime.now(timezone.utc),
-                    result=f"error: {type(exc).__name__}: {exc}"[:500],
+                    result=f"error: {type(exc).__name__}: {exc}"[:CRON_RESULT_MAX_CHARS],
                 )
         return fired
 
@@ -110,13 +112,13 @@ class CronRunner:
             self.store.mark_fired(entry.id, result="skipped: no callback")
             return
         result_summary = await cb(entry)
-        self.store.mark_fired(entry.id, result=str(result_summary)[:500])
+        self.store.mark_fired(entry.id, result=str(result_summary)[:CRON_RESULT_MAX_CHARS])
         if self.notify_dm and entry.notify_user_id and result_summary:
             try:
                 msg = (
                     f"⏰ **Tarefa agendada executada** ({entry.id})\n"
-                    f"> {entry.prompt[:300]}\n\n"
-                    f"**Resultado:** {str(result_summary)[:1500]}"
+                    f"> {entry.prompt[:CRON_DM_PROMPT_MAX_CHARS]}\n\n"
+                    f"**Resultado:** {str(result_summary)[:CRON_DM_RESULT_MAX_CHARS]}"
                 )
                 await self.notify_dm(entry.notify_user_id, msg)
             except Exception as exc:  # noqa: BLE001

--- a/deile/cron/store.py
+++ b/deile/cron/store.py
@@ -14,6 +14,7 @@ entries. The ``next_fire_at`` column is denormalized so the runner can
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 import threading
 import uuid
@@ -27,6 +28,17 @@ from deile.core.exceptions import DEILEError
 from deile.orchestration.pipeline.cron import CronExpressionError, next_after
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_db_path() -> Path:
+    """Return the CronStore DB path from env vars or a cwd-relative default."""
+    raw = os.environ.get("DEILE_CRON_DB_PATH")
+    if raw:
+        return Path(raw).resolve()
+    base = os.environ.get("DEILE_PIPELINE_BASE_PATH")
+    if base:
+        return Path(base).resolve() / "data" / "cron.db"
+    return Path.cwd() / "data" / "cron.db"
 
 
 class CronStoreError(DEILEError):
@@ -206,16 +218,19 @@ class CronStore:
 
     def mark_fired(self, entry_id: str, *, when: Optional[datetime] = None,
                    result: Optional[str] = None) -> None:
-        """Update ``last_fired_at`` + ``next_fire_at`` after firing."""
+        """Update ``last_fired_at`` + ``next_fire_at`` after firing (atomic)."""
         when = when or _now_utc()
-        entry = self.get(entry_id)
-        if entry is None:
-            return
-        entry.last_fired_at = when
-        if result is not None:
-            entry.last_result = result[:1000]
-        entry.advance(after=when)
         with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM cron_entries WHERE id = ?", (entry_id,)
+            ).fetchone()
+            if row is None:
+                return
+            entry = self._row_to_entry(row)
+            entry.last_fired_at = when
+            if result is not None:
+                entry.last_result = result[:1000]
+            entry.advance(after=when)
             conn.execute(
                 """UPDATE cron_entries
                    SET last_fired_at = ?, next_fire_at = ?, enabled = ?,
@@ -243,7 +258,7 @@ class CronStore:
     @staticmethod
     def _row_to_entry(row: sqlite3.Row) -> CronEntry:
         # Build via __new__ to bypass __post_init__'s next_fire_at recompute
-        # (we trust the persisted value).
+        # (we trust the persisted value for next_fire_at).
         e = CronEntry.__new__(CronEntry)
         e.id = row["id"]
         e.prompt = row["prompt"]
@@ -256,6 +271,11 @@ class CronStore:
         e.enabled = bool(row["enabled"])
         e.created_at = _from_iso(row["created_at"]) or _now_utc()
         e.last_result = row["last_result"]
+        # Guard: cron XOR run_at — catches DB corruption early.
+        assert bool(e.cron) != bool(e.run_at), (
+            f"DB row {e.id!r}: expected exactly one of cron/run_at, "
+            f"got cron={e.cron!r} run_at={e.run_at!r}"
+        )
         return e
 
 

--- a/deile/orchestration/pipeline/claude_dispatcher.py
+++ b/deile/orchestration/pipeline/claude_dispatcher.py
@@ -9,12 +9,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shlex
 import shutil
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Mapping, Optional, Sequence
+
+from deile.orchestration.pipeline.constants import (CLAUDE_TIMEOUT_SECONDS,
+                                                    ISSUE_BODY_MAX_CHARS)
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +49,7 @@ class ClaudeDispatcher:
         self,
         *,
         claude_path: Optional[str] = None,
-        timeout_seconds: int = 1800,
+        timeout_seconds: int = CLAUDE_TIMEOUT_SECONDS,
         prefer_subscription_auth: bool = True,
     ) -> None:
         self._claude = claude_path or shutil.which("claude") or "claude"
@@ -74,8 +78,7 @@ class ClaudeDispatcher:
             return dict(override)
         if not self.prefer_subscription_auth:
             return None
-        import os as _os
-        env = dict(_os.environ)
+        env = dict(os.environ)
         for k in self._STRIP_KEYS:
             env.pop(k, None)
         return env
@@ -178,7 +181,7 @@ def render_implement_prompt(repo: str, number: int, title: str, issue_body: str)
         repo=repo,
         number=number,
         title=title,
-        issue_body=issue_body.strip()[:6000],
+        issue_body=issue_body.strip()[:ISSUE_BODY_MAX_CHARS],
     )
 
 

--- a/deile/orchestration/pipeline/constants.py
+++ b/deile/orchestration/pipeline/constants.py
@@ -1,0 +1,31 @@
+"""Central constants for the autonomous pipeline.
+
+Deployment-tunable values are backed by env vars so operators can override
+them without code changes.  Internal sizing limits are pure Python constants
+and are not intended to be changed without a code review.
+"""
+from __future__ import annotations
+
+import os
+
+# ── ClaudeDispatcher ──────────────────────────────────────────────────────
+#: Maximum seconds a ``claude -p`` subprocess may run before it is killed.
+CLAUDE_TIMEOUT_SECONDS: int = int(os.environ.get("DEILE_PIPELINE_CLAUDE_TIMEOUT", "1800"))
+
+# ── PipelineMonitor ───────────────────────────────────────────────────────
+#: Default polling cadence for :class:`PipelineMonitor`.
+PIPELINE_POLL_INTERVAL_SECONDS: int = int(
+    os.environ.get("DEILE_PIPELINE_POLL_INTERVAL", "60")
+)
+#: Seconds ``stop()`` waits for the loop task before cancelling it.
+PIPELINE_STOP_TIMEOUT_SECONDS: int = 5
+
+# ── GitHub / pipeline repo ────────────────────────────────────────────────
+#: Default ``owner/name`` when ``DEILE_PIPELINE_REPO`` is not set.
+PIPELINE_DEFAULT_REPO: str = "elimarcavalli/deile"
+
+# ── Prompt / message truncation ───────────────────────────────────────────
+#: Max chars of issue body sent to the implement prompt.
+ISSUE_BODY_MAX_CHARS: int = 6000
+#: Max chars of stderr / error detail shown in Discord notifications.
+PIPELINE_MSG_TRUNCATE_CHARS: int = 1500

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -17,19 +17,18 @@ import json
 import logging
 import shutil
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
+from deile.core.exceptions import DEILEError
 from deile.orchestration.pipeline.labels import (LABEL_COLORS,
                                                  LABEL_DESCRIPTIONS,
                                                  REVIEW_LABELS,
                                                  WORKFLOW_LABELS,
+                                                 batch_id_from_label,
                                                  is_batch_label,
                                                  make_batch_label)
 
 logger = logging.getLogger(__name__)
-
-
-from deile.core.exceptions import DEILEError
 
 
 class GhCommandError(DEILEError):
@@ -56,7 +55,7 @@ class IssueRef:
     def batch_id(self) -> Optional[str]:
         for label in self.labels:
             if is_batch_label(label):
-                return label[len("~batch:"):]
+                return batch_id_from_label(label)
         return None
 
 
@@ -75,7 +74,7 @@ class PrRef:
     def batch_id(self) -> Optional[str]:
         for label in self.labels:
             if is_batch_label(label):
-                return label[len("~batch:"):]
+                return batch_id_from_label(label)
         return None
 
 
@@ -155,6 +154,30 @@ class GitHubClient:
             state=item.get("state", "open"),
         )
 
+    async def get_pr(self, number: int) -> Optional[PrRef]:
+        """Fetch a single PR by number; returns None if not found / not open."""
+        try:
+            out = await self._run_checked(
+                "pr", "view", str(number),
+                "--repo", self.repo,
+                "--json", "number,title,url,labels,headRefName,baseRefName,state,isDraft",
+            )
+        except GhCommandError:
+            return None
+        item = json.loads(out)
+        if item.get("state", "open").lower() not in ("open",):
+            return None
+        return PrRef(
+            number=item["number"],
+            title=item["title"],
+            url=item["url"],
+            labels=tuple(lab["name"] for lab in item.get("labels", [])),
+            head_ref=item.get("headRefName", ""),
+            base_ref=item.get("baseRefName", "main"),
+            state=item.get("state", "open"),
+            is_draft=bool(item.get("isDraft", False)),
+        )
+
     # -- pull requests ------------------------------------------------
 
     async def list_open_prs(self, *, limit: int = 50) -> List[PrRef]:
@@ -202,28 +225,28 @@ class GitHubClient:
             "--remove-label", ",".join(labels_list),
         )
 
-    async def transition_issue(
+    async def transition(
         self,
+        kind: str,
         number: int,
         *,
         from_label: Optional[str],
         to_label: str,
     ) -> None:
-        """Atomically swap a workflow label on an issue."""
+        """Swap a workflow label on an issue or PR (kind='issue'|'pr')."""
         if from_label is not None:
-            await self.remove_labels("issue", number, [from_label])
-        await self.add_labels("issue", number, [to_label])
+            await self.remove_labels(kind, number, [from_label])
+        await self.add_labels(kind, number, [to_label])
+
+    async def transition_issue(
+        self, number: int, *, from_label: Optional[str], to_label: str,
+    ) -> None:
+        await self.transition("issue", number, from_label=from_label, to_label=to_label)
 
     async def transition_pr(
-        self,
-        number: int,
-        *,
-        from_label: Optional[str],
-        to_label: str,
+        self, number: int, *, from_label: Optional[str], to_label: str,
     ) -> None:
-        if from_label is not None:
-            await self.remove_labels("pr", number, [from_label])
-        await self.add_labels("pr", number, [to_label])
+        await self.transition("pr", number, from_label=from_label, to_label=to_label)
 
     async def claim_with_batch(
         self,
@@ -241,8 +264,7 @@ class GitHubClient:
         if kind == "issue":
             current = await self.get_issue(number)
         elif kind == "pr":
-            prs = await self.list_open_prs(limit=200)
-            current = next((p for p in prs if p.number == number), None)
+            current = await self.get_pr(number)
             if current is None:
                 return None
         else:
@@ -268,7 +290,7 @@ class GitHubClient:
 
     async def ensure_pipeline_labels(self) -> None:
         """Create all pipeline-managed labels on the repo if they don't exist."""
-        for label in (*WORKFLOW_LABELS, *REVIEW_LABELS):
+        async def _create_one(label: str) -> None:
             color = LABEL_COLORS.get(label, "ededed")
             description = LABEL_DESCRIPTIONS.get(label, "Pipeline-managed label")
             rc, _, _ = await self._run(
@@ -280,6 +302,8 @@ class GitHubClient:
             # rc != 0 typically means "already exists"; we ignore that case.
             if rc != 0:
                 logger.debug("label %s already exists or could not be created", label)
+
+        await asyncio.gather(*[_create_one(label) for label in (*WORKFLOW_LABELS, *REVIEW_LABELS)])
 
     async def comment_on_issue(self, number: int, text: str) -> None:
         await self._run_checked(

--- a/deile/orchestration/pipeline/lockfile.py
+++ b/deile/orchestration/pipeline/lockfile.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import errno
 import logging
 import os
-import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -23,15 +23,18 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional
 
 from deile.orchestration.pipeline.claude_dispatcher import (
     ClaudeDispatcher, render_implement_prompt, render_review_prompt)
+from deile.orchestration.pipeline.constants import (PIPELINE_MSG_TRUNCATE_CHARS,
+                                                    PIPELINE_POLL_INTERVAL_SECONDS,
+                                                    PIPELINE_STOP_TIMEOUT_SECONDS)
 from deile.orchestration.pipeline.github_client import (GhCommandError,
                                                         GitHubClient,
-                                                        IssueRef, PrRef)
+                                                        IssueRef)
 from deile.orchestration.pipeline.identity import MonitorIdentity
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
@@ -41,8 +44,7 @@ from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  WORKFLOW_REVIEWING)
 from deile.orchestration.pipeline.lockfile import LockHeldError, acquire as acquire_lock, release as release_lock
 from deile.orchestration.pipeline.notifier import DiscordNotifier
-from deile.orchestration.pipeline.scheduler import (PendingRun, Schedule,
-                                                    ScheduleStore)
+from deile.orchestration.pipeline.scheduler import (PendingRun, ScheduleStore)
 from deile.orchestration.pipeline.worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
@@ -54,7 +56,7 @@ _PR_URL_RE = re.compile(r"https://github\.com/[^\s\"'<>]+/pull/\d+", re.IGNORECA
 class PipelineConfig:
     repo: str
     base_repo_path: Path
-    poll_interval_seconds: int = 60
+    poll_interval_seconds: int = PIPELINE_POLL_INTERVAL_SECONDS
     main_branch: str = "main"
     # ``branch_prefix`` is the *legacy* per-instance default. When an
     # ``identity`` is provided to :class:`PipelineMonitor`, the actual prefix
@@ -153,6 +155,10 @@ class PipelineMonitor:
     def stats(self) -> _Stats:
         return self._stats
 
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
     # ------------------------------------------------------------------
     # lifecycle
     # ------------------------------------------------------------------
@@ -170,7 +176,7 @@ class PipelineMonitor:
         worktree sub-directory and schedule file. The lockfile is the last line
         of defence against operator error.
         """
-        if self._task is not None and not self._task.done():
+        if self.is_running:
             return
         should_lock = self.config.use_pid_lock or not self.identity.is_default
         if should_lock:
@@ -228,7 +234,7 @@ class PipelineMonitor:
         self._stop_event.set()
         if self._task is not None:
             try:
-                await asyncio.wait_for(self._task, timeout=5)
+                await asyncio.wait_for(self._task, timeout=PIPELINE_STOP_TIMEOUT_SECONDS)
             except asyncio.TimeoutError:
                 self._task.cancel()
                 try:
@@ -254,6 +260,12 @@ class PipelineMonitor:
             except asyncio.TimeoutError:
                 pass
 
+    def _this_monitor_owns(self, issue: IssueRef) -> bool:
+        """Return True if this monitor should process the given issue."""
+        if self.identity.is_default:
+            return self.identity.owns(issue.title)
+        return self.identity.ownership_label() in issue.labels
+
     # ------------------------------------------------------------------
     # one tick
     # ------------------------------------------------------------------
@@ -268,7 +280,8 @@ class PipelineMonitor:
         # back to legacy "every action every tick" behaviour.
         try:
             schedule = self.schedule_store.load()
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("schedule load failed on tick; falling back to legacy mode: %s", exc)
             schedule = None
         if schedule and (schedule.recurring or schedule.oneshot):
             pending = schedule.compute_pending()
@@ -339,20 +352,13 @@ class PipelineMonitor:
         except GhCommandError as exc:
             logger.warning("could not list reviewed issues: %s", exc)
             return
-        # Stage 2 only picks up issues this monitor claimed in stage 1
-        # (ownership label) OR — for backwards compat — issues with a batch
-        # lock when running with the default identity.
-        own = self.identity.ownership_label()
+        # Stage 2 only picks up issues this monitor claimed in stage 1.
         target = next(
             (
                 i for i in issues
                 if WORKFLOW_PR not in i.labels
                 and i.batch_id is not None
-                and (
-                    own in i.labels
-                    if not self.identity.is_default
-                    else self.identity.owns(i.title)
-                )
+                and self._this_monitor_owns(i)
             ),
             None,
         )
@@ -373,7 +379,7 @@ class PipelineMonitor:
         pr_url = _extract_pr_url(result.stdout)
         if not result.ok:
             await self.notifier.error(
-                f"implement #{target.number}", result.stderr.strip()[:1500] or "non-zero exit"
+                f"implement #{target.number}", result.stderr.strip()[:PIPELINE_MSG_TRUNCATE_CHARS] or "non-zero exit"
             )
             return
         try:

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -18,6 +18,8 @@ import logging
 import os
 from typing import Awaitable, Callable, Optional
 
+from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
+
 logger = logging.getLogger(__name__)
 
 _DM_FN: Optional[Callable[[str, str], Awaitable[dict]]] = None
@@ -115,4 +117,4 @@ class DiscordNotifier:
         await self._send(f"{emoji} **PR #{number} {verb}**: {title}\n🔗 {url}")
 
     async def error(self, where: str, detail: str) -> None:
-        await self._send(f"⚠️ **Pipeline error** em `{where}`:\n```\n{detail[:1500]}\n```")
+        await self._send(f"⚠️ **Pipeline error** em `{where}`:\n```\n{detail[:PIPELINE_MSG_TRUNCATE_CHARS]}\n```")

--- a/deile/orchestration/pipeline/scheduler.py
+++ b/deile/orchestration/pipeline/scheduler.py
@@ -40,10 +40,10 @@ case where every missed slot must run individually.
 from __future__ import annotations
 
 import logging
-from dataclasses import asdict, dataclass, field, replace
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import List, Optional
 
 import yaml
 

--- a/deile/orchestration/pipeline/worktree_manager.py
+++ b/deile/orchestration/pipeline/worktree_manager.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -129,11 +128,13 @@ class WorktreeManager:
         # Create / switch to the feature branch.
         rc, _, err = await self._git_in_capture(target, "checkout", "-b", branch)
         if rc != 0:
-            # Branch may already exist locally; try a plain checkout.
+            # Branch may already exist; try plain checkout and surface both errors on failure.
+            logger.debug("checkout -b %s failed (%s); trying plain checkout", branch, err.strip()[:200])
             rc2, _, err2 = await self._git_in_capture(target, "checkout", branch)
             if rc2 != 0:
                 raise WorktreeError(
-                    f"could not create branch {branch!r} in {target}: {err or err2}"
+                    f"could not create or checkout branch {branch!r} in {target}: "
+                    f"create-err={err.strip()[:200]!r} checkout-err={err2.strip()[:200]!r}"
                 )
         return Worktree(path=target, branch=branch, base_repo=self.base_repo)
 
@@ -156,16 +157,10 @@ class WorktreeManager:
 
     @staticmethod
     async def _git_in(cwd: Path, *args: str) -> None:
-        proc = await asyncio.create_subprocess_exec(
-            "git", "-C", str(cwd), *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr_b = await proc.communicate()
-        if (proc.returncode or 0) != 0:
+        rc, _, err = await WorktreeManager._git_in_capture(cwd, *args)
+        if rc != 0:
             raise WorktreeError(
-                f"git -C {cwd} {' '.join(args)} failed: "
-                f"{stderr_b.decode('utf-8', 'replace').strip()[:300]}"
+                f"git -C {cwd} {' '.join(args)} failed: {err.strip()[:300]}"
             )
 
     @staticmethod

--- a/deile/tests/cron/test_tools.py
+++ b/deile/tests/cron/test_tools.py
@@ -70,13 +70,13 @@ class TestCronCreate:
         r = await tool.execute(_ctx(prompt="x", cron="* * * * *",
                                     run_at="2030-01-01T00:00:00Z"))
         assert r.status == ToolStatus.ERROR
-        assert r.metadata["error_code"] == "INVALID_SCHEDULE"
+        assert r.metadata["error_code"] == "AMBIGUOUS_SCHEDULE"
 
     async def test_neither_cron_nor_run_at_rejected(self, cron_db):
         tool = CronCreateTool()
         r = await tool.execute(_ctx(prompt="x"))
         assert r.status == ToolStatus.ERROR
-        assert r.metadata["error_code"] == "INVALID_SCHEDULE"
+        assert r.metadata["error_code"] == "MISSING_SCHEDULE"
 
     async def test_invalid_run_at(self, cron_db):
         tool = CronCreateTool()

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -141,10 +141,10 @@ class TestClaimWithBatch:
             bid = await client.claim_with_batch("issue", 5, "claim me")
         assert bid is None
 
-    async def test_claim_pr_uses_pr_list(self):
+    async def test_claim_pr_uses_pr_view(self):
         client = GitHubClient("owner/name")
         pr = PrRef(number=7, title="t", url="u", labels=(REVIEW_PENDING,))
-        with patch.object(client, "list_open_prs", new=AsyncMock(return_value=[pr])), \
+        with patch.object(client, "get_pr", new=AsyncMock(return_value=pr)), \
              patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
             bid = await client.claim_with_batch("pr", 7, "t")
         assert bid is not None
@@ -221,7 +221,7 @@ class TestEnsureLabelOnClaim:
             calls.append(("_run_checked", *args))
             return ""
 
-        with patch.object(client, "list_open_prs", new=AsyncMock(return_value=[unclaimed_pr])), \
+        with patch.object(client, "get_pr", new=AsyncMock(return_value=unclaimed_pr)), \
              patch.object(client, "_run", side_effect=fake_run), \
              patch.object(client, "_run_checked", side_effect=fake_run_checked):
             bid = await client.claim_with_batch("pr", 11, "pr title")

--- a/deile/tools/cron_create_tool.py
+++ b/deile/tools/cron_create_tool.py
@@ -8,28 +8,16 @@ schedule fires.
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
 
-from deile.cron.store import CronEntry, CronStore, CronStoreError, make_id
+from deile.cron.store import CronEntry, CronStore, CronStoreError, make_id, resolve_db_path
 from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
                               ToolResult, ToolSchema)
 
 
-def _resolve_db_path() -> Path:
-    raw = os.environ.get("DEILE_CRON_DB_PATH")
-    if raw:
-        return Path(raw).resolve()
-    base = os.environ.get("DEILE_PIPELINE_BASE_PATH")
-    if base:
-        return Path(base).resolve() / "data" / "cron.db"
-    return Path.cwd() / "data" / "cron.db"
-
-
 def _get_store() -> CronStore:
-    return CronStore(_resolve_db_path())
+    return CronStore(resolve_db_path())
 
 
 class CronCreateTool(Tool):
@@ -124,10 +112,15 @@ class CronCreateTool(Tool):
                 message="prompt is required and must be non-empty",
                 error_code="MISSING_PROMPT",
             )
-        if bool(cron) == bool(run_at_str):
+        if not cron and not run_at_str:
             return ToolResult.error_result(
-                message="provide EITHER cron OR run_at, not both",
-                error_code="INVALID_SCHEDULE",
+                message="provide either cron (recurring) or run_at (one-shot)",
+                error_code="MISSING_SCHEDULE",
+            )
+        if cron and run_at_str:
+            return ToolResult.error_result(
+                message="cron and run_at are mutually exclusive; provide only one",
+                error_code="AMBIGUOUS_SCHEDULE",
             )
 
         run_at: Optional[datetime] = None

--- a/deile/tools/cron_delete_tool.py
+++ b/deile/tools/cron_delete_tool.py
@@ -2,22 +2,9 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
-from deile.cron.store import CronStore
+from deile.cron.store import CronStore, resolve_db_path
 from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
                               ToolResult, ToolSchema)
-
-
-def _resolve_db_path() -> Path:
-    raw = os.environ.get("DEILE_CRON_DB_PATH")
-    if raw:
-        return Path(raw).resolve()
-    base = os.environ.get("DEILE_PIPELINE_BASE_PATH")
-    if base:
-        return Path(base).resolve() / "data" / "cron.db"
-    return Path.cwd() / "data" / "cron.db"
 
 
 class CronDeleteTool(Tool):
@@ -78,7 +65,7 @@ class CronDeleteTool(Tool):
             )
 
         try:
-            store = CronStore(_resolve_db_path())
+            store = CronStore(resolve_db_path())
             if disable_only:
                 ok = store.set_enabled(entry_id, False)
                 action_label = "disabled"

--- a/deile/tools/cron_list_tool.py
+++ b/deile/tools/cron_list_tool.py
@@ -2,22 +2,9 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
-from deile.cron.store import CronStore
+from deile.cron.store import CronStore, resolve_db_path
 from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
                               ToolResult, ToolSchema)
-
-
-def _resolve_db_path() -> Path:
-    raw = os.environ.get("DEILE_CRON_DB_PATH")
-    if raw:
-        return Path(raw).resolve()
-    base = os.environ.get("DEILE_PIPELINE_BASE_PATH")
-    if base:
-        return Path(base).resolve() / "data" / "cron.db"
-    return Path.cwd() / "data" / "cron.db"
 
 
 class CronListTool(Tool):
@@ -69,7 +56,7 @@ class CronListTool(Tool):
         only_enabled = bool(args.get("only_enabled", False))
         creator = args.get("created_by")
         try:
-            store = CronStore(_resolve_db_path())
+            store = CronStore(resolve_db_path())
             entries = store.list_all(only_enabled=only_enabled)
         except Exception as exc:  # noqa: BLE001
             return ToolResult.error_result(

--- a/deile/tools/pipeline_tool.py
+++ b/deile/tools/pipeline_tool.py
@@ -16,17 +16,15 @@ import os
 from pathlib import Path
 from typing import Any, Optional
 
+from deile.orchestration.pipeline.constants import PIPELINE_DEFAULT_REPO
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
 from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
                               ToolResult, ToolSchema)
 
 
-_DEFAULT_REPO = "elimarcavalli/deile"
-
-
 def _resolve_repo() -> str:
-    return os.environ.get("DEILE_PIPELINE_REPO", _DEFAULT_REPO)
+    return os.environ.get("DEILE_PIPELINE_REPO", PIPELINE_DEFAULT_REPO)
 
 
 def _resolve_base_path() -> Path:

--- a/deile/tools/worktree_tool.py
+++ b/deile/tools/worktree_tool.py
@@ -32,7 +32,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from deile.orchestration.pipeline.worktree_manager import (WorktreeError,
                                                            WorktreeManager)
@@ -224,15 +224,16 @@ class WorktreeTool(Tool):
             )
 
         entries = []
-        for item in sorted(worktrees_dir.rglob("*")):
-            if item.is_dir() and (item / ".git").exists():
-                entries.append(
-                    {
-                        "path": str(item),
-                        "branch": item.name,
-                        "base_repo": str(base_path),
-                    }
-                )
+        for item in sorted(worktrees_dir.iterdir()):
+            if not item.is_dir():
+                continue
+            if (item / ".git").exists():
+                entries.append({"path": str(item), "branch": item.name, "base_repo": str(base_path)})
+            else:
+                # One level deeper for subdir-namespaced worktrees (e.g. .worktrees/<monitor>/<branch>)
+                for sub in sorted(item.iterdir()):
+                    if sub.is_dir() and (sub / ".git").exists():
+                        entries.append({"path": str(sub), "branch": sub.name, "base_repo": str(base_path)})
 
         return ToolResult.success_result(
             data={"worktrees": entries},


### PR DESCRIPTION
## Summary

- Extracts all hardcoded magic numbers from `pipeline/` and `cron/` into two dedicated constants modules with env-var overrides for deployment-tunable values.
- Deduplicates `_DEFAULT_REPO = "elimarcavalli/deile"` (was copy-pasted in `pipeline_tool.py` and `pipeline_command.py`).
- Includes all `/simplify` session improvements: `resolve_db_path` dedup, `mark_fired` atomicity, `get_pr()` direct fetch, `asyncio.gather` in `ensure_pipeline_labels`, `is_running` property, `_this_monitor_owns` predicate, bounded worktree scan.

### New constants modules

**`deile/orchestration/pipeline/constants.py`**
| Constant | Default | Env var |
|---|---|---|
| `CLAUDE_TIMEOUT_SECONDS` | `1800` | `DEILE_PIPELINE_CLAUDE_TIMEOUT` |
| `PIPELINE_POLL_INTERVAL_SECONDS` | `60` | `DEILE_PIPELINE_POLL_INTERVAL` |
| `PIPELINE_STOP_TIMEOUT_SECONDS` | `5` | — |
| `PIPELINE_DEFAULT_REPO` | `"elimarcavalli/deile"` | `DEILE_PIPELINE_REPO` |
| `ISSUE_BODY_MAX_CHARS` | `6000` | — |
| `PIPELINE_MSG_TRUNCATE_CHARS` | `1500` | — |

**`deile/cron/constants.py`**
| Constant | Default | Env var |
|---|---|---|
| `CRON_POLL_INTERVAL_SECONDS` | `30` | `DEILE_CRON_POLL_INTERVAL` |
| `CRON_STOP_TIMEOUT_SECONDS` | `5` | — |
| `CRON_RESULT_MAX_CHARS` | `500` | — |
| `CRON_DM_PROMPT_MAX_CHARS` | `300` | — |
| `CRON_DM_RESULT_MAX_CHARS` | `1500` | — |

### Critique of remaining hardcoded configs (not addressed — out of scope)

- `_resolve_base_path()` is duplicated in `pipeline_tool.py`, `pipeline_command.py`, and `worktree_tool.py` — three near-identical implementations. Should move to `pipeline/constants.py` or a shared utils module.
- `branch_prefix = "auto/issue-"` in `PipelineConfig` and `_owns_pr_branch()` — coherent but the string `"auto"` is also hardcoded in `branch_for_issue()`.
- Log diagnostic truncations (`[:200]`, `[:300]` in error messages across `worktree_manager.py` and `github_client.py`) — minor, not business-logic.

## Test plan

- [x] `1240 passed, 12 skipped` — full suite, ignoring 2 pre-existing collection errors (`deilebot` module not installed)
- [x] 3 pre-existing failures unchanged (`test_streaming_ui_empirical`, 2 discord `TypeError`)
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)