### PR TITLE
fix(tools): log warnings em except Exception silenciosos (#110)

### DIFF
--- a/deile/tests/tools/test_git_execution_exception_logging.py
+++ b/deile/tests/tools/test_git_execution_exception_logging.py
@@ -1,0 +1,114 @@
+"""Tests for exception logging in git_tool.py and execution_tools.py (issue #110)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deile.tools.base import ToolContext
+from deile.tools.execution_tools import EnhancedExecutionTool
+from deile.tools.git_tool import GitTool
+
+
+def _make_context(**kwargs):
+    ctx = MagicMock(spec=ToolContext)
+    ctx.parsed_args = kwargs
+    ctx.working_directory = "/tmp"
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# git_tool.py — remote fetch in _git_status
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_git_status_remote_fetch_logs_warning():
+    mock_repo = MagicMock()
+    mock_repo.active_branch.name = "main"
+    mock_repo.head.commit.hexsha = "abcd1234"
+    mock_repo.index.diff.return_value = []
+    mock_repo.untracked_files = []
+    mock_origin = MagicMock()
+    mock_origin.fetch.side_effect = RuntimeError("network unreachable")
+    mock_repo.remote.return_value = mock_origin
+
+    tool = GitTool()
+
+    with patch("deile.tools.git_tool.logger") as mock_logger:
+        result = tool._git_status(mock_repo)
+
+    assert result["success"] is True
+    mock_logger.warning.assert_called_once()
+    assert "network unreachable" in str(mock_logger.warning.call_args)
+
+
+# ---------------------------------------------------------------------------
+# git_tool.py — file diff in _git_diff
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_git_diff_file_logs_warning():
+    mock_repo = MagicMock()
+    mock_repo.git.diff.side_effect = RuntimeError("path not found")
+
+    tool = GitTool()
+
+    with patch("deile.tools.git_tool.logger") as mock_logger:
+        result = tool._git_diff(mock_repo, {"files": ["missing_file.py"]})
+
+    assert result["success"] is True
+    assert "File not found or no diff" in result["output"]
+    mock_logger.warning.assert_called_once()
+    assert "path not found" in str(mock_logger.warning.call_args)
+
+
+# ---------------------------------------------------------------------------
+# git_tool.py — remote fetch before push in _git_push
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_git_push_precheck_logs_warning():
+    mock_repo = MagicMock()
+    mock_repo.active_branch.name = "feature"
+    mock_remote = MagicMock()
+    mock_remote.fetch.side_effect = RuntimeError("connection refused")
+    push_info = MagicMock()
+    push_info.summary = "pushed ok"
+    mock_remote.push.return_value = [push_info]
+    mock_repo.remote.return_value = mock_remote
+
+    tool = GitTool()
+
+    with patch("deile.tools.git_tool.logger") as mock_logger:
+        result = tool._git_push(mock_repo, {"remote": "origin", "force": False, "dry_run": False})
+
+    assert result["success"] is True
+    mock_logger.warning.assert_called_once()
+    assert "connection refused" in str(mock_logger.warning.call_args)
+
+
+# ---------------------------------------------------------------------------
+# execution_tools.py — session cleanup in _execute_interactive
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_execute_interactive_cleanup_logs_warning():
+    tool = EnhancedExecutionTool()
+
+    broken_session = MagicMock()
+    broken_session.start.return_value = True
+    broken_session.write_input.return_value = None
+    broken_session.read_output.return_value = ""
+    broken_session.read_errors.return_value = ""
+    broken_session.get_exit_code.return_value = None
+    broken_session.is_alive.side_effect = RuntimeError("PTY exploded")
+    broken_session.terminate.side_effect = RuntimeError("terminate failed")
+
+    ctx = _make_context(command="echo hi", interactive=True, timeout=1, env={}, input="")
+
+    with patch("deile.tools.execution_tools.PTYSession", return_value=broken_session):
+        with patch("deile.tools.execution_tools.logger") as mock_logger:
+            tool._execute_interactive("echo hi", ctx, 1, {}, "")
+
+    mock_logger.warning.assert_called()
+    warning_messages = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+    assert any(keyword in warning_messages.lower() for keyword in ["terminate", "cleanup", "session"])

--- a/deile/tools/execution_tools.py
+++ b/deile/tools/execution_tools.py
@@ -138,11 +138,9 @@ class PTYSession:
                         output = self.pty_process.read(timeout=100)  # 100ms timeout
                         if output:
                             self.output_buffer.append(output)
-                    except Exception:
-                        break
-                    except Exception as e:
+                    except Exception as exc:
                         if self.is_running:
-                            logger.error(f"Error reading PTY output: {e}")
+                            logger.warning("Error reading PTY output: %s", exc)
                         break
         except Exception as e:
             logger.error(f"PTY output thread error: {e}")

--- a/deile/tools/execution_tools.py
+++ b/deile/tools/execution_tools.py
@@ -480,8 +480,8 @@ class EnhancedExecutionTool(SyncTool):
                 try:
                     self.active_sessions[session_id].terminate()
                     del self.active_sessions[session_id]
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning("Failed to terminate session %s during cleanup: %s", session_id, exc)
             
             return ToolResult(
                 status=ToolStatus.ERROR,

--- a/deile/tools/git_tool.py
+++ b/deile/tools/git_tool.py
@@ -1,5 +1,6 @@
 """Git Tool - Integração completa com Git através do GitPython"""
 
+import logging
 from typing import Any, Dict, Optional
 
 try:
@@ -15,6 +16,8 @@ except ImportError:
 
 from ..security.secrets_scanner import SecretsScanner
 from .base import DisplayPolicy, SyncTool, ToolContext, ToolResult, ToolStatus
+
+logger = logging.getLogger(__name__)
 
 
 class GitTool(SyncTool):
@@ -222,8 +225,8 @@ class GitTool(SyncTool):
             origin.fetch()
             status_data["remote_behind"] = len(list(repo.iter_commits(f'{repo.active_branch}..origin/{repo.active_branch}')))
             status_data["remote_ahead"] = len(list(repo.iter_commits(f'origin/{repo.active_branch}..{repo.active_branch}')))
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Could not fetch remote status: %s", exc)
         
         # Format output
         output_lines = [
@@ -271,7 +274,8 @@ class GitTool(SyncTool):
                     diff = repo.git.diff("HEAD", file)
                     if diff:
                         diff_output += f"\n--- {file} ---\n{diff}\n"
-                except Exception:
+                except Exception as exc:
+                    logger.warning("Could not diff %s: %s", file, exc)
                     diff_output += f"\n--- {file} ---\nFile not found or no diff\n"
         else:
             # Get all diffs
@@ -438,8 +442,8 @@ class GitTool(SyncTool):
                         "data": {"remote": remote_name, "branch": branch},
                         "output": "Everything up-to-date"
                     }
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("Could not check remote status before push: %s", exc)
 
             # Perform push
             if force:


### PR DESCRIPTION
## Resumo

Converte 4 blocos `except Exception: pass` (ou equivalentes sem log) em `git_tool.py` e `execution_tools.py` para emitir `logger.warning` com contexto da exceção, satisfazendo pilar 03 §6 ("nunca engolir exceções silenciosamente").

Closes #110

## Mudanças

### `deile/tools/git_tool.py`
- Adicionado `import logging` e `logger = logging.getLogger(__name__)` (arquivo não tinha logger)
- `_git_status`: `except Exception: pass` → `logger.warning("Could not fetch remote status: %s", exc)`
- `_git_diff`: `except Exception:` sem log → `logger.warning("Could not diff %s: %s", file, exc)` + fallback mantido
- `_git_push`: `except Exception: pass` → `logger.warning("Could not check remote status before push: %s", exc)`

### `deile/tools/execution_tools.py`
- `_execute_interactive` cleanup: `except Exception: pass` → `logger.warning("Failed to terminate session %s during cleanup: %s", session_id, exc)`

### `deile/tests/tools/test_git_execution_exception_logging.py` (novo)
- 4 testes unitários que mockam o logger via `patch` e assertam que `logger.warning` é chamado com a mensagem da exceção

## Checklist de testes

- [x] `pytest deile/tests/` — 1411 passed (era 1407), 3 failed pré-existentes inalterados
- [x] `ruff check deile/tools/git_tool.py deile/tools/execution_tools.py` — clean
- [x] `isort --check-only` nos arquivos alterados — clean
- [x] 4 novos testes passam em isolamento e no suite completo

## Decisões-chave

1. **`logger.warning` para todos os 4 casos**: todos são falhas esperadas/opcionais (offline, arquivo fora do git, sessão já terminada) — `warning` é o nível correto; nenhum re-raise porque o comportamento de fallback é intencional.
2. **Comportamento preservado**: nenhum fallback existente foi removido; apenas logging foi adicionado antes/depois.
3. **Mock via `patch` nos testes**: uso de `caplog` falha em suite completa quando outros testes alteram a configuração de logging; `patch("deile.tools.git_tool.logger")` é robusto ao estado global de logging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTZFd3mNNpa1Se96iUzQxh)_