### PR TITLE
fix(pipeline): fecha gaps residuais (#132)

### DIFF
--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -1,11 +1,17 @@
 """``/pipeline`` command — start/stop/status of the autonomous pipeline.
 
 Usage:
-    /pipeline start             start the 1-min polling loop
-    /pipeline stop              stop the polling loop
-    /pipeline status            print stats + current state
-    /pipeline tick              run a single tick synchronously (debug)
-    /pipeline reset <issue#>    remove ~batch: + ~by:* labels from an issue (gap #34)
+    /pipeline start [--identity <id>] [--schedule-file <path>] [--no-pid-lock]
+                        start the 1-min polling loop
+    /pipeline stop          stop the polling loop
+    /pipeline status        print stats + current state
+    /pipeline tick          run a single tick synchronously (debug)
+    /pipeline reset <issue#>    remove ~batch: + ~by:* labels from an issue
+
+Flags (all optional, override env vars):
+    --identity <id>        DEILE_PIPELINE_MONITOR_ID override
+    --schedule-file <path> path to a custom schedule YAML
+    --no-pid-lock          disable PID lockfile (useful for dev/test)
 
 The command is idempotent: running ``start`` twice does nothing on the second
 call. The monitor instance is held on ``context.agent.pipeline_monitor``.
@@ -13,7 +19,9 @@ call. The monitor instance is held on ``context.agent.pipeline_monitor``.
 
 from __future__ import annotations
 
+import argparse
 import logging
+import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -25,6 +33,23 @@ from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_start_flags(raw: str):
+    """Parse optional flags from the ``start`` subcommand tail.
+
+    Returns a namespace with ``identity``, ``schedule_file``, ``no_pid_lock``.
+    Unknown tokens are silently ignored so future flags don't break old callers.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--identity", default=None)
+    parser.add_argument("--schedule-file", dest="schedule_file", default=None)
+    parser.add_argument("--no-pid-lock", dest="no_pid_lock", action="store_true", default=False)
+    try:
+        ns, _ = parser.parse_known_args(shlex.split(raw))
+    except (ValueError, SystemExit):
+        ns = argparse.Namespace(identity=None, schedule_file=None, no_pid_lock=False)
+    return ns
 
 
 def _resolve_repo() -> str:
@@ -64,8 +89,9 @@ class PipelineCommand(DirectCommand):
         self.category = "orchestration"
 
     async def execute(self, context: CommandContext) -> CommandResult:
-        parts = context.args.strip().split(None, 2)
+        parts = context.args.strip().split(None, 1)
         sub = parts[0].lower() if parts else "status"
+        tail = parts[1] if len(parts) > 1 else ""
         agent = context.agent
         monitor: Optional[PipelineMonitor] = getattr(agent, "pipeline_monitor", None)
 
@@ -83,12 +109,50 @@ class PipelineCommand(DirectCommand):
             agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
 
         if sub == "start":
+            flags = _parse_start_flags(tail)
+            # Flags override the monitor's current config when supplied.
+            if flags.identity or flags.schedule_file or flags.no_pid_lock:
+                from deile.config.settings import get_settings
+                from deile.orchestration.pipeline.identity import \
+                    MonitorIdentity
+                from deile.orchestration.pipeline.review_callback import \
+                    make_review_callback
+                from deile.orchestration.pipeline.scheduler import \
+                    ScheduleStore
+
+                cfg = PipelineConfig(
+                    repo=_resolve_repo(),
+                    base_repo_path=_resolve_base_path(),
+                    notify_user_id=get_settings().pipeline_notify_user_id,
+                    use_pid_lock=not flags.no_pid_lock,
+                )
+                identity = (
+                    MonitorIdentity(monitor_id=flags.identity)
+                    if flags.identity
+                    else None
+                )
+                schedule_store = (
+                    ScheduleStore(
+                        Path(flags.schedule_file).parent,
+                        monitor_id=Path(flags.schedule_file).stem,
+                    )
+                    if flags.schedule_file
+                    else None
+                )
+                monitor = PipelineMonitor(
+                    cfg,
+                    identity=identity,
+                    schedule_store=schedule_store,
+                    review_callback=make_review_callback(agent),
+                )
+                agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
             await monitor.start()
             return CommandResult(
                 success=True,
                 content=(
                     f"✅ pipeline iniciado (repo={monitor.config.repo}, "
-                    f"interval={monitor.config.poll_interval_seconds}s)"
+                    f"interval={monitor.config.poll_interval_seconds}s, "
+                    f"identity={monitor.identity.monitor_id})"
                 ),
             )
         if sub == "stop":
@@ -106,16 +170,17 @@ class PipelineCommand(DirectCommand):
                 ),
             )
         if sub == "reset":
-            # gap #34: remove ~batch: + ~by:* labels from an issue so it can be re-processed
-            if len(parts) < 2:
+            # Remove ~batch: + ~by:* labels from an issue so it can be re-processed.
+            if not tail.strip():
                 return CommandResult(
                     success=False, content="❌ uso: /pipeline reset <issue_number>"
                 )
+            raw_num = tail.strip().split()[0].lstrip("#")
             try:
-                issue_number = int(parts[1].lstrip("#"))
+                issue_number = int(raw_num)
             except ValueError:
                 return CommandResult(
-                    success=False, content=f"❌ número de issue inválido: {parts[1]!r}"
+                    success=False, content=f"❌ número de issue inválido: {raw_num!r}"
                 )
             return await _reset_issue(monitor, issue_number)
 

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -281,23 +281,58 @@ class GitHubClient:
 
         Returns the batch_id on success, or None if the issue already has a
         ``~batch:`` label (someone else picked it up).
+
+        Best-effort TOCTOU mitigation: after ``add_labels`` we re-fetch the
+        item and verify that only OUR batch label is present.  If another
+        ``~batch:`` label appeared between our read and our write we remove the
+        label we just added and yield to the winner.  This is not a true
+        distributed lock (no ``If-Match``/ETag support in ``gh``), but it
+        catches the common case where two monitors overlap on a fast repo.
         """
-        # Re-read the latest labels — list-then-add is racy across runners but
-        # acceptable for a single-instance pipeline (the typical deployment).
-        if kind == "issue":
-            current = await self.get_issue(number)
-        elif kind == "pr":
-            current = await self.get_pr(number)
-            if current is None:
-                return None
-        else:
+        async def _fetch_current():
+            if kind == "issue":
+                return await self.get_issue(number)
+            cur = await self.get_pr(number)
+            return cur  # may be None
+
+        if kind not in ("issue", "pr"):
             raise ValueError(f"kind must be 'issue' or 'pr', got {kind!r}")
+
+        current = await _fetch_current()
+        if current is None:
+            return None
         if current.batch_id is not None:
             return None
+
         batch_id = compute_batch_id_for_number(kind, number)
         label = make_batch_label(batch_id)
         await self._ensure_label(label, color="d73a4a", description="Pipeline batch lock")
         await self.add_labels(kind, number, [label])
+
+        # Re-fetch to verify we are the sole claimant.
+        after = await _fetch_current()
+        if after is None:
+            return None
+        foreign = [
+            lb for lb in after.labels
+            if is_batch_label(lb) and lb != label
+        ]
+        if foreign:
+            # Another monitor also applied a batch label — we lost the race.
+            # Remove ours and yield.
+            logger.warning(
+                "claim_with_batch: TOCTOU race detected on %s #%d; "
+                "foreign labels=%s; removing our label and yielding",
+                kind, number, foreign,
+            )
+            try:
+                await self.remove_labels(kind, number, [label])
+            except GhCommandError as exc:
+                logger.warning(
+                    "claim_with_batch: could not remove our label after race: %s", exc
+                )
+            return None
+
         return batch_id
 
     async def _ensure_label(self, name: str, *, color: str, description: str) -> None:
@@ -453,6 +488,38 @@ class GitHubClient:
                 len(seen), offset + page_size,
             )
         return result
+
+    async def list_recently_merged_prs(self, *, limit: int = 20) -> List[PrRef]:
+        """Return recently merged PRs, ordered most-recent-first.
+
+        Used by standalone stage 4 to find PRs that need follow-up processing.
+        Returns an empty list on ``gh`` error (logged at WARNING).
+        """
+        try:
+            out = await self._run_checked(
+                "pr", "list",
+                "--repo", self.repo,
+                "--state", "merged",
+                "--limit", str(limit),
+                "--json", "number,title,url,labels,headRefName,baseRefName,state,isDraft",
+            )
+        except GhCommandError as exc:
+            logger.warning("list_recently_merged_prs failed: %s", exc)
+            return []
+        data = json.loads(out or "[]")
+        return [
+            PrRef(
+                number=item["number"],
+                title=item["title"],
+                url=item["url"],
+                labels=tuple(lab["name"] for lab in item.get("labels", [])),
+                head_ref=item.get("headRefName", ""),
+                base_ref=item.get("baseRefName", "main"),
+                state=item.get("state", "merged"),
+                is_draft=bool(item.get("isDraft", False)),
+            )
+            for item in data
+        ]
 
     async def clear_batch_label(self, kind: str, number: int) -> None:
         """Remove all ``~batch:*`` labels from an issue or PR (gap #9).

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -86,6 +86,11 @@ class PipelineConfig:
     use_pid_lock: bool = True
     # When True, Stage 3 reviews any non-draft PR regardless of head branch origin.
     enable_review_human_prs: bool = False
+    # Limit catch-up to runs missed within the last N hours.  None = no limit (legacy).
+    # Recommended: 1–2 hours so a long outage does not flood the queue.
+    bootstrap_replay_window_hours: Optional[int] = 1
+    # When True, cleanup_merged_branches() runs once on startup.
+    enable_worktree_cleanup: bool = True
 
 
 @dataclass
@@ -103,6 +108,8 @@ class _Stats:
     scheduled_runs: int = 0
     follow_ups_opened: int = 0
     follow_ups_skipped: int = 0
+    # Incremented when a scheduled action is disabled via enable_* config.
+    skipped_runs: int = 0
 
 
 class PipelineMonitor:
@@ -229,13 +236,34 @@ class PipelineMonitor:
 
     async def _catch_up_pending(self) -> None:
         """On startup, drain any schedule entries whose time already passed."""
+        # Opportunistic cleanup: remove on-disk worktrees for already-merged PRs.
+        if self.config.enable_worktree_cleanup:
+            try:
+                deleted = await self.worktrees.cleanup_merged_branches(self.config.repo)
+                if deleted:
+                    logger.info("startup: cleaned up %d merged worktrees", deleted)
+            except Exception as exc:  # noqa: BLE001 — cleanup is best-effort
+                logger.warning("startup worktree cleanup failed: %s", exc)
+
         try:
             schedule = self.schedule_store.load()
         except Exception as exc:  # noqa: BLE001 — schedule errors must not block boot
             logger.warning("schedule load failed; skipping catch-up: %s", exc)
             return
-        pending = schedule.compute_pending()
+
+        # GC completed oneshots so the YAML doesn't grow indefinitely.
+        removed = schedule.gc_completed_oneshots()
+        if removed:
+            logger.info("startup: gc'd %d completed oneshots from schedule", removed)
+
+        pending = schedule.compute_pending(
+            replay_window_hours=self.config.bootstrap_replay_window_hours
+        )
         if not pending:
+            try:
+                self.schedule_store.save(schedule)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("could not persist schedule after startup gc: %s", exc)
             return
         logger.info(
             "monitor %s catching up on %d missed runs",
@@ -252,16 +280,36 @@ class PipelineMonitor:
 
     async def _run_scheduled(self, run: PendingRun) -> None:
         """Execute a single scheduled action by name."""
-        if run.action == "classify" and self.config.enable_classify:
+        _ENABLE_FLAGS = {
+            "classify": self.config.enable_classify,
+            "review": self.config.enable_review,
+            "implement": self.config.enable_implement,
+            "pr_review": self.config.enable_pr_review,
+            "follow_ups": self.config.enable_follow_ups,
+        }
+        flag = _ENABLE_FLAGS.get(run.action)
+        if flag is False:
+            # Operator scheduled this action but disabled it in config — warn loudly.
+            logger.warning(
+                "scheduled action %r is disabled (enable_%s=False); "
+                "skipping run at %s. Remove the schedule entry or re-enable the flag.",
+                run.action, run.action.replace("_", "_"), run.when.isoformat(),
+            )
+            self._stats.skipped_runs += 1
+            return
+
+        if run.action == "classify":
             await self._classify_new_issues()
-        elif run.action == "review" and self.config.enable_review:
+        elif run.action == "review":
             await self._review_one_new_issue()
-        elif run.action == "implement" and self.config.enable_implement:
+        elif run.action == "implement":
             await self._implement_one_reviewed_issue()
-        elif run.action == "pr_review" and self.config.enable_pr_review:
+        elif run.action == "pr_review":
             await self._review_one_open_pr()
+        elif run.action == "follow_ups":
+            await self._standalone_follow_ups()
         else:
-            logger.debug("scheduled action %s skipped (disabled or unknown)", run.action)
+            logger.debug("scheduled action %s unknown; skipped", run.action)
 
     async def stop(self) -> None:
         self._stop_event.set()
@@ -715,6 +763,35 @@ class PipelineMonitor:
             logger.warning("stage 4: could not post follow-up report on PR #%s: %s", pr_number, exc)
 
         await self.notifier.follow_ups_processed(pr_number, len(opened), len(skipped))
+
+    # ----- standalone stage 4: follow_ups action -------------------
+
+    async def _standalone_follow_ups(self) -> None:
+        """Process follow-ups for recently merged PRs that haven't been processed yet.
+
+        This is the standalone version of stage 4, invocable via the schedule
+        without requiring a concurrent stage 3 run.  Idempotency is enforced by
+        the ``~follow_ups:processed`` label: PRs that already have this label
+        are skipped.
+        """
+        _PROCESSED_LABEL = "~follow_ups:processed"
+        try:
+            merged_prs = await self.github.list_recently_merged_prs()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("standalone follow_ups: could not list merged PRs: %s", exc)
+            return
+
+        for pr in merged_prs:
+            if _PROCESSED_LABEL in pr.labels:
+                continue
+            await self._stage4_follow_ups(pr.number, pr.title, pr.url)
+            try:
+                await self.github.add_labels("pr", pr.number, [_PROCESSED_LABEL])
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "standalone follow_ups: could not mark PR #%d processed: %s",
+                    pr.number, exc,
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -293,7 +293,7 @@ class PipelineMonitor:
             logger.warning(
                 "scheduled action %r is disabled (enable_%s=False); "
                 "skipping run at %s. Remove the schedule entry or re-enable the flag.",
-                run.action, run.action.replace("_", "_"), run.when.isoformat(),
+                run.action, run.action, run.when.isoformat(),
             )
             self._stats.skipped_runs += 1
             return

--- a/deile/orchestration/pipeline/scheduler.py
+++ b/deile/orchestration/pipeline/scheduler.py
@@ -53,7 +53,7 @@ from deile.orchestration.pipeline.cron import CronExpressionError, next_after
 logger = logging.getLogger(__name__)
 
 
-VALID_ACTIONS = {"review", "implement", "pr_review", "classify"}
+VALID_ACTIONS = {"review", "implement", "pr_review", "classify", "follow_ups"}
 
 
 class ScheduleError(DEILEError):
@@ -203,15 +203,30 @@ class Schedule:
 
     # ---- catch-up + tick selection -------------------------------
 
-    def compute_pending(self, now: Optional[datetime] = None) -> List[PendingRun]:
+    def compute_pending(
+        self,
+        now: Optional[datetime] = None,
+        *,
+        replay_window_hours: Optional[int] = None,
+    ) -> List[PendingRun]:
         """Return all schedule entries whose run time is <= now.
 
         Sorted by ``when`` ascending (oldest miss first). For coalescing
         recurring entries, only ONE PendingRun is emitted per entry —
         the most recent missed slot. With ``replay_all=True``, every
         missed slot becomes its own PendingRun.
+
+        ``replay_window_hours``: when set, recurring entries are only
+        considered "pending" if their missed slot falls within the last
+        *N* hours.  Slots older than the window are skipped (their
+        ``last_run_at`` is still advanced on the next explicit save, so
+        they are not replayed on the following startup).  This limits
+        catch-up after a long outage to at most one run per entry.
+        ``None`` (default) means unlimited look-back — the same as the
+        legacy behaviour.
         """
         now = now or _now_utc()
+        cutoff = (now - timedelta(hours=replay_window_hours)) if replay_window_hours else None
         out: List[PendingRun] = []
 
         for r in self.recurring:
@@ -226,6 +241,18 @@ class Schedule:
                 continue
             if next_at > now:
                 continue  # not due yet
+            if cutoff is not None and next_at < cutoff:
+                # The first pending slot is older than the replay window;
+                # treat it as "already ran" for catch-up purposes — advance
+                # to the latest slot within the window instead.
+                # Re-compute with the cutoff as anchor so we only replay slots
+                # that are recent enough to matter.
+                try:
+                    next_at = next_after(r.cron, cutoff)
+                except CronExpressionError:
+                    continue
+                if next_at > now:
+                    continue
             if not r.replay_all:
                 # Coalesce: collapse N misses to 1, fire at the latest miss.
                 latest = next_at

--- a/deile/orchestration/pipeline/worktree_manager.py
+++ b/deile/orchestration/pipeline/worktree_manager.py
@@ -133,6 +133,14 @@ class WorktreeManager:
         # land back there (and from there get pushed to GitHub by the pipeline).
         await self._git_in(target, "remote", "set-url", "origin", str(self.base_repo))
 
+        # Ensure a `github` remote pointing directly at GitHub exists so that
+        # `gh pr create` and `git push github <branch>` work from within the
+        # worktree.  We discover the URL from the base repo's existing `github`
+        # remote (if configured) or fall back to the `origin` remote URL of the
+        # base repo itself.  Errors are non-fatal — Claude can still attempt to
+        # push via `origin` and let `gh` figure it out.
+        await self._ensure_github_remote(target)
+
         # Create / switch to the feature branch.
         rc, _, err = await self._git_in_capture(target, "checkout", "-b", branch)
         if rc != 0:
@@ -200,6 +208,59 @@ class WorktreeManager:
                     logger.warning("cleanup_merged_branches: failed to remove %s: %s", candidate, exc)
 
         return deleted
+
+    async def _ensure_github_remote(self, worktree: Path) -> None:
+        """Add or update the ``github`` remote in *worktree* to point at GitHub.
+
+        Priority order for discovering the GitHub URL:
+        1. The ``github`` remote of the base repo (if it already exists).
+        2. The ``origin`` remote of the base repo (may be a local path).
+        3. No-op: log a warning and leave the worktree without a ``github`` remote.
+
+        This is best-effort: failures are logged at WARNING but never raised.
+        """
+        # Try to get the `github` remote from the base repo first.
+        rc, github_url, _ = await self._git_in_capture(
+            self.base_repo, "remote", "get-url", "github"
+        )
+        if rc != 0 or not github_url.strip():
+            # Fall back to `origin` of the base repo.
+            rc, github_url, _ = await self._git_in_capture(
+                self.base_repo, "remote", "get-url", "origin"
+            )
+        if rc != 0 or not github_url.strip():
+            logger.warning(
+                "_ensure_github_remote: could not determine GitHub URL for %s; "
+                "worktree will lack a 'github' remote. "
+                "Claude may need to configure it manually.",
+                worktree,
+            )
+            return
+
+        github_url = github_url.strip()
+        # Only add if it looks like a real GitHub URL (not a local path).
+        if "github.com" not in github_url:
+            logger.debug(
+                "_ensure_github_remote: base repo origin %r is not a GitHub URL; skipping",
+                github_url[:80],
+            )
+            return
+
+        # Check whether `github` remote already exists in the worktree.
+        rc_existing, existing_url, _ = await self._git_in_capture(
+            worktree, "remote", "get-url", "github"
+        )
+        try:
+            if rc_existing == 0:
+                # Remote exists — update the URL if it changed.
+                if existing_url.strip() != github_url:
+                    await self._git_in(worktree, "remote", "set-url", "github", github_url)
+                    logger.debug("updated 'github' remote in %s to %s", worktree, github_url[:80])
+            else:
+                await self._git_in(worktree, "remote", "add", "github", github_url)
+                logger.debug("added 'github' remote %s to %s", github_url[:80], worktree)
+        except WorktreeError as exc:
+            logger.warning("_ensure_github_remote: could not set remote in %s: %s", worktree, exc)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/deile/tests/orchestration/pipeline/test_gaps_132.py
+++ b/deile/tests/orchestration/pipeline/test_gaps_132.py
@@ -1,0 +1,932 @@
+"""Regression tests for issue #132 — gaps residuais do pipeline autônomo.
+
+Covers all items from #132:
+  #11 — TOCTOU re-fetch in claim_with_batch
+  #15 — github remote wiring in create_branch_worktree
+  #16 — WARNING + skipped_runs when enable_* is False in schedule mode
+  #21 — batch label created before claim finalized (order check)
+  #23/#24 — bootstrap_replay_window_hours in compute_pending
+  #28 — PipelineCommand --identity/--schedule-file/--no-pid-lock flags
+  #31 — schedule-driven classify triggers notifications
+  #32 — follow_ups as standalone action
+  Wiring C — cleanup_merged_branches + gc_completed_oneshots on startup
+Coverage — github_client, review_callback, worktree_manager
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.github_client import (
+    GhCommandError, GitHubClient, IssueRef, PrRef, compute_batch_id_for_number)
+from deile.orchestration.pipeline.labels import REVIEW_PENDING, WORKFLOW_NEW
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+from deile.orchestration.pipeline.scheduler import (VALID_ACTIONS,
+                                                    RecurringEntry, Schedule)
+
+# ---------------------------------------------------------------------------
+# #11 — TOCTOU re-fetch in claim_with_batch
+# ---------------------------------------------------------------------------
+
+class TestClaimWithBatchTOCTOU:
+    async def test_yields_when_foreign_batch_label_appears_after_add(self):
+        """After add_labels, if a foreign ~batch: label is present, we remove
+        ours and return None."""
+        client = GitHubClient("owner/repo")
+        unclaimed = IssueRef(number=1, title="t", url="u", labels=(WORKFLOW_NEW,))
+        # After add, a foreign batch label appears.
+        after_add = IssueRef(
+            number=1, title="t", url="u",
+            labels=(WORKFLOW_NEW, "~batch:deadbeef", "~batch:cafebabe"),
+        )
+        with patch.object(client, "get_issue", new=AsyncMock(side_effect=[unclaimed, after_add])), \
+             patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
+            result = await client.claim_with_batch("issue", 1, "t")
+        assert result is None
+
+    async def test_succeeds_when_only_our_batch_label_present_after_add(self):
+        """Happy path: after add_labels, only our label is present — return batch_id."""
+        client = GitHubClient("owner/repo")
+        our_batch = compute_batch_id_for_number("issue", 5)
+        our_label = f"~batch:{our_batch}"
+        unclaimed = IssueRef(number=5, title="x", url="u", labels=(WORKFLOW_NEW,))
+        after_add = IssueRef(
+            number=5, title="x", url="u",
+            labels=(WORKFLOW_NEW, our_label),
+        )
+        with patch.object(client, "get_issue", new=AsyncMock(side_effect=[unclaimed, after_add])), \
+             patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
+            result = await client.claim_with_batch("issue", 5, "x")
+        assert result == our_batch
+
+    async def test_returns_none_when_after_fetch_returns_none(self):
+        """PR disappears between claim and re-fetch."""
+        client = GitHubClient("owner/repo")
+        pr = PrRef(number=3, title="p", url="u", labels=(REVIEW_PENDING,))
+        with patch.object(client, "get_pr", new=AsyncMock(side_effect=[pr, None])), \
+             patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")):
+            result = await client.claim_with_batch("pr", 3, "p")
+        assert result is None
+
+    async def test_race_removal_gh_error_logged_not_raised(self):
+        """If remove_labels fails after detecting race, a warning is logged but
+        claim_with_batch still returns None cleanly."""
+        client = GitHubClient("owner/repo")
+        unclaimed = IssueRef(number=7, title="t2", url="u", labels=(WORKFLOW_NEW,))
+        after_add = IssueRef(
+            number=7, title="t2", url="u",
+            labels=(WORKFLOW_NEW, "~batch:deadbeef", "~batch:cafecafe"),
+        )
+        remove_calls = []
+
+        async def fake_remove(kind, number, labels):
+            remove_calls.append(labels)
+            raise GhCommandError(("gh",), 1, "", "network error")
+
+        with patch.object(client, "get_issue", new=AsyncMock(side_effect=[unclaimed, after_add])), \
+             patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")), \
+             patch.object(client, "remove_labels", side_effect=fake_remove):
+            result = await client.claim_with_batch("issue", 7, "t2")
+        assert result is None
+        assert remove_calls  # remove was attempted
+
+
+# ---------------------------------------------------------------------------
+# #15 — github remote wiring in create_branch_worktree
+# ---------------------------------------------------------------------------
+
+class TestEnsureGithubRemote:
+    async def test_github_remote_added_when_missing(self, tmp_path):
+        from deile.orchestration.pipeline.worktree_manager import \
+            WorktreeManager
+
+        # Set up a minimal git repo.
+        base = tmp_path / "repo"
+        base.mkdir()
+        (base / ".git").mkdir()
+
+        mgr = WorktreeManager.__new__(WorktreeManager)
+        mgr.base_repo = base
+        mgr.main_branch = "main"
+        mgr.subdir = None
+        mgr.worktrees_dir = base / ".worktrees"
+        mgr.branches_dir = base / ".worktrees"
+
+        worktree = base / ".worktrees" / "feat"
+        worktree.mkdir(parents=True)
+
+        calls = []
+
+        async def fake_capture(cwd, *args):
+            calls.append(args)
+            if args == ("remote", "get-url", "github"):
+                # base_repo has no github remote
+                return (1, "", "not found")
+            if args == ("remote", "get-url", "origin"):
+                return (0, "git@github.com:owner/repo.git\n", "")
+            if args == ("remote", "get-url",) and len(args) == 3:
+                # worktree check: no github remote yet
+                return (1, "", "not found")
+            return (0, "", "")
+
+        async def fake_git_in(cwd, *args):
+            calls.append(args)
+
+        mgr._git_in_capture = staticmethod(lambda cwd, *args: fake_capture(cwd, *args))
+        mgr._git_in = staticmethod(lambda cwd, *args: fake_git_in(cwd, *args))
+
+        await mgr._ensure_github_remote(worktree)
+
+        # Verify remote add was attempted
+        add_calls = [c for c in calls if len(c) >= 2 and c[0] == "remote" and c[1] == "add"]
+        assert any("github" in str(c) for c in add_calls)
+
+    async def test_skips_non_github_origin(self, tmp_path):
+        from deile.orchestration.pipeline.worktree_manager import \
+            WorktreeManager
+
+        base = tmp_path / "repo2"
+        base.mkdir()
+        (base / ".git").mkdir()
+
+        mgr = WorktreeManager.__new__(WorktreeManager)
+        mgr.base_repo = base
+        mgr.main_branch = "main"
+        mgr.subdir = None
+        mgr.worktrees_dir = base / ".worktrees"
+        mgr.branches_dir = base / ".worktrees"
+
+        worktree = base / ".worktrees" / "feat2"
+        worktree.mkdir(parents=True)
+
+        add_calls = []
+
+        async def fake_capture(cwd, *args):
+            if "get-url" in args and "github" in args:
+                return (1, "", "no remote")
+            if "get-url" in args and "origin" in args:
+                return (0, "/local/path/to/repo\n", "")
+            return (0, "", "")
+
+        async def fake_git_in(cwd, *args):
+            if args[0] == "remote" and args[1] == "add":
+                add_calls.append(args)
+
+        mgr._git_in_capture = staticmethod(lambda cwd, *args: fake_capture(cwd, *args))
+        mgr._git_in = staticmethod(lambda cwd, *args: fake_git_in(cwd, *args))
+
+        await mgr._ensure_github_remote(worktree)
+
+        # Should NOT add a remote for a local path.
+        assert not add_calls
+
+
+# ---------------------------------------------------------------------------
+# #16 — WARNING + skipped_runs when enable_* is False
+# ---------------------------------------------------------------------------
+
+class TestSkippedRunsWarning:
+    def _make_monitor(self, tmp_path, **config_overrides):
+        cfg = PipelineConfig(
+            repo="owner/repo",
+            base_repo_path=tmp_path,
+            use_pid_lock=False,
+            **config_overrides,
+        )
+        github = AsyncMock()
+        github.list_issues_with_label = AsyncMock(return_value=[])
+        github.list_open_prs = AsyncMock(return_value=[])
+        github.list_unclassified_issues = AsyncMock(return_value=[])
+        notifier = AsyncMock()
+        worktrees = AsyncMock()
+        return PipelineMonitor(
+            cfg,
+            github=github,
+            worktrees=worktrees,
+            claude=AsyncMock(),
+            notifier=notifier,
+        )
+
+    async def test_disabled_classify_increments_skipped_runs(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        monitor = self._make_monitor(tmp_path, enable_classify=False)
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="r1",
+            action="classify",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+
+        assert monitor._stats.skipped_runs == 1
+        # Classify was NOT actually run (no issue list call made).
+        monitor.github.list_unclassified_issues.assert_not_called()
+
+    async def test_disabled_review_increments_skipped_runs(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        monitor = self._make_monitor(tmp_path, enable_review=False)
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="r1",
+            action="review",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        assert monitor._stats.skipped_runs == 1
+
+    async def test_enabled_classify_does_not_increment_skipped(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        monitor = self._make_monitor(tmp_path, enable_classify=True)
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="r1",
+            action="classify",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        assert monitor._stats.skipped_runs == 0
+
+
+# ---------------------------------------------------------------------------
+# #23/#24 — bootstrap_replay_window_hours
+# ---------------------------------------------------------------------------
+
+class TestBootstrapReplayWindow:
+    def test_compute_pending_skips_very_old_slots_with_window(self):
+        """With a 1h window, an entry that last ran 3h ago skips directly to
+        the most recent slot within the window rather than replaying from 3h ago.
+
+        Concretely: last_ran=3h ago, cron=every30min.
+        Without window: oldest pending slot = 2.5h ago.
+        With window=1h: anchor advances to (now - 1h), first slot within window
+        = next_after(cutoff) = ~30min ago (still ≤ now) → ONE run fired.
+        The important thing is we do NOT get dozens of coalesced replays from 3h ago;
+        instead we get exactly one slot (or zero if even the window slot is in future).
+        """
+        now = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        # Last ran 3h ago.
+        anchor = datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc)
+        entry = RecurringEntry(
+            id="r1", action="review", cron="*/30 * * * *",
+            enabled=True, last_run_at=anchor,
+        )
+        sched_no_window = Schedule(recurring=[entry])
+        sched_with_window = Schedule(recurring=[entry])
+
+        without_window = sched_no_window.compute_pending(now, replay_window_hours=None)
+        with_window = sched_with_window.compute_pending(now, replay_window_hours=1)
+
+        # With coalescing, both return exactly 1 run — but with window the slot
+        # timestamp is within the 1h window (> cutoff = now - 1h).
+        assert len(with_window) == 1
+        # The run time should be within the last 1 hour.
+        cutoff = now - __import__("datetime").timedelta(hours=1)
+        assert with_window[0].when >= cutoff
+
+        # Without window the coalesced run is also 1, but its timestamp can be older.
+        assert len(without_window) == 1
+
+    def test_compute_pending_no_slot_within_window_returns_nothing(self):
+        """If even the cron's next slot after cutoff is still in the future, no run."""
+        now = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        # cron fires daily at midnight; last ran yesterday.
+        anchor = datetime(2026, 4, 30, tzinfo=timezone.utc)
+        entry = RecurringEntry(
+            id="r2", action="classify", cron="0 0 * * *",
+            enabled=True, last_run_at=anchor,
+        )
+        sched = Schedule(recurring=[entry])
+        # With window=1h, the next midnight after (now-1h)=11:00 is tomorrow midnight.
+        pending = sched.compute_pending(now, replay_window_hours=1)
+        # No pending run because next midnight > now.
+        assert not pending
+
+    def test_compute_pending_within_window_returns_run(self):
+        """Slots within the replay window are returned."""
+        now = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        # Last ran 20 minutes ago — next slot is 19 minutes ago (within 1h window).
+        anchor = datetime(2026, 5, 1, 11, 40, tzinfo=timezone.utc)
+        entry = RecurringEntry(
+            id="r1", action="review", cron="*/1 * * * *",
+            enabled=True, last_run_at=anchor,
+        )
+        sched = Schedule(recurring=[entry])
+        pending = sched.compute_pending(now, replay_window_hours=1)
+        assert pending
+
+    def test_compute_pending_none_window_uses_full_history(self):
+        """None window = no limit; old slots are still returned (coalesced)."""
+        now = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        anchor = datetime(2026, 4, 1, tzinfo=timezone.utc)  # 30 days ago
+        entry = RecurringEntry(
+            id="r1", action="review", cron="*/30 * * * *",
+            enabled=True, last_run_at=anchor,
+        )
+        sched = Schedule(recurring=[entry])
+        pending = sched.compute_pending(now, replay_window_hours=None)
+        # Should return exactly one pending run (coalesced).
+        assert len(pending) == 1
+
+
+# ---------------------------------------------------------------------------
+# #32 — follow_ups in VALID_ACTIONS
+# ---------------------------------------------------------------------------
+
+class TestFollowUpsAction:
+    def test_follow_ups_in_valid_actions(self):
+        assert "follow_ups" in VALID_ACTIONS
+
+    def test_schedule_accepts_follow_ups_action(self):
+        entry = RecurringEntry(
+            id="fu-loop", action="follow_ups", cron="0 * * * *",
+        )
+        assert entry.action == "follow_ups"
+
+    async def test_run_scheduled_follow_ups_calls_standalone(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path, use_pid_lock=False,
+        )
+        monitor = PipelineMonitor(
+            cfg,
+            github=AsyncMock(),
+            worktrees=AsyncMock(),
+            claude=AsyncMock(),
+            notifier=AsyncMock(),
+        )
+        called = []
+
+        async def fake_standalone():
+            called.append(True)
+
+        monitor._standalone_follow_ups = fake_standalone
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="fu",
+            action="follow_ups",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        assert called
+
+
+# ---------------------------------------------------------------------------
+# Wiring C — cleanup_merged_branches + gc_completed_oneshots in catch_up
+# ---------------------------------------------------------------------------
+
+class TestStartupWiring:
+    async def test_cleanup_merged_branches_called_on_catchup(self, tmp_path):
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path,
+            use_pid_lock=False, enable_worktree_cleanup=True,
+        )
+        schedule_store = MagicMock()
+        schedule_store.load = MagicMock(return_value=Schedule())
+        schedule_store.save = MagicMock()
+
+        worktrees = AsyncMock()
+        worktrees.cleanup_merged_branches = AsyncMock(return_value=2)
+
+        monitor = PipelineMonitor(
+            cfg,
+            github=AsyncMock(),
+            worktrees=worktrees,
+            claude=AsyncMock(),
+            notifier=AsyncMock(),
+            schedule_store=schedule_store,
+        )
+        await monitor._catch_up_pending()
+        worktrees.cleanup_merged_branches.assert_called_once_with("owner/repo")
+
+    async def test_cleanup_skipped_when_disabled(self, tmp_path):
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path,
+            use_pid_lock=False, enable_worktree_cleanup=False,
+        )
+        schedule_store = MagicMock()
+        schedule_store.load = MagicMock(return_value=Schedule())
+        schedule_store.save = MagicMock()
+
+        worktrees = AsyncMock()
+        worktrees.cleanup_merged_branches = AsyncMock(return_value=0)
+
+        monitor = PipelineMonitor(
+            cfg,
+            github=AsyncMock(),
+            worktrees=worktrees,
+            claude=AsyncMock(),
+            notifier=AsyncMock(),
+            schedule_store=schedule_store,
+        )
+        await monitor._catch_up_pending()
+        worktrees.cleanup_merged_branches.assert_not_called()
+
+    async def test_gc_completed_oneshots_called_on_catchup(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import OneshotEntry
+
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path,
+            use_pid_lock=False, enable_worktree_cleanup=False,
+        )
+        # Build a schedule with one completed old oneshot.
+        old_oneshot = OneshotEntry(
+            id="old-1",
+            action="review",
+            run_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            completed=True,
+        )
+        schedule = Schedule(oneshot=[old_oneshot])
+        saved_schedules = []
+
+        schedule_store = MagicMock()
+        schedule_store.load = MagicMock(return_value=schedule)
+        def capture_save(s):
+            saved_schedules.append(list(s.oneshot))
+        schedule_store.save = capture_save
+
+        monitor = PipelineMonitor(
+            cfg,
+            github=AsyncMock(),
+            worktrees=AsyncMock(),
+            claude=AsyncMock(),
+            notifier=AsyncMock(),
+            schedule_store=schedule_store,
+        )
+        await monitor._catch_up_pending()
+        # The old oneshot should be GC'd before saving.
+        assert saved_schedules
+        # After GC, the completed old entry should be gone.
+        assert not any(o.id == "old-1" for o in saved_schedules[-1])
+
+
+# ---------------------------------------------------------------------------
+# #28 — PipelineCommand flags
+# ---------------------------------------------------------------------------
+
+class TestPipelineCommandFlags:
+    def test_parse_start_flags_identity(self):
+        from deile.commands.builtin.pipeline_command import _parse_start_flags
+        ns = _parse_start_flags("--identity my-monitor")
+        assert ns.identity == "my-monitor"
+        assert not ns.no_pid_lock
+
+    def test_parse_start_flags_no_pid_lock(self):
+        from deile.commands.builtin.pipeline_command import _parse_start_flags
+        ns = _parse_start_flags("--no-pid-lock")
+        assert ns.no_pid_lock is True
+
+    def test_parse_start_flags_schedule_file(self):
+        from deile.commands.builtin.pipeline_command import _parse_start_flags
+        ns = _parse_start_flags("--schedule-file /tmp/sched.yaml")
+        assert ns.schedule_file == "/tmp/sched.yaml"
+
+    def test_parse_start_flags_defaults(self):
+        from deile.commands.builtin.pipeline_command import _parse_start_flags
+        ns = _parse_start_flags("")
+        assert ns.identity is None
+        assert ns.schedule_file is None
+        assert not ns.no_pid_lock
+
+    def test_parse_start_flags_combined(self):
+        from deile.commands.builtin.pipeline_command import _parse_start_flags
+        ns = _parse_start_flags("--identity alpha --no-pid-lock --schedule-file /s.yaml")
+        assert ns.identity == "alpha"
+        assert ns.no_pid_lock
+        assert ns.schedule_file == "/s.yaml"
+
+    def test_parse_start_flags_unknown_ignored(self):
+        from deile.commands.builtin.pipeline_command import _parse_start_flags
+        ns = _parse_start_flags("--unknown-future-flag foo")
+        assert ns.identity is None  # graceful degradation
+
+
+# ---------------------------------------------------------------------------
+# Coverage: review_callback.py
+# ---------------------------------------------------------------------------
+
+class TestReviewCallback:
+    async def test_returns_none_when_agent_is_none(self):
+        from deile.orchestration.pipeline.review_callback import \
+            make_review_callback
+        cb = make_review_callback(None)
+        assert cb is None
+
+    async def test_returns_none_when_agent_lacks_process(self):
+        from deile.orchestration.pipeline.review_callback import \
+            make_review_callback
+        cb = make_review_callback(object())
+        assert cb is None
+
+    async def test_callback_calls_agent_process(self):
+        from deile.orchestration.pipeline.review_callback import \
+            make_review_callback
+
+        agent = MagicMock()
+        agent.process = AsyncMock(return_value="Summary: do X")
+        cb = make_review_callback(agent)
+        assert cb is not None
+
+        issue = IssueRef(number=1, title="test", url="u", labels=(), body="some body")
+        result = await cb(issue)
+        assert "Summary" in result
+        agent.process.assert_called_once()
+
+    async def test_callback_returns_empty_on_agent_exception(self):
+        from deile.orchestration.pipeline.review_callback import \
+            make_review_callback
+
+        agent = MagicMock()
+        agent.process = AsyncMock(side_effect=RuntimeError("boom"))
+        cb = make_review_callback(agent)
+
+        issue = IssueRef(number=2, title="err test", url="u", labels=(), body="body")
+        result = await cb(issue)
+        assert result == ""
+
+    async def test_callback_returns_empty_on_none_response(self):
+        from deile.orchestration.pipeline.review_callback import \
+            make_review_callback
+
+        agent = MagicMock()
+        agent.process = AsyncMock(return_value=None)
+        cb = make_review_callback(agent)
+
+        issue = IssueRef(number=3, title="nil", url="u", labels=(), body="b")
+        result = await cb(issue)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Coverage: github_client — additional methods
+# ---------------------------------------------------------------------------
+
+class TestGetPrMethods:
+    async def test_get_pr_returns_none_for_non_open_state(self):
+        client = GitHubClient("owner/repo")
+        payload = json.dumps({
+            "number": 10, "title": "old", "url": "u",
+            "labels": [], "headRefName": "", "baseRefName": "main",
+            "state": "merged", "isDraft": False,
+        })
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.get_pr(10)
+        assert result is None
+
+    async def test_get_pr_returns_none_on_gh_error(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(
+            client, "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("gh",), 1, "", "not found"))
+        ):
+            result = await client.get_pr(99)
+        assert result is None
+
+    async def test_list_open_prs_parses_json(self):
+        client = GitHubClient("owner/repo")
+        payload = json.dumps([{
+            "number": 1, "title": "pr", "url": "u",
+            "labels": [], "headRefName": "auto/issue-1",
+            "baseRefName": "main", "state": "open", "isDraft": False,
+        }])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            prs = await client.list_open_prs()
+        assert len(prs) == 1
+        assert prs[0].head_ref == "auto/issue-1"
+
+    async def test_create_issue_returns_number(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(
+            client, "_run_checked",
+            new=AsyncMock(return_value="https://github.com/owner/repo/issues/42\n")
+        ):
+            num = await client.create_issue("title", "body", labels=["intent"])
+        assert num == 42
+
+    async def test_create_issue_returns_zero_on_error(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(
+            client, "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("gh",), 1, "", "err"))
+        ):
+            num = await client.create_issue("t", "b")
+        assert num == 0
+
+    async def test_get_pr_body_returns_empty_on_error(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(
+            client, "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("gh",), 1, "", "err"))
+        ):
+            body = await client.get_pr_body(1)
+        assert body == ""
+
+    async def test_list_pr_comments_returns_empty_on_error(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(
+            client, "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("gh",), 1, "", "err"))
+        ):
+            comments = await client.list_pr_comments(1)
+        assert comments == []
+
+    async def test_list_pr_comments_returns_bodies(self):
+        client = GitHubClient("owner/repo")
+        payload = json.dumps({"comments": [{"body": "comment1"}, {"body": "comment2"}]})
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            comments = await client.list_pr_comments(1)
+        assert comments == ["comment1", "comment2"]
+
+    async def test_comment_on_pr_calls_gh(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+            await client.comment_on_pr(5, "test comment")
+        args = run.call_args.args
+        assert "pr" in args and "comment" in args
+
+    async def test_comment_on_issue_calls_gh(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+            await client.comment_on_issue(3, "hi")
+        args = run.call_args.args
+        assert "issue" in args and "comment" in args
+
+    async def test_list_recently_merged_prs_returns_prs(self):
+        client = GitHubClient("owner/repo")
+        payload = json.dumps([{
+            "number": 5, "title": "merged pr", "url": "u",
+            "labels": [{"name": "~follow_ups:processed"}],
+            "headRefName": "auto/issue-5",
+            "baseRefName": "main", "state": "merged", "isDraft": False,
+        }])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            prs = await client.list_recently_merged_prs()
+        assert len(prs) == 1
+        assert "~follow_ups:processed" in prs[0].labels
+
+    async def test_list_recently_merged_prs_returns_empty_on_error(self):
+        client = GitHubClient("owner/repo")
+        with patch.object(
+            client, "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("gh",), 1, "", "err"))
+        ):
+            prs = await client.list_recently_merged_prs()
+        assert prs == []
+
+    async def test_clear_batch_label_removes_batch_labels(self):
+        client = GitHubClient("owner/repo")
+        issue = IssueRef(number=1, title="t", url="u",
+                         labels=("~batch:abc12345", WORKFLOW_NEW))
+        with patch.object(client, "get_issue", new=AsyncMock(return_value=issue)), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+            await client.clear_batch_label("issue", 1)
+        # Should have called remove_labels with the batch label.
+        assert run.called
+
+    async def test_clear_batch_label_noop_when_no_batch(self):
+        client = GitHubClient("owner/repo")
+        issue = IssueRef(number=1, title="t", url="u", labels=(WORKFLOW_NEW,))
+        with patch.object(client, "get_issue", new=AsyncMock(return_value=issue)), \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+            await client.clear_batch_label("issue", 1)
+        # No labels to remove, so run_checked should NOT be called.
+        assert not run.called
+
+    async def test_clear_batch_label_invalid_kind_raises(self):
+        client = GitHubClient("owner/repo")
+        with pytest.raises(ValueError):
+            await client.clear_batch_label("comment", 1)
+
+    async def test_list_unclassified_paginates_until_short_page(self):
+        client = GitHubClient("owner/repo")
+        # First batch: full 100 issues (all with ~labels → filtered out).
+        batch1 = [
+            {"number": i, "title": f"t{i}", "url": "u",
+             "labels": [{"name": "~workflow:nova"}], "body": "", "state": "open"}
+            for i in range(100)
+        ]
+        # Second batch: 3 unclassified issues.
+        batch2 = [
+            {"number": 200 + i, "title": f"new{i}", "url": "u",
+             "labels": [], "body": "b", "state": "open"}
+            for i in range(3)
+        ]
+        call_count = [0]
+
+        async def fake_run_checked(*args):
+            call_count[0] += 1
+            limit_idx = args.index("--limit") + 1 if "--limit" in args else None
+            if limit_idx and int(args[limit_idx]) <= 100:
+                return json.dumps(batch1)
+            return json.dumps(batch1 + batch2)
+
+        with patch.object(client, "_run_checked", side_effect=fake_run_checked):
+            results = await client.list_unclassified_issues()
+        assert len(results) == 3
+        assert all(r.number >= 200 for r in results)
+
+
+# ---------------------------------------------------------------------------
+# #31 — schedule-driven classify still triggers notification
+# ---------------------------------------------------------------------------
+
+class TestClassifyNotificationInScheduleMode:
+    async def test_classify_notifies_when_schedule_driven(self, tmp_path):
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path,
+            use_pid_lock=False, enable_classify=True,
+        )
+        issue = IssueRef(
+            number=99, title="new issue", url="https://github.com/o/r/issues/99",
+            labels=("intent",), body="some body",
+        )
+        github = AsyncMock()
+        github.list_unclassified_issues = AsyncMock(return_value=[issue])
+        github.claim_with_batch = AsyncMock(return_value="abc12345")
+        github.add_labels = AsyncMock()
+        github.comment_on_issue = AsyncMock()
+        notifier = AsyncMock()
+
+        # Use default identity (shard_count=1 → always owns)
+        identity = MonitorIdentity(monitor_id="default", shard_index=0, shard_count=1)
+        monitor = PipelineMonitor(
+            cfg, github=github, worktrees=AsyncMock(),
+            claude=AsyncMock(), notifier=notifier,
+            identity=identity,
+        )
+
+        # Simulate a schedule-driven tick by calling _run_scheduled directly.
+        from deile.orchestration.pipeline.scheduler import PendingRun
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="classify",
+            action="classify",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+
+        # Notification must have fired (same as legacy mode).
+        notifier.issue_auto_classified.assert_called_once_with(
+            99, "new issue", "https://github.com/o/r/issues/99"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Additional monitor.py coverage
+# ---------------------------------------------------------------------------
+
+class TestCatchUpPendingEdgeCases:
+    def _make_monitor(self, tmp_path, schedule_store=None, worktrees=None):
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path,
+            use_pid_lock=False, enable_worktree_cleanup=True,
+        )
+        monitor = PipelineMonitor(
+            cfg,
+            github=AsyncMock(),
+            worktrees=worktrees or AsyncMock(),
+            claude=AsyncMock(),
+            notifier=AsyncMock(),
+            schedule_store=schedule_store or MagicMock(),
+        )
+        return monitor
+
+    async def test_schedule_load_error_does_not_raise(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import ScheduleError
+        schedule_store = MagicMock()
+        schedule_store.load = MagicMock(side_effect=ScheduleError("corrupt"))
+        worktrees = AsyncMock()
+        worktrees.cleanup_merged_branches = AsyncMock(return_value=0)
+
+        monitor = self._make_monitor(tmp_path, schedule_store=schedule_store, worktrees=worktrees)
+        # Must not raise.
+        await monitor._catch_up_pending()
+
+    async def test_save_error_after_gc_does_not_raise(self, tmp_path):
+        schedule_store = MagicMock()
+        schedule_store.load = MagicMock(return_value=Schedule())
+        schedule_store.save = MagicMock(side_effect=OSError("disk full"))
+
+        worktrees = AsyncMock()
+        worktrees.cleanup_merged_branches = AsyncMock(return_value=0)
+
+        monitor = self._make_monitor(tmp_path, schedule_store=schedule_store, worktrees=worktrees)
+        await monitor._catch_up_pending()  # must not raise despite save error
+
+    async def test_worktree_cleanup_error_does_not_block_startup(self, tmp_path):
+        schedule_store = MagicMock()
+        schedule_store.load = MagicMock(return_value=Schedule())
+        schedule_store.save = MagicMock()
+
+        worktrees = AsyncMock()
+        worktrees.cleanup_merged_branches = AsyncMock(side_effect=RuntimeError("gh down"))
+
+        monitor = self._make_monitor(tmp_path, schedule_store=schedule_store, worktrees=worktrees)
+        await monitor._catch_up_pending()  # must not raise
+
+    async def test_save_error_after_catchup_does_not_raise(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import OneshotEntry
+
+        # Build a schedule with one pending oneshot.
+        run_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        oneshot = OneshotEntry(id="o1", action="classify", run_at=run_at)
+        sched = Schedule(oneshot=[oneshot])
+
+        schedule_store = MagicMock()
+        schedule_store.load = MagicMock(return_value=sched)
+        schedule_store.save = MagicMock(side_effect=OSError("disk full"))
+
+        worktrees = AsyncMock()
+        worktrees.cleanup_merged_branches = AsyncMock(return_value=0)
+
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path,
+            use_pid_lock=False, enable_worktree_cleanup=False,
+            enable_classify=True,
+        )
+        github = AsyncMock()
+        github.list_unclassified_issues = AsyncMock(return_value=[])
+        monitor = PipelineMonitor(
+            cfg, github=github, worktrees=worktrees,
+            claude=AsyncMock(), notifier=AsyncMock(),
+            schedule_store=schedule_store,
+        )
+        await monitor._catch_up_pending()  # must not raise
+
+
+class TestStandaloneFollowUps:
+    async def test_skips_already_processed_prs(self, tmp_path):
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path, use_pid_lock=False,
+        )
+        already_processed = PrRef(
+            number=1, title="done", url="u",
+            labels=("~follow_ups:processed",),
+        )
+        github = AsyncMock()
+        github.list_recently_merged_prs = AsyncMock(return_value=[already_processed])
+        stage4_calls = []
+
+        monitor = PipelineMonitor(
+            cfg, github=github, worktrees=AsyncMock(),
+            claude=AsyncMock(), notifier=AsyncMock(),
+        )
+
+        async def fake_stage4(*args):
+            stage4_calls.append(args)
+
+        monitor._stage4_follow_ups = fake_stage4
+        await monitor._standalone_follow_ups()
+        assert not stage4_calls
+
+    async def test_processes_unprocessed_prs(self, tmp_path):
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path, use_pid_lock=False,
+        )
+        pr = PrRef(number=2, title="new merged", url="https://gh/o/r/pull/2", labels=())
+        github = AsyncMock()
+        github.list_recently_merged_prs = AsyncMock(return_value=[pr])
+        github.add_labels = AsyncMock()
+
+        monitor = PipelineMonitor(
+            cfg, github=github, worktrees=AsyncMock(),
+            claude=AsyncMock(), notifier=AsyncMock(),
+        )
+        stage4_calls = []
+
+        async def fake_stage4(number, title, url):
+            stage4_calls.append((number, title, url))
+
+        monitor._stage4_follow_ups = fake_stage4
+        await monitor._standalone_follow_ups()
+        assert stage4_calls == [(2, "new merged", "https://gh/o/r/pull/2")]
+        github.add_labels.assert_called_once_with(
+            "pr", 2, ["~follow_ups:processed"]
+        )
+
+    async def test_list_error_is_caught(self, tmp_path):
+        cfg = PipelineConfig(
+            repo="owner/repo", base_repo_path=tmp_path, use_pid_lock=False,
+        )
+        github = AsyncMock()
+        github.list_recently_merged_prs = AsyncMock(side_effect=RuntimeError("boom"))
+
+        monitor = PipelineMonitor(
+            cfg, github=github, worktrees=AsyncMock(),
+            claude=AsyncMock(), notifier=AsyncMock(),
+        )
+        await monitor._standalone_follow_ups()  # must not raise

--- a/deile/tests/orchestration/pipeline/test_gaps_132.py
+++ b/deile/tests/orchestration/pipeline/test_gaps_132.py
@@ -930,3 +930,120 @@ class TestStandaloneFollowUps:
             claude=AsyncMock(), notifier=AsyncMock(),
         )
         await monitor._standalone_follow_ups()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# #16 — additional stages (implement, pr_review, follow_ups)
+# ---------------------------------------------------------------------------
+
+class TestSkippedRunsWarningAllStages:
+    """Ensure skipped_runs is incremented for ALL scheduled actions, not just classify/review."""
+
+    def _make_monitor(self, tmp_path, **config_overrides):
+        cfg = PipelineConfig(
+            repo="owner/repo",
+            base_repo_path=tmp_path,
+            use_pid_lock=False,
+            **config_overrides,
+        )
+        return PipelineMonitor(
+            cfg,
+            github=AsyncMock(),
+            worktrees=AsyncMock(),
+            claude=AsyncMock(),
+            notifier=AsyncMock(),
+        )
+
+    async def test_disabled_implement_increments_skipped_runs(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        monitor = self._make_monitor(tmp_path, enable_implement=False)
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="r1",
+            action="implement",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        assert monitor._stats.skipped_runs == 1
+
+    async def test_disabled_pr_review_increments_skipped_runs(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        monitor = self._make_monitor(tmp_path, enable_pr_review=False)
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="r1",
+            action="pr_review",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        assert monitor._stats.skipped_runs == 1
+
+    async def test_disabled_follow_ups_increments_skipped_runs(self, tmp_path):
+        from deile.orchestration.pipeline.scheduler import PendingRun
+
+        monitor = self._make_monitor(tmp_path, enable_follow_ups=False)
+        run = PendingRun(
+            when=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_id="r1",
+            action="follow_ups",
+            is_oneshot=False,
+        )
+        await monitor._run_scheduled(run)
+        assert monitor._stats.skipped_runs == 1
+
+
+# ---------------------------------------------------------------------------
+# #21 — _ensure_label called before add_labels inside claim_with_batch
+# ---------------------------------------------------------------------------
+
+class TestClaimWithBatchLabelOrdering:
+    """Verifies that _ensure_label (label creation) precedes add_labels (label assignment)."""
+
+    async def test_ensure_label_called_before_add_labels(self):
+        client = GitHubClient("owner/repo")
+        unclaimed = IssueRef(number=10, title="t", url="u", labels=(WORKFLOW_NEW,))
+        our_batch = compute_batch_id_for_number("issue", 10)
+        our_label = f"~batch:{our_batch}"
+        after_add = IssueRef(number=10, title="t", url="u", labels=(WORKFLOW_NEW, our_label))
+
+        call_order: list[str] = []
+
+        async def fake_ensure_label(name, *, color, description):
+            call_order.append("ensure_label")
+
+        async def fake_add_labels(kind, number, labels):
+            call_order.append("add_labels")
+
+        with (
+            patch.object(client, "get_issue", new=AsyncMock(side_effect=[unclaimed, after_add])),
+            patch.object(client, "_ensure_label", side_effect=fake_ensure_label),
+            patch.object(client, "add_labels", side_effect=fake_add_labels),
+        ):
+            result = await client.claim_with_batch("issue", 10, "t")
+
+        assert result == our_batch
+        assert "ensure_label" in call_order
+        assert "add_labels" in call_order
+        assert call_order.index("ensure_label") < call_order.index("add_labels")
+
+
+# ---------------------------------------------------------------------------
+# #28 — --schedule-file relative path is resolved via Path()
+# ---------------------------------------------------------------------------
+
+class TestScheduleFileRelativePath:
+    def test_schedule_file_relative_path_stem_is_filename(self):
+        """Path('config/my_sched.yaml').stem == 'my_sched' and .parent == PurePosixPath('config')."""
+        from pathlib import Path
+        p = Path("config/my_sched.yaml")
+        assert p.stem == "my_sched"
+        assert str(p.parent) == "config"
+
+    def test_schedule_file_bare_name_parent_is_dot(self):
+        """A bare filename has parent == '.' (current directory)."""
+        from pathlib import Path
+        p = Path("sched.yaml")
+        assert p.stem == "sched"
+        assert str(p.parent) == "."

--- a/docs/2026-05-06_PIPELINE-AUTONOMO.md
+++ b/docs/2026-05-06_PIPELINE-AUTONOMO.md
@@ -113,9 +113,11 @@ PipelineMonitor
 │   ├── main_branch: str (default "main")
 │   ├── branch_prefix: str (default "auto/issue-")
 │   ├── notify_user_id: Optional[str]
-│   ├── enable_classify/review/implement/pr_review: bool
+│   ├── enable_classify/review/implement/pr_review/follow_ups: bool
 │   ├── enable_review_human_prs: bool (gap #8)
 │   ├── use_pid_lock: bool (default True — gap #27)
+│   ├── bootstrap_replay_window_hours: Optional[int] (default 1 — gap #23/#24)
+│   ├── enable_worktree_cleanup: bool (default True — gap #26)
 │   └── classifiable_labels: set (includes "security" — gap #4)
 ├── identity: MonitorIdentity
 │   ├── monitor_id: str
@@ -127,9 +129,11 @@ PipelineMonitor
 │   ├── ticks, issues_reviewed, issues_classified, issues_implemented
 │   ├── prs_reviewed, errors, gh_errors, claude_errors (gap #18)
 │   ├── catchup_runs, scheduled_runs
+│   └── skipped_runs  # incremented when enable_*=False blocks a scheduled action
 ├── async start() → acquires PID lock → catch_up_pending → create_task(_run_forever)
 ├── async stop() → set stop_event → wait task → release lock
 ├── async tick() → check schedule → run pending + legacy-fallback for missing stages (gap #1)
+│   └── _run_scheduled: if enable_*=False → WARNING + skipped_runs++ (gap #16)
 ├── Stage 0: _classify_new_issues()
 │   ├── list_unclassified_issues() with pagination (gap #30)
 │   ├── identity.owns(issue.title) shard filter
@@ -151,13 +155,18 @@ PipelineMonitor
 │   ├── ClaudeDispatcher.run(implement_prompt, cwd=worktree)
 │   ├── _extract_pr_url uses last match (gap #14)
 │   └── transition revisada → em_pr
-└── Stage 3: _review_one_open_pr()
-    ├── list open PRs not draft, no ~review:concluida, owned branch
-    ├── _owns_pr_branch: warns on empty head_ref (gap #22)
-    ├── claim_with_batch → transition pendente → em_andamento
-    ├── ClaudeDispatcher.run(review_prompt, cwd=worktree)
-    ├── transition em_andamento → concluida
-    └── clear_batch_label("pr", number) after conclude (gap #9)
+├── Stage 3: _review_one_open_pr()
+│   ├── list open PRs not draft, no ~review:concluida, owned branch
+│   ├── _owns_pr_branch: warns on empty head_ref (gap #22)
+│   ├── claim_with_batch → transition pendente → em_andamento
+│   ├── ClaudeDispatcher.run(review_prompt, cwd=worktree)
+│   ├── transition em_andamento → concluida
+│   └── clear_batch_label("pr", number) after conclude (gap #9)
+└── Stage 4: _standalone_follow_ups()  [triggered by action="follow_ups" — gap #32]
+    ├── list_recently_merged_prs() via gh CLI
+    ├── skip if ~follow_ups:processed label already present (idempotent)
+    ├── _stage4_follow_ups(pr.number, pr.title, pr.url)
+    └── add ~follow_ups:processed after completion
 
 CronRunner
 ├── store: CronStore
@@ -217,7 +226,7 @@ CronRunner
 
 | Method | Parameters | Return | Notes |
 |---|---|---|---|
-| `compute_pending(now=None)` | `datetime` | `List[PendingRun]` | Coalesça misseds por padrão; `replay_all=True` replica cada slot |
+| `compute_pending(now=None, *, replay_window_hours=None)` | `datetime`, `Optional[int]` | `List[PendingRun]` | Coalesça misseds por padrão; `replay_all=True` replica cada slot; `replay_window_hours` limita catch-up ao janela de N horas (gap #23/#24) |
 | `mark_run(run, when=None)` | `PendingRun` | `None` | Atualiza last_run_at (recurring) ou completed (oneshot) |
 
 ---
@@ -232,7 +241,7 @@ CronRunner
 # em modo legacy (a cada tick), garantindo que nenhum estágio fique silencioso.
 recurring:
   - id: classify_loop         # str, alphanum + _- obrigatório
-    action: classify          # classify | review | implement | pr_review
+    action: classify          # classify | review | implement | pr_review | follow_ups
     cron: "*/2 * * * *"       # 5-field cron expression em UTC
     enabled: true
     last_run_at: null
@@ -252,6 +261,12 @@ recurring:
   - id: pr_review_loop
     action: pr_review
     cron: "*/4 * * * *"
+    enabled: true
+    last_run_at: null
+    replay_all: false
+  - id: follow_ups_loop       # Stage 4: follow-up automático de issues pós-merge
+    action: follow_ups
+    cron: "*/10 * * * *"
     enabled: true
     last_run_at: null
     replay_all: false
@@ -352,6 +367,12 @@ async def test_monitor_identity_shard():
 # Iniciar o pipeline
 /pipeline start
 
+# Iniciar com identidade e arquivo de schedule customizados (gap #28)
+/pipeline start --identity monitor-prod --schedule-file config/my_schedule.yaml
+
+# Iniciar sem PID lock (útil em dev/teste)
+/pipeline start --no-pid-lock
+
 # Verificar status (inclui gh_errors e claude_errors — gap #18)
 /pipeline status
 
@@ -429,7 +450,7 @@ await cron_runner.start()
 | Cron runner poll | 30s por padrão; configurável em `CronRunner.poll_interval_seconds` |
 | Claude Code timeout | 1800s (30 min) por invocação; configurável em `ClaudeDispatcher.timeout_seconds` |
 | GitHub API | Cada tick faz no máximo 3 chamadas de listagem + N operações de label (N ≤ 3 por issue/PR) |
-| Worktrees | Criados em disco; removidos manualmente (worktree cleanup não é automático — ver § Rollback) |
+| Worktrees | Criados em disco; `cleanup_merged_branches()` removido automaticamente no startup se `enable_worktree_cleanup=True` (gap #26) |
 | `CronStore.list_due` | `O(log N)` via índice `(enabled, next_fire_at)` |
 | Schedule YAML | Parse a cada tick; aceitável para schedules com < 100 entradas |
 | Concorrência | Um monitor por identidade por host; shards rodam em processos/máquinas separadas |
@@ -462,6 +483,7 @@ await cron_runner.start()
 | `claude_errors` | Erros de `ClaudeDispatcher` (rc != 0) — gap #18 |
 | `catchup_runs` | Runs de catch-up executados no startup |
 | `scheduled_runs` | Runs de schedule executados em ticks normais |
+| `skipped_runs` | Runs ignorados porque `enable_*=False` para a action (gap #16) |
 
 ### Discord DMs
 
@@ -486,6 +508,10 @@ await cron_runner.start()
 - **Tools não registradas automaticamente:** `pipeline_tool`, `pipeline_schedule_tool`, `cron_*` requerem registro explícito via `register_tool(...)`. O `auto_discover()` existente não os cobre — o daemon/bootstrap deve registrá-los.
 - **`use_pid_lock` agora `True` por padrão (gap #27):** em deploys que rodavam sem PID lock, isso pode levantar `LockHeldError` se dois processos subirem simultâneamente. Para desabilitar explicitamente: `PipelineConfig(use_pid_lock=False)`.
 - **`compute_batch_id` alterado (gap #10):** o batch ID agora é derivado do número da issue/PR (não do título), eliminando colisões entre issues com o mesmo título. Batch IDs existentes no GitHub continuarão válidos; apenas novos claims usarão o novo cálculo.
+- **`enable_worktree_cleanup=True` por padrão (gap #26):** ao iniciar, o monitor remove worktrees de branches já mergeadas. Para desabilitar: `PipelineConfig(enable_worktree_cleanup=False)`.
+- **`bootstrap_replay_window_hours=1` por padrão (gap #23/#24):** ao iniciar, o catch-up limita-se a slots das últimas 1h. Deploys que esperavam replay ilimitado devem configurar `PipelineConfig(bootstrap_replay_window_hours=None)`.
+- **Nova action `follow_ups` (gap #32):** o `VALID_ACTIONS` do scheduler agora inclui `"follow_ups"`; schedules antigos com `action: follow_ups` (se houver) passarão a ser reconhecidos em vez de ignorados silenciosamente.
+- **`/pipeline start` aceita flags (gap #28):** `--identity`, `--schedule-file`, `--no-pid-lock`. Chamadas existentes sem flags continuam idênticas.
 
 ### Deploy de múltiplos monitores
 
@@ -530,7 +556,10 @@ DEILE_CRON_AUTOSTART=1
 | Issue não é claimed | `batch_id` já presente ou `identity.owns()` retorna False | Verificar `DEILE_PIPELINE_SHARD_*`; inspecionar labels da issue via `gh issue view` |
 | `claude -p` timeout | Log `claude -p timed out after 1800s` | Issue/PR muito complexo; aumentar `ClaudeDispatcher.timeout_seconds` |
 | PR não aberta após implementação | `_extract_pr_url` não encontrou URL no stdout | Claude Code não abriu PR; inspecionar logs do subprocess em `result.stderr` |
-| Worktrees acumulando em disco | Não há cleanup automático | Rodar `git worktree prune` + `git worktree list` manualmente na raiz do repo; ou usar `WorktreeManager.cleanup_merged_branches()` (gap #26) |
+| Worktrees acumulando em disco | `enable_worktree_cleanup=True` mas merge ainda não detectado | Aguardar próximo `start()` ou chamar `WorktreeManager.cleanup_merged_branches()` manualmente; verificar que o branch da PR aparece em `gh pr list --state merged` |
+| `gh pr create` falha no worktree | Worktree sem remote `github` apontando para GitHub | `_ensure_github_remote` (gap #15) tenta configurar automaticamente; verificar que o base repo tem remote `github` ou `origin` apontando para `github.com` |
+| `enable_classify=False` mas classify ainda aparece no schedule | Ação está desabilitada mas ainda está no YAML | Comportamento correto: ação é ignorada com WARNING e `skipped_runs` incrementado (gap #16); remover a entrada do YAML se não quiser o aviso |
+| Catch-up pós-restart dispara ações antigas (horas atrás) | `bootstrap_replay_window_hours` não configurado | Default é 1h; aumentar em `PipelineConfig(bootstrap_replay_window_hours=N)` ou passar `None` para replay ilimitado |
 | `CronStore` falha ao abrir | `data/` não existe ou sem permissão | Verificar `DEILE_CRON_DB_PATH`; criar diretório manualmente |
 | Entry cron nunca dispara | `enabled=0` ou `next_fire_at` no passado sem advance | Usar `cron_list` tool para inspecionar; `cron_delete` + `cron_create` para re-agendar |
 | DMs não chegam | `DEILE_PIPELINE_NOTIFY_USER_ID` não configurado ou `deilebot` offline | Verificar env var; checar log `DiscordNotifier: no DM function available` (gap #19) |
@@ -545,7 +574,7 @@ DEILE_CRON_AUTOSTART=1
 
 | Aspecto | Nota |
 |---|---|
-| Cleanup automático de worktrees | `WorktreeManager` poderia listar e remover worktrees de branches já mergeadas |
+| Cleanup automático de worktrees | Implementado (gap #26): `cleanup_merged_branches()` chamado no startup quando `enable_worktree_cleanup=True` |
 | Retry com backoff | `ClaudeDispatcher` atualmente não retenta; um resultado `ok=False` encerra o estágio sem retry |
 | Dashboard de pipeline | Stats em `PipelineMonitor.stats` são efêmeros (em memória); persistir em SQLite permitiria queries históricas |
 | Cron com suporte a timezones | `CronStore` e `next_after` operam em UTC; UI de Discord pode querer aceitar "às 9h BRT" e converter |

--- a/docs/system_design/00-VISAO-GERAL.md
+++ b/docs/system_design/00-VISAO-GERAL.md
@@ -92,6 +92,7 @@
 | 21 | Schedule padrão completo + fallback legacy para stages ausentes (`tick()` gap #1 — issue #129) | V1 patch | Arquitetura (02), Configuração (09) |
 | 22 | Stage 1 atômico com rollback `em_revisao → nova` em caso de falha (gap #13 — issue #129) | V1 patch | Princípios (03) |
 | 23 | Batch ID derivado do número (não título) via `compute_batch_id_for_number` (gap #10 — issue #129) | V1 patch | Arquitetura (02) |
+| 24 | TOCTOU mitigation em `claim_with_batch`: re-fetch após `add_labels` para detectar race condition (gap #11 — issue #132) | V1 patch | Princípios (03), Arquitetura (02) |
 
 ## Estado dos pilares
 

--- a/docs/system_design/DECISOES.md
+++ b/docs/system_design/DECISOES.md
@@ -291,6 +291,18 @@
 
 ---
 
+## Decisão #24 — TOCTOU mitigation em `claim_with_batch`: re-fetch após `add_labels`
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 patch |
+| Pilar dono | 03-Princípios (Security-First), 02-Arquitetura |
+| Decisão | Após `add_labels(label)` em `claim_with_batch`, o cliente faz um re-fetch da issue/PR e verifica se há labels de batch de outros monitores além do próprio. Se detectado, remove o label próprio e retorna `None` (falha silenciosa). Isso mitiga a race condition TOCTOU onde dois monitores adicionam labels quase simultaneamente (GitHub API não é transacional). |
+| Evidência | `deile/orchestration/pipeline/github_client.py:claim_with_batch` |
+| Motivação | O GitHub REST API não oferece operação atômica "adicionar label apenas se ausente". A janela entre `get_issue` (check) e `add_labels` (use) é explorável. O re-fetch post-add detecta o conflito após o fato e recua, garantindo que apenas um monitor processe o item. O recuo é best-effort (remoção pode falhar em caso de erro de rede). |
+
+---
+
 ## Como adicionar uma nova decisão
 
 | # | Passo |


### PR DESCRIPTION
## Summary

- **#11** — TOCTOU race mitigation em `claim_with_batch`: re-fetch da issue/PR após `add_labels`; se outro monitor já adicionou label de batch, recua e retorna `None`
- **#15** — `_ensure_github_remote()` no `WorktreeManager`: todo worktree criado recebe remote `github` apontando para GitHub, necessário para `gh pr create` operar no worktree
- **#16** — `enable_*=False` em modo schedule-driven agora emite WARNING em vez de ignorar silenciosamente; novo contador `_Stats.skipped_runs`
- **#21** — teste de regressão confirma que `_ensure_label` é chamado antes de `add_labels` (ordering correto já existia desde PR #131)
- **#23/#24** — `bootstrap_replay_window_hours=1` em `PipelineConfig` limita catch-up a slots das últimas N horas; parâmetro `replay_window_hours` propagado para `compute_pending()`
- **#28** — `/pipeline start` aceita flags: `--identity <id>`, `--schedule-file <path>`, `--no-pid-lock` (parsing via `argparse`/`shlex`)
- **#31** — teste de regressão confirma que `action="classify"` no schedule aciona `_classify_new_issues()` que por sua vez chama `notifier.issue_auto_classified()`
- **#32** — nova action `follow_ups` em `VALID_ACTIONS`; `_standalone_follow_ups()` lista PRs mergeadas recentes via `list_recently_merged_prs()`, roda Stage 4 por PR não processada, e marca `~follow_ups:processed` para idempotência

Wiring de startup (`_catch_up_pending`): chama `cleanup_merged_branches` (quando `enable_worktree_cleanup=True`) e `gc_completed_oneshots` a cada arranque.

## Coverage

| Módulo | Antes | Depois |
|---|---|---|
| `github_client.py` | 65% | **88%** |
| `review_callback.py` | 57% | **100%** |
| `monitor.py` | — | **82%** |
| `worktree_manager.py` | — | **82%** |
| `scheduler.py` | — | **89%** |

## Test plan

- [ ] `python3 -m pytest deile/tests/orchestration/pipeline/test_gaps_132.py -v` — 54 novos testes passam
- [ ] `python3 -m pytest deile/tests/ -q` — 1674 passed, 14 skipped
- [ ] `ruff check deile/` — clean
- [ ] `isort --check-only deile/` — clean
- [ ] Revisar diff de `claim_with_batch` para confirmar re-fetch pós-`add_labels`
- [ ] Revisar `_ensure_github_remote` para confirmar fallback origin→github URL
- [ ] Confirmar que `/pipeline start --no-pid-lock` não levanta `LockHeldError` em teste dev

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)