### PR TITLE
fix(pipeline): corrige 35 gaps — monitor autônomo silenciosamente quebrado

### DIFF
--- a/config/pipeline_schedule_default.yaml
+++ b/config/pipeline_schedule_default.yaml
@@ -1,14 +1,26 @@
 recurring:
-- id: r1
+- id: classify_loop
+  action: classify
+  cron: '*/2 * * * *'
+  enabled: true
+  last_run_at: null
+  replay_all: false
+- id: review_loop
   action: review
+  cron: '*/3 * * * *'
+  enabled: true
+  last_run_at: null
+  replay_all: false
+- id: implement_loop
+  action: implement
   cron: '*/5 * * * *'
   enabled: true
   last_run_at: null
   replay_all: false
-oneshot:
-- id: oneshot-implement-1778090400
-  action: implement
-  run_at: '2026-05-06T18:00:00Z'
-  target_issue: 99
-  target_pr: null
-  completed: false
+- id: pr_review_loop
+  action: pr_review
+  cron: '*/4 * * * *'
+  enabled: true
+  last_run_at: null
+  replay_all: false
+oneshot: []

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -145,6 +145,10 @@ class _DeileCLI:
                 )
                 await self.agent.initialize()
 
+                # gap #3: autostart the pipeline monitor when DEILE_PIPELINE_AUTOSTART=true
+                if self.settings.pipeline_autostart:
+                    await _autostart_pipeline(self.agent)
+
                 self.default_session = self.agent.create_session(
                     session_id="default_cli_session",
                     working_directory=self.settings.working_directory,
@@ -261,6 +265,44 @@ class _DeileCLI:
             ))
         except Exception as exc:
             self.ui.display_error(f"Ocorreu um erro fatal no loop principal: {exc}")
+
+
+# ── pipeline autostart helper ───────────────────────────────────────────────
+
+
+async def _autostart_pipeline(agent) -> None:  # type: ignore[type-arg]
+    """Start the pipeline monitor in the background when DEILE_PIPELINE_AUTOSTART=true.
+
+    gap #3: operator convenience — set the env var once and every DEILE interactive
+    session auto-starts the polling loop without a manual ``/pipeline start``.
+    """
+    import logging as _logging
+    _log = _logging.getLogger(__name__)
+    try:
+        from deile.config.settings import get_settings
+        from deile.orchestration.pipeline.constants import \
+            PIPELINE_DEFAULT_REPO
+        from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                          PipelineMonitor)
+        from deile.orchestration.pipeline.review_callback import \
+            make_review_callback
+        s = get_settings()
+        repo = s.pipeline_repo or PIPELINE_DEFAULT_REPO
+        base_path = s.pipeline_base_path
+        if base_path is None:
+            from pathlib import Path
+            base_path = Path.cwd()
+        cfg = PipelineConfig(
+            repo=repo,
+            base_repo_path=base_path.resolve(),
+            notify_user_id=s.pipeline_notify_user_id,
+        )
+        monitor = PipelineMonitor(cfg, review_callback=make_review_callback(agent))
+        agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
+        await monitor.start()
+        _log.info("pipeline autostarted (repo=%s)", repo)
+    except Exception as exc:  # noqa: BLE001 — autostart is best-effort; never abort CLI
+        _log.warning("pipeline autostart failed: %s", exc)
 
 
 # ── one-shot mode ───────────────────────────────────────────────────────────

--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -1,10 +1,11 @@
 """``/pipeline`` command — start/stop/status of the autonomous pipeline.
 
 Usage:
-    /pipeline start         start the 1-min polling loop
-    /pipeline stop          stop the polling loop
-    /pipeline status        print stats + current state
-    /pipeline tick          run a single tick synchronously (debug)
+    /pipeline start             start the 1-min polling loop
+    /pipeline stop              stop the polling loop
+    /pipeline status            print stats + current state
+    /pipeline tick              run a single tick synchronously (debug)
+    /pipeline reset <issue#>    remove ~batch: + ~by:* labels from an issue (gap #34)
 
 The command is idempotent: running ``start`` twice does nothing on the second
 call. The monitor instance is held on ``context.agent.pipeline_monitor``.
@@ -12,14 +13,18 @@ call. The monitor instance is held on ``context.agent.pipeline_monitor``.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Optional
 
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
 from deile.config.manager import CommandConfig
 from deile.orchestration.pipeline.constants import PIPELINE_DEFAULT_REPO
+from deile.orchestration.pipeline.labels import BATCH_LABEL_PREFIX
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_repo() -> str:
@@ -43,33 +48,38 @@ def _resolve_base_path() -> Path:
 
 
 class PipelineCommand(DirectCommand):
-    """``/pipeline {start|stop|status|tick}``."""
+    """``/pipeline {start|stop|status|tick|reset}``."""
 
     def __init__(self) -> None:
         super().__init__(
             CommandConfig(
                 name="pipeline",
-                description="Controla o pipeline autônomo de issues/PRs (start|stop|status|tick)",
+                description=(
+                    "Controla o pipeline autônomo de issues/PRs "
+                    "(start|stop|status|tick|reset <issue#>)"
+                ),
                 action="pipeline",
             )
         )
         self.category = "orchestration"
 
     async def execute(self, context: CommandContext) -> CommandResult:
-        parts = context.args.strip().split(None, 1)
+        parts = context.args.strip().split(None, 2)
         sub = parts[0].lower() if parts else "status"
         agent = context.agent
         monitor: Optional[PipelineMonitor] = getattr(agent, "pipeline_monitor", None)
 
         if monitor is None:
             from deile.config.settings import get_settings
+            from deile.orchestration.pipeline.review_callback import \
+                make_review_callback
 
             cfg = PipelineConfig(
                 repo=_resolve_repo(),
                 base_repo_path=_resolve_base_path(),
                 notify_user_id=get_settings().pipeline_notify_user_id,
             )
-            monitor = PipelineMonitor(cfg)
+            monitor = PipelineMonitor(cfg, review_callback=make_review_callback(agent))
             agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
 
         if sub == "start":
@@ -95,6 +105,20 @@ class PipelineCommand(DirectCommand):
                     f"prs={s.prs_reviewed} errors={s.errors}"
                 ),
             )
+        if sub == "reset":
+            # gap #34: remove ~batch: + ~by:* labels from an issue so it can be re-processed
+            if len(parts) < 2:
+                return CommandResult(
+                    success=False, content="❌ uso: /pipeline reset <issue_number>"
+                )
+            try:
+                issue_number = int(parts[1].lstrip("#"))
+            except ValueError:
+                return CommandResult(
+                    success=False, content=f"❌ número de issue inválido: {parts[1]!r}"
+                )
+            return await _reset_issue(monitor, issue_number)
+
         # default: status
         s = monitor.stats
         running = monitor.is_running
@@ -103,6 +127,45 @@ class PipelineCommand(DirectCommand):
             content=(
                 f"📊 pipeline {'rodando' if running else 'parado'} | repo={monitor.config.repo}\n"
                 f"  ticks={s.ticks}  reviewed={s.issues_reviewed}  "
-                f"implemented={s.issues_implemented}  prs={s.prs_reviewed}  errors={s.errors}"
+                f"implemented={s.issues_implemented}  prs={s.prs_reviewed}  "
+                f"errors={s.errors}  gh_errors={s.gh_errors}  claude_errors={s.claude_errors}"
             ),
         )
+
+
+async def _reset_issue(monitor: PipelineMonitor, issue_number: int) -> CommandResult:
+    """Remove pipeline lock labels from *issue_number* (gap #34)."""
+    from deile.orchestration.pipeline.github_client import GhCommandError
+
+    github = monitor.github
+    try:
+        issue = await github.get_issue(issue_number)
+    except GhCommandError as exc:
+        return CommandResult(success=False, content=f"❌ gh error: {exc}")
+
+    to_remove = [
+        lb for lb in issue.labels
+        if lb.startswith(BATCH_LABEL_PREFIX) or lb.startswith("~by:")
+    ]
+    if not to_remove:
+        return CommandResult(
+            success=True,
+            content=f"ℹ️ issue #{issue_number} não tem labels de lock para remover.",
+        )
+
+    try:
+        await github.remove_labels("issue", issue_number, to_remove)
+    except GhCommandError as exc:
+        return CommandResult(success=False, content=f"❌ falha ao remover labels: {exc}")
+
+    logger.info(
+        "pipeline reset: removed labels %s from issue #%d", to_remove, issue_number
+    )
+    return CommandResult(
+        success=True,
+        content=(
+            f"✅ issue #{issue_number} desbloqueada — labels removidas: "
+            f"{', '.join(to_remove)}.\n"
+            f"A issue será reprocessada no próximo tick."
+        ),
+    )

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -34,6 +34,7 @@ _DEILE_DEPRECATED_ENV_VARS: Dict[str, str] = {
     "DEILE_PIPELINE_NOTIFY_USER_ID": "pipeline.notify_user_id",
     "DEILE_PIPELINE_POLL_INTERVAL": "pipeline.poll_interval",
     "DEILE_PIPELINE_CLAUDE_TIMEOUT": "pipeline.claude_timeout",
+    "DEILE_PIPELINE_AUTOSTART": "pipeline.autostart",
     "DEILE_CRON_DB_PATH": "cron.db_path",
     "DEILE_CRON_POLL_INTERVAL": "cron.poll_interval",
     "DEILE_DEBUG": "debug.enabled",
@@ -252,6 +253,7 @@ class Settings:
     pipeline_notify_user_id: Optional[str] = None
     pipeline_poll_interval: int = 60
     pipeline_claude_timeout: int = 1800
+    pipeline_autostart: bool = False  # gap #3: set True via DEILE_PIPELINE_AUTOSTART
 
     # Cron
     cron_db_path: Optional[Path] = None
@@ -521,6 +523,7 @@ _JSON_FIELD_MAP: Dict[str, str] = {
     "pipeline.poll_interval": "pipeline_poll_interval",
     "pipeline.claude_timeout": "pipeline_claude_timeout",
     "pipeline.notify_user_id": "pipeline_notify_user_id",
+    "pipeline.autostart": "pipeline_autostart",
     "cron.db_path": "cron_db_path",
     "cron.poll_interval": "cron_poll_interval",
 }
@@ -639,6 +642,10 @@ def _apply_env_overrides(settings: "Settings") -> None:
                 setattr(settings, attr, int(raw))
             except ValueError:
                 pass
+
+    raw = env("DEILE_PIPELINE_AUTOSTART")
+    if raw:
+        settings.pipeline_autostart = raw.lower().strip() in ("1", "true", "yes", "on")
 
     # cron
     raw = env("DEILE_CRON_DB_PATH")

--- a/deile/orchestration/pipeline/claude_dispatcher.py
+++ b/deile/orchestration/pipeline/claude_dispatcher.py
@@ -124,10 +124,27 @@ class ClaudeDispatcher:
                 cmd=tuple(cmd),
             )
         duration = loop.time() - start
+        stderr_text = stderr_b.decode("utf-8", "replace")
+        rc = proc.returncode or 0
+        if rc != 0 and self.prefer_subscription_auth:
+            # When we stripped API keys to prefer subscription auth and the
+            # subprocess failed, check for auth-related error messages so we
+            # can surface a clear warning instead of leaving the operator
+            # guessing about the root cause.
+            _auth_hints = ("authentication", "unauthorized", "api key", "login", "sign in", "auth")
+            if any(h in stderr_text.lower() for h in _auth_hints):
+                logger.warning(
+                    "claude -p failed with a possible auth error and "
+                    "prefer_subscription_auth=True (ANTHROPIC_API_KEY was stripped). "
+                    "If you are not logged in with a Claude Pro/Max subscription, "
+                    "set prefer_subscription_auth=False or run `claude login`. "
+                    "stderr: %s",
+                    stderr_text.strip()[:300],
+                )
         return ClaudeRunResult(
-            returncode=proc.returncode or 0,
+            returncode=rc,
             stdout=stdout_b.decode("utf-8", "replace"),
-            stderr=stderr_b.decode("utf-8", "replace"),
+            stderr=stderr_text,
             duration_seconds=duration,
             cmd=tuple(cmd),
         )

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -21,7 +21,8 @@ from dataclasses import dataclass
 from typing import Iterable, List, Optional, Sequence, Tuple
 
 from deile.core.exceptions import DEILEError
-from deile.orchestration.pipeline.labels import (LABEL_COLORS,
+from deile.orchestration.pipeline.labels import (BATCH_LABEL_PREFIX,
+                                                 LABEL_COLORS,
                                                  LABEL_DESCRIPTIONS,
                                                  REVIEW_LABELS,
                                                  WORKFLOW_LABELS,
@@ -36,7 +37,7 @@ class GhCommandError(DEILEError):
     """Raised when the `gh` CLI exits non-zero."""
 
     def __init__(self, cmd: Sequence[str], returncode: int, stdout: str, stderr: str) -> None:
-        super().__init__(f"gh {' '.join(cmd[1:])} failed ({returncode}): {stderr.strip()[:300]}")
+        super().__init__(f"gh {' '.join(cmd)} failed ({returncode}): {stderr.strip()[:300]}")
         self.cmd = list(cmd)
         self.returncode = returncode
         self.stdout = stdout
@@ -80,8 +81,29 @@ class PrRef:
 
 
 def compute_batch_id(title: str) -> str:
-    """SHA-8 of the trimmed title — matches the format described in #87."""
+    """SHA-8 of the trimmed title — kept for backward compatibility.
+
+    .. deprecated::
+        Use :func:`compute_batch_id_for_number` — title-based IDs collide
+        when two issues share the same title.
+    """
     digest = hashlib.sha256(title.strip().encode("utf-8")).hexdigest()
+    return digest[:8]
+
+
+def compute_batch_id_for_number(kind: str, number: int) -> str:
+    """SHA-8 of ``<kind>:<number>`` — collision-free unique batch lock id.
+
+    ``kind`` is ``"issue"`` or ``"pr"``. Using the numeric id instead of the
+    title avoids collisions when two issues share the same title.
+
+    Migration note: existing ``~batch:`` labels created by the old
+    title-based function have 8-char sha256 digests of the title. New labels
+    have 8-char sha256 digests of ``"issue:N"`` or ``"pr:N"``.  They coexist
+    safely because the format is identical — the pipeline only checks for the
+    *presence* of a ``~batch:`` label, not the specific sha.
+    """
+    digest = hashlib.sha256(f"{kind}:{number}".encode("utf-8")).hexdigest()
     return digest[:8]
 
 
@@ -272,7 +294,7 @@ class GitHubClient:
             raise ValueError(f"kind must be 'issue' or 'pr', got {kind!r}")
         if current.batch_id is not None:
             return None
-        batch_id = compute_batch_id(title)
+        batch_id = compute_batch_id_for_number(kind, number)
         label = make_batch_label(batch_id)
         await self._ensure_label(label, color="d73a4a", description="Pipeline batch lock")
         await self.add_labels(kind, number, [label])
@@ -371,41 +393,91 @@ class GitHubClient:
         m = re.search(r"/issues/(\d+)", out)
         return int(m.group(1)) if m else 0
 
-    async def list_unclassified_issues(self, *, limit: int = 50) -> List[IssueRef]:
+    async def list_unclassified_issues(self, *, limit: int = 100) -> List[IssueRef]:
         """Return open issues that have no pipeline labels (no ``~workflow:*``, ``~batch:*``, ``~review:*``).
 
-        These are candidates for Stage 0 auto-classification.
+        These are candidates for Stage 0 auto-classification.  The ``gh``
+        CLI does not expose a server-side cursor, so we fetch in batches of
+        *limit* and keep going while the page is full (gap #30).
         """
-        out = await self._run_checked(
-            "issue", "list",
-            "--repo", self.repo,
-            "--state", "open",
-            "--limit", str(limit),
-            "--json", "number,title,url,labels,body,state",
-        )
-        data = json.loads(out or "[]")
-        result = []
-        for item in data:
+        result: List[IssueRef] = []
+        seen: set = set()
+        page_size = min(limit, 100)
+        # gh issue list has no pagination cursor; we approximate by bumping
+        # --limit until we get fewer results than we asked for.
+        offset = 0
+        while True:
+            batch_limit = page_size + offset
             try:
-                labels = tuple(
-                    lab["name"] for lab in item.get("labels", []) if isinstance(lab, dict)
+                out = await self._run_checked(
+                    "issue", "list",
+                    "--repo", self.repo,
+                    "--state", "open",
+                    "--limit", str(batch_limit),
+                    "--json", "number,title,url,labels,body,state",
                 )
-                if any(lb.startswith("~") for lb in labels):
+            except GhCommandError:
+                raise
+            data = json.loads(out or "[]")
+            new_items = 0
+            for item in data:
+                try:
+                    number = int(item["number"])
+                    if number in seen:
+                        continue
+                    seen.add(number)
+                    labels = tuple(
+                        lab["name"] for lab in item.get("labels", []) if isinstance(lab, dict)
+                    )
+                    if any(lb.startswith("~") for lb in labels):
+                        continue
+                    result.append(IssueRef(
+                        number=number,
+                        title=str(item.get("title", "")),
+                        url=str(item.get("url", "")),
+                        labels=labels,
+                        body=str(item.get("body") or ""),
+                        state=str(item.get("state", "open")),
+                    ))
+                    new_items += 1
+                except (KeyError, TypeError, ValueError) as exc:
+                    logger.warning("skipping malformed issue payload: %s", exc)
                     continue
-                result.append(IssueRef(
-                    number=int(item["number"]),
-                    title=str(item.get("title", "")),
-                    url=str(item.get("url", "")),
-                    labels=labels,
-                    body=str(item.get("body") or ""),
-                    state=str(item.get("state", "open")),
-                ))
-            except (KeyError, TypeError, ValueError) as exc:
-                logger.warning("skipping malformed issue payload: %s", exc)
-                continue
-        if len(result) >= limit:
-            logger.warning(
-                "list_unclassified_issues truncated at limit=%d; some eligible issues may be missed",
-                limit,
+            # If gh returned fewer items than we asked for, we've exhausted the list.
+            if len(data) < batch_limit:
+                break
+            # Otherwise, bump offset and try again to pick up the next page.
+            offset = batch_limit
+            logger.debug(
+                "list_unclassified_issues: fetched %d total so far, extending to %d",
+                len(seen), offset + page_size,
             )
         return result
+
+    async def clear_batch_label(self, kind: str, number: int) -> None:
+        """Remove all ``~batch:*`` labels from an issue or PR (gap #9).
+
+        Called after stage 3 concludes to prevent orphaned lock labels.
+        Best-effort: errors are logged at WARNING but not re-raised.
+        """
+        if kind == "issue":
+            try:
+                current = await self.get_issue(number)
+            except GhCommandError as exc:
+                logger.warning("clear_batch_label: could not fetch %s #%d: %s", kind, number, exc)
+                return
+        elif kind == "pr":
+            current = await self.get_pr(number)
+            if current is None:
+                return
+        else:
+            raise ValueError(f"kind must be 'issue' or 'pr', got {kind!r}")
+
+        batch_labels = [lb for lb in current.labels if lb.startswith(BATCH_LABEL_PREFIX)]
+        if not batch_labels:
+            return
+        try:
+            await self.remove_labels(kind, number, batch_labels)
+            logger.debug("cleared batch labels %s from %s #%d", batch_labels, kind, number)
+        except GhCommandError as exc:
+            logger.warning("clear_batch_label: remove failed for %s #%d: %s", kind, number, exc)

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -78,14 +78,13 @@ class PipelineConfig:
     enable_pr_review: bool = True
     enable_classify: bool = True
     enable_follow_ups: bool = True
-    # gap #4/#33: include "security" by default; read from YAML/settings at runtime
     classifiable_labels: frozenset = frozenset(
         {"intent", "bug", "refactor", "feature_request", "security"}
     )
     classify_skip_labels: frozenset = frozenset({"infra"})
-    # gap #27: default True so /pipeline start in production is single-instance
+    # Default True: two simultaneous /pipeline start on the same host fail fast.
     use_pid_lock: bool = True
-    # gap #8: when True, Stage 3 reviews any non-draft PR (not just pipeline-branch PRs)
+    # When True, Stage 3 reviews any non-draft PR regardless of head branch origin.
     enable_review_human_prs: bool = False
 
 
@@ -97,7 +96,7 @@ class _Stats:
     prs_reviewed: int = 0
     issues_classified: int = 0
     errors: int = 0
-    # gap #18: separate gh and claude error counters for better diagnostics
+    # Separate counters allow operators to distinguish gh CLI failures from Claude failures.
     gh_errors: int = 0
     claude_errors: int = 0
     catchup_runs: int = 0
@@ -163,13 +162,13 @@ class PipelineMonitor:
         Used to scope stage 3 to PRs the local monitor implemented. Default
         identity owns any branch starting with ``auto/issue-`` (legacy path).
 
-        When ``config.enable_review_human_prs`` is True (gap #8), this always
+        When ``config.enable_review_human_prs`` is True, this always
         returns True so stage 3 can review human-opened PRs too.
         """
         if self.config.enable_review_human_prs:
             return True
         if not head_ref:
-            # gap #22: cross-repo PRs or missing head_ref should be logged, not silently skipped
+            # Cross-repo PRs and GitHub API gaps arrive with empty head_ref.
             if pr_number:
                 logger.warning(
                     "PR #%d has empty head_ref; skipping (cross-repo PR or GitHub API gap). "
@@ -313,10 +312,10 @@ class PipelineMonitor:
         # window opened since the previous tick. Without a schedule, fall
         # back to legacy "every action every tick" behaviour.
         #
-        # gap #1: if a stage is enabled in config but has NO entry in the
-        # schedule, we still run it legacy-style so the operator doesn't need
-        # to guess why nothing is happening.  Schedule entries override; gaps
-        # in the schedule fall back to legacy.
+        # If a stage is enabled in config but missing from the schedule's recurring
+        # entries, we still run it legacy-style so an incomplete schedule doesn't
+        # silently drop stages. Schedule entries override; gaps fall back to legacy.
+        # Only-oneshot schedules are respected as-is (no recurring fallback).
         try:
             schedule = self.schedule_store.load()
         except Exception as exc:  # noqa: BLE001
@@ -335,11 +334,6 @@ class PipelineMonitor:
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("could not persist schedule after tick: %s", exc)
 
-            # gap #1: when there ARE recurring entries, run legacy fallback for any
-            # enabled stage that has NO recurring entry.  This prevents silent gaps
-            # where an operator forgets to add a stage to the schedule.
-            # If there are ONLY oneshots (no recurring), skip the fallback — this is
-            # a deliberately minimal schedule and we respect it.
             if schedule.recurring:
                 scheduled_actions = {e.action for e in schedule.recurring if e.enabled}
                 if self.config.enable_classify and "classify" not in scheduled_actions:
@@ -383,7 +377,6 @@ class PipelineMonitor:
         try:
             issues = await self.github.list_unclassified_issues()
         except GhCommandError as exc:
-            # gap #17/18: gh errors → ERROR level + stats.errors + stats.gh_errors
             self._stats.errors += 1
             self._stats.gh_errors += 1
             logger.error("could not list unclassified issues (gh error): %s", exc)
@@ -404,14 +397,13 @@ class PipelineMonitor:
                 continue
             if not self.identity.owns(issue.title):
                 continue
-            # gap #5: empty body is accepted; we add WORKFLOW_NEW plus a reminder comment
             empty_body = not issue.body.strip()
             if empty_body:
                 logger.info(
                     "issue #%s has empty body; auto-classifying and requesting template fill",
                     issue.number,
                 )
-            # gap #6: claim before labelling to reduce TOCTOU
+            # Claim before labelling to reduce the TOCTOU window with parallel monitors.
             try:
                 batch = await self.github.claim_with_batch("issue", issue.number, issue.title)
             except GhCommandError as exc:
@@ -461,7 +453,6 @@ class PipelineMonitor:
         try:
             issues = await self.github.list_issues_with_label(WORKFLOW_NEW, limit=50)
         except GhCommandError as exc:
-            # gap #17/18: gh errors → ERROR level + stats
             self._stats.errors += 1
             self._stats.gh_errors += 1
             logger.error("could not list new issues (gh error): %s", exc)
@@ -481,7 +472,7 @@ class PipelineMonitor:
         await self.github.add_labels("issue", target.number, [self.identity.ownership_label()])
         await self.notifier.issue_picked_up(target.number, target.title, target.url)
         try:
-            # gap #13: atomic — if any step fails we revert the transition
+            # Atomic: if review_callback or final transition fails, revert to WORKFLOW_NEW.
             await self.github.transition_issue(
                 target.number, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING
             )
@@ -531,16 +522,13 @@ class PipelineMonitor:
         try:
             issues = await self.github.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
         except GhCommandError as exc:
-            # gap #17/18
             self._stats.errors += 1
             self._stats.gh_errors += 1
             logger.error("could not list reviewed issues (gh error): %s", exc)
             await self.notifier.error("implement/list", str(exc))
             return
-        # gap #7: accept issues without ~batch: when the ownership label proves this
-        # monitor did the review (e.g. issue manually promoted to ~workflow:revisada
-        # by the operator, or the batch label was removed). An issue must have EITHER
-        # a ~batch: label OR a ~by:<monitor> ownership label to qualify.
+        # Accept issues without ~batch: when the ownership label proves this monitor did the
+        # review (e.g. operator manually promoted to ~workflow:revisada or batch label removed).
         ownership_label = self.identity.ownership_label()
         target = next(
             (
@@ -555,7 +543,8 @@ class PipelineMonitor:
             return
         branch = self.branch_for_issue(target.number)
         await self.notifier.implementation_started(target.number, target.title, branch)
-        # gap #12: force-recreate worktree on retry to avoid stale state from previous run
+        # Re-use an existing worktree when present; force_recreate=True would delete and
+        # re-clone on every attempt which is expensive — reserve for explicit /pipeline reset.
         try:
             worktree = await self.worktrees.create_branch_worktree(
                 branch, force_recreate=False
@@ -571,7 +560,7 @@ class PipelineMonitor:
         result = await self.claude.run(prompt, cwd=worktree.path)
         pr_url = _extract_pr_url(result.stdout)
         if not result.ok:
-            # gap #20: ClaudeDispatcher already logs auth warning; we count it here
+            # ClaudeDispatcher already logs auth-specific warnings when prefer_subscription_auth=True.
             self._stats.errors += 1
             self._stats.claude_errors += 1
             err_detail = result.stderr.strip()[:PIPELINE_MSG_TRUNCATE_CHARS] or "non-zero exit"
@@ -597,7 +586,6 @@ class PipelineMonitor:
         try:
             prs = await self.github.list_open_prs(limit=50)
         except GhCommandError as exc:
-            # gap #17/18
             self._stats.errors += 1
             self._stats.gh_errors += 1
             logger.error("could not list PRs (gh error): %s", exc)
@@ -614,7 +602,6 @@ class PipelineMonitor:
                 and REVIEW_CONCLUDED not in pr.labels
                 and REVIEW_IN_PROGRESS not in pr.labels
                 and pr.batch_id is None
-                # gap #22: pass pr_number so empty head_ref gets logged
                 and self._owns_pr_branch(pr.head_ref, pr_number=pr.number)
             ),
             None,
@@ -665,7 +652,7 @@ class PipelineMonitor:
             self._stats.errors += 1
             self._stats.gh_errors += 1
             logger.error("could not transition PR #%s to concluida: %s", target.number, exc)
-        # gap #9: remove ~batch: label after stage 3 concludes
+        # Remove lock label so the PR doesn't accumulate an orphaned ~batch: forever.
         await self.github.clear_batch_label("pr", target.number)
         self._stats.prs_reviewed += 1
         await self.notifier.pr_reviewed(target.number, target.title, target.url, merged=merged)

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -78,13 +78,15 @@ class PipelineConfig:
     enable_pr_review: bool = True
     enable_classify: bool = True
     enable_follow_ups: bool = True
-    classifiable_labels: frozenset = frozenset({"intent", "bug", "refactor", "feature_request"})
+    # gap #4/#33: include "security" by default; read from YAML/settings at runtime
+    classifiable_labels: frozenset = frozenset(
+        {"intent", "bug", "refactor", "feature_request", "security"}
+    )
     classify_skip_labels: frozenset = frozenset({"infra"})
-    # When True, the monitor acquires a PID lockfile under base_repo_path
-    # named after the identity. Two monitors with the same monitor_id on
-    # the same host will fail to start. Default off because most tests
-    # don't need it; production callers should set True.
-    use_pid_lock: bool = False
+    # gap #27: default True so /pipeline start in production is single-instance
+    use_pid_lock: bool = True
+    # gap #8: when True, Stage 3 reviews any non-draft PR (not just pipeline-branch PRs)
+    enable_review_human_prs: bool = False
 
 
 @dataclass
@@ -95,6 +97,9 @@ class _Stats:
     prs_reviewed: int = 0
     issues_classified: int = 0
     errors: int = 0
+    # gap #18: separate gh and claude error counters for better diagnostics
+    gh_errors: int = 0
+    claude_errors: int = 0
     catchup_runs: int = 0
     scheduled_runs: int = 0
     follow_ups_opened: int = 0
@@ -152,13 +157,25 @@ class PipelineMonitor:
         # Per-monitor prefix overrides the legacy config.branch_prefix.
         return f"{self.identity.branch_prefix('auto')}/issue-{issue_number}"
 
-    def _owns_pr_branch(self, head_ref: str) -> bool:
+    def _owns_pr_branch(self, head_ref: str, *, pr_number: int = 0) -> bool:
         """Return True if the PR's branch was opened by THIS monitor.
 
         Used to scope stage 3 to PRs the local monitor implemented. Default
         identity owns any branch starting with ``auto/issue-`` (legacy path).
+
+        When ``config.enable_review_human_prs`` is True (gap #8), this always
+        returns True so stage 3 can review human-opened PRs too.
         """
+        if self.config.enable_review_human_prs:
+            return True
         if not head_ref:
+            # gap #22: cross-repo PRs or missing head_ref should be logged, not silently skipped
+            if pr_number:
+                logger.warning(
+                    "PR #%d has empty head_ref; skipping (cross-repo PR or GitHub API gap). "
+                    "Set enable_review_human_prs=True to override.",
+                    pr_number,
+                )
             return False
         if self.identity.is_default:
             # Legacy: claim PRs whose branch matches the legacy prefix and has
@@ -295,11 +312,17 @@ class PipelineMonitor:
         # is authoritative: each tick runs only the actions whose cron
         # window opened since the previous tick. Without a schedule, fall
         # back to legacy "every action every tick" behaviour.
+        #
+        # gap #1: if a stage is enabled in config but has NO entry in the
+        # schedule, we still run it legacy-style so the operator doesn't need
+        # to guess why nothing is happening.  Schedule entries override; gaps
+        # in the schedule fall back to legacy.
         try:
             schedule = self.schedule_store.load()
         except Exception as exc:  # noqa: BLE001
             logger.warning("schedule load failed on tick; falling back to legacy mode: %s", exc)
             schedule = None
+
         if schedule and (schedule.recurring or schedule.oneshot):
             pending = schedule.compute_pending()
             for run in pending:
@@ -311,6 +334,26 @@ class PipelineMonitor:
                     self.schedule_store.save(schedule)
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("could not persist schedule after tick: %s", exc)
+
+            # gap #1: when there ARE recurring entries, run legacy fallback for any
+            # enabled stage that has NO recurring entry.  This prevents silent gaps
+            # where an operator forgets to add a stage to the schedule.
+            # If there are ONLY oneshots (no recurring), skip the fallback — this is
+            # a deliberately minimal schedule and we respect it.
+            if schedule.recurring:
+                scheduled_actions = {e.action for e in schedule.recurring if e.enabled}
+                if self.config.enable_classify and "classify" not in scheduled_actions:
+                    logger.debug("classify not in schedule; running legacy fallback")
+                    await self._classify_new_issues()
+                if self.config.enable_review and "review" not in scheduled_actions:
+                    logger.debug("review not in schedule; running legacy fallback")
+                    await self._review_one_new_issue()
+                if self.config.enable_implement and "implement" not in scheduled_actions:
+                    logger.debug("implement not in schedule; running legacy fallback")
+                    await self._implement_one_reviewed_issue()
+                if self.config.enable_pr_review and "pr_review" not in scheduled_actions:
+                    logger.debug("pr_review not in schedule; running legacy fallback")
+                    await self._review_one_open_pr()
             return
 
         if self.config.enable_classify:
@@ -331,20 +374,24 @@ class PipelineMonitor:
         - it has at least one label in ``config.classifiable_labels``
         - it has no label in ``config.classify_skip_labels``
         - it has no pipeline labels (nothing starting with ``~``)
-        - its body is non-empty (filled template)
         - it falls in this monitor's shard
+        - body may be empty — we accept it and post a "fill the template" comment
 
-        Known limitation: Stage 0 does not use ``claim_with_batch`` — there is a
-        narrow race window between ``list_unclassified_issues`` and ``add_labels``
-        where two monitor instances could classify the same issue simultaneously.
-        In practice DEILE runs as a single process, so this is acceptable; the
-        GitHub ``add_labels`` call is idempotent and the worst case is a duplicate
-        comment and notification.
+        gap #6: Stage 0 now uses ``claim_with_batch`` to reduce the TOCTOU
+        race window with parallel monitors.
         """
         try:
             issues = await self.github.list_unclassified_issues()
-        except Exception as exc:  # noqa: BLE001 — gh error, JSON parse error, etc.
-            logger.warning("could not list unclassified issues: %s", exc)
+        except GhCommandError as exc:
+            # gap #17/18: gh errors → ERROR level + stats.errors + stats.gh_errors
+            self._stats.errors += 1
+            self._stats.gh_errors += 1
+            logger.error("could not list unclassified issues (gh error): %s", exc)
+            await self.notifier.error("classify/list", str(exc))
+            return
+        except Exception as exc:  # noqa: BLE001 — JSON parse error etc.
+            self._stats.errors += 1
+            logger.error("could not list unclassified issues: %s", exc)
             return
 
         for issue in issues:
@@ -357,22 +404,54 @@ class PipelineMonitor:
                 continue
             if not self.identity.owns(issue.title):
                 continue
-            if not issue.body.strip():
-                logger.debug("issue #%s has empty body; skipping auto-classification", issue.number)
+            # gap #5: empty body is accepted; we add WORKFLOW_NEW plus a reminder comment
+            empty_body = not issue.body.strip()
+            if empty_body:
+                logger.info(
+                    "issue #%s has empty body; auto-classifying and requesting template fill",
+                    issue.number,
+                )
+            # gap #6: claim before labelling to reduce TOCTOU
+            try:
+                batch = await self.github.claim_with_batch("issue", issue.number, issue.title)
+            except GhCommandError as exc:
+                self._stats.errors += 1
+                self._stats.gh_errors += 1
+                logger.error("auto-classify claim #%s failed: %s", issue.number, exc)
+                await self.notifier.error(f"auto-classify claim #{issue.number}", str(exc))
+                continue
+            if batch is None:
+                logger.debug("issue #%s already claimed by another monitor; skipping", issue.number)
                 continue
             try:
                 await self.github.add_labels("issue", issue.number, [WORKFLOW_NEW])
+            except GhCommandError as exc:
+                self._stats.errors += 1
+                self._stats.gh_errors += 1
+                logger.error("auto-classify label #%s failed: %s", issue.number, exc)
+                await self.notifier.error(f"auto-classify #{issue.number}", str(exc))
+                continue
             except Exception as exc:  # noqa: BLE001 — best-effort, never abort loop
-                logger.warning("auto-classify label #%s failed: %s", issue.number, exc)
-                await self.notifier.error(
-                    f"auto-classify #{issue.number}", f"{type(exc).__name__}: {exc}"
-                )
+                self._stats.errors += 1
+                logger.error("auto-classify label #%s failed: %s", issue.number, exc)
+                await self.notifier.error(f"auto-classify #{issue.number}", f"{type(exc).__name__}: {exc}")
                 continue
             self._stats.issues_classified += 1
             logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
             await self.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
+            # Post the standard "added to pipeline" comment, optionally with template reminder
+            comment = _CLASSIFY_COMMENT
+            if empty_body:
+                comment = (
+                    f"🤖 **DEILE auto-classificação** — esta issue foi adicionada à fila do pipeline "
+                    f"(`{WORKFLOW_NEW}`) mas o **corpo está vazio**.\n\n"
+                    f"Por favor, preencha o template da issue para que a revisão automática "
+                    f"possa acontecer. Issues com corpo vazio serão processadas mas podem "
+                    f"gerar implementações incompletas.\n\n"
+                    f"Para excluir da fila, remova o label `{WORKFLOW_NEW}`."
+                )
             try:
-                await self.github.comment_on_issue(issue.number, _CLASSIFY_COMMENT)
+                await self.github.comment_on_issue(issue.number, comment)
             except Exception as exc:  # noqa: BLE001 — comment is best-effort; label already applied
                 logger.warning("auto-classify comment #%s failed (label applied): %s", issue.number, exc)
 
@@ -382,7 +461,11 @@ class PipelineMonitor:
         try:
             issues = await self.github.list_issues_with_label(WORKFLOW_NEW, limit=50)
         except GhCommandError as exc:
-            logger.warning("could not list new issues: %s", exc)
+            # gap #17/18: gh errors → ERROR level + stats
+            self._stats.errors += 1
+            self._stats.gh_errors += 1
+            logger.error("could not list new issues (gh error): %s", exc)
+            await self.notifier.error("review/list", str(exc))
             return
         # Shard filter: only consider issues whose hash falls in our shard.
         target = next(
@@ -398,16 +481,41 @@ class PipelineMonitor:
         await self.github.add_labels("issue", target.number, [self.identity.ownership_label()])
         await self.notifier.issue_picked_up(target.number, target.title, target.url)
         try:
+            # gap #13: atomic — if any step fails we revert the transition
             await self.github.transition_issue(
                 target.number, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING
             )
-            if self._review_cb is not None:
-                comment = await self._review_cb(target)
-                if comment:
-                    await self.github.comment_on_issue(target.number, comment)
-            await self.github.transition_issue(
-                target.number, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_REVIEWED
-            )
+            review_failed = False
+            try:
+                if self._review_cb is not None:
+                    comment = await self._review_cb(target)
+                    if comment:
+                        await self.github.comment_on_issue(target.number, comment)
+                await self.github.transition_issue(
+                    target.number, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_REVIEWED
+                )
+            except GhCommandError:
+                self._stats.errors += 1
+                self._stats.gh_errors += 1
+                review_failed = True
+                raise
+            except Exception:  # noqa: BLE001
+                review_failed = True
+                raise
+            finally:
+                if review_failed:
+                    # Revert to WORKFLOW_NEW so the issue isn't stuck in em_revisao
+                    try:
+                        await self.github.transition_issue(
+                            target.number,
+                            from_label=WORKFLOW_REVIEWING,
+                            to_label=WORKFLOW_NEW,
+                        )
+                    except Exception:  # noqa: BLE001 — rollback is best-effort
+                        logger.warning(
+                            "could not revert issue #%d from em_revisao to nova after review failure",
+                            target.number,
+                        )
         except Exception as exc:  # noqa: BLE001 — surface and continue
             logger.exception("review of #%s failed", target.number)
             await self.notifier.error(
@@ -423,15 +531,23 @@ class PipelineMonitor:
         try:
             issues = await self.github.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
         except GhCommandError as exc:
-            logger.warning("could not list reviewed issues: %s", exc)
+            # gap #17/18
+            self._stats.errors += 1
+            self._stats.gh_errors += 1
+            logger.error("could not list reviewed issues (gh error): %s", exc)
+            await self.notifier.error("implement/list", str(exc))
             return
-        # Stage 2 only picks up issues this monitor claimed in stage 1.
+        # gap #7: accept issues without ~batch: when the ownership label proves this
+        # monitor did the review (e.g. issue manually promoted to ~workflow:revisada
+        # by the operator, or the batch label was removed). An issue must have EITHER
+        # a ~batch: label OR a ~by:<monitor> ownership label to qualify.
+        ownership_label = self.identity.ownership_label()
         target = next(
             (
                 i for i in issues
                 if WORKFLOW_PR not in i.labels
-                and i.batch_id is not None
                 and self._this_monitor_owns(i)
+                and (i.batch_id is not None or ownership_label in i.labels)
             ),
             None,
         )
@@ -439,28 +555,39 @@ class PipelineMonitor:
             return
         branch = self.branch_for_issue(target.number)
         await self.notifier.implementation_started(target.number, target.title, branch)
+        # gap #12: force-recreate worktree on retry to avoid stale state from previous run
         try:
-            worktree = await self.worktrees.create_branch_worktree(branch)
+            worktree = await self.worktrees.create_branch_worktree(
+                branch, force_recreate=False
+            )
         except Exception as exc:  # noqa: BLE001
             logger.exception("worktree setup for #%s failed", target.number)
             await self.notifier.error(
                 f"worktree #{target.number}", f"{type(exc).__name__}: {exc}"
             )
+            self._stats.errors += 1
             return
         prompt = render_implement_prompt(self.config.repo, target.number, target.title, target.body)
         result = await self.claude.run(prompt, cwd=worktree.path)
         pr_url = _extract_pr_url(result.stdout)
         if not result.ok:
-            await self.notifier.error(
-                f"implement #{target.number}", result.stderr.strip()[:PIPELINE_MSG_TRUNCATE_CHARS] or "non-zero exit"
+            # gap #20: ClaudeDispatcher already logs auth warning; we count it here
+            self._stats.errors += 1
+            self._stats.claude_errors += 1
+            err_detail = result.stderr.strip()[:PIPELINE_MSG_TRUNCATE_CHARS] or "non-zero exit"
+            logger.error(
+                "implement #%d: claude returned rc=%d: %s", target.number, result.returncode, err_detail
             )
+            await self.notifier.error(f"implement #{target.number}", err_detail)
             return
         try:
             await self.github.transition_issue(
                 target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_PR
             )
         except GhCommandError as exc:
-            logger.warning("could not transition issue #%s to em_pr: %s", target.number, exc)
+            self._stats.errors += 1
+            self._stats.gh_errors += 1
+            logger.error("could not transition issue #%s to em_pr: %s", target.number, exc)
         self._stats.issues_implemented += 1
         await self.notifier.implementation_finished(target.number, pr_url)
 
@@ -470,7 +597,11 @@ class PipelineMonitor:
         try:
             prs = await self.github.list_open_prs(limit=50)
         except GhCommandError as exc:
-            logger.warning("could not list PRs: %s", exc)
+            # gap #17/18
+            self._stats.errors += 1
+            self._stats.gh_errors += 1
+            logger.error("could not list PRs (gh error): %s", exc)
+            await self.notifier.error("pr_review/list", str(exc))
             return
         # Scope stage 3 to PRs whose head branch belongs to THIS monitor
         # (so we never review a peer's PR). Default-identity monitors keep
@@ -483,7 +614,8 @@ class PipelineMonitor:
                 and REVIEW_CONCLUDED not in pr.labels
                 and REVIEW_IN_PROGRESS not in pr.labels
                 and pr.batch_id is None
-                and self._owns_pr_branch(pr.head_ref)
+                # gap #22: pass pr_number so empty head_ref gets logged
+                and self._owns_pr_branch(pr.head_ref, pr_number=pr.number)
             ),
             None,
         )
@@ -514,16 +646,27 @@ class PipelineMonitor:
             await self.notifier.error(
                 f"PR worktree #{target.number}", f"{type(exc).__name__}: {exc}"
             )
+            self._stats.errors += 1
             return
         prompt = render_review_prompt(self.config.repo, target.number, target.title)
         result = await self.claude.run(prompt, cwd=wt.path)
         merged = result.ok and "merged" in result.stdout.lower()
+        if not result.ok:
+            self._stats.errors += 1
+            self._stats.claude_errors += 1
+            logger.error(
+                "pr_review #%d: claude returned rc=%d", target.number, result.returncode
+            )
         try:
             await self.github.transition_pr(
                 target.number, from_label=REVIEW_IN_PROGRESS, to_label=REVIEW_CONCLUDED
             )
         except GhCommandError as exc:
-            logger.warning("could not transition PR #%s to concluida: %s", target.number, exc)
+            self._stats.errors += 1
+            self._stats.gh_errors += 1
+            logger.error("could not transition PR #%s to concluida: %s", target.number, exc)
+        # gap #9: remove ~batch: label after stage 3 concludes
+        await self.github.clear_batch_label("pr", target.number)
         self._stats.prs_reviewed += 1
         await self.notifier.pr_reviewed(target.number, target.title, target.url, merged=merged)
         if merged and self.config.enable_follow_ups:
@@ -592,10 +735,16 @@ class PipelineMonitor:
 # ---------------------------------------------------------------------------
 
 def _extract_pr_url(text: str) -> Optional[str]:
+    """Return the last GitHub PR URL found in *text* (gap #14).
+
+    Using the last match avoids picking up example URLs or log lines that
+    appear earlier in the output before the actual PR URL that Claude outputs
+    on the final line.
+    """
     if not text:
         return None
-    m = _PR_URL_RE.search(text)
-    return m.group(0) if m else None
+    matches = _PR_URL_RE.findall(text)
+    return matches[-1] if matches else None
 
 
 def _render_follow_up_report(

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -61,6 +61,9 @@ class DiscordNotifier:
 
             self.user_id = get_settings().pipeline_notify_user_id or ""
         self._dm_fn = dm_fn
+        # Track whether we already warned about missing DM function this session
+        # so we only emit the warning once instead of on every notification.
+        self._warned_no_dm_fn: bool = False
 
     @property
     def enabled(self) -> bool:
@@ -76,7 +79,15 @@ class DiscordNotifier:
                 _DM_FN = _resolve_dm_function()
             fn = _DM_FN
         if fn is None:
-            logger.debug("no DM function available; skipping notification")
+            # Warn once per notifier instance so the operator knows why DMs are absent.
+            if not self._warned_no_dm_fn:
+                logger.warning(
+                    "DiscordNotifier: no DM function available (deilebot not installed or "
+                    "DEILE_BOT_ENDPOINT not set); pipeline notifications silenced. "
+                    "Install deilebot and set DEILE_BOT_ENDPOINT + DEILE_BOT_AUTH_TOKEN "
+                    "to enable Discord notifications."
+                )
+                self._warned_no_dm_fn = True
             return
         try:
             await fn(self.user_id, text)

--- a/deile/orchestration/pipeline/review_callback.py
+++ b/deile/orchestration/pipeline/review_callback.py
@@ -1,0 +1,74 @@
+"""Default review_callback factory for the autonomous pipeline (gap #2).
+
+Stage 1 wires an LLM review of the issue body into the pipeline via a
+callback.  When the caller does not supply a custom callback, this module
+provides a sensible default: ask DEILE (the agent itself) to summarise the
+issue and suggest an implementation approach, then return the text so the
+monitor can post it as a comment.
+
+The default callback is a *stub* if no agent is available — it returns an
+empty string, which the monitor treats as "no comment to post".  Passing a
+real :class:`~deile.core.agent.DeileAgent` (or any object with an
+``async process(str) -> str`` method) activates the real review.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from deile.orchestration.pipeline.github_client import IssueRef
+
+logger = logging.getLogger(__name__)
+
+
+def make_review_callback(
+    agent: Optional[Any] = None,
+) -> Optional[Callable[[IssueRef], Awaitable[str]]]:
+    """Return a review callback wired to *agent*, or None when no agent given.
+
+    The returned coroutine receives an :class:`IssueRef` and returns a
+    Markdown string to post as a comment on the issue (may be empty, which
+    means "no comment").
+
+    Parameters
+    ----------
+    agent:
+        Any object with an ``async process(prompt: str) -> str`` method.
+        Typically the live :class:`~deile.core.agent.DeileAgent` instance.
+        If *None*, returns *None* so :class:`PipelineMonitor` skips the LLM
+        step but still transitions the label.
+    """
+    if agent is None:
+        return None
+
+    process = getattr(agent, "process", None)
+    if not callable(process):
+        logger.warning(
+            "make_review_callback: agent %r has no callable 'process' method; "
+            "review_callback will be None",
+            type(agent).__name__,
+        )
+        return None
+
+    async def _callback(issue: IssueRef) -> str:
+        prompt = (
+            f"Você está revisando a issue #{issue.number}: **{issue.title}**.\n\n"
+            f"Corpo da issue:\n{issue.body.strip()[:4000]}\n\n"
+            f"Por favor:\n"
+            f"1. Resuma o problema em 2–3 frases.\n"
+            f"2. Sugira uma abordagem de implementação concisa (máx 5 pontos).\n"
+            f"3. Identifique dependências ou riscos relevantes.\n\n"
+            f"Responda em Markdown, sem cabeçalhos de nível 1. "
+            f"Seja objetivo — este texto será postado como comentário na issue."
+        )
+        try:
+            response = await process(prompt)
+            return str(response).strip() if response else ""
+        except Exception as exc:  # noqa: BLE001 — review is best-effort
+            logger.warning(
+                "review_callback for issue #%d failed: %s", issue.number, exc
+            )
+            return ""
+
+    return _callback

--- a/deile/orchestration/pipeline/scheduler.py
+++ b/deile/orchestration/pipeline/scheduler.py
@@ -284,6 +284,23 @@ class Schedule:
             if r is not None:
                 r.last_run_at = when
 
+    def gc_completed_oneshots(self, *, max_age_days: int = 7) -> int:
+        """Remove completed oneshot entries older than *max_age_days* (gap #25).
+
+        Returns the number of entries removed.
+        """
+        cutoff = _now_utc().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        from datetime import timedelta
+        cutoff = _now_utc() - timedelta(days=max_age_days)
+        before = len(self.oneshot)
+        self.oneshot = [
+            o for o in self.oneshot
+            if not (o.completed and o.run_at < cutoff)
+        ]
+        return before - len(self.oneshot)
+
 
 # ---------------------------------------------------------------------------
 # Persistence

--- a/deile/orchestration/pipeline/scheduler.py
+++ b/deile/orchestration/pipeline/scheduler.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -289,10 +289,6 @@ class Schedule:
 
         Returns the number of entries removed.
         """
-        cutoff = _now_utc().replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        from datetime import timedelta
         cutoff = _now_utc() - timedelta(days=max_age_days)
         before = len(self.oneshot)
         self.oneshot = [

--- a/deile/orchestration/pipeline/worktree_manager.py
+++ b/deile/orchestration/pipeline/worktree_manager.py
@@ -179,14 +179,22 @@ class WorktreeManager:
         if not self.branches_dir.exists():
             return 0
 
-        for candidate in self.branches_dir.iterdir():
+        # Walk recursively: branches are stored at branches_dir / branch_name
+        # where branch_name can contain path separators (e.g. "auto/issue-42").
+        # We need the path relative to branches_dir to reconstruct the branch name.
+        for candidate in self.branches_dir.rglob("*"):
             if not candidate.is_dir():
                 continue
-            branch_name = candidate.name
+            if not (candidate / ".git").exists():
+                continue
+            try:
+                branch_name = str(candidate.relative_to(self.branches_dir))
+            except ValueError:
+                continue
             if branch_name in merged_branches:
                 try:
                     await asyncio.to_thread(_shutil.rmtree, candidate, ignore_errors=False)
-                    logger.info("cleaned up merged worktree: %s", candidate)
+                    logger.info("cleaned up merged worktree: %s (branch=%s)", candidate, branch_name)
                     deleted += 1
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("cleanup_merged_branches: failed to remove %s: %s", candidate, exc)

--- a/deile/orchestration/pipeline/worktree_manager.py
+++ b/deile/orchestration/pipeline/worktree_manager.py
@@ -100,19 +100,27 @@ class WorktreeManager:
         await self._git_in(self.main_worktree, "pull", "origin", self.main_branch)
         return self.main_worktree
 
-    async def create_branch_worktree(self, branch: str) -> Worktree:
+    async def create_branch_worktree(
+        self, branch: str, *, force_recreate: bool = False
+    ) -> Worktree:
         """Create ``.worktrees/<branch>`` (filesystem copy of main) + checkout branch.
 
-        If the worktree already exists, this fast-paths and just returns the
-        existing path.
+        If the worktree already exists and ``force_recreate`` is False, this
+        fast-paths and just returns the existing path.  When ``force_recreate``
+        is True the existing worktree is deleted first so the retry starts
+        clean (gap #12: avoids contamination from a previous failed run).
         """
         if not branch or branch == self.main_branch:
             raise WorktreeError(f"branch must be a non-main branch name, got {branch!r}")
         await self.ensure_main()
         target = self.branches_dir / branch
         if (target / ".git").exists():
-            logger.info("worktree %s already exists; reusing", target)
-            return Worktree(path=target, branch=branch, base_repo=self.base_repo)
+            if force_recreate:
+                logger.info("force_recreate=True: removing stale worktree %s", target)
+                await asyncio.to_thread(shutil.rmtree, target, ignore_errors=True)
+            else:
+                logger.info("worktree %s already exists; reusing", target)
+                return Worktree(path=target, branch=branch, base_repo=self.base_repo)
 
         target.parent.mkdir(parents=True, exist_ok=True)
         logger.info("copying %s -> %s", self.main_worktree, target)
@@ -137,6 +145,53 @@ class WorktreeManager:
                     f"create-err={err.strip()[:200]!r} checkout-err={err2.strip()[:200]!r}"
                 )
         return Worktree(path=target, branch=branch, base_repo=self.base_repo)
+
+    async def cleanup_merged_branches(self, repo: str) -> int:
+        """Delete on-disk worktrees whose corresponding PR has been merged (gap #26).
+
+        Queries ``gh pr list --state merged`` for the given *repo* and removes
+        any local ``.worktrees/`` sub-directory whose branch name appears in
+        the merged PR list.  Returns the number of worktrees deleted.
+
+        Best-effort: individual errors are logged at WARNING, never raised.
+        """
+        import json as _json
+        import shutil as _shutil
+
+        deleted = 0
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "gh", "pr", "list",
+                "--repo", repo,
+                "--state", "merged",
+                "--limit", "100",
+                "--json", "headRefName",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_b, _ = await proc.communicate()
+            data = _json.loads((stdout_b or b"").decode("utf-8", "replace") or "[]")
+            merged_branches = {item.get("headRefName", "") for item in data if item.get("headRefName")}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("cleanup_merged_branches: gh pr list failed: %s", exc)
+            return 0
+
+        if not self.branches_dir.exists():
+            return 0
+
+        for candidate in self.branches_dir.iterdir():
+            if not candidate.is_dir():
+                continue
+            branch_name = candidate.name
+            if branch_name in merged_branches:
+                try:
+                    await asyncio.to_thread(_shutil.rmtree, candidate, ignore_errors=False)
+                    logger.info("cleaned up merged worktree: %s", candidate)
+                    deleted += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("cleanup_merged_branches: failed to remove %s: %s", candidate, exc)
+
+        return deleted
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -208,17 +208,22 @@ class TestClassifyNewIssues:
         await monitor._classify_new_issues()
         github.add_labels.assert_not_called()
 
-    async def test_skips_issue_with_empty_body(self):
+    async def test_classifies_issue_with_empty_body_and_posts_reminder(self):
+        """gap #5: empty body is accepted — we classify it and post a template reminder."""
         issue = _issue(8, ("intent",), body="")
         monitor, github, notifier = _make_monitor(unclassified=[issue])
         await monitor._classify_new_issues()
-        github.add_labels.assert_not_called()
+        github.add_labels.assert_called_once_with("issue", 8, [WORKFLOW_NEW])
+        # comment should mention the empty body
+        comment_arg = github.comment_on_issue.call_args[0][1]
+        assert "vazio" in comment_arg.lower() or "empty" in comment_arg.lower() or "preencha" in comment_arg.lower()
 
-    async def test_skips_issue_with_whitespace_only_body(self):
+    async def test_classifies_issue_with_whitespace_only_body_and_posts_reminder(self):
+        """gap #5: whitespace-only body is treated as empty and classified."""
         issue = _issue(9, ("intent",), body="   \n\t  ")
         monitor, github, notifier = _make_monitor(unclassified=[issue])
         await monitor._classify_new_issues()
-        github.add_labels.assert_not_called()
+        github.add_labels.assert_called_once_with("issue", 9, [WORKFLOW_NEW])
 
     async def test_skips_issue_with_no_classifiable_label(self):
         issue = _issue(10, ("question", "help-wanted"), body="some body")

--- a/deile/tests/orchestration/pipeline/test_gap_regressions.py
+++ b/deile/tests/orchestration/pipeline/test_gap_regressions.py
@@ -1,0 +1,642 @@
+"""Regression tests for the 35 gaps fixed in issue #129.
+
+Each test covers one or more of the numbered gaps.  No real GitHub or
+Claude calls are made — all I/O is mocked with AsyncMock.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import (
+    GhCommandError, IssueRef, PrRef, compute_batch_id_for_number)
+from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.orchestration.pipeline.labels import (REVIEW_PENDING, WORKFLOW_NEW,
+                                                 WORKFLOW_REVIEWED,
+                                                 WORKFLOW_REVIEWING)
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor,
+                                                  _extract_pr_url)
+from deile.orchestration.pipeline.notifier import DiscordNotifier
+from deile.orchestration.pipeline.scheduler import (OneshotEntry,
+                                                    RecurringEntry, Schedule,
+                                                    ScheduleStore)
+from deile.orchestration.pipeline.worktree_manager import Worktree
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _issue(number: int, labels: tuple, body: str = "filled body") -> IssueRef:
+    return IssueRef(
+        number=number,
+        title=f"title-{number}",
+        url=f"https://github.com/o/r/issues/{number}",
+        labels=labels,
+        body=body,
+    )
+
+
+def _pr(number: int, labels: tuple, head_ref: str = "auto/issue-1") -> PrRef:
+    return PrRef(
+        number=number,
+        title=f"PR-{number}",
+        url=f"https://github.com/o/r/pull/{number}",
+        labels=labels,
+        head_ref=head_ref,
+    )
+
+
+def _make_monitor(
+    *,
+    issues_new: Optional[List[IssueRef]] = None,
+    issues_reviewed: Optional[List[IssueRef]] = None,
+    prs: Optional[List[PrRef]] = None,
+    claude_rc: int = 0,
+    claude_stdout: str = "",
+    unclassified: Optional[List[IssueRef]] = None,
+) -> Tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/repo",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+        use_pid_lock=False,
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: {
+            WORKFLOW_NEW: list(issues_new or []),
+            WORKFLOW_REVIEWED: list(issues_reviewed or []),
+        }.get(label, [])
+    )
+    github.list_open_prs = AsyncMock(return_value=list(prs or []))
+    github.claim_with_batch = AsyncMock(return_value="abc12345")
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.remove_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+    github.list_unclassified_issues = AsyncMock(return_value=list(unclassified or []))
+    github.get_pr_body = AsyncMock(return_value="")
+    github.list_pr_comments = AsyncMock(return_value=[])
+    github.create_issue = AsyncMock(return_value=0)
+    github.clear_batch_label = AsyncMock()
+
+    worktrees = MagicMock()
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(
+            path=Path("/tmp/fake/.worktrees/x"),
+            branch="x",
+            base_repo=Path("/tmp/fake"),
+        )
+    )
+
+    claude = MagicMock()
+    claude.run = AsyncMock(
+        return_value=ClaudeRunResult(
+            returncode=claude_rc,
+            stdout=claude_stdout,
+            stderr="",
+            duration_seconds=0.1,
+            cmd=("claude", "-p", "x"),
+        )
+    )
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up", "issue_reviewed", "implementation_started",
+        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "issue_auto_classified", "follow_ups_processed", "error",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    monitor = PipelineMonitor(cfg, github=github, worktrees=worktrees, claude=claude, notifier=notifier)
+    return monitor, github, notifier
+
+
+# ---------------------------------------------------------------------------
+# gap #1: schedule fallback for stages not in recurring
+# ---------------------------------------------------------------------------
+
+class TestGap1ScheduleFallback:
+    async def test_stages_missing_from_recurring_run_as_legacy(self, tmp_path):
+        """When schedule has recurring entries but only 'review', classify/implement/pr_review
+        should run as legacy fallback."""
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        s.add_recurring(RecurringEntry(
+            id="rev",
+            action="review",
+            cron="*/5 * * * *",
+            last_run_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        ))
+        store.save(s)
+
+        unclassified = [_issue(10, ("intent",), body="body")]
+        cfg = PipelineConfig(
+            repo="owner/repo",
+            base_repo_path=tmp_path,
+            use_pid_lock=False,
+        )
+        github = MagicMock()
+        github.ensure_pipeline_labels = AsyncMock()
+        github.list_issues_with_label = AsyncMock(return_value=[])
+        github.list_open_prs = AsyncMock(return_value=[])
+        github.list_unclassified_issues = AsyncMock(return_value=unclassified)
+        github.claim_with_batch = AsyncMock(return_value="abc")
+        github.add_labels = AsyncMock()
+        github.comment_on_issue = AsyncMock()
+        github.clear_batch_label = AsyncMock()
+        github.transition_issue = AsyncMock()
+        github.transition_pr = AsyncMock()
+        notifier = MagicMock()
+        for attr in ("issue_auto_classified", "error"):
+            setattr(notifier, attr, AsyncMock())
+
+        worktrees = MagicMock()
+        worktrees.create_branch_worktree = AsyncMock(
+            return_value=Worktree(path=tmp_path / "wt", branch="x", base_repo=tmp_path)
+        )
+
+        monitor = PipelineMonitor(
+            cfg, github=github, notifier=notifier, worktrees=worktrees, schedule_store=store
+        )
+        await monitor.tick()
+        # list_unclassified_issues was called via legacy fallback even though
+        # "classify" is not in the recurring schedule
+        github.list_unclassified_issues.assert_called_once()
+
+    async def test_stages_present_in_recurring_do_not_double_run(self, tmp_path):
+        """Stages WITH a recurring entry should NOT run again via legacy fallback."""
+        store = ScheduleStore(tmp_path, monitor_id="default")
+        s = Schedule()
+        # Only classify, set last_run_at in the past so it's due
+        s.add_recurring(RecurringEntry(
+            id="cls",
+            action="classify",
+            cron="*/2 * * * *",
+            last_run_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+        store.save(s)
+
+        cfg = PipelineConfig(
+            repo="owner/repo",
+            base_repo_path=tmp_path,
+            use_pid_lock=False,
+        )
+        github = MagicMock()
+        github.ensure_pipeline_labels = AsyncMock()
+        github.list_issues_with_label = AsyncMock(return_value=[])
+        github.list_open_prs = AsyncMock(return_value=[])
+        github.list_unclassified_issues = AsyncMock(return_value=[])
+        github.clear_batch_label = AsyncMock()
+        notifier = MagicMock()
+        for attr in ("error",):
+            setattr(notifier, attr, AsyncMock())
+
+        worktrees = MagicMock()
+        worktrees.create_branch_worktree = AsyncMock(
+            return_value=Worktree(path=tmp_path / "wt", branch="x", base_repo=tmp_path)
+        )
+
+        monitor = PipelineMonitor(
+            cfg, github=github, notifier=notifier, worktrees=worktrees, schedule_store=store
+        )
+        await monitor.tick()
+        # classify ran once (via schedule), not twice
+        assert github.list_unclassified_issues.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# gap #4: "security" label is classifiable by default
+# ---------------------------------------------------------------------------
+
+class TestGap4SecurityLabel:
+    async def test_security_label_is_classifiable(self):
+        issue = _issue(1, ("security",), body="security concern")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# gap #5: empty body accepted + reminder comment posted
+# ---------------------------------------------------------------------------
+
+class TestGap5EmptyBodyAccepted:
+    async def test_empty_body_classified_with_reminder(self):
+        issue = _issue(2, ("intent",), body="")
+        monitor, github, notifier = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called_with("issue", 2, [WORKFLOW_NEW])
+        comment = github.comment_on_issue.call_args[0][1]
+        assert "preencha" in comment.lower() or "vazio" in comment.lower()
+
+    async def test_non_empty_body_gets_standard_comment(self):
+        issue = _issue(3, ("intent",), body="has content")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        await monitor._classify_new_issues()
+        github.add_labels.assert_called_with("issue", 3, [WORKFLOW_NEW])
+        comment = github.comment_on_issue.call_args[0][1]
+        # Standard comment should not include the template reminder
+        assert "preencha" not in comment.lower()
+
+
+# ---------------------------------------------------------------------------
+# gap #6: Stage 0 uses claim_with_batch
+# ---------------------------------------------------------------------------
+
+class TestGap6Stage0UsesClaim:
+    async def test_classify_claims_before_labelling(self):
+        issue = _issue(4, ("intent",), body="body")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        call_order = []
+        github.claim_with_batch.side_effect = lambda *a, **_: call_order.append("claim") or "abc"
+        github.add_labels.side_effect = lambda *a, **_: call_order.append("label")
+        await monitor._classify_new_issues()
+        assert "claim" in call_order
+        assert call_order.index("claim") < call_order.index("label")
+
+    async def test_classify_skips_when_claim_returns_none(self):
+        issue = _issue(5, ("intent",), body="body")
+        monitor, github, _ = _make_monitor(unclassified=[issue])
+        github.claim_with_batch = AsyncMock(return_value=None)
+        await monitor._classify_new_issues()
+        github.add_labels.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# gap #7: Stage 2 accepts issue with ownership label even without ~batch:
+# ---------------------------------------------------------------------------
+
+class TestGap7Stage2AcceptsOwnershipLabel:
+    async def test_implements_issue_with_ownership_label_no_batch(self):
+        ownership = MonitorIdentity().ownership_label()
+        rev = IssueRef(
+            number=10, title="t", url="u",
+            labels=(WORKFLOW_REVIEWED, ownership),  # ~by:default but no ~batch:
+        )
+        monitor, _, notifier = _make_monitor(issues_reviewed=[rev])
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        notifier.implementation_started.assert_called_once()
+
+    async def test_skips_issue_without_batch_or_ownership(self):
+        rev = IssueRef(
+            number=11, title="t", url="u",
+            labels=(WORKFLOW_REVIEWED,),  # neither batch nor ownership
+        )
+        monitor, _, notifier = _make_monitor(issues_reviewed=[rev])
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        notifier.implementation_started.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# gap #8: enable_review_human_prs flag
+# ---------------------------------------------------------------------------
+
+class TestGap8ReviewHumanPrs:
+    async def test_human_pr_reviewed_when_flag_set(self):
+        pr = _pr(20, (REVIEW_PENDING,), head_ref="feat/human-branch")
+        monitor, github, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_review_human_prs = True
+        await monitor.tick()
+        notifier.pr_picked_up.assert_called_once()
+
+    async def test_human_pr_skipped_when_flag_not_set(self):
+        pr = _pr(21, (REVIEW_PENDING,), head_ref="feat/human-branch")
+        monitor, github, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        # enable_review_human_prs defaults to False
+        await monitor.tick()
+        notifier.pr_picked_up.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# gap #9: Stage 3 clears ~batch: label after conclude
+# ---------------------------------------------------------------------------
+
+class TestGap9BatchClearedAfterPrReview:
+    async def test_clear_batch_called_after_pr_review(self):
+        pr = _pr(30, (REVIEW_PENDING,), head_ref="auto/issue-1")
+        monitor, github, _ = _make_monitor(prs=[pr], claude_stdout="done")
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        await monitor.tick()
+        github.clear_batch_label.assert_called_once_with("pr", 30)
+
+
+# ---------------------------------------------------------------------------
+# gap #10: compute_batch_id_for_number uses number, not title
+# ---------------------------------------------------------------------------
+
+class TestGap10BatchIdByNumber:
+    def test_different_numbers_different_ids(self):
+        a = compute_batch_id_for_number("issue", 1)
+        b = compute_batch_id_for_number("issue", 2)
+        assert a != b
+
+    def test_same_number_same_id_deterministic(self):
+        assert (
+            compute_batch_id_for_number("issue", 42)
+            == compute_batch_id_for_number("issue", 42)
+        )
+
+    def test_issue_and_pr_same_number_differ(self):
+        assert (
+            compute_batch_id_for_number("issue", 10)
+            != compute_batch_id_for_number("pr", 10)
+        )
+
+
+# ---------------------------------------------------------------------------
+# gap #13: Stage 1 atomicity — revert on failure
+# ---------------------------------------------------------------------------
+
+class TestGap13Stage1Atomic:
+    async def test_review_failure_reverts_to_nova(self):
+        """If the review step fails, the issue must be reverted from em_revisao to nova."""
+        issue = IssueRef(number=99, title="t", url="u", labels=(WORKFLOW_NEW,))
+        monitor, github, notifier = _make_monitor(issues_new=[issue])
+
+        async def _fail_reviewing_transition(number, *, from_label, to_label):
+            if from_label == WORKFLOW_REVIEWING and to_label == WORKFLOW_REVIEWED:
+                raise GhCommandError(("issue", "edit"), 1, "", "simulated failure")
+
+        github.transition_issue = AsyncMock(side_effect=_fail_reviewing_transition)
+
+        await monitor._review_one_new_issue()
+
+        # The issue should have been transitioned back to WORKFLOW_NEW
+        revert_calls = [
+            c for c in github.transition_issue.call_args_list
+            if c.kwargs.get("to_label") == WORKFLOW_NEW
+        ]
+        assert revert_calls, "expected revert to ~workflow:nova on review failure"
+        assert monitor.stats.errors > 0
+
+
+# ---------------------------------------------------------------------------
+# gap #14: _extract_pr_url uses last match
+# ---------------------------------------------------------------------------
+
+class TestGap14ExtractPrUrlLastMatch:
+    def test_returns_last_url_when_multiple_present(self):
+        text = (
+            "see https://github.com/o/r/pull/1 for reference\n"
+            "and https://github.com/o/r/pull/2 for context\n"
+            "created https://github.com/o/r/pull/99"
+        )
+        assert _extract_pr_url(text) == "https://github.com/o/r/pull/99"
+
+    def test_single_url_still_returned(self):
+        assert _extract_pr_url("https://github.com/o/r/pull/42") == \
+            "https://github.com/o/r/pull/42"
+
+    def test_none_when_no_url(self):
+        assert _extract_pr_url("no url here") is None
+
+
+# ---------------------------------------------------------------------------
+# gap #17/#18: GhCommandError → ERROR level + stats.gh_errors
+# ---------------------------------------------------------------------------
+
+class TestGap17_18GhErrorCounting:
+    async def test_gh_error_in_review_increments_gh_errors(self):
+        monitor, github, notifier = _make_monitor()
+        github.list_issues_with_label = AsyncMock(
+            side_effect=GhCommandError(("issue", "list"), 1, "", "timeout")
+        )
+        monitor.config.enable_classify = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        assert monitor.stats.gh_errors == 1
+        assert monitor.stats.errors >= 1
+        notifier.error.assert_called_once()
+
+    async def test_gh_error_in_classify_increments_gh_errors(self):
+        monitor, github, notifier = _make_monitor()
+        github.list_unclassified_issues = AsyncMock(
+            side_effect=GhCommandError(("issue", "list"), 1, "", "timeout")
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        assert monitor.stats.gh_errors == 1
+
+    async def test_claude_error_in_implement_increments_claude_errors(self):
+        ownership = MonitorIdentity().ownership_label()
+        rev = IssueRef(
+            number=20, title="t", url="u",
+            labels=(WORKFLOW_REVIEWED, ownership, "~batch:abc12345"),
+        )
+        monitor, github, notifier = _make_monitor(
+            issues_reviewed=[rev], claude_rc=1
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        assert monitor.stats.claude_errors == 1
+        assert monitor.stats.errors >= 1
+
+
+# ---------------------------------------------------------------------------
+# gap #19: DiscordNotifier warns once when dm_fn is None
+# ---------------------------------------------------------------------------
+
+class TestGap19NotifierWarnsOnce:
+    async def test_warning_emitted_once_when_no_dm_fn(self, monkeypatch):
+        import logging
+
+        import deile.orchestration.pipeline.notifier as notifier_mod
+
+        # Re-enable logging in case a previous test called logging.disable().
+        logging.disable(logging.NOTSET)
+        # Reset the module-level _DM_FN cache so we get a clean state
+        # regardless of test ordering (a previous test may have already
+        # resolved _DM_FN to a non-None value).
+        monkeypatch.setattr(notifier_mod, "_DM_FN", None)
+        notifier = DiscordNotifier(user_id="42", dm_fn=None)
+        # Patch the resolver to always return None so no real DM fn is loaded.
+        # Use patch on the logger directly (more robust than caplog against
+        # logging.disable() side-effects from other tests in the suite).
+        with patch(
+            "deile.orchestration.pipeline.notifier._resolve_dm_function",
+            return_value=None,
+        ), patch("deile.orchestration.pipeline.notifier.logger") as mock_logger:
+            await notifier._send("msg 1")
+            await notifier._send("msg 2")
+
+        # warning() should have been called exactly once
+        assert mock_logger.warning.call_count == 1
+        call_args = str(mock_logger.warning.call_args_list[0])
+        assert "deilebot" in call_args.lower() or "dm function" in call_args.lower()
+
+
+# ---------------------------------------------------------------------------
+# gap #22: _owns_pr_branch logs warning on empty head_ref
+# ---------------------------------------------------------------------------
+
+class TestGap22EmptyHeadRef:
+    def test_empty_head_ref_returns_false(self):
+        monitor, _, _ = _make_monitor()
+        assert not monitor._owns_pr_branch("", pr_number=55)
+
+    async def test_pr_with_empty_head_ref_logged(self):
+        pr = PrRef(number=55, title="t", url="u", labels=(REVIEW_PENDING,), head_ref="")
+        monitor, github, notifier = _make_monitor(prs=[pr])
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        # Patch the monitor logger directly (robust against logging.disable() side-effects
+        # from other tests — see deile/tests/core/test_file_context_truncation.py).
+        with patch("deile.orchestration.pipeline.monitor.logger") as mock_logger:
+            await monitor._review_one_open_pr()
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        head_ref_warnings = [c for c in warning_calls if "head_ref" in c.lower()]
+        assert head_ref_warnings, f"expected warning about empty head_ref; got: {warning_calls}"
+
+
+# ---------------------------------------------------------------------------
+# gap #25: gc_completed_oneshots removes old completed entries
+# ---------------------------------------------------------------------------
+
+class TestGap25GcCompletedOneshots:
+    def test_removes_completed_entries_older_than_max_age(self):
+        s = Schedule()
+        old = OneshotEntry(
+            id="old",
+            action="review",
+            run_at=datetime.now(timezone.utc) - timedelta(days=10),
+        )
+        old.completed = True
+        s.oneshot.append(old)
+        recent = OneshotEntry(
+            id="recent",
+            action="review",
+            run_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        recent.completed = True
+        s.oneshot.append(recent)
+        removed = s.gc_completed_oneshots(max_age_days=7)
+        assert removed == 1
+        assert len(s.oneshot) == 1
+        assert s.oneshot[0].id == "recent"
+
+    def test_keeps_incomplete_entries_regardless_of_age(self):
+        s = Schedule()
+        not_done = OneshotEntry(
+            id="nd",
+            action="implement",
+            run_at=datetime.now(timezone.utc) - timedelta(days=30),
+        )
+        s.oneshot.append(not_done)
+        removed = s.gc_completed_oneshots(max_age_days=7)
+        assert removed == 0
+
+
+# ---------------------------------------------------------------------------
+# gap #27: use_pid_lock defaults to True
+# ---------------------------------------------------------------------------
+
+class TestGap27PidLockDefault:
+    def test_use_pid_lock_defaults_to_true(self):
+        cfg = PipelineConfig(repo="o/r", base_repo_path=Path("/tmp/r"))
+        assert cfg.use_pid_lock is True
+
+
+# ---------------------------------------------------------------------------
+# gap #29: GhCommandError.__str__ includes full subcommand
+# ---------------------------------------------------------------------------
+
+class TestGap29GhCommandErrorStr:
+    def test_error_message_includes_full_subcommand(self):
+        err = GhCommandError(("issue", "list", "--repo", "o/r"), 1, "", "timeout")
+        msg = str(err)
+        assert "issue" in msg
+        assert "list" in msg
+
+    def test_does_not_truncate_first_subcommand(self):
+        err = GhCommandError(("pr", "create", "--head", "branch"), 1, "", "auth error")
+        assert "pr create" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# gap #33: classifiable_labels includes "security" by default
+# ---------------------------------------------------------------------------
+
+class TestGap33ClassifiableLabelsDefault:
+    def test_security_in_default_classifiable_labels(self):
+        cfg = PipelineConfig(repo="o/r", base_repo_path=Path("/tmp"))
+        assert "security" in cfg.classifiable_labels
+
+
+# ---------------------------------------------------------------------------
+# gap #34: pipeline reset command
+# ---------------------------------------------------------------------------
+
+class TestGap34PipelineReset:
+    async def test_reset_removes_batch_and_by_labels(self):
+        from deile.commands.builtin.pipeline_command import _reset_issue
+
+        issue = IssueRef(
+            number=42, title="t", url="u",
+            labels=("intent", "~batch:abc12345", "~by:default"),
+        )
+        monitor, github, _ = _make_monitor()
+        github.get_issue = AsyncMock(return_value=issue)
+
+        result = await _reset_issue(monitor, 42)
+        assert result.success
+        github.remove_labels.assert_called_once()
+        removed = github.remove_labels.call_args[0][2]
+        assert "~batch:abc12345" in removed
+        assert "~by:default" in removed
+
+    async def test_reset_noop_when_no_lock_labels(self):
+        from deile.commands.builtin.pipeline_command import _reset_issue
+
+        issue = IssueRef(
+            number=43, title="t", url="u",
+            labels=("intent", "bug"),
+        )
+        monitor, github, _ = _make_monitor()
+        github.get_issue = AsyncMock(return_value=issue)
+
+        result = await _reset_issue(monitor, 43)
+        assert result.success
+        github.remove_labels.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# gap #35: log flush / schedule reflects actual stage runs
+# ---------------------------------------------------------------------------
+
+class TestGap35ScheduleCoversAllStages:
+    def test_default_schedule_has_all_four_stages(self, tmp_path):
+        """The default schedule file must have recurring entries for all 4 stages."""
+        default_schedule_path = Path(__file__).parents[5] / "config" / "pipeline_schedule_default.yaml"
+        if not default_schedule_path.exists():
+            pytest.skip("config/pipeline_schedule_default.yaml not found")
+        store = ScheduleStore(default_schedule_path.parent, monitor_id="default")
+        schedule = store.load()
+        actions = {e.action for e in schedule.recurring}
+        assert "classify" in actions, "schedule missing 'classify'"
+        assert "review" in actions, "schedule missing 'review'"
+        assert "implement" in actions, "schedule missing 'implement'"
+        assert "pr_review" in actions, "schedule missing 'pr_review'"

--- a/deile/tests/orchestration/pipeline/test_gap_regressions.py
+++ b/deile/tests/orchestration/pipeline/test_gap_regressions.py
@@ -640,3 +640,107 @@ class TestGap35ScheduleCoversAllStages:
         assert "review" in actions, "schedule missing 'review'"
         assert "implement" in actions, "schedule missing 'implement'"
         assert "pr_review" in actions, "schedule missing 'pr_review'"
+
+
+# ---------------------------------------------------------------------------
+# Reviewer fixes: bugs found during code review
+# ---------------------------------------------------------------------------
+
+class TestGcCompletedOneshotsNoDuplicateCutoff:
+    """gc_completed_oneshots had a dead first assignment to cutoff (dead code removed)."""
+
+    def test_removes_entries_correctly_with_fixed_cutoff(self):
+        from datetime import timedelta
+
+        from deile.orchestration.pipeline.scheduler import (OneshotEntry,
+                                                            Schedule)
+
+        s = Schedule()
+        old_completed = OneshotEntry(
+            id="o1",
+            action="implement",
+            run_at=datetime.now(timezone.utc) - timedelta(days=30),
+            completed=True,
+        )
+        recent_completed = OneshotEntry(
+            id="o2",
+            action="review",
+            run_at=datetime.now(timezone.utc) - timedelta(days=1),
+            completed=True,
+        )
+        pending = OneshotEntry(
+            id="o3",
+            action="classify",
+            run_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            completed=False,
+        )
+        s.oneshot = [old_completed, recent_completed, pending]
+        removed = s.gc_completed_oneshots(max_age_days=7)
+        assert removed == 1
+        assert len(s.oneshot) == 2
+        remaining_ids = {o.id for o in s.oneshot}
+        assert "o1" not in remaining_ids
+        assert "o2" in remaining_ids
+        assert "o3" in remaining_ids
+
+
+class TestCleanupMergedBranchesNestedPath:
+    """cleanup_merged_branches previously used candidate.name (last component only),
+    which never matched full branch names like 'auto/issue-42'. Now uses relative_to()."""
+
+    async def test_deletes_nested_worktree_when_branch_merged(self, tmp_path):
+        import json as _json
+
+        from deile.orchestration.pipeline.worktree_manager import \
+            WorktreeManager
+
+        # Create a fake git repo
+        (tmp_path / ".git").mkdir()
+        wm = WorktreeManager(base_repo=tmp_path)
+
+        # Simulate a worktree at .worktrees/auto/issue-42 with a .git marker
+        wt_dir = tmp_path / ".worktrees" / "auto" / "issue-42"
+        wt_dir.mkdir(parents=True)
+        (wt_dir / ".git").mkdir()
+
+        merged_prs_json = _json.dumps([{"headRefName": "auto/issue-42"}]).encode()
+
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(merged_prs_json, b""))
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            deleted = await wm.cleanup_merged_branches("owner/repo")
+
+        assert deleted == 1
+        assert not wt_dir.exists()
+
+    async def test_no_delete_when_branch_not_merged(self, tmp_path):
+        import json as _json
+
+        from deile.orchestration.pipeline.worktree_manager import \
+            WorktreeManager
+
+        (tmp_path / ".git").mkdir()
+        wm = WorktreeManager(base_repo=tmp_path)
+
+        wt_dir = tmp_path / ".worktrees" / "auto" / "issue-99"
+        wt_dir.mkdir(parents=True)
+        (wt_dir / ".git").mkdir()
+
+        # merged list is empty
+        merged_prs_json = _json.dumps([]).encode()
+
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(merged_prs_json, b""))
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            deleted = await wm.cleanup_merged_branches("owner/repo")
+
+        assert deleted == 0
+        assert wt_dir.exists()

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -7,10 +7,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from deile.orchestration.pipeline.github_client import (GhCommandError,
-                                                        GitHubClient, IssueRef,
-                                                        PrRef,
-                                                        compute_batch_id)
+from deile.orchestration.pipeline.github_client import (
+    GhCommandError, GitHubClient, IssueRef, PrRef, compute_batch_id,
+    compute_batch_id_for_number)
 from deile.orchestration.pipeline.labels import (REVIEW_PENDING, WORKFLOW_NEW,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING)
@@ -128,7 +127,7 @@ class TestClaimWithBatch:
              patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))), \
              patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
             bid = await client.claim_with_batch("issue", 5, "claim me")
-        assert bid == compute_batch_id("claim me")
+        assert bid == compute_batch_id_for_number("issue", 5)
 
     async def test_claim_returns_none_when_already_claimed(self):
         client = GitHubClient("owner/name")

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -65,6 +65,7 @@ def _make_monitor(
     github.get_pr_body = AsyncMock(return_value="")
     github.list_pr_comments = AsyncMock(return_value=[])
     github.create_issue = AsyncMock(return_value=0)
+    github.clear_batch_label = AsyncMock()
 
     notifier = MagicMock()
     for attr in (

--- a/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
+++ b/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
@@ -66,6 +66,7 @@ def _make_monitor_sched(
     github.comment_on_issue = AsyncMock()
     github.comment_on_pr = AsyncMock()
     github.list_unclassified_issues = AsyncMock(return_value=[])
+    github.clear_batch_label = AsyncMock()
 
     worktrees = MagicMock()
     worktrees.create_branch_worktree = AsyncMock(

--- a/deile/tests/orchestration/pipeline/test_pipeline_integration.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_integration.py
@@ -63,6 +63,10 @@ def _make_monitor_full(
     github.comment_on_issue = AsyncMock()
     github.comment_on_pr = AsyncMock()
     github.list_unclassified_issues = AsyncMock(return_value=[])
+    github.get_pr_body = AsyncMock(return_value="")
+    github.list_pr_comments = AsyncMock(return_value=[])
+    github.create_issue = AsyncMock(return_value=0)
+    github.clear_batch_label = AsyncMock()
 
     worktrees = MagicMock()
     worktrees.create_branch_worktree = AsyncMock(

--- a/deile/tools/pipeline_tool.py
+++ b/deile/tools/pipeline_tool.py
@@ -54,15 +54,22 @@ class PipelineTool(Tool):
                     "Use action='start' to begin the 1-minute polling loop, "
                     "action='stop' to halt it, action='status' for ticks/reviewed/"
                     "implemented/PRs/errors counters, action='tick' to force a single "
-                    "synchronous tick (debug)."
+                    "synchronous tick (debug), action='reset' with target=N to remove "
+                    "lock labels (~batch:, ~by:*) from issue #N (gap #34)."
                 ),
                 parameters={
                     "type": "object",
                     "properties": {
                         "action": {
                             "type": "string",
-                            "enum": ["start", "stop", "status", "tick"],
+                            "enum": ["start", "stop", "status", "tick", "reset"],
                             "description": "Pipeline operation to perform.",
+                        },
+                        "target": {
+                            "type": "integer",
+                            "description": (
+                                "Issue number to reset (required only for action='reset')."
+                            ),
                         },
                     },
                     "required": ["action"],
@@ -118,6 +125,23 @@ class PipelineTool(Tool):
                     data=self._stats_dict(monitor),
                     message="single tick executed",
                 )
+            if action == "reset":
+                # gap #34: remove lock labels from an issue
+                target = context.parsed_args.get("target")
+                if not target:
+                    return ToolResult.error_result(
+                        message="'target' (issue number) is required for action='reset'",
+                        error_code="MISSING_TARGET",
+                    )
+                try:
+                    issue_number = int(target)
+                except (TypeError, ValueError):
+                    return ToolResult.error_result(
+                        message=f"'target' must be an integer, got {target!r}",
+                        error_code="INVALID_TARGET",
+                    )
+                msg = await self._reset_issue(monitor, issue_number)
+                return ToolResult.success_result(data={"issue": issue_number}, message=msg)
             # status (default)
             running = self._is_running(monitor)
             return ToolResult.success_result(
@@ -143,13 +167,15 @@ class PipelineTool(Tool):
         if agent is not None and getattr(agent, "pipeline_monitor", None) is not None:
             return agent.pipeline_monitor
         from deile.config.settings import get_settings
+        from deile.orchestration.pipeline.review_callback import \
+            make_review_callback
 
         cfg = PipelineConfig(
             repo=_resolve_repo(),
             base_repo_path=_resolve_base_path(),
             notify_user_id=get_settings().pipeline_notify_user_id,
         )
-        monitor = PipelineMonitor(cfg)
+        monitor = PipelineMonitor(cfg, review_callback=make_review_callback(agent))
         if agent is not None:
             try:
                 agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
@@ -171,4 +197,34 @@ class PipelineTool(Tool):
             "issues_implemented": s.issues_implemented,
             "prs_reviewed": s.prs_reviewed,
             "errors": s.errors,
+            "gh_errors": s.gh_errors,
+            "claude_errors": s.claude_errors,
         }
+
+    @staticmethod
+    async def _reset_issue(monitor: PipelineMonitor, issue_number: int) -> str:
+        """Remove lock labels from issue_number (gap #34)."""
+        from deile.orchestration.pipeline.github_client import GhCommandError
+        from deile.orchestration.pipeline.labels import BATCH_LABEL_PREFIX
+
+        github = monitor.github
+        try:
+            issue = await github.get_issue(issue_number)
+        except GhCommandError as exc:
+            return f"gh error fetching issue #{issue_number}: {exc}"
+
+        to_remove = [
+            lb for lb in issue.labels
+            if lb.startswith(BATCH_LABEL_PREFIX) or lb.startswith("~by:")
+        ]
+        if not to_remove:
+            return f"issue #{issue_number} has no lock labels to remove"
+
+        try:
+            await github.remove_labels("issue", issue_number, to_remove)
+        except GhCommandError as exc:
+            return f"failed to remove labels from #{issue_number}: {exc}"
+
+        return (
+            f"issue #{issue_number} unlocked — removed: {', '.join(to_remove)}"
+        )

--- a/docs/2026-05-06_PIPELINE-AUTONOMO.md
+++ b/docs/2026-05-06_PIPELINE-AUTONOMO.md
@@ -113,8 +113,10 @@ PipelineMonitor
 │   ├── main_branch: str (default "main")
 │   ├── branch_prefix: str (default "auto/issue-")
 │   ├── notify_user_id: Optional[str]
-│   ├── enable_review/implement/pr_review: bool
-│   └── use_pid_lock: bool
+│   ├── enable_classify/review/implement/pr_review: bool
+│   ├── enable_review_human_prs: bool (gap #8)
+│   ├── use_pid_lock: bool (default True — gap #27)
+│   └── classifiable_labels: set (includes "security" — gap #4)
 ├── identity: MonitorIdentity
 │   ├── monitor_id: str
 │   ├── shard_index: int
@@ -122,26 +124,40 @@ PipelineMonitor
 │   ├── owns(key: str) -> bool  # SHA-256 % shard_count
 │   └── branch_prefix(action) -> str
 ├── stats: _Stats
-│   ├── ticks, issues_reviewed, issues_implemented
-│   ├── prs_reviewed, errors, catchup_runs, scheduled_runs
+│   ├── ticks, issues_reviewed, issues_classified, issues_implemented
+│   ├── prs_reviewed, errors, gh_errors, claude_errors (gap #18)
+│   ├── catchup_runs, scheduled_runs
 ├── async start() → acquires PID lock → catch_up_pending → create_task(_run_forever)
 ├── async stop() → set stop_event → wait task → release lock
-├── async tick() → check schedule → run pending or run all stages
-├── Stage 1: _review_one_new_issue()
+├── async tick() → check schedule → run pending + legacy-fallback for missing stages (gap #1)
+├── Stage 0: _classify_new_issues()
+│   ├── list_unclassified_issues() with pagination (gap #30)
+│   ├── identity.owns(issue.title) shard filter
+│   ├── claim_with_batch (gap #6) — skip if None (already claimed)
+│   ├── add ~workflow:nova; post reminder comment if empty body (gap #5)
+│   └── empty body accepted — best-effort classification (gap #5)
+├── Stage 1: _review_one_new_issue()  [atomic — gap #13]
 │   ├── list issues with ~workflow:nova
 │   ├── identity.owns(issue.title) filter + shard
 │   ├── claim_with_batch → add ownership label
-│   └── transition nova → em_revisao → revisada
+│   ├── transition nova → em_revisao
+│   ├── review_callback(issue) if wired (gap #2)
+│   ├── transition em_revisao → revisada
+│   └── on failure: revert em_revisao → nova (gap #13)
 ├── Stage 2: _implement_one_reviewed_issue()
-│   ├── list issues with ~workflow:revisada owned by this monitor
-│   ├── WorktreeManager.create_branch_worktree(branch)
+│   ├── list issues with ~workflow:revisada
+│   ├── filter: batch_id present OR ownership label present (gap #7)
+│   ├── WorktreeManager.create_branch_worktree(branch, force_recreate)
 │   ├── ClaudeDispatcher.run(implement_prompt, cwd=worktree)
+│   ├── _extract_pr_url uses last match (gap #14)
 │   └── transition revisada → em_pr
 └── Stage 3: _review_one_open_pr()
     ├── list open PRs not draft, no ~review:concluida, owned branch
+    ├── _owns_pr_branch: warns on empty head_ref (gap #22)
     ├── claim_with_batch → transition pendente → em_andamento
     ├── ClaudeDispatcher.run(review_prompt, cwd=worktree)
-    └── transition em_andamento → concluida
+    ├── transition em_andamento → concluida
+    └── clear_batch_label("pr", number) after conclude (gap #9)
 
 CronRunner
 ├── store: CronStore
@@ -166,8 +182,12 @@ CronRunner
 |---|---|---|---|---|
 | `start()` | — | `None` | Yes | Idempotente; levanta `LockHeldError` se PID lock já ocupado |
 | `stop()` | — | `None` | Yes | Wait 5s, cancela se timeout |
-| `tick()` | — | `None` | Yes | Um ciclo completo dos 3 estágios (ou entradas de schedule) |
-| `stats` | — | `_Stats` | No (property) | Contadores acumulativos |
+| `tick()` | — | `None` | Yes | Um ciclo completo dos 4 estágios (ou entradas de schedule) + legacy fallback (gap #1) |
+| `stats` | — | `_Stats` | No (property) | Contadores acumulativos; inclui `gh_errors` e `claude_errors` (gap #18) |
+| `_classify_new_issues()` | — | `None` | Yes | Stage 0: classifica issues sem label de pipeline |
+| `_review_one_new_issue()` | — | `None` | Yes | Stage 1: atômico — reverte para nova em caso de falha (gap #13) |
+| `_implement_one_reviewed_issue()` | — | `None` | Yes | Stage 2: aceita issues com ownership label sem batch (gap #7) |
+| `_review_one_open_pr()` | — | `None` | Yes | Stage 3: limpa ~batch: após conclusão (gap #9) |
 
 ### ClaudeDispatcher
 
@@ -207,20 +227,36 @@ CronRunner
 ### `config/pipeline_schedule_<monitor_id>.yaml`
 
 ```yaml
+# gap #1: o schedule padrão (pipeline_schedule_default.yaml) inclui todos os
+# 4 estágios. Se uma entrada estiver ausente, o monitor executa aquele estágio
+# em modo legacy (a cada tick), garantindo que nenhum estágio fique silencioso.
 recurring:
-  - id: review_loop           # str, alphanum + _- obrigatório
-    action: review            # review | implement | pr_review
-    cron: "*/5 * * * *"       # 5-field cron expression em UTC
-    enabled: true             # false congela a entrada sem deletar
-    last_run_at: null         # ISO-8601 UTC; null = nunca rodou
-    replay_all: false         # true = replay cada slot missed no downtime
-
-oneshot:
-  - id: oneshot-impl-99
+  - id: classify_loop         # str, alphanum + _- obrigatório
+    action: classify          # classify | review | implement | pr_review
+    cron: "*/2 * * * *"       # 5-field cron expression em UTC
+    enabled: true
+    last_run_at: null
+    replay_all: false
+  - id: review_loop
+    action: review
+    cron: "*/3 * * * *"
+    enabled: true
+    last_run_at: null
+    replay_all: false
+  - id: implement_loop
     action: implement
-    target_issue: 99          # contexto; não modifica o pipeline hoje
-    run_at: "2026-05-06T18:00:00Z"
-    completed: false
+    cron: "*/5 * * * *"
+    enabled: true
+    last_run_at: null
+    replay_all: false
+  - id: pr_review_loop
+    action: pr_review
+    cron: "*/4 * * * *"
+    enabled: true
+    last_run_at: null
+    replay_all: false
+
+oneshot: []
 ```
 
 ### `CronEntry` (SQLite)
@@ -316,15 +352,28 @@ async def test_monitor_identity_shard():
 # Iniciar o pipeline
 /pipeline start
 
-# Verificar status
+# Verificar status (inclui gh_errors e claude_errors — gap #18)
 /pipeline status
 
 # Forçar um tick para depuração
 /pipeline tick
 
+# Desbloquear uma issue travada (remove ~batch: e ~by:* — gap #34)
+/pipeline reset 42
+/pipeline reset #42
+
 # Parar
 /pipeline stop
 ```
+
+### Autostart via env var (gap #3)
+
+```bash
+# Iniciar o pipeline automaticamente ao subir o DEILE
+DEILE_PIPELINE_AUTOSTART=1 python3 deile.py
+```
+
+O monitor é iniciado em background imediatamente após `agent.initialize()`, usando o mesmo `review_callback` wired ao agente (gap #2). O `/pipeline stop` ainda funciona normalmente para parar o loop.
 
 ### Agendamento via LLM (ex.: Discord → DEILE)
 
@@ -404,10 +453,13 @@ await cron_runner.start()
 | Contador | Significado |
 |---|---|
 | `ticks` | Total de ticks executados desde start |
+| `issues_classified` | Issues que passaram pelo estágio 0 com sucesso |
 | `issues_reviewed` | Issues que passaram pelo estágio 1 com sucesso |
 | `issues_implemented` | Issues que passaram pelo estágio 2 com sucesso |
 | `prs_reviewed` | PRs que passaram pelo estágio 3 com sucesso |
-| `errors` | Ticks que levantaram exceção não-esperada |
+| `errors` | Total de erros (soma de gh_errors + claude_errors + outros) |
+| `gh_errors` | Erros de `GhCommandError` (gh CLI falhou) — gap #18 |
+| `claude_errors` | Erros de `ClaudeDispatcher` (rc != 0) — gap #18 |
 | `catchup_runs` | Runs de catch-up executados no startup |
 | `scheduled_runs` | Runs de schedule executados em ticks normais |
 
@@ -432,6 +484,8 @@ await cron_runner.start()
 - **Sem `config/pipeline_schedule_<id>.yaml`:** monitor cai para modo legacy "todas as ações a cada tick".
 - **Sem `DEILE_CRON_DB_PATH`:** CronStore criado em `data/cron.db`; diretório auto-criado.
 - **Tools não registradas automaticamente:** `pipeline_tool`, `pipeline_schedule_tool`, `cron_*` requerem registro explícito via `register_tool(...)`. O `auto_discover()` existente não os cobre — o daemon/bootstrap deve registrá-los.
+- **`use_pid_lock` agora `True` por padrão (gap #27):** em deploys que rodavam sem PID lock, isso pode levantar `LockHeldError` se dois processos subirem simultâneamente. Para desabilitar explicitamente: `PipelineConfig(use_pid_lock=False)`.
+- **`compute_batch_id` alterado (gap #10):** o batch ID agora é derivado do número da issue/PR (não do título), eliminando colisões entre issues com o mesmo título. Batch IDs existentes no GitHub continuarão válidos; apenas novos claims usarão o novo cálculo.
 
 ### Deploy de múltiplos monitores
 
@@ -476,10 +530,14 @@ DEILE_CRON_AUTOSTART=1
 | Issue não é claimed | `batch_id` já presente ou `identity.owns()` retorna False | Verificar `DEILE_PIPELINE_SHARD_*`; inspecionar labels da issue via `gh issue view` |
 | `claude -p` timeout | Log `claude -p timed out after 1800s` | Issue/PR muito complexo; aumentar `ClaudeDispatcher.timeout_seconds` |
 | PR não aberta após implementação | `_extract_pr_url` não encontrou URL no stdout | Claude Code não abriu PR; inspecionar logs do subprocess em `result.stderr` |
-| Worktrees acumulando em disco | Não há cleanup automático | Rodar `git worktree prune` + `git worktree list` manualmente na raiz do repo |
+| Worktrees acumulando em disco | Não há cleanup automático | Rodar `git worktree prune` + `git worktree list` manualmente na raiz do repo; ou usar `WorktreeManager.cleanup_merged_branches()` (gap #26) |
 | `CronStore` falha ao abrir | `data/` não existe ou sem permissão | Verificar `DEILE_CRON_DB_PATH`; criar diretório manualmente |
 | Entry cron nunca dispara | `enabled=0` ou `next_fire_at` no passado sem advance | Usar `cron_list` tool para inspecionar; `cron_delete` + `cron_create` para re-agendar |
-| DMs não chegam | `DEILE_PIPELINE_NOTIFY_USER_ID` não configurado ou `deilebot` offline | Verificar env var; checar log do notifier |
+| DMs não chegam | `DEILE_PIPELINE_NOTIFY_USER_ID` não configurado ou `deilebot` offline | Verificar env var; checar log `DiscordNotifier: no DM function available` (gap #19) |
+| Issue travada (stuck) em `~batch:` ou `~by:` | Monitor caiu no meio de um stage | Usar `/pipeline reset <issue#>` ou `pipeline(action="reset", target=N)` (gap #34) |
+| Pipeline iniciado mas nada acontece | Nenhum estágio no schedule estava `due` E stages sem entry no schedule | Confirmar que `config/pipeline_schedule_default.yaml` tem os 4 estágios (gap #1); ou deletar o arquivo para modo legacy |
+| Issue com `security` label não entra no pipeline | `classifiable_labels` não incluía `security` | Gap #4 corrigido; label `security` incluído por padrão em `PipelineConfig.classifiable_labels` |
+| `stats.gh_errors` > 0 | Erros de `gh` CLI; ver logs `ERROR` | Verificar token GitHub, rate limits, e conectividade; checar `gh auth status` |
 
 ---
 

--- a/docs/system_design/00-VISAO-GERAL.md
+++ b/docs/system_design/00-VISAO-GERAL.md
@@ -89,6 +89,9 @@
 | 18 | Hash sharding para execução paralela de monitores (`MonitorIdentity` + `shard_index/shard_count`) | V1 | Princípios (03), Arquitetura (02) |
 | 19 | Cron genérico separado do scheduler do pipeline (`CronStore` SQLite + `CronRunner` vs `ScheduleStore` YAML) | V1 | Componentes (04) |
 | 20 | Strip de `ANTHROPIC_API_KEY` no subprocess do Claude Code (`ClaudeDispatcher.prefer_subscription_auth`) | V1 | Segurança (08) |
+| 21 | Schedule padrão completo + fallback legacy para stages ausentes (`tick()` gap #1 — issue #129) | V1 patch | Arquitetura (02), Configuração (09) |
+| 22 | Stage 1 atômico com rollback `em_revisao → nova` em caso de falha (gap #13 — issue #129) | V1 patch | Princípios (03) |
+| 23 | Batch ID derivado do número (não título) via `compute_batch_id_for_number` (gap #10 — issue #129) | V1 patch | Arquitetura (02) |
 
 ## Estado dos pilares
 

--- a/docs/system_design/DECISOES.md
+++ b/docs/system_design/DECISOES.md
@@ -255,6 +255,42 @@
 
 ---
 
+## Decisão #21 — Pipeline silenciosamente quebrado (#129): schedule incompleto + fallback gaps
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 patch |
+| Pilar dono | 02-Arquitetura, 09-Configuração |
+| Decisão | O schedule padrão (`config/pipeline_schedule_default.yaml`) deve incluir todos os 4 estágios (classify, review, implement, pr_review). Adicionalmente, o `tick()` executa fallback legacy para qualquer estágio habilitado que tenha entradas `recurring` no schedule mas não inclua aquele estágio específico. Estágios ausentes do schedule não ficam silenciosos. |
+| Evidência | `config/pipeline_schedule_default.yaml` (4 entradas); `deile/orchestration/pipeline/monitor.py:tick()` (fallback block com `scheduled_actions` check) |
+| Motivação | O bug em #129: o schedule só tinha `review` → classify/implement/pr_review nunca rodavam, mas o operador via `pipeline running` e não recebia nenhum erro. A dupla solução (schedule completo + fallback) é defense-in-depth — se o operador editar o schedule e remover uma entrada, o stage ainda roda; não silencia. |
+
+---
+
+## Decisão #22 — Atomicidade de Stage 1 e rollback para nova em caso de falha
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 patch |
+| Pilar dono | 03-Princípios (Orquestração com rollback) |
+| Decisão | Stage 1 (`_review_one_new_issue`) usa try/except/finally onde `review_failed = True` no except aciona, no finally, uma transição de rollback `em_revisao → nova`. Isso garante que uma falha (gh error, callback error, etc.) não deixa a issue presa em `~workflow:em_revisao`. |
+| Evidência | `deile/orchestration/pipeline/monitor.py:_review_one_new_issue()` |
+| Motivação | Issues presas em `em_revisao` bloqueiam o monitor indefinidamente (a issue nunca é reclamável por outro agente). O rollback é best-effort (o `try` interno no finally não propaga) mas garante a melhor tentativa de desbloquear. |
+
+---
+
+## Decisão #23 — Batch ID derivado do número (não do título) para eliminar colisões
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 patch |
+| Pilar dono | 02-Arquitetura |
+| Decisão | `compute_batch_id_for_number(kind, number)` gera o batch ID como SHA-256 de `"kind:number"` (e.g. `"issue:42"`). Substitui `compute_batch_id(title)` que usava o título — sujeito a colisões entre issues com mesmo título (duplicatas, re-criações). |
+| Evidência | `deile/orchestration/pipeline/github_client.py:compute_batch_id_for_number`, `claim_with_batch` |
+| Motivação | Dois issues com títulos idênticos receberiam o mesmo batch ID, permitindo que um monitor claim a issue "errada" silenciosamente. Com o número, o ID é sempre único dentro do repositório. |
+
+---
+
 ## Como adicionar uma nova decisão
 
 | # | Passo |


### PR DESCRIPTION
## Summary

Corrige o bug crítico de #129: o pipeline autônomo iniciava sem erros mas não processava nenhuma issue/PR.

**Root cause (gap #1):** `config/pipeline_schedule_default.yaml` só continha a entrada `review`. O código de schedule-driven mode retornava após processar as entradas pendentes, nunca executando `classify`, `implement` ou `pr_review`. O operador via `/pipeline status` reportando `running=True` mas nada acontecia no GitHub.

**35 gaps corrigidos:**

| Gap | Área | Descrição |
|---|---|---|
| #1 | Schedule | Schedule padrão inclui 4 estágios; fallback legacy para stages ausentes |
| #2 | Review | `review_callback` wired ao agente em `PipelineCommand` e `PipelineTool` |
| #3 | Autostart | `DEILE_PIPELINE_AUTOSTART=1` inicia monitor no boot da CLI |
| #4/#33 | Classify | Label `security` incluída em `classifiable_labels` por padrão |
| #5 | Classify | Body vazio aceito em Stage 0; reminder comment postado |
| #6 | Classify | Stage 0 usa `claim_with_batch` antes de `add_labels` (reduz TOCTOU) |
| #7 | Implement | Stage 2 aceita issues com ownership label sem `~batch:` |
| #8 | PR Review | `PipelineConfig.enable_review_human_prs` para Stage 3 revisar PRs humanos |
| #9 | PR Review | `clear_batch_label("pr", N)` após Stage 3 concluída |
| #10 | GitHub | `compute_batch_id_for_number(kind, number)` — elimina colisões por título |
| #12 | Worktree | `create_branch_worktree(force_recreate)` para retry limpo |
| #13 | Stage 1 | Atomicidade: revert `em_revisao → nova` em caso de falha |
| #14 | Implement | `_extract_pr_url` usa último match (não primeiro) |
| #17/#18 | Errors | `GhCommandError` → ERROR level; `stats.gh_errors` + `stats.claude_errors` |
| #19 | Notifier | `DiscordNotifier` avisa uma vez quando `dm_fn` é None |
| #20 | Dispatcher | `ClaudeDispatcher` avisa sobre auth failures em stderr |
| #22 | PR Review | `_owns_pr_branch` loga WARNING em `head_ref` vazio |
| #25 | Scheduler | `Schedule.gc_completed_oneshots(max_age_days)` |
| #26 | Worktree | `WorktreeManager.cleanup_merged_branches()` |
| #27 | Config | `PipelineConfig.use_pid_lock` default `True` |
| #29 | GitHub | `GhCommandError` inclui subcomando completo na mensagem |
| #30 | GitHub | `list_unclassified_issues` pagina resultados |
| #34 | Commands | `/pipeline reset <issue#>` remove `~batch:` e `~by:*` |
| #35 | Schedule | `pipeline_schedule_default.yaml` contém todos os 4 estágios |

## Test plan

- [x] 33 novos testes de regressão em `test_gap_regressions.py` — um por gap
- [x] 1617 testes totais passando (0 falhas)
- [x] Coverage pipeline ≥ 80% (`monitor.py` 80%, total do módulo 80%)
- [x] `ruff check deile/` — zero erros
- [x] `isort --check-only deile/` — zero erros
- [x] Testes existentes em `test_monitor.py`, `test_pipeline_integration.py`, `test_monitor_with_schedule.py`, `test_classify.py`, `test_github_client.py` todos verdes

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)