### PR TITLE
feat(pipeline): Stage 0 — auto-classify newly opened issues

### DIFF
--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -334,17 +334,23 @@ class GitHubClient:
         data = json.loads(out or "[]")
         result = []
         for item in data:
-            labels = tuple(lab["name"] for lab in item.get("labels", []))
-            if any(lb.startswith("~") for lb in labels):
+            try:
+                labels = tuple(
+                    lab["name"] for lab in item.get("labels", []) if isinstance(lab, dict)
+                )
+                if any(lb.startswith("~") for lb in labels):
+                    continue
+                result.append(IssueRef(
+                    number=int(item["number"]),
+                    title=str(item.get("title", "")),
+                    url=str(item.get("url", "")),
+                    labels=labels,
+                    body=str(item.get("body") or ""),
+                    state=str(item.get("state", "open")),
+                ))
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning("skipping malformed issue payload: %s", exc)
                 continue
-            result.append(IssueRef(
-                number=item["number"],
-                title=item["title"],
-                url=item["url"],
-                labels=labels,
-                body=item.get("body", "") or "",
-                state=item.get("state", "open"),
-            ))
         if len(result) >= limit:
             logger.warning(
                 "list_unclassified_issues truncated at limit=%d; some eligible issues may be missed",

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -319,7 +319,7 @@ class GitHubClient:
             "--body", text,
         )
 
-    async def list_unclassified_issues(self, *, limit: int = 100) -> List[IssueRef]:
+    async def list_unclassified_issues(self, *, limit: int = 50) -> List[IssueRef]:
         """Return open issues that have no pipeline labels (no ``~workflow:*``, ``~batch:*``, ``~review:*``).
 
         These are candidates for Stage 0 auto-classification.
@@ -345,4 +345,9 @@ class GitHubClient:
                 body=item.get("body", "") or "",
                 state=item.get("state", "open"),
             ))
+        if len(result) >= limit:
+            logger.warning(
+                "list_unclassified_issues truncated at limit=%d; some eligible issues may be missed",
+                limit,
+            )
         return result

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -318,3 +318,31 @@ class GitHubClient:
             "--repo", self.repo,
             "--body", text,
         )
+
+    async def list_unclassified_issues(self, *, limit: int = 100) -> List[IssueRef]:
+        """Return open issues that have no pipeline labels (no ``~workflow:*``, ``~batch:*``, ``~review:*``).
+
+        These are candidates for Stage 0 auto-classification.
+        """
+        out = await self._run_checked(
+            "issue", "list",
+            "--repo", self.repo,
+            "--state", "open",
+            "--limit", str(limit),
+            "--json", "number,title,url,labels,body,state",
+        )
+        data = json.loads(out or "[]")
+        result = []
+        for item in data:
+            labels = tuple(lab["name"] for lab in item.get("labels", []))
+            if any(lb.startswith("~") for lb in labels):
+                continue
+            result.append(IssueRef(
+                number=item["number"],
+                title=item["title"],
+                url=item["url"],
+                labels=labels,
+                body=item.get("body", "") or "",
+                state=item.get("state", "open"),
+            ))
+        return result

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -25,7 +25,7 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Awaitable, Callable, Optional, Tuple
+from typing import Awaitable, Callable, Optional
 
 from deile.orchestration.pipeline.claude_dispatcher import (
     ClaudeDispatcher, render_implement_prompt, render_review_prompt)
@@ -52,6 +52,12 @@ logger = logging.getLogger(__name__)
 
 _PR_URL_RE = re.compile(r"https://github\.com/[^\s\"'<>]+/pull/\d+", re.IGNORECASE)
 
+_CLASSIFY_COMMENT = (
+    f"🤖 **DEILE auto-classificação** — esta issue foi adicionada à fila do pipeline "
+    f"autônomo (`{WORKFLOW_NEW}`).\n\n"
+    f"Para excluir da fila, remova o label `{WORKFLOW_NEW}`."
+)
+
 
 @dataclass
 class PipelineConfig:
@@ -70,8 +76,8 @@ class PipelineConfig:
     enable_implement: bool = True
     enable_pr_review: bool = True
     enable_classify: bool = True
-    classifiable_labels: Tuple[str, ...] = ("intent", "bug", "refactor", "feature_request")
-    classify_skip_labels: Tuple[str, ...] = ("infra",)
+    classifiable_labels: frozenset = frozenset({"intent", "bug", "refactor", "feature_request"})
+    classify_skip_labels: frozenset = frozenset({"infra"})
     # When True, the monitor acquires a PID lockfile under base_repo_path
     # named after the identity. Two monitors with the same monitor_id on
     # the same host will fail to start. Default off because most tests
@@ -322,6 +328,13 @@ class PipelineMonitor:
         - it has no pipeline labels (nothing starting with ``~``)
         - its body is non-empty (filled template)
         - it falls in this monitor's shard
+
+        Known limitation: Stage 0 does not use ``claim_with_batch`` — there is a
+        narrow race window between ``list_unclassified_issues`` and ``add_labels``
+        where two monitor instances could classify the same issue simultaneously.
+        In practice DEILE runs as a single process, so this is acceptable; the
+        GitHub ``add_labels`` call is idempotent and the worst case is a duplicate
+        comment and notification.
         """
         try:
             issues = await self.github.list_unclassified_issues()
@@ -350,12 +363,7 @@ class PipelineMonitor:
             logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
             await self.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
             try:
-                await self.github.comment_on_issue(
-                    issue.number,
-                    f"🤖 **DEILE auto-classificação** — esta issue foi adicionada à fila do pipeline "
-                    f"autônomo (`{WORKFLOW_NEW}`).\n\n"
-                    f"Para excluir da fila, remova o label `{WORKFLOW_NEW}`.",
-                )
+                await self.github.comment_on_issue(issue.number, _CLASSIFY_COMMENT)
             except Exception as exc:  # noqa: BLE001 — comment is best-effort; label already applied
                 logger.warning("auto-classify comment #%s failed (label applied): %s", issue.number, exc)
 

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -91,6 +91,7 @@ class _Stats:
     issues_reviewed: int = 0
     issues_implemented: int = 0
     prs_reviewed: int = 0
+    issues_classified: int = 0
     errors: int = 0
     catchup_runs: int = 0
     scheduled_runs: int = 0
@@ -338,11 +339,14 @@ class PipelineMonitor:
         """
         try:
             issues = await self.github.list_unclassified_issues()
-        except GhCommandError as exc:
+        except Exception as exc:  # noqa: BLE001 — gh error, JSON parse error, etc.
             logger.warning("could not list unclassified issues: %s", exc)
             return
 
         for issue in issues:
+            # Defense-in-depth: never touch an issue that already has a pipeline label.
+            if any(lb.startswith("~") for lb in issue.labels):
+                continue
             if not any(lb in self.config.classifiable_labels for lb in issue.labels):
                 continue
             if any(lb in self.config.classify_skip_labels for lb in issue.labels):
@@ -360,6 +364,7 @@ class PipelineMonitor:
                     f"auto-classify #{issue.number}", f"{type(exc).__name__}: {exc}"
                 )
                 continue
+            self._stats.issues_classified += 1
             logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
             await self.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
             try:

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -25,16 +25,15 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional, Tuple
 
 from deile.orchestration.pipeline.claude_dispatcher import (
     ClaudeDispatcher, render_implement_prompt, render_review_prompt)
-from deile.orchestration.pipeline.constants import (PIPELINE_MSG_TRUNCATE_CHARS,
-                                                    PIPELINE_POLL_INTERVAL_SECONDS,
-                                                    PIPELINE_STOP_TIMEOUT_SECONDS)
+from deile.orchestration.pipeline.constants import (
+    PIPELINE_MSG_TRUNCATE_CHARS, PIPELINE_POLL_INTERVAL_SECONDS,
+    PIPELINE_STOP_TIMEOUT_SECONDS)
 from deile.orchestration.pipeline.github_client import (GhCommandError,
-                                                        GitHubClient,
-                                                        IssueRef)
+                                                        GitHubClient, IssueRef)
 from deile.orchestration.pipeline.identity import MonitorIdentity
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
@@ -42,9 +41,11 @@ from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  WORKFLOW_PR,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING)
-from deile.orchestration.pipeline.lockfile import LockHeldError, acquire as acquire_lock, release as release_lock
+from deile.orchestration.pipeline.lockfile import LockHeldError
+from deile.orchestration.pipeline.lockfile import acquire as acquire_lock
+from deile.orchestration.pipeline.lockfile import release as release_lock
 from deile.orchestration.pipeline.notifier import DiscordNotifier
-from deile.orchestration.pipeline.scheduler import (PendingRun, ScheduleStore)
+from deile.orchestration.pipeline.scheduler import PendingRun, ScheduleStore
 from deile.orchestration.pipeline.worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,9 @@ class PipelineConfig:
     enable_review: bool = True
     enable_implement: bool = True
     enable_pr_review: bool = True
+    enable_classify: bool = True
+    classifiable_labels: Tuple[str, ...] = ("intent", "bug", "refactor", "feature_request")
+    classify_skip_labels: Tuple[str, ...] = ("infra",)
     # When True, the monitor acquires a PID lockfile under base_repo_path
     # named after the identity. Two monitors with the same monitor_id on
     # the same host will fail to start. Default off because most tests
@@ -221,7 +225,9 @@ class PipelineMonitor:
 
     async def _run_scheduled(self, run: PendingRun) -> None:
         """Execute a single scheduled action by name."""
-        if run.action == "review" and self.config.enable_review:
+        if run.action == "classify" and self.config.enable_classify:
+            await self._classify_new_issues()
+        elif run.action == "review" and self.config.enable_review:
             await self._review_one_new_issue()
         elif run.action == "implement" and self.config.enable_implement:
             await self._implement_one_reviewed_issue()
@@ -296,12 +302,58 @@ class PipelineMonitor:
                     logger.warning("could not persist schedule after tick: %s", exc)
             return
 
+        if self.config.enable_classify:
+            await self._classify_new_issues()
         if self.config.enable_review:
             await self._review_one_new_issue()
         if self.config.enable_implement:
             await self._implement_one_reviewed_issue()
         if self.config.enable_pr_review:
             await self._review_one_open_pr()
+
+    # ----- stage 0: auto-classify new issues -----------------------
+
+    async def _classify_new_issues(self) -> None:
+        """Apply ``~workflow:nova`` to open issues that are eligible but unclassified.
+
+        An issue is eligible when:
+        - it has at least one label in ``config.classifiable_labels``
+        - it has no label in ``config.classify_skip_labels``
+        - it has no pipeline labels (nothing starting with ``~``)
+        - its body is non-empty (filled template)
+        - it falls in this monitor's shard
+        """
+        try:
+            issues = await self.github.list_unclassified_issues()
+        except GhCommandError as exc:
+            logger.warning("could not list unclassified issues: %s", exc)
+            return
+
+        for issue in issues:
+            if not any(lb in self.config.classifiable_labels for lb in issue.labels):
+                continue
+            if any(lb in self.config.classify_skip_labels for lb in issue.labels):
+                continue
+            if not self.identity.owns(issue.title):
+                continue
+            if not issue.body.strip():
+                logger.debug("issue #%s has empty body; skipping auto-classification", issue.number)
+                continue
+            try:
+                await self.github.add_labels("issue", issue.number, [WORKFLOW_NEW])
+                await self.github.comment_on_issue(
+                    issue.number,
+                    f"🤖 **DEILE auto-classificação** — esta issue foi adicionada à fila do pipeline "
+                    f"autônomo (`{WORKFLOW_NEW}`).\n\n"
+                    f"Para excluir da fila, remova o label `{WORKFLOW_NEW}`.",
+                )
+                await self.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
+                logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
+            except Exception as exc:  # noqa: BLE001 — best-effort, never abort loop
+                logger.warning("auto-classification of #%s failed: %s", issue.number, exc)
+                await self.notifier.error(
+                    f"auto-classify #{issue.number}", f"{type(exc).__name__}: {exc}"
+                )
 
     # ----- stage 1: review ------------------------------------------
 

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -341,19 +341,23 @@ class PipelineMonitor:
                 continue
             try:
                 await self.github.add_labels("issue", issue.number, [WORKFLOW_NEW])
+            except Exception as exc:  # noqa: BLE001 — best-effort, never abort loop
+                logger.warning("auto-classify label #%s failed: %s", issue.number, exc)
+                await self.notifier.error(
+                    f"auto-classify #{issue.number}", f"{type(exc).__name__}: {exc}"
+                )
+                continue
+            logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
+            await self.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
+            try:
                 await self.github.comment_on_issue(
                     issue.number,
                     f"🤖 **DEILE auto-classificação** — esta issue foi adicionada à fila do pipeline "
                     f"autônomo (`{WORKFLOW_NEW}`).\n\n"
                     f"Para excluir da fila, remova o label `{WORKFLOW_NEW}`.",
                 )
-                await self.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
-                logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
-            except Exception as exc:  # noqa: BLE001 — best-effort, never abort loop
-                logger.warning("auto-classification of #%s failed: %s", issue.number, exc)
-                await self.notifier.error(
-                    f"auto-classify #{issue.number}", f"{type(exc).__name__}: {exc}"
-                )
+            except Exception as exc:  # noqa: BLE001 — comment is best-effort; label already applied
+                logger.warning("auto-classify comment #%s failed (label applied): %s", issue.number, exc)
 
     # ----- stage 1: review ------------------------------------------
 

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -116,5 +116,11 @@ class DiscordNotifier:
         emoji = "🟣" if merged else "✅"
         await self._send(f"{emoji} **PR #{number} {verb}**: {title}\n🔗 {url}")
 
+    async def issue_auto_classified(self, number: int, title: str, url: str) -> None:
+        await self._send(
+            f"📋 **Issue auto-classificada** #{number}: {title}\n"
+            f"Label `~workflow:nova` adicionado — na fila do pipeline.\n🔗 {url}"
+        )
+
     async def error(self, where: str, detail: str) -> None:
         await self._send(f"⚠️ **Pipeline error** em `{where}`:\n```\n{detail[:PIPELINE_MSG_TRUNCATE_CHARS]}\n```")

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -19,6 +19,7 @@ import os
 from typing import Awaitable, Callable, Optional
 
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
+from deile.orchestration.pipeline.labels import WORKFLOW_NEW
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,7 @@ class DiscordNotifier:
     async def issue_auto_classified(self, number: int, title: str, url: str) -> None:
         await self._send(
             f"📋 **Issue auto-classificada** #{number}: {title}\n"
-            f"Label `~workflow:nova` adicionado — na fila do pipeline.\n🔗 {url}"
+            f"Label `{WORKFLOW_NEW}` adicionado — na fila do pipeline.\n🔗 {url}"
         )
 
     async def error(self, where: str, detail: str) -> None:

--- a/deile/orchestration/pipeline/scheduler.py
+++ b/deile/orchestration/pipeline/scheduler.py
@@ -53,7 +53,7 @@ from deile.orchestration.pipeline.cron import CronExpressionError, next_after
 logger = logging.getLogger(__name__)
 
 
-VALID_ACTIONS = {"review", "implement", "pr_review"}
+VALID_ACTIONS = {"review", "implement", "pr_review", "classify"}
 
 
 class ScheduleError(DEILEError):

--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -347,3 +347,101 @@ class TestSchedulerClassifyAction:
         s = Schedule()
         s.add_recurring(entry)
         assert any(e.action == "classify" for e in s.recurring)
+
+    async def test_schedule_roundtrip_triggers_classify(self, tmp_path):
+        from datetime import datetime, timedelta, timezone
+
+        from deile.orchestration.pipeline.scheduler import (RecurringEntry,
+                                                            Schedule,
+                                                            ScheduleStore)
+
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        s.add_recurring(RecurringEntry(
+            id="cls-loop",
+            action="classify",
+            cron="*/5 * * * *",
+            last_run_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        ))
+        store.save(s)
+
+        issue = _issue(70, ("intent",), body="body")
+        cfg = PipelineConfig(
+            repo="owner/name",
+            base_repo_path=tmp_path,
+            notify_user_id="42",
+        )
+        github = MagicMock()
+        github.ensure_pipeline_labels = AsyncMock()
+        github.list_unclassified_issues = AsyncMock(return_value=[issue])
+        github.list_issues_with_label = AsyncMock(return_value=[])
+        github.list_open_prs = AsyncMock(return_value=[])
+        github.add_labels = AsyncMock()
+        github.comment_on_issue = AsyncMock()
+        github.comment_on_pr = AsyncMock()
+        github.claim_with_batch = AsyncMock(return_value="abc")
+        github.transition_issue = AsyncMock()
+        github.transition_pr = AsyncMock()
+
+        notifier = MagicMock()
+        for attr in (
+            "issue_picked_up", "issue_reviewed", "implementation_started",
+            "implementation_finished", "pr_picked_up", "pr_reviewed",
+            "issue_auto_classified", "error",
+        ):
+            setattr(notifier, attr, AsyncMock())
+
+        monitor = PipelineMonitor(
+            cfg,
+            github=github,
+            worktrees=MagicMock(),
+            notifier=notifier,
+            schedule_store=store,
+        )
+        await monitor.tick()
+        github.list_unclassified_issues.assert_called_once()
+        github.add_labels.assert_called_once_with("issue", 70, [WORKFLOW_NEW])
+
+    async def test_run_scheduled_classify_disabled_noop(self):
+        from datetime import datetime, timezone
+
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        issue = _issue(80, ("intent",), body="body")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        monitor.config.enable_classify = False
+        run = PendingRun(
+            when=datetime.now(timezone.utc),
+            entry_id="x",
+            action="classify",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        github.list_unclassified_issues.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Shard filter in Stage 0
+# ---------------------------------------------------------------------------
+
+class TestClassifySharding:
+    async def test_skips_issue_outside_own_shard(self):
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+
+        # "issue 60" hashes to shard 0 with shard_count=2.
+        # A monitor on shard_index=1 must NOT classify it.
+        issue = _issue(60, ("intent",), body="body")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        monitor.identity = MonitorIdentity(monitor_id="m1", shard_index=1, shard_count=2)
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+
+    async def test_classifies_issue_inside_own_shard(self):
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+
+        # "issue 61" hashes to shard 1 with shard_count=2.
+        issue = _issue(61, ("intent",), body="body")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        monitor.identity = MonitorIdentity(monitor_id="m1", shard_index=1, shard_count=2)
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called_once_with("issue", 61, [WORKFLOW_NEW])

--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -1,0 +1,296 @@
+"""Tests for Stage 0: auto-classification of newly opened issues.
+
+Covers:
+- GitHubClient.list_unclassified_issues() — filtering logic
+- PipelineMonitor._classify_new_issues() — Stage 0 behavior
+- DiscordNotifier.issue_auto_classified() — notification message
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from deile.orchestration.pipeline.github_client import (GhCommandError,
+                                                        GitHubClient, IssueRef)
+from deile.orchestration.pipeline.labels import WORKFLOW_NEW
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+from deile.orchestration.pipeline.notifier import DiscordNotifier
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _issue(number: int, labels: tuple, body: str = "filled body") -> IssueRef:
+    return IssueRef(
+        number=number,
+        title=f"issue {number}",
+        url=f"https://github.com/o/r/issues/{number}",
+        labels=labels,
+        body=body,
+    )
+
+
+def _make_monitor(*, unclassified: list | None = None) -> tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(return_value=[])
+    github.list_open_prs = AsyncMock(return_value=[])
+    github.list_unclassified_issues = AsyncMock(return_value=list(unclassified or []))
+    github.claim_with_batch = AsyncMock(return_value="abc12345")
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up", "issue_reviewed", "implementation_started",
+        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "issue_auto_classified", "error",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    worktrees = MagicMock()
+
+    monitor = PipelineMonitor(cfg, github=github, worktrees=worktrees, notifier=notifier)
+    return monitor, github, notifier
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.list_unclassified_issues
+# ---------------------------------------------------------------------------
+
+class TestListUnclassifiedIssues:
+    async def test_returns_issues_without_pipeline_labels(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 1,
+                "title": "plain intent",
+                "url": "https://github.com/o/r/issues/1",
+                "labels": [{"name": "intent"}],
+                "body": "some body",
+                "state": "open",
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_issues()
+        assert len(result) == 1
+        assert result[0].number == 1
+
+    async def test_filters_out_issues_with_workflow_label(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 2,
+                "title": "already in pipeline",
+                "url": "https://github.com/o/r/issues/2",
+                "labels": [{"name": "intent"}, {"name": "~workflow:nova"}],
+                "body": "body",
+                "state": "open",
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_issues()
+        assert result == []
+
+    async def test_filters_out_issues_with_batch_label(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 3,
+                "title": "batch locked",
+                "url": "https://github.com/o/r/issues/3",
+                "labels": [{"name": "bug"}, {"name": "~batch:abc12345"}],
+                "body": "body",
+                "state": "open",
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_issues()
+        assert result == []
+
+    async def test_filters_out_issues_with_review_label(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 4,
+                "title": "under review",
+                "url": "https://github.com/o/r/issues/4",
+                "labels": [{"name": "intent"}, {"name": "~review:pendente"}],
+                "body": "body",
+                "state": "open",
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_issues()
+        assert result == []
+
+    async def test_returns_empty_on_empty_output(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
+            result = await client.list_unclassified_issues()
+        assert result == []
+
+    async def test_mixed_returns_only_unclassified(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 10,
+                "title": "eligible",
+                "url": "u",
+                "labels": [{"name": "intent"}],
+                "body": "body",
+                "state": "open",
+            },
+            {
+                "number": 11,
+                "title": "already classified",
+                "url": "u",
+                "labels": [{"name": "intent"}, {"name": "~workflow:nova"}],
+                "body": "body",
+                "state": "open",
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_issues()
+        assert len(result) == 1
+        assert result[0].number == 10
+
+
+# ---------------------------------------------------------------------------
+# PipelineMonitor._classify_new_issues (Stage 0)
+# ---------------------------------------------------------------------------
+
+class TestClassifyNewIssues:
+    async def test_no_unclassified_issues_noop(self):
+        monitor, github, notifier = _make_monitor(unclassified=[])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+        notifier.issue_auto_classified.assert_not_called()
+
+    async def test_classifies_intent_issue_with_body(self):
+        issue = _issue(5, ("intent",), body="Intent description")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called_once_with("issue", 5, [WORKFLOW_NEW])
+        github.comment_on_issue.assert_called_once()
+        notifier.issue_auto_classified.assert_called_once_with(5, issue.title, issue.url)
+
+    async def test_classifies_bug_issue(self):
+        issue = _issue(6, ("bug",), body="Bug description")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called_once()
+
+    async def test_skips_infra_issue(self):
+        issue = _issue(7, ("intent", "infra"), body="Infra issue")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+
+    async def test_skips_issue_with_empty_body(self):
+        issue = _issue(8, ("intent",), body="")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+
+    async def test_skips_issue_with_whitespace_only_body(self):
+        issue = _issue(9, ("intent",), body="   \n\t  ")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+
+    async def test_skips_issue_with_no_classifiable_label(self):
+        issue = _issue(10, ("question", "help-wanted"), body="some body")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+
+    async def test_gh_error_does_not_crash(self):
+        monitor, github, notifier = _make_monitor()
+        github.list_unclassified_issues = AsyncMock(
+            side_effect=GhCommandError(("gh",), 1, "", "network error")
+        )
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+
+    async def test_add_labels_failure_continues_loop(self):
+        issues = [
+            _issue(20, ("intent",), body="body 1"),
+            _issue(21, ("intent",), body="body 2"),
+        ]
+        monitor, github, notifier = _make_monitor(unclassified=issues)
+        github.add_labels = AsyncMock(side_effect=[RuntimeError("network"), None])
+        await monitor._classify_new_issues()
+        notifier.error.assert_called_once()
+        notifier.issue_auto_classified.assert_called_once_with(21, issues[1].title, issues[1].url)
+
+    async def test_disabled_classify_skips_stage0(self):
+        issue = _issue(30, ("intent",), body="body")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        monitor.config.enable_classify = False
+        await monitor.tick()
+        github.list_unclassified_issues.assert_not_called()
+
+    async def test_tick_calls_classify_before_review(self):
+        issue = _issue(40, ("intent",), body="body")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        call_order = []
+        github.list_unclassified_issues.side_effect = lambda **_: call_order.append("classify") or []
+        github.list_issues_with_label.side_effect = lambda *a, **_: call_order.append("review") or []
+        await monitor.tick()
+        assert call_order.index("classify") < call_order.index("review")
+
+    async def test_classify_via_scheduled_action(self):
+        from datetime import datetime, timezone
+
+        from deile.orchestration.pipeline.scheduler import PendingRun
+        issue = _issue(50, ("intent",), body="body")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        run = PendingRun(
+            when=datetime.now(timezone.utc),
+            entry_id="x",
+            action="classify",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        github.list_unclassified_issues.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# DiscordNotifier.issue_auto_classified
+# ---------------------------------------------------------------------------
+
+class TestIssueAutoClassifiedNotification:
+    async def test_sends_dm_with_issue_number(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append(text)
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.issue_auto_classified(99, "My Issue", "https://github.com/o/r/issues/99")
+        assert len(sent) == 1
+        assert "#99" in sent[0]
+        assert "My Issue" in sent[0]
+        assert "~workflow:nova" in sent[0]
+
+    async def test_disabled_notifier_noops(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append(text)
+
+        n = DiscordNotifier(user_id="", dm_fn=fake_dm)
+        await n.issue_auto_classified(1, "t", "u")
+        assert sent == []

--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -235,6 +235,15 @@ class TestClassifyNewIssues:
         notifier.error.assert_called_once()
         notifier.issue_auto_classified.assert_called_once_with(21, issues[1].title, issues[1].url)
 
+    async def test_comment_failure_does_not_trigger_error_notification(self):
+        issue = _issue(22, ("intent",), body="body")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        github.comment_on_issue = AsyncMock(side_effect=RuntimeError("timeout"))
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called_once()
+        notifier.issue_auto_classified.assert_called_once()
+        notifier.error.assert_not_called()
+
     async def test_disabled_classify_skips_stage0(self):
         issue = _issue(30, ("intent",), body="body")
         monitor, github, notifier = _make_monitor(unclassified=[issue])

--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -12,6 +12,9 @@ import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
 from deile.orchestration.pipeline.github_client import (GhCommandError,
                                                         GitHubClient, IssueRef)
 from deile.orchestration.pipeline.labels import WORKFLOW_NEW
@@ -61,7 +64,14 @@ def _make_monitor(*, unclassified: list | None = None) -> tuple[PipelineMonitor,
 
     worktrees = MagicMock()
 
-    monitor = PipelineMonitor(cfg, github=github, worktrees=worktrees, notifier=notifier)
+    claude = MagicMock()
+    claude.run = AsyncMock(
+        return_value=ClaudeRunResult(
+            returncode=0, stdout="", stderr="", duration_seconds=0.0, cmd=("claude", "-p", "x")
+        )
+    )
+
+    monitor = PipelineMonitor(cfg, github=github, worktrees=worktrees, claude=claude, notifier=notifier)
     return monitor, github, notifier
 
 
@@ -230,10 +240,16 @@ class TestClassifyNewIssues:
             _issue(21, ("intent",), body="body 2"),
         ]
         monitor, github, notifier = _make_monitor(unclassified=issues)
-        github.add_labels = AsyncMock(side_effect=[RuntimeError("network"), None])
+
+        async def _add_labels_by_issue(kind, num, labels):
+            if num == 20:
+                raise RuntimeError("network")
+
+        github.add_labels = AsyncMock(side_effect=_add_labels_by_issue)
         await monitor._classify_new_issues()
         notifier.error.assert_called_once()
         notifier.issue_auto_classified.assert_called_once_with(21, issues[1].title, issues[1].url)
+        github.comment_on_issue.assert_called_once()
 
     async def test_comment_failure_does_not_trigger_error_notification(self):
         issue = _issue(22, ("intent",), body="body")
@@ -303,3 +319,31 @@ class TestIssueAutoClassifiedNotification:
         n = DiscordNotifier(user_id="", dm_fn=fake_dm)
         await n.issue_auto_classified(1, "t", "u")
         assert sent == []
+
+
+# ---------------------------------------------------------------------------
+# Parametrized: all classifiable labels are handled
+# ---------------------------------------------------------------------------
+
+class TestClassifiableLabelCoverage:
+    @pytest.mark.parametrize("label", ["intent", "bug", "refactor", "feature_request"])
+    async def test_classifies_each_classifiable_label(self, label):
+        issue = _issue(99, (label,), body="some body")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called_once_with("issue", 99, [WORKFLOW_NEW])
+
+
+# ---------------------------------------------------------------------------
+# Scheduler integration: RecurringEntry with action="classify" is valid
+# ---------------------------------------------------------------------------
+
+class TestSchedulerClassifyAction:
+    def test_recurring_classify_entry_is_valid(self):
+        from deile.orchestration.pipeline.scheduler import (RecurringEntry,
+                                                            Schedule)
+
+        entry = RecurringEntry(id="cls-loop", action="classify", cron="*/5 * * * *")
+        s = Schedule()
+        s.add_recurring(entry)
+        assert any(e.action == "classify" for e in s.recurring)

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -64,10 +64,13 @@ def _make_monitor(
         cmd=("claude", "-p", "x"),
     ))
 
+    github.list_unclassified_issues = AsyncMock(return_value=[])
+
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
-        "implementation_finished", "pr_picked_up", "pr_reviewed", "error",
+        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "issue_auto_classified", "error",
     ):
         setattr(notifier, attr, AsyncMock())
 
@@ -309,6 +312,7 @@ def _make_minimal_monitor(
     github.ensure_pipeline_labels = AsyncMock()
     github.list_issues_with_label = AsyncMock(return_value=[])
     github.list_open_prs = AsyncMock(return_value=[])
+    github.list_unclassified_issues = AsyncMock(return_value=[])
 
     worktrees = MagicMock()
     worktrees.create_branch_worktree = AsyncMock(
@@ -317,7 +321,8 @@ def _make_minimal_monitor(
 
     notifier = MagicMock()
     for attr in ("issue_picked_up", "issue_reviewed", "implementation_started",
-                 "implementation_finished", "pr_picked_up", "pr_reviewed", "error"):
+                 "implementation_finished", "pr_picked_up", "pr_reviewed",
+                 "issue_auto_classified", "error"):
         setattr(notifier, attr, AsyncMock())
 
     schedule_store = MagicMock()

--- a/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
+++ b/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
@@ -77,6 +77,7 @@ def _make_monitor_sched(
     github.add_labels = AsyncMock()
     github.comment_on_issue = AsyncMock()
     github.comment_on_pr = AsyncMock()
+    github.list_unclassified_issues = AsyncMock(return_value=[])
 
     worktrees = MagicMock()
     worktrees.create_branch_worktree = AsyncMock(
@@ -106,6 +107,7 @@ def _make_monitor_sched(
         "implementation_finished",
         "pr_picked_up",
         "pr_reviewed",
+        "issue_auto_classified",
         "error",
     ):
         setattr(notifier, attr, AsyncMock())

--- a/deile/tests/orchestration/pipeline/test_pipeline_integration.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_integration.py
@@ -67,6 +67,7 @@ def _make_monitor_full(
     github.add_labels = AsyncMock()
     github.comment_on_issue = AsyncMock()
     github.comment_on_pr = AsyncMock()
+    github.list_unclassified_issues = AsyncMock(return_value=[])
 
     worktrees = MagicMock()
     worktrees.create_branch_worktree = AsyncMock(
@@ -96,6 +97,7 @@ def _make_monitor_full(
         "implementation_finished",
         "pr_picked_up",
         "pr_reviewed",
+        "issue_auto_classified",
         "error",
     ):
         setattr(notifier, attr, AsyncMock())

--- a/deile/tools/pipeline_schedule_tool.py
+++ b/deile/tools/pipeline_schedule_tool.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
 
 from deile.orchestration.pipeline.identity import MonitorIdentity
 from deile.orchestration.pipeline.scheduler import (OneshotEntry,
@@ -72,7 +71,7 @@ class PipelineScheduleTool(Tool):
                         },
                         "trigger_action": {
                             "type": "string",
-                            "enum": ["review", "implement", "pr_review"],
+                            "enum": ["review", "implement", "pr_review", "classify"],
                             "description": "Pipeline action this entry fires.",
                         },
                         "cron": {


### PR DESCRIPTION
## Resumo

Implementa o **Stage 0** do pipeline autônomo: ao abrir uma issue com label `intent`, `bug`, `refactor` ou `feature_request` (com corpo preenchido e sem label `infra`), o monitor detecta automaticamente e aplica `~workflow:nova` na próxima tick (≤60s), postando comentário explicativo e notificando via Discord.

Resolve o gatilho **"Issue aberta"** (#4 da issue #86).

**Closes #86**

---

## Decisão arquitetural

| Alternativa | Escolha |
|---|---|
| **A — Polling no `tick()` (Stage 0)** | ✅ Escolhida |
| B — GitHub Actions webhook dispatch | Complementar (já existe via sessão atual) |

Alt A vence pelo alinhamento com o pilar 03: sem dependência de infra externa, zero SDK externo em `orchestration/`, I/O 100% async, extensível via `_run_scheduled("classify")`. A latência de 60s é aceitável para o caso de uso (triagem de issues).

---

## Mudanças

### `github_client.py`
- `GitHubClient.list_unclassified_issues()`: lista issues abertas sem nenhuma label `~` (não processadas ainda pelo pipeline)

### `monitor.py`
- `PipelineMonitor._classify_new_issues()`: Stage 0 — itera issues não classificadas, aplica `~workflow:nova`, comenta, notifica
- `PipelineConfig`: campos `enable_classify`, `classifiable_labels`, `classify_skip_labels`
- `tick()`: chama Stage 0 antes de Stage 1
- `_run_scheduled()`: ação `"classify"` para uso via `/pipeline-schedule`

### `notifier.py`
- `DiscordNotifier.issue_auto_classified()`: nova notificação de evento

### Testes
- `test_classify.py`: 20 testes unitários novos
- `test_monitor.py`, `test_pipeline_integration.py`, `test_monitor_with_schedule.py`: mocks atualizados

---

## Checklist

- [x] `python3 -m pytest deile/tests/orchestration/pipeline/` — 211 passed, 2 pre-existing failures (gh binário ausente no sandbox)
- [x] `ruff check deile/orchestration/pipeline/` — OK
- [x] `isort --check-only deile/orchestration/pipeline/` — OK
- [x] 20 novos testes (Stage 0 classifier) todos verdes
- [x] Nenhum breaking change nas interfaces existentes

---

## Gatilhos restantes (#86)

Triggers a implementar em issues derivadas:
- PR aberto (Stage 0 paralelo para PRs)
- PR mergeado (callback pós-merge)
- Agendamento temporal (validação E2E do CronRunner)
- Menção `@deile-one` (webhook comments)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xhx9E5u8YeUPvKcanuizau)_