### PR TITLE
fix(security): remove dead SANDBOX_VIOLATION audit API (closes #58)

### DIFF
--- a/deile/commands/builtin/logs_command.py
+++ b/deile/commands/builtin/logs_command.py
@@ -179,7 +179,7 @@ class LogsCommand(DirectCommand):
                 "/logs summary           - Detailed statistics\n"
                 "/logs export <file>     - Export logs to file\n\n"
                 "📊 **Filters Available**\n"
-                "Type: permission, secret, tool, plan, approval, sandbox\n"
+                "Type: permission, secret, tool, plan, approval\n"
                 "Severity: debug, info, warning, error, critical\n"
                 "Actor: tool_name, user, system",
                 style="dim"

--- a/deile/commands/builtin/logs_command.py
+++ b/deile/commands/builtin/logs_command.py
@@ -1,18 +1,17 @@
 """Logs Command - View security audit logs and system events"""
 
-from typing import Dict, Any, Optional, List
-from rich.panel import Panel
-from rich.text import Text
-from rich.table import Table
-from rich.tree import Tree
-from rich.console import Group
-from datetime import datetime, timedelta
+from datetime import datetime
+from typing import List
 
-from ..base import DirectCommand, CommandResult, CommandContext
+from rich.console import Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
 from ...core.exceptions import CommandError
-from ...security.audit_logger import (
-    get_audit_logger, AuditEventType, SeverityLevel
-)
+from ...security.audit_logger import (AuditEventType, SeverityLevel,
+                                      get_audit_logger)
+from ..base import CommandContext, CommandResult, DirectCommand
 
 
 class LogsCommand(DirectCommand):
@@ -149,8 +148,7 @@ class LogsCommand(DirectCommand):
                 "secret_redacted": "Data sanitized",
                 "tool_execution": "Tool run events",
                 "plan_execution": "Plan workflow events",
-                "approval_required": "Manual approval needed",
-                "sandbox_violation": "Security policy violation"
+                "approval_required": "Manual approval needed"
             }
             
             for event_type, count in sorted(type_counts.items(), key=lambda x: x[1], reverse=True):
@@ -258,7 +256,6 @@ class LogsCommand(DirectCommand):
             AuditEventType.PERMISSION_DENIED,
             AuditEventType.SECRET_DETECTED,
             AuditEventType.SECRET_REDACTED,
-            AuditEventType.SANDBOX_VIOLATION,
             AuditEventType.SUSPICIOUS_ACTIVITY
         ]
         
@@ -357,7 +354,7 @@ class LogsCommand(DirectCommand):
         
         # Permission events table  
         perm_table = Table(
-            title=f"🔐 Permission Events (Last 30)",
+            title="🔐 Permission Events (Last 30)",
             show_header=True,
             header_style="bold blue"
         )
@@ -459,7 +456,6 @@ class LogsCommand(DirectCommand):
         
         # Tool execution stats
         successful_runs = len([e for e in tool_events if e.result == "success"])
-        failed_runs = len([e for e in tool_events if e.result == "failure"])
         success_rate = (successful_runs / len(tool_events) * 100) if tool_events else 0
         
         # Tools table
@@ -617,7 +613,6 @@ class LogsCommand(DirectCommand):
     async def _show_summary(self) -> CommandResult:
         """Show detailed audit log summary"""
         
-        summary = self.audit_logger.get_security_summary()
         recent_events = self.audit_logger.get_recent_events(1000)  # Larger sample
         
         # Detailed statistics
@@ -716,7 +711,6 @@ Event Types:
   • plan_execution        - Plan workflow events
   • approval_required     - Manual approval needed
   • approval_granted      - Manual approval given
-  • sandbox_violation     - Security policy violation
 
 Severity Levels:
   • debug       - Debug information

--- a/deile/security/__init__.py
+++ b/deile/security/__init__.py
@@ -1,12 +1,12 @@
 """Security module for DEILE"""
 
-from .permissions import PermissionManager, PermissionRule, PermissionLevel, get_permission_manager
+from .audit_logger import (AuditEvent, AuditEventType, AuditLogger,
+                           SeverityLevel, get_audit_logger, log_approval_event,
+                           log_permission_check, log_plan_execution,
+                           log_secret_detection, log_tool_execution)
+from .permissions import (PermissionLevel, PermissionManager, PermissionRule,
+                          get_permission_manager)
 from .secrets_scanner import SecretsScanner
-from .audit_logger import (
-    AuditLogger, AuditEvent, AuditEventType, SeverityLevel,
-    get_audit_logger, log_permission_check, log_secret_detection,
-    log_tool_execution, log_sandbox_violation, log_plan_execution, log_approval_event
-)
 
 __all__ = [
     "PermissionManager",
@@ -22,7 +22,6 @@ __all__ = [
     "log_permission_check",
     "log_secret_detection",
     "log_tool_execution",
-    "log_sandbox_violation",
     "log_plan_execution",
     "log_approval_event"
 ]

--- a/deile/security/audit_logger.py
+++ b/deile/security/audit_logger.py
@@ -2,11 +2,11 @@
 
 import json
 import logging
+from dataclasses import asdict, dataclass
 from datetime import datetime
-from pathlib import Path
-from typing import Dict, Any, Optional, List, Union
-from dataclasses import dataclass, asdict
 from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 
 class AuditEventType(Enum):
@@ -15,7 +15,6 @@ class AuditEventType(Enum):
     PERMISSION_DENIED = "permission_denied"
     SECRET_DETECTED = "secret_detected"
     SECRET_REDACTED = "secret_redacted"
-    SANDBOX_VIOLATION = "sandbox_violation"
     TOOL_EXECUTION = "tool_execution"
     PLAN_EXECUTION = "plan_execution"
     APPROVAL_REQUIRED = "approval_required"
@@ -209,29 +208,6 @@ class AuditLogger:
             action="scan",
             result="redacted" if redacted else "detected",
             details=details
-        )
-    
-    def log_sandbox_violation(self,
-                            tool_name: str,
-                            violated_resource: str,
-                            violation_type: str,
-                            blocked: bool = True) -> None:
-        """Log sandbox policy violation"""
-        
-        details = {
-            "violation_type": violation_type,
-            "enforcement_action": "blocked" if blocked else "allowed_with_warning"
-        }
-        
-        self.log_event(
-            event_type=AuditEventType.SANDBOX_VIOLATION,
-            severity=SeverityLevel.WARNING if blocked else SeverityLevel.ERROR,
-            actor=tool_name,
-            resource=violated_resource,
-            action="access_attempt",
-            result="blocked" if blocked else "allowed",
-            details=details,
-            tool_name=tool_name
         )
     
     def log_tool_execution(self,
@@ -456,11 +432,6 @@ def log_secret_detection(file_path: str, secret_type: str, line_number: int, con
 def log_tool_execution(tool_name: str, resource: str, success: bool, **kwargs) -> None:
     """Convenience function for logging tool executions"""
     get_audit_logger().log_tool_execution(tool_name, resource, success, **kwargs)
-
-
-def log_sandbox_violation(tool_name: str, violated_resource: str, violation_type: str, blocked: bool = True) -> None:
-    """Convenience function for logging sandbox violations"""
-    get_audit_logger().log_sandbox_violation(tool_name, violated_resource, violation_type, blocked)
 
 
 def log_plan_execution(plan_id: str, action: str, result: str, step_count: int = 0, duration_ms: int = 0, **kwargs) -> None:

--- a/docs/system_design/08-SEGURANCA.md
+++ b/docs/system_design/08-SEGURANCA.md
@@ -16,7 +16,7 @@
 
 | Símbolo | Papel |
 |---|---|
-| `AuditEventType` (enum) | Tipos: `SANDBOX_VIOLATION`, etc. |
+| `AuditEventType` (enum) | Tipos: `PERMISSION_DENIED`, `SECRET_DETECTED`, `TOOL_EXECUTION`, `PLAN_EXECUTION`, etc. |
 | `SeverityLevel` (enum) | Severidade |
 | `AuditEvent` (dataclass) | Evento tipado com `timestamp`, `event_type`, `severity`, `details`, etc. |
 | `AuditLogger` | Persiste e indexa eventos; singleton via `get_audit_logger()` |
@@ -28,7 +28,6 @@
 | `log_permission_check(tool_name, resource, action, allowed, **kwargs)` | Decisões de permissão |
 | `log_secret_detection(file_path, secret_type, line_number, confidence, redacted=True)` | Detecção de segredo |
 | `log_tool_execution(tool_name, resource, success, **kwargs)` | Execução de tool |
-| `log_sandbox_violation(tool_name, violated_resource, violation_type, blocked=True)` | Violação de sandbox |
 | `log_plan_execution(plan_id, action, result, step_count=0, duration_ms=0, **kwargs)` | Execução de plano |
 | `log_approval_event(plan_id, step_id, approval_action, tool_name, risk_level, **kwargs)` | Decisão de aprovação |
 

--- a/docs/system_design/10-DIAGRAMAS.md
+++ b/docs/system_design/10-DIAGRAMAS.md
@@ -294,7 +294,6 @@ EventBus.publish(Event)
    ├── budget_alert                — quando uso aproxima de threshold
    ├── permission_check            — log_permission_check
    ├── secret_detection            — log_secret_detection
-   ├── sandbox_violation           — log_sandbox_violation
    ├── plan_execution              — log_plan_execution
    └── approval_event              — log_approval_event
 


### PR DESCRIPTION
## Summary

Two commits removing the dead SANDBOX_VIOLATION audit API:

1. **b055d1f**: Atomically removes the SANDBOX_VIOLATION enum value, AuditLogger.log_sandbox_violation method, module-level helper, security/__init__.py exports, logs_command type-descriptions/security-events/help-text, and docs in 08-SEGURANCA.md + 10-DIAGRAMAS.md. Also cleaned pre-existing ruff/isort issues already in scope. Issue #59 was already resolved by PR #66 commit 57fe298.

2. **4c360d1**: Drops the stale "sandbox" Type-filter hint from /logs overview panel — leftover from the same removal.

Closes #58 (and follow-up note: #59).

## Test plan

- [ ] pytest deile/tests/ — 849 passed locally
- [ ] /logs and /sandbox no longer reference SANDBOX_VIOLATION

---
By [DEILE One](mailto:deile@deile.info)