### PR TITLE
feat(install): isolated venv (global/local) + auto PATH setup + --install-mode flag

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -20,6 +20,7 @@ import asyncio
 import os
 import subprocess
 import sys
+import tempfile
 import venv as _venv  # noqa: N812 — local alias for testability (patched as deile.cli._venv)
 from pathlib import Path
 from typing import List, Optional
@@ -156,7 +157,7 @@ def _run_env_recovery() -> bool:
     return True
 
 
-# ── interactive mode ────────────────────────────────────────────────────────
+# ── interactive mode ─────────────────────────────────────────────────────────
 
 class _DeileCLI:
     """Thin wrapper that reuses the DEILE agent + UI stack."""
@@ -361,7 +362,7 @@ class _DeileCLI:
             self.ui.display_error(f"Ocorreu um erro fatal no loop principal: {exc}")
 
 
-# ── pipeline autostart helper ───────────────────────────────────────────────
+# ── pipeline autostart helper ────────────────────────────────────────────────
 
 
 async def _autostart_pipeline(agent) -> None:  # type: ignore[type-arg]
@@ -399,7 +400,7 @@ async def _autostart_pipeline(agent) -> None:  # type: ignore[type-arg]
         _log.warning("pipeline autostart failed: %s", exc)
 
 
-# ── one-shot mode ───────────────────────────────────────────────────────────
+# ── one-shot mode ────────────────────────────────────────────────────────────
 
 
 def _print_oneshot_content(content) -> None:
@@ -479,58 +480,7 @@ async def _run_oneshot(message: str, forced_model: Optional[str] = None) -> int:
     return 0 if status != "error" else 1
 
 
-def _ensure_scripts_dir_on_path(scripts_dir: Path) -> tuple[bool, Optional[Path], str]:
-    """Append `export PATH=...` to the user's shell rc file if not already there.
-
-    Returns (modified, rc_path, fallback_hint):
-      modified=True            → rc file was edited.
-      modified=False, rc set, hint==""  → already configured in rc; just needs reload.
-      modified=False, rc=None  → could not auto-edit (Windows / unknown shell);
-                                 caller should print fallback_hint.
-      modified=False, rc set, hint!=""  → tried but failed (perm/IO); print hint.
-    """
-    export_line_posix = f'export PATH="{scripts_dir}:$PATH"'
-
-    if os.name == "nt":
-        hint = (
-            f'PowerShell: $env:Path = "{scripts_dir};$env:Path"\n'
-            "  (persist via System Properties → Environment Variables)"
-        )
-        return (False, None, hint)
-
-    shell = os.path.basename(os.environ.get("SHELL", ""))
-    home = Path.home()
-
-    if shell == "zsh":
-        rc = home / ".zshrc"
-        export_line = export_line_posix
-    elif shell == "bash":
-        rc = home / (".bash_profile" if sys.platform == "darwin" else ".bashrc")
-        export_line = export_line_posix
-    elif shell == "fish":
-        rc = home / ".config" / "fish" / "config.fish"
-        export_line = f'set -gx PATH "{scripts_dir}" $PATH'
-    else:
-        return (False, None, f'Add to your shell rc:\n    {export_line_posix}')
-
-    try:
-        existing = rc.read_text(encoding="utf-8") if rc.exists() else ""
-    except OSError as exc:
-        return (False, rc, f"Could not read {rc}: {exc}.\nAdd manually:\n    {export_line}")
-
-    if str(scripts_dir) in existing:
-        return (False, rc, "")  # idempotent — already configured
-
-    marker = "# Added by `deile --install` — places the `deile` command on PATH"
-    new_content = (existing.rstrip("\n") + "\n\n" if existing else "") + marker + "\n" + export_line + "\n"
-
-    try:
-        rc.parent.mkdir(parents=True, exist_ok=True)
-        rc.write_text(new_content, encoding="utf-8")
-    except OSError as exc:
-        return (False, rc, f"Could not write {rc}: {exc}.\nAdd manually:\n    {export_line}")
-
-    return (True, rc, "")
+# ── install helpers ──────────────────────────────────────────────────────────
 
 
 def _user_scripts_dir() -> Path:
@@ -566,7 +516,26 @@ def _wrapper_target_dir() -> Path:
     return Path.home() / ".local" / "bin"
 
 
-def _create_venv_with_deile(venv_dir: Path, repo_root: Path, mode_label: str) -> Path:
+async def _pip_run(*args: str, step: str, sanitized_path: Optional[str] = None) -> None:
+    """Run a pip sub-command; raise DEILEInstallError on non-zero exit."""
+    from deile.core.exceptions import DEILEInstallError
+
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        stderr_text = (stderr or b"").decode("utf-8", errors="replace")[:500]
+        raise DEILEInstallError(
+            f"pip {step} failed (rc={proc.returncode}): {stderr_text}",
+            step=step,
+            sanitized_path=sanitized_path,
+        )
+
+
+async def _create_venv_with_deile(venv_dir: Path, repo_root: Path, mode_label: str) -> Path:
     """Ensure an isolated venv at ``venv_dir`` has DEILE + deps installed.
 
     Steps (idempotent):
@@ -578,46 +547,81 @@ def _create_venv_with_deile(venv_dir: Path, repo_root: Path, mode_label: str) ->
 
     Returns the absolute path to ``<venv>/bin/deile`` (or ``Scripts\\deile.exe``).
     """
+    from deile.core.exceptions import DEILEInstallError
+
+    # Canonicalize paths to prevent injection / traversal (Pilar 08)
+    try:
+        venv_dir = venv_dir.resolve()
+        repo_root = repo_root.resolve()
+    except OSError as exc:
+        raise DEILEInstallError(
+            f"failed to resolve path: {exc}",
+            step="resolve_paths",
+            sanitized_path=venv_dir.name,
+        ) from exc
+
+    # Safety: ensure venv_dir is within a reasonable location
+    home = Path.home().resolve()
+    if not (str(venv_dir).startswith(str(repo_root)) or str(venv_dir).startswith(str(home))):
+        raise DEILEInstallError(
+            "venv_dir is outside allowed locations (must be under repo or home)",
+            step="validate_venv_path",
+        )
+
     venv_py = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
-    if not venv_py.exists():
-        print(f"[{mode_label}] Creating venv at {venv_dir}…")
-        venv_dir.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            _venv.EnvBuilder(with_pip=True).create(str(venv_dir))
-        except Exception as exc:
-            raise RuntimeError(f"failed to create venv at {venv_dir}: {exc}") from exc
-    else:
-        print(f"[{mode_label}] Reusing existing venv at {venv_dir}")
+    try:
+        if not venv_py.exists():
+            print(f"[{mode_label}] Creating venv…")
+            venv_dir.parent.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(
+                _venv.EnvBuilder(with_pip=True).create, str(venv_dir)
+            )
+        else:
+            print(f"[{mode_label}] Reusing existing venv")
 
-    print(f"[{mode_label}] Upgrading pip…")
-    subprocess.run(
-        [str(venv_py), "-m", "pip", "install", "--disable-pip-version-check", "-q", "--upgrade", "pip"],
-        check=False,
-    )
+        print(f"[{mode_label}] Upgrading pip…")
+        await _pip_run(
+            str(venv_py), "-m", "pip", "install",
+            "--disable-pip-version-check", "-q", "--upgrade", "pip",
+            step="upgrade_pip", sanitized_path=venv_dir.name,
+        )
 
-    requirements = repo_root / "requirements.txt"
-    if requirements.exists():
-        print(f"[{mode_label}] Installing dependencies from {requirements.name} (this can take a while on first run)…")
-        rc = subprocess.run(
-            [str(venv_py), "-m", "pip", "install", "--disable-pip-version-check", "-r", str(requirements)],
-        ).returncode
-        if rc != 0:
-            raise RuntimeError(f"pip install -r {requirements.name} failed (rc={rc})")
-    else:
-        print(f"[{mode_label}] WARNING: no requirements.txt at {repo_root} — skipping dep install")
+        requirements = repo_root / "requirements.txt"
+        if requirements.exists():
+            print(f"[{mode_label}] Installing dependencies from {requirements.name}…")
+            await _pip_run(
+                str(venv_py), "-m", "pip", "install",
+                "--disable-pip-version-check", "-r", str(requirements),
+                step="install_deps", sanitized_path=requirements.name,
+            )
+        else:
+            print(f"[{mode_label}] WARNING: no requirements.txt — skipping dep install")
 
-    print(f"[{mode_label}] Registering DEILE entry script (editable, no-deps)…")
-    rc = subprocess.run(
-        [str(venv_py), "-m", "pip", "install", "--disable-pip-version-check", "-q", "--no-deps", "-e", str(repo_root)],
-    ).returncode
-    if rc != 0:
-        raise RuntimeError(f"pip install --no-deps -e {repo_root} failed (rc={rc})")
+        print(f"[{mode_label}] Registering DEILE entry script (editable, no-deps)…")
+        await _pip_run(
+            str(venv_py), "-m", "pip", "install",
+            "--disable-pip-version-check", "-q", "--no-deps", "-e", str(repo_root),
+            step="install_editable",
+        )
 
-    deile_script = venv_dir / ("Scripts/deile.exe" if os.name == "nt" else "bin/deile")
-    if not deile_script.exists():
-        raise RuntimeError(f"console script not created at {deile_script}")
-    return deile_script
+        deile_script = venv_dir / ("Scripts/deile.exe" if os.name == "nt" else "bin/deile")
+        if not deile_script.exists():
+            raise DEILEInstallError(
+                "console script not created",
+                step="verify_script",
+                sanitized_path=deile_script.name,
+            )
+        return deile_script
+
+    except DEILEInstallError:
+        raise
+    except Exception as exc:
+        raise DEILEInstallError(
+            f"venv creation failed: {exc}",
+            step="create_venv",
+            sanitized_path=venv_dir.name,
+        ) from exc
 
 
 def _link_global_command(target_dir: Path, source_script: Path, *, force: bool = False) -> Path:
@@ -629,28 +633,39 @@ def _link_global_command(target_dir: Path, source_script: Path, *, force: bool =
     If a file/symlink already exists at the target, we ask before replacing
     (or replace silently when ``force=True``).
     """
+    from deile.core.exceptions import DEILEInstallError
+
     target_dir.mkdir(parents=True, exist_ok=True)
     target = target_dir / ("deile.cmd" if os.name == "nt" else "deile")
 
     if target.exists() or target.is_symlink():
         if target.is_symlink():
             try:
-                existing = f"symlink → {os.readlink(target)}"
+                existing = "symlink"
+                # Don't leak the real path in user-facing messages
             except OSError:
-                existing = "symlink (unreadable target)"
+                existing = "symlink (unreadable)"
         else:
             existing = "regular file"
         if not force:
             try:
-                ans = input(f"  {target} already exists ({existing}). Replace? [Y/n]: ").strip().lower()
+                ans = input(f"  {target.name} already exists ({existing}). Replace? [Y/n]: ").strip().lower()
             except (KeyboardInterrupt, EOFError):
                 ans = "n"
             if ans not in ("", "y", "yes"):
-                raise RuntimeError(f"refusing to overwrite {target}")
+                raise DEILEInstallError(
+                    "refusing to overwrite existing shim",
+                    step="link_command",
+                    sanitized_path=target.name,
+                )
         try:
             target.unlink()
         except OSError as exc:
-            raise RuntimeError(f"could not remove existing {target}: {exc}") from exc
+            raise DEILEInstallError(
+                f"could not remove existing shim: {exc}",
+                step="unlink_old_shim",
+                sanitized_path=target.name,
+            ) from exc
 
     if os.name == "nt":
         target.write_text(f'@echo off\r\n"{source_script}" %*\r\n', encoding="utf-8")
@@ -658,8 +673,98 @@ def _link_global_command(target_dir: Path, source_script: Path, *, force: bool =
         try:
             target.symlink_to(source_script)
         except OSError as exc:
-            raise RuntimeError(f"could not create symlink {target} → {source_script}: {exc}") from exc
+            raise DEILEInstallError(
+                f"could not create symlink: {exc}",
+                step="create_symlink",
+                sanitized_path=target.name,
+            ) from exc
     return target
+
+
+def _ensure_scripts_dir_on_path(scripts_dir: Path) -> tuple[bool, Optional[Path], str]:
+    """Append ``export PATH=...`` to the user's shell rc file if not already there.
+
+    Returns (modified, rc_path, fallback_hint):
+      modified=True            → rc file was edited.
+      modified=False, rc set, hint==""  → already configured in rc; just needs reload.
+      modified=False, rc=None  → could not auto-edit (Windows / unknown shell);
+                                 caller should print fallback_hint.
+      modified=False, rc set, hint!=""  → tried but failed (perm/IO); print hint.
+
+    Security (Pilar 08):
+      - The rc file path is resolved to canonical form (no symlink traversal).
+      - Writing is atomic: tempfile in same directory, then os.replace().
+      - The check for already-configured is line-by-line (not substring match).
+
+    """
+    from deile.core.exceptions import DEILEInstallError
+
+    export_line_posix = f'export PATH="{scripts_dir}:$PATH"'
+
+    if os.name == "nt":
+        hint = (
+            f'PowerShell: $env:Path = "{scripts_dir};$env:Path"\n'
+            "  (persist via System Properties → Environment Variables)"
+        )
+        return (False, None, hint)
+
+    shell = os.path.basename(os.environ.get("SHELL", ""))
+    home = Path.home().resolve()  # canonical home
+
+    if shell == "zsh":
+        rc = (home / ".zshrc").resolve()
+        export_line = export_line_posix
+    elif shell == "bash":
+        rc = (home / (".bash_profile" if sys.platform == "darwin" else ".bashrc")).resolve()
+        export_line = export_line_posix
+    elif shell == "fish":
+        rc = (home / ".config" / "fish" / "config.fish").resolve()
+        export_line = f'set -gx PATH "{scripts_dir}" $PATH'
+    else:
+        return (False, None, f'Add to your shell rc:\n    {export_line_posix}')
+
+    # Safety: rc file must be within $HOME (prevent symlink traversal out of home)
+    if not str(rc).startswith(str(home)):
+        raise DEILEInstallError(
+            "rc file resolves outside of home directory",
+            step="validate_rc_path",
+            sanitized_path=rc.name,
+        )
+
+    try:
+        existing = rc.read_text(encoding="utf-8") if rc.exists() else ""
+    except OSError as exc:
+        return (False, rc, f"Could not read {rc.name}: {exc}.\nAdd manually:\n    {export_line}")
+
+    # ── Idempotency: line-by-line check (not substring) ──
+    scripts_dir_str = str(scripts_dir)
+    for line in existing.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue  # skip commented-out lines
+        if scripts_dir_str in stripped and "PATH" in stripped.upper():
+            return (False, rc, "")  # already configured
+
+    marker = "# Added by `deile --install` — places the `deile` command on PATH\n"
+    new_content = (existing.rstrip("\n") + "\n\n" if existing else "") + marker + export_line + "\n"
+
+    # ── Atomic write: tempfile in same directory, then os.replace ──
+    try:
+        rc.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(rc.parent), prefix=".deile_rc_", suffix=".tmp")
+        try:
+            os.write(fd, new_content.encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(tmp_path, str(rc))  # atomic on POSIX
+    except OSError as exc:
+        raise DEILEInstallError(
+            f"Could not write {rc.name}: {exc}",
+            step="write_rc_file",
+            sanitized_path=rc.name,
+        ) from exc
+
+    return (True, rc, "")
 
 
 def _prompt_install_mode() -> Optional[str]:
@@ -692,7 +797,7 @@ def _prompt_install_mode() -> Optional[str]:
         print(f"Unrecognized choice: {choice!r}. Please answer g, l, or q.")
 
 
-def _run_self_install(mode: Optional[str] = None) -> int:
+async def _run_self_install_async(mode: Optional[str] = None) -> int:
     """Install DEILE so `deile` is reachable from any working directory.
 
     Two modes (interactive prompt unless ``mode`` is provided):
@@ -707,6 +812,8 @@ def _run_self_install(mode: Optional[str] = None) -> int:
     %USERPROFILE%/.../Scripts/deile.cmd (Windows) so the command works from
     any directory without polluting site-packages.
     """
+    from deile.core.exceptions import DEILEInstallError
+
     repo_root = _PROJECT_ROOT
 
     if mode is None:
@@ -726,29 +833,33 @@ def _run_self_install(mode: Optional[str] = None) -> int:
     print()
     print(f"Installing DEILE — mode: {mode}")
     print(f"  repo: {repo_root}")
-    print(f"  venv: {venv_dir}")
 
     try:
-        deile_script = _create_venv_with_deile(venv_dir, repo_root, mode)
-    except Exception as exc:  # noqa: BLE001 — surface message, not traceback
-        print(f"ERROR: {exc}", file=sys.stderr)
+        deile_script = await _create_venv_with_deile(venv_dir, repo_root, mode)
+    except DEILEInstallError as exc:
+        # Sanitize: never leak full paths in user-facing error messages
+        detail = exc.sanitized_path or "unknown"
+        print(f"ERROR: {exc.message} ({detail})", file=sys.stderr)
         return 1
 
     target_dir = _wrapper_target_dir()
     try:
         wrapper = _link_global_command(target_dir, deile_script)
-    except RuntimeError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
+    except DEILEInstallError as exc:
+        detail = exc.sanitized_path or "unknown"
+        print(f"ERROR: {exc.message} ({detail})", file=sys.stderr)
         return 1
 
     print()
     print("DEILE installed successfully.")
-    print(f"  shim:   {wrapper}")
-    print(f"  target: {deile_script}")
+    print(f"  shim:   {wrapper.name} (in {wrapper.parent})")
+    print("  target: venv")
 
     if os.name != "nt":
-        which = subprocess.run(
-            ["/usr/bin/env", "which", "deile"], text=True, capture_output=True, check=False
+        which = await asyncio.to_thread(
+            subprocess.run,
+            ["/usr/bin/env", "which", "deile"],
+            text=True, capture_output=True, check=False,
         )
         on_path_now = which.returncode == 0 and which.stdout.strip() == str(wrapper)
     else:
@@ -760,14 +871,19 @@ def _run_self_install(mode: Optional[str] = None) -> int:
         return 0
 
     print()
-    print(f"Note: {target_dir} is not active in your current PATH.")
-    modified, rc_path, hint = _ensure_scripts_dir_on_path(target_dir)
+    try:
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(target_dir)
+    except DEILEInstallError as exc:
+        print(f"Note: could not auto-configure PATH ({exc.message}).")
+        print(f"Add {target_dir.name} to your PATH manually.")
+        return 0
+
     if modified:
-        print(f"Added PATH export to {rc_path}.")
+        print(f"Added PATH export to {rc_path.name}.")
         print(f"Run:  source {rc_path}   (or open a new terminal)")
         print("Then: deile --help")
     elif rc_path is not None and not hint:
-        print(f"PATH already configured in {rc_path}, but not in current shell session.")
+        print(f"PATH already configured in {rc_path.name}, but not in current shell session.")
         print(f"Run:  source {rc_path}   (or open a new terminal)")
         print("Then: deile --help")
     else:
@@ -775,7 +891,12 @@ def _run_self_install(mode: Optional[str] = None) -> int:
     return 0
 
 
-# ── command-flag dispatch (issue #126) ──────────────────────────────────────
+def _run_self_install(mode: Optional[str] = None) -> int:
+    """Synchronous wrapper around _run_self_install_async for CLI entry point."""
+    return asyncio.run(_run_self_install_async(mode))
+
+
+# ── command-flag dispatch (issue #126) ───────────────────────────────────────
 
 
 async def _run_command_flag(
@@ -894,7 +1015,7 @@ def _format_help_with_commands(parser: "argparse.ArgumentParser") -> str:
     return base_help + "\n".join(lines) + "\n"
 
 
-# ── main entry point ────────────────────────────────────────────────────────
+# ── main entry point ─────────────────────────────────────────────────────────
 
 def main(argv: Optional[List[str]] = None) -> int:
     """`deile` console_script entry point.

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -14,13 +14,13 @@ to invoke DEILE anywhere:
 """
 
 from __future__ import annotations
-import venv as _venv  # noqa: N812 — local alias for testability (patched as deile.cli._venv)
 
 import argparse
 import asyncio
 import os
 import subprocess
 import sys
+import venv as _venv  # noqa: N812 — local alias for testability (patched as deile.cli._venv)
 from pathlib import Path
 from typing import List, Optional
 

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -478,78 +478,300 @@ async def _run_oneshot(message: str, forced_model: Optional[str] = None) -> int:
     return 0 if status != "error" else 1
 
 
-def _run_self_install() -> int:
-    """Install DEILE globally for the current user via pip editable mode."""
-    python_exe = sys.executable
-    project_root = _PROJECT_ROOT
+def _ensure_scripts_dir_on_path(scripts_dir: Path) -> tuple[bool, Optional[Path], str]:
+    """Append `export PATH=...` to the user's shell rc file if not already there.
 
-    base_install_cmd = [
-        python_exe,
-        "-m",
-        "pip",
-        "install",
-        "--user",
-        "-e",
-        str(project_root),
-    ]
+    Returns (modified, rc_path, fallback_hint):
+      modified=True            → rc file was edited.
+      modified=False, rc set, hint==""  → already configured in rc; just needs reload.
+      modified=False, rc=None  → could not auto-edit (Windows / unknown shell);
+                                 caller should print fallback_hint.
+      modified=False, rc set, hint!=""  → tried but failed (perm/IO); print hint.
+    """
+    export_line_posix = f'export PATH="{scripts_dir}:$PATH"'
 
-    print(f"Installing DEILE from: {project_root}")
-    print(f"Running: {' '.join(base_install_cmd)}")
+    if os.name == "nt":
+        hint = (
+            f'PowerShell: $env:Path = "{scripts_dir};$env:Path"\n'
+            "  (persist via System Properties → Environment Variables)"
+        )
+        return (False, None, hint)
+
+    shell = os.path.basename(os.environ.get("SHELL", ""))
+    home = Path.home()
+
+    if shell == "zsh":
+        rc = home / ".zshrc"
+        export_line = export_line_posix
+    elif shell == "bash":
+        rc = home / (".bash_profile" if sys.platform == "darwin" else ".bashrc")
+        export_line = export_line_posix
+    elif shell == "fish":
+        rc = home / ".config" / "fish" / "config.fish"
+        export_line = f'set -gx PATH "{scripts_dir}" $PATH'
+    else:
+        return (False, None, f'Add to your shell rc:\n    {export_line_posix}')
 
     try:
-        result = subprocess.run(
-            base_install_cmd,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-    except Exception as exc:
-        print(f"ERROR: failed to run pip: {type(exc).__name__}: {exc}", file=sys.stderr)
+        existing = rc.read_text(encoding="utf-8") if rc.exists() else ""
+    except OSError as exc:
+        return (False, rc, f"Could not read {rc}: {exc}.\nAdd manually:\n    {export_line}")
+
+    if str(scripts_dir) in existing:
+        return (False, rc, "")  # idempotent — already configured
+
+    marker = "# Added by `deile --install` — places the `deile` command on PATH"
+    new_content = (existing.rstrip("\n") + "\n\n" if existing else "") + marker + "\n" + export_line + "\n"
+
+    try:
+        rc.parent.mkdir(parents=True, exist_ok=True)
+        rc.write_text(new_content, encoding="utf-8")
+    except OSError as exc:
+        return (False, rc, f"Could not write {rc}: {exc}.\nAdd manually:\n    {export_line}")
+
+    return (True, rc, "")
+
+
+def _user_scripts_dir() -> Path:
+    """Return the directory where `pip install --user` places console scripts.
+
+    Picks the right sysconfig scheme per platform:
+      - Linux:        posix_user           → ~/.local/bin
+      - macOS (framework Python):
+                      osx_framework_user   → ~/Library/Python/X.Y/bin
+      - Windows:      nt_user              → %APPDATA%\\Python\\PythonXY\\Scripts
+    """
+    import sysconfig
+
+    if hasattr(sysconfig, "get_preferred_scheme"):
+        scheme = sysconfig.get_preferred_scheme("user")
+    elif os.name == "nt":
+        scheme = "nt_user"
+    elif sys.platform == "darwin" and getattr(sys, "_framework", ""):
+        scheme = "osx_framework_user"
+    else:
+        scheme = "posix_user"
+    return Path(sysconfig.get_path("scripts", scheme=scheme))
+
+
+def _wrapper_target_dir() -> Path:
+    """Pick the directory where the global `deile` wrapper should land.
+
+    On POSIX, prefer ~/.local/bin (commonly already on PATH). On Windows or if
+    ~/.local/bin is unusable, fall back to the sysconfig user-scripts dir.
+    """
+    if os.name == "nt":
+        return _user_scripts_dir()
+    return Path.home() / ".local" / "bin"
+
+
+def _create_venv_with_deile(venv_dir: Path, repo_root: Path, mode_label: str) -> Path:
+    """Ensure an isolated venv at ``venv_dir`` has DEILE + deps installed.
+
+    Steps (idempotent):
+      1. Create the venv if missing.
+      2. Upgrade pip.
+      3. Install ``requirements.txt`` (frozen versions — same set the bootstrap uses).
+      4. Register the deile package editable with ``--no-deps`` so the
+         ``deile`` console script is created without disturbing pinned deps.
+
+    Returns the absolute path to ``<venv>/bin/deile`` (or ``Scripts\\deile.exe``).
+    """
+    venv_py = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+    if not venv_py.exists():
+        print(f"[{mode_label}] Creating venv at {venv_dir}…")
+        venv_dir.parent.mkdir(parents=True, exist_ok=True)
+        import venv as _venv
+        try:
+            _venv.EnvBuilder(with_pip=True).create(str(venv_dir))
+        except Exception as exc:
+            raise RuntimeError(f"failed to create venv at {venv_dir}: {exc}") from exc
+    else:
+        print(f"[{mode_label}] Reusing existing venv at {venv_dir}")
+
+    print(f"[{mode_label}] Upgrading pip…")
+    subprocess.run(
+        [str(venv_py), "-m", "pip", "install", "--disable-pip-version-check", "-q", "--upgrade", "pip"],
+        check=False,
+    )
+
+    requirements = repo_root / "requirements.txt"
+    if requirements.exists():
+        print(f"[{mode_label}] Installing dependencies from {requirements.name} (this can take a while on first run)…")
+        rc = subprocess.run(
+            [str(venv_py), "-m", "pip", "install", "--disable-pip-version-check", "-r", str(requirements)],
+        ).returncode
+        if rc != 0:
+            raise RuntimeError(f"pip install -r {requirements.name} failed (rc={rc})")
+    else:
+        print(f"[{mode_label}] WARNING: no requirements.txt at {repo_root} — skipping dep install")
+
+    print(f"[{mode_label}] Registering DEILE entry script (editable, no-deps)…")
+    rc = subprocess.run(
+        [str(venv_py), "-m", "pip", "install", "--disable-pip-version-check", "-q", "--no-deps", "-e", str(repo_root)],
+    ).returncode
+    if rc != 0:
+        raise RuntimeError(f"pip install --no-deps -e {repo_root} failed (rc={rc})")
+
+    deile_script = venv_dir / ("Scripts/deile.exe" if os.name == "nt" else "bin/deile")
+    if not deile_script.exists():
+        raise RuntimeError(f"console script not created at {deile_script}")
+    return deile_script
+
+
+def _link_global_command(target_dir: Path, source_script: Path, *, force: bool = False) -> Path:
+    """Create the user-facing `deile` shim that points at ``source_script``.
+
+    On POSIX: a symlink at ``target_dir/deile``.
+    On Windows: a ``.cmd`` shim that execs the source script.
+
+    If a file/symlink already exists at the target, we ask before replacing
+    (or replace silently when ``force=True``).
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / ("deile.cmd" if os.name == "nt" else "deile")
+
+    if target.exists() or target.is_symlink():
+        if target.is_symlink():
+            try:
+                existing = f"symlink → {os.readlink(target)}"
+            except OSError:
+                existing = "symlink (unreadable target)"
+        else:
+            existing = "regular file"
+        if not force:
+            try:
+                ans = input(f"  {target} already exists ({existing}). Replace? [Y/n]: ").strip().lower()
+            except (KeyboardInterrupt, EOFError):
+                ans = "n"
+            if ans not in ("", "y", "yes"):
+                raise RuntimeError(f"refusing to overwrite {target}")
+        try:
+            target.unlink()
+        except OSError as exc:
+            raise RuntimeError(f"could not remove existing {target}: {exc}") from exc
+
+    if os.name == "nt":
+        target.write_text(f'@echo off\r\n"{source_script}" %*\r\n', encoding="utf-8")
+    else:
+        try:
+            target.symlink_to(source_script)
+        except OSError as exc:
+            raise RuntimeError(f"could not create symlink {target} → {source_script}: {exc}") from exc
+    return target
+
+
+def _prompt_install_mode() -> Optional[str]:
+    """Interactively pick install mode. Returns 'global', 'local', or None."""
+    print()
+    print("Install mode:")
+    print()
+    print("  [g] Global  — isolated venv at ~/.deile/venv/")
+    print("                Recommended. DEILE deps don't touch your system or user-site Python.")
+    print("                Works no matter where you cd to.")
+    print()
+    print("  [l] Local   — uses this repo's .venv/")
+    print("                The `deile` command points at this specific clone. If you")
+    print("                move or delete this directory, the command stops working.")
+    print()
+    print("  [q] Quit")
+    print()
+    while True:
+        try:
+            choice = input("Choice [g/l/q] (default g): ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return None
+        if choice in ("", "g", "global"):
+            return "global"
+        if choice in ("l", "local"):
+            return "local"
+        if choice in ("q", "quit", "exit"):
+            return None
+        print(f"Unrecognized choice: {choice!r}. Please answer g, l, or q.")
+
+
+def _run_self_install(mode: Optional[str] = None) -> int:
+    """Install DEILE so `deile` is reachable from any working directory.
+
+    Two modes (interactive prompt unless ``mode`` is provided):
+
+      global → creates an isolated venv at ~/.deile/venv/ that is dedicated
+               to DEILE. Your system / user-site Python is untouched.
+
+      local  → uses <repo>/.venv/ (created on the fly if missing). The
+               `deile` command is bound to *this* clone of the repo.
+
+    Both modes drop a thin shim at ~/.local/bin/deile (POSIX) or
+    %USERPROFILE%/.../Scripts/deile.cmd (Windows) so the command works from
+    any directory without polluting site-packages.
+    """
+    repo_root = _PROJECT_ROOT
+
+    if mode is None:
+        mode = _prompt_install_mode()
+        if mode is None:
+            print("Cancelled.")
+            return 1
+
+    if mode == "global":
+        venv_dir = Path.home() / ".deile" / "venv"
+    elif mode == "local":
+        venv_dir = repo_root / ".venv"
+    else:
+        print(f"ERROR: unknown install mode {mode!r} (expected 'global' or 'local').", file=sys.stderr)
+        return 2
+
+    print()
+    print(f"Installing DEILE — mode: {mode}")
+    print(f"  repo: {repo_root}")
+    print(f"  venv: {venv_dir}")
+
+    try:
+        deile_script = _create_venv_with_deile(venv_dir, repo_root, mode)
+    except Exception as exc:  # noqa: BLE001 — surface message, not traceback
+        print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    stderr = result.stderr.strip() or "(no stderr)"
-    is_pep668 = "externally-managed-environment" in stderr or "PEP 668" in stderr
-    if result.returncode != 0 and is_pep668:
-        fallback_cmd = [
-            python_exe,
-            "-m",
-            "pip",
-            "install",
-            "--user",
-            "--break-system-packages",
-            "-e",
-            str(project_root),
-        ]
-        print(
-            "Detected externally-managed Python. Retrying with --break-system-packages..."
-        )
-        print(f"Running: {' '.join(fallback_cmd)}")
-        result = subprocess.run(
-            fallback_cmd,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        stderr = result.stderr.strip() or "(no stderr)"
+    target_dir = _wrapper_target_dir()
+    try:
+        wrapper = _link_global_command(target_dir, deile_script)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
 
-    if result.returncode != 0:
-        print("ERROR: installation failed.", file=sys.stderr)
-        print(stderr, file=sys.stderr)
-        if "externally-managed-environment" in stderr or "PEP 668" in stderr:
-            print(
-                "Tip: this Python is externally managed. "
-                "Use pipx (`brew install pipx && pipx install -e .`) if needed.",
-                file=sys.stderr,
-            )
-        return result.returncode or 1
-
-    which_cmd = ["/usr/bin/env", "which", "deile"]
-    which_result = subprocess.run(which_cmd, text=True, capture_output=True, check=False)
-    deile_path = which_result.stdout.strip() if which_result.returncode == 0 else "not found in PATH"
-
+    print()
     print("DEILE installed successfully.")
-    print(f"deile path: {deile_path}")
-    print("Try: deile --help")
+    print(f"  shim:   {wrapper}")
+    print(f"  target: {deile_script}")
+
+    if os.name != "nt":
+        which = subprocess.run(
+            ["/usr/bin/env", "which", "deile"], text=True, capture_output=True, check=False
+        )
+        on_path_now = which.returncode == 0 and which.stdout.strip() == str(wrapper)
+    else:
+        on_path_now = False  # PowerShell `where.exe` lookup not implemented here
+
+    if on_path_now:
+        print()
+        print("Try: deile --help")
+        return 0
+
+    print()
+    print(f"Note: {target_dir} is not active in your current PATH.")
+    modified, rc_path, hint = _ensure_scripts_dir_on_path(target_dir)
+    if modified:
+        print(f"Added PATH export to {rc_path}.")
+        print(f"Run:  source {rc_path}   (or open a new terminal)")
+        print("Then: deile --help")
+    elif rc_path is not None and not hint:
+        print(f"PATH already configured in {rc_path}, but not in current shell session.")
+        print(f"Run:  source {rc_path}   (or open a new terminal)")
+        print("Then: deile --help")
+    else:
+        print(hint)
     return 0
 
 
@@ -721,7 +943,16 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--install",
         action="store_true",
-        help="Install DEILE globally for the current user (`pip install --user -e <repo>`).",
+        help="Install DEILE so `deile` is reachable from any directory. Prompts for global "
+             "(isolated venv at ~/.deile/venv/) or local (uses <repo>/.venv/). Use --install-mode "
+             "to skip the prompt.",
+    )
+    parser.add_argument(
+        "--install-mode",
+        choices=("global", "local"),
+        default=None,
+        help="Non-interactive install target for --install. 'global' = isolated venv at "
+             "~/.deile/venv/. 'local' = <repo>/.venv/. Both write a shim to ~/.local/bin/deile.",
     )
 
     # Auto-generate one --flag per registered slash command (issue #126).
@@ -754,7 +985,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 0
 
     if args.install:
-        return _run_self_install()
+        return _run_self_install(mode=args.install_mode)
+    if args.install_mode and not args.install:
+        print("ERROR: --install-mode requires --install.", file=sys.stderr)
+        return 2
 
     # --debug is a global modifier: enable debug mode in settings BEFORE any
     # one-shot dispatch or interactive run, so it actually has an effect.

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import shutil
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import venv as _venv  # noqa: N812 — local alias for testability (patched as deile.cli._venv)
 from pathlib import Path
@@ -29,6 +31,9 @@ from typing import List, Optional
 _PACKAGE_ROOT = Path(__file__).parent.resolve()
 _PROJECT_ROOT = _PACKAGE_ROOT.parent  # repo root when editable, same when installed
 _ENV_KEY_NAMES = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DEEPSEEK_API_KEY", "GOOGLE_API_KEY")
+
+# ── install helpers — module-level constants ─────────────────────────────────
+_KNOWN_SHELLS = frozenset({"zsh", "bash", "fish"})
 _TTY = sys.stdout.isatty()
 _RESET = "\033[0m" if _TTY else ""
 _BOLD = "\033[1m" if _TTY else ""
@@ -492,8 +497,6 @@ def _user_scripts_dir() -> Path:
                       osx_framework_user   → ~/Library/Python/X.Y/bin
       - Windows:      nt_user              → %APPDATA%\\Python\\PythonXY\\Scripts
     """
-    import sysconfig
-
     if hasattr(sysconfig, "get_preferred_scheme"):
         scheme = sysconfig.get_preferred_scheme("user")
     elif os.name == "nt":
@@ -699,6 +702,15 @@ def _ensure_scripts_dir_on_path(scripts_dir: Path) -> tuple[bool, Optional[Path]
     """
     from deile.core.exceptions import DEILEInstallError
 
+    # double-quote would break `export PATH="..."` syntax; newline would split the rc line.
+    scripts_dir_str = str(scripts_dir)
+    if '"' in scripts_dir_str or "\n" in scripts_dir_str:
+        return (
+            False, None,
+            f"Path contains unsupported characters for auto-configuration.\n"
+            f"Add manually:\n    export PATH=\"{scripts_dir_str}:$PATH\""
+        )
+
     export_line_posix = f'export PATH="{scripts_dir}:$PATH"'
 
     if os.name == "nt":
@@ -709,6 +721,9 @@ def _ensure_scripts_dir_on_path(scripts_dir: Path) -> tuple[bool, Optional[Path]
         return (False, None, hint)
 
     shell = os.path.basename(os.environ.get("SHELL", ""))
+    if shell not in _KNOWN_SHELLS:
+        return (False, None, f'Add to your shell rc:\n    {export_line_posix}')
+
     home = Path.home().resolve()  # canonical home
 
     if shell == "zsh":
@@ -717,11 +732,9 @@ def _ensure_scripts_dir_on_path(scripts_dir: Path) -> tuple[bool, Optional[Path]
     elif shell == "bash":
         rc = (home / (".bash_profile" if sys.platform == "darwin" else ".bashrc")).resolve()
         export_line = export_line_posix
-    elif shell == "fish":
+    else:  # fish
         rc = (home / ".config" / "fish" / "config.fish").resolve()
         export_line = f'set -gx PATH "{scripts_dir}" $PATH'
-    else:
-        return (False, None, f'Add to your shell rc:\n    {export_line_posix}')
 
     # Safety: rc file must be within $HOME (prevent symlink traversal out of home)
     if not str(rc).startswith(str(home)):
@@ -737,7 +750,6 @@ def _ensure_scripts_dir_on_path(scripts_dir: Path) -> tuple[bool, Optional[Path]
         return (False, rc, f"Could not read {rc.name}: {exc}.\nAdd manually:\n    {export_line}")
 
     # ── Idempotency: line-by-line check (not substring) ──
-    scripts_dir_str = str(scripts_dir)
     for line in existing.splitlines():
         stripped = line.strip()
         if stripped.startswith("#"):
@@ -834,10 +846,13 @@ async def _run_self_install_async(mode: Optional[str] = None) -> int:
     print(f"Installing DEILE — mode: {mode}")
     print(f"  repo: {repo_root}")
 
+    created_venv: Optional[Path] = None
+
     try:
         deile_script = await _create_venv_with_deile(venv_dir, repo_root, mode)
+        # Capture resolved path for rollback; success guarantees venv exists.
+        created_venv = deile_script.parent.parent
     except DEILEInstallError as exc:
-        # Sanitize: never leak full paths in user-facing error messages
         detail = exc.sanitized_path or "unknown"
         print(f"ERROR: {exc.message} ({detail})", file=sys.stderr)
         return 1
@@ -846,8 +861,11 @@ async def _run_self_install_async(mode: Optional[str] = None) -> int:
     try:
         wrapper = _link_global_command(target_dir, deile_script)
     except DEILEInstallError as exc:
+        # Roll back the venv to avoid a partially-installed state (Princípio 9).
+        if created_venv is not None:
+            shutil.rmtree(created_venv, ignore_errors=True)
         detail = exc.sanitized_path or "unknown"
-        print(f"ERROR: {exc.message} ({detail})", file=sys.stderr)
+        print(f"ERROR: {exc.message} ({detail}) — rolled back venv.", file=sys.stderr)
         return 1
 
     print()
@@ -861,7 +879,21 @@ async def _run_self_install_async(mode: Optional[str] = None) -> int:
             ["/usr/bin/env", "which", "deile"],
             text=True, capture_output=True, check=False,
         )
-        on_path_now = which.returncode == 0 and which.stdout.strip() == str(wrapper)
+        if which.returncode == 0:
+            found_path = Path(which.stdout.strip())
+            # Resolve symlink to confirm it points to the venv we just installed
+            try:
+                on_path_now = found_path.resolve() == wrapper.resolve()
+            except OSError:
+                on_path_now = False
+            if not on_path_now and found_path.exists():
+                # A stale or different `deile` binary is on PATH — warn the user.
+                print(
+                    f"Note: `which deile` returned {found_path.name!r} which does not "
+                    "point to the newly installed wrapper. You may have a stale binary."
+                )
+        else:
+            on_path_now = False
     else:
         on_path_now = False  # PowerShell `where.exe` lookup not implemented here
 
@@ -1105,11 +1137,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         sys.stdout.write(_format_help_with_commands(parser))
         return 0
 
-    if args.install:
-        return _run_self_install(mode=args.install_mode)
     if args.install_mode and not args.install:
         print("ERROR: --install-mode requires --install.", file=sys.stderr)
         return 2
+    if args.install:
+        return _run_self_install(mode=args.install_mode)
 
     # --debug is a global modifier: enable debug mode in settings BEFORE any
     # one-shot dispatch or interactive run, so it actually has an effect.

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -14,6 +14,7 @@ to invoke DEILE anywhere:
 """
 
 from __future__ import annotations
+import venv as _venv  # noqa: N812 — local alias for testability (patched as deile.cli._venv)
 
 import argparse
 import asyncio
@@ -582,7 +583,6 @@ def _create_venv_with_deile(venv_dir: Path, repo_root: Path, mode_label: str) ->
     if not venv_py.exists():
         print(f"[{mode_label}] Creating venv at {venv_dir}…")
         venv_dir.parent.mkdir(parents=True, exist_ok=True)
-        import venv as _venv
         try:
             _venv.EnvBuilder(with_pip=True).create(str(venv_dir))
         except Exception as exc:

--- a/deile/core/exceptions.py
+++ b/deile/core/exceptions.py
@@ -121,6 +121,35 @@ class CommandError(DEILEError):
             self.context["command_name"] = command_name
 
 
+class DEILEInstallError(DEILEError):
+    """Erro durante o processo de instalação (--install / --install-mode).
+
+    Todas as funções do pipeline de instalação (``_create_venv_with_deile``,
+    ``_link_global_command``, ``_ensure_scripts_dir_on_path``) levantam esta
+    exceção em vez de ``RuntimeError`` stdlib, conforme Pilar 03 §6 (Error
+    Handling tipado) e o template de Pilar 12.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        step: Optional[str] = None,
+        sanitized_path: Optional[str] = None,
+        **kwargs
+    ):
+        super().__init__(
+            message,
+            error_code="DEILE_INSTALL_FAILED",
+            **kwargs
+        )
+        self.step = step
+        self.sanitized_path = sanitized_path
+        if step:
+            self.context["install_step"] = step
+        if sanitized_path:
+            self.context["sanitized_path"] = sanitized_path
+
+
 class PersonaError(DEILEError):
     """Exceção base para erros relacionados ao sistema de personas"""
 

--- a/deile/tests/test_install_functions.py
+++ b/deile/tests/test_install_functions.py
@@ -1,0 +1,573 @@
+"""Tests for the isolated-venv install functions in deile/cli.py.
+
+Functions under test:
+  * _ensure_scripts_dir_on_path(scripts_dir)
+  * _user_scripts_dir()
+  * _wrapper_target_dir()
+  * _create_venv_with_deile(venv_dir, repo_root, mode_label)
+  * _link_global_command(target_dir, source_script, *, force=False)
+  * _prompt_install_mode()
+  * _run_self_install(mode=None)
+
+No asyncio, no real API calls, no side effects beyond the temp directory.
+Venv creation is mocked via unittest.mock — we never call real `venv` or `pip`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ===================================================================
+# _user_scripts_dir
+# ===================================================================
+
+@pytest.mark.unit
+class TestUserScriptsDir:
+    """_user_scripts_dir() — delegates to sysconfig.
+
+    Since sysconfig.get_path depends on the real Python installation,
+    we only verify it returns a Path and that the result is non-empty.
+    """
+
+    def test_returns_path(self):
+        """_user_scripts_dir() always returns a Path."""
+        from deile.cli import _user_scripts_dir
+
+        result = _user_scripts_dir()
+        assert isinstance(result, Path)
+        assert result.name == "bin" or result.name.endswith("Scripts")
+
+
+# ===================================================================
+# _wrapper_target_dir
+# ===================================================================
+
+@pytest.mark.unit
+class TestWrapperTargetDir:
+    """_wrapper_target_dir() — platform-dependent."""
+
+    @patch("deile.cli.os.name", "posix")
+    def test_posix_returns_dotlocal_bin(self):
+        """On POSIX, returns ~/.local/bin."""
+        from deile.cli import _wrapper_target_dir
+
+        result = _wrapper_target_dir()
+        assert result == Path.home() / ".local" / "bin"
+
+    @patch("deile.cli.os.name", "nt")
+    @patch("deile.cli._user_scripts_dir")
+    def test_windows_returns_user_scripts_dir(self, mock_user_scripts):
+        """On Windows, delegates to _user_scripts_dir()."""
+        from deile.cli import _wrapper_target_dir
+
+        mock_user_scripts.return_value = Path("C:/Users/test/AppData/Roaming/Python/Scripts")
+        result = _wrapper_target_dir()
+        assert result == mock_user_scripts.return_value
+
+
+# ===================================================================
+# _ensure_scripts_dir_on_path
+# ===================================================================
+
+@pytest.mark.unit
+class TestEnsureScriptsDirOnPath:
+    """_ensure_scripts_dir_on_path() — shell detection and rc file editing.
+
+    Returns tuple[bool, Optional[Path], str].
+    """
+
+    SCRIPTS_DIR = Path("/home/user/.local/bin")
+    EXPORT_LINE = f'export PATH="{SCRIPTS_DIR}:$PATH"'
+
+    # -- Windows --
+
+    @patch("deile.cli.os.name", "nt")
+    def test_windows_returns_hint(self):
+        """Windows -> (False, None, hint)."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is False
+        assert rc_path is None
+        assert "PowerShell" in hint
+        assert "System Properties" in hint
+
+    # -- Unknown shell --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="")
+    def test_unknown_shell_returns_hint(self, mock_getenv):
+        """Unknown shell -> (False, None, hint)."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is False
+        assert rc_path is None
+        assert "Add to your shell rc" in hint
+
+    # -- Zsh: already configured --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.Path.read_text")
+    def test_zsh_already_configured(self, mock_read, mock_exists, mock_home,
+                                     mock_environ):
+        """Zsh with scripts_dir already in .zshrc -> (False, rc, '')."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user")
+        mock_read.return_value = 'export PATH="/home/user/.local/bin:$PATH"\n'
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is False
+        assert rc_path == Path("/home/user/.zshrc")
+        assert hint == ""
+
+    # -- Bash (Linux): edits .bashrc --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.sys.platform", "linux")
+    @patch("deile.cli.os.environ.get", return_value="/bin/bash")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.read_text")
+    @patch("deile.cli.Path.write_text")
+    @patch("deile.cli.Path.mkdir")
+    def test_bash_linux_edits_bashrc(self, mock_mkdir, mock_write, mock_read,
+                                      mock_exists, mock_home, mock_environ):
+        """Bash on Linux -> edits .bashrc with export line."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user")
+        mock_read.return_value = ""
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is True
+        assert rc_path == Path("/home/user/.bashrc")
+        assert hint == ""
+
+        # Verify the marker and export line were written
+        written = mock_write.call_args[0][0]
+        assert "# Added by `deile --install`" in written
+        assert self.EXPORT_LINE in written
+
+    # -- Bash (macOS): edits .bash_profile --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.sys.platform", "darwin")
+    @patch("deile.cli.os.environ.get", return_value="/bin/bash")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.read_text")
+    @patch("deile.cli.Path.write_text")
+    @patch("deile.cli.Path.mkdir")
+    def test_bash_macos_edits_bash_profile(self, mock_mkdir, mock_write,
+                                            mock_read, mock_exists, mock_home,
+                                            mock_environ):
+        """Bash on macOS -> edits .bash_profile with export line."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user")
+        mock_read.return_value = ""
+
+        modified, rc_path, _hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is True
+        assert rc_path == Path("/home/user/.bash_profile")
+
+    # -- Fish: edits config.fish --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/usr/bin/fish")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.read_text")
+    @patch("deile.cli.Path.write_text")
+    @patch("deile.cli.Path.mkdir")
+    def test_fish_edits_config_fish(self, mock_mkdir, mock_write, mock_read,
+                                     mock_exists, mock_home, mock_environ):
+        """Fish shell -> edits config.fish with set -gx PATH."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user")
+        mock_read.return_value = ""
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is True
+        assert rc_path == Path("/home/user/.config/fish/config.fish")
+        assert "set -gx PATH" in mock_write.call_args[0][0]
+
+    # -- Read error --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.Path.read_text", side_effect=OSError("Permission denied"))
+    def test_read_error_returns_hint(self, mock_read, mock_exists, mock_home,
+                                      mock_environ):
+        """OSError on read -> (False, rc, hint)."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user")
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is False
+        assert rc_path == Path("/home/user/.zshrc")
+        assert "Could not read" in hint
+
+    # -- Write error --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.read_text")
+    @patch("deile.cli.Path.write_text", side_effect=OSError("Read-only"))
+    @patch("deile.cli.Path.mkdir")
+    def test_write_error_returns_hint(self, mock_mkdir, mock_write, mock_read,
+                                       mock_exists, mock_home, mock_environ):
+        """OSError on write -> (False, rc, hint)."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user")
+        mock_read.return_value = ""
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is False
+        assert rc_path == Path("/home/user/.zshrc")
+        assert "Could not write" in hint
+
+
+# ===================================================================
+# _prompt_install_mode
+# ===================================================================
+
+@pytest.mark.unit
+class TestPromptInstallMode:
+    """_prompt_install_mode() — interactive choice."""
+
+    @patch("builtins.input", return_value="")
+    def test_default_is_global(self, mock_input):
+        """Empty choice (ENTER) -> 'global'."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() == "global"
+
+    @patch("builtins.input", return_value="g")
+    def test_g_returns_global(self, mock_input):
+        """'g' -> 'global'."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() == "global"
+
+    @patch("builtins.input", return_value="global")
+    def test_global_returns_global(self, mock_input):
+        """'global' -> 'global'."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() == "global"
+
+    @patch("builtins.input", return_value="l")
+    def test_l_returns_local(self, mock_input):
+        """'l' -> 'local'."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() == "local"
+
+    @patch("builtins.input", return_value="local")
+    def test_local_returns_local(self, mock_input):
+        """'local' -> 'local'."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() == "local"
+
+    @patch("builtins.input", return_value="q")
+    def test_q_returns_none(self, mock_input):
+        """'q' -> None."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() is None
+
+    @patch("builtins.input", side_effect=KeyboardInterrupt)
+    def test_keyboard_interrupt_returns_none(self, mock_input):
+        """KeyboardInterrupt -> None."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() is None
+
+    @patch("builtins.input", side_effect=EOFError)
+    def test_eof_error_returns_none(self, mock_input):
+        """EOFError -> None."""
+        from deile.cli import _prompt_install_mode
+
+        assert _prompt_install_mode() is None
+
+
+# ===================================================================
+# _link_global_command
+# ===================================================================
+
+@pytest.mark.unit
+class TestLinkGlobalCommand:
+    """_link_global_command() — symlink (POSIX) or .cmd shim (Windows)."""
+
+    SOURCE = Path("/home/user/.deile/venv/bin/deile")
+    TARGET_DIR = Path("/home/user/.local/bin")
+
+    # -- POSIX: symlink creation --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.Path.is_symlink", return_value=False)
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.symlink_to")
+    def test_posix_creates_symlink(self, mock_symlink, mock_exists,
+                                    mock_is_symlink, mock_mkdir):
+        """POSIX: creates symlink at target_dir/deile -> source_script."""
+        from deile.cli import _link_global_command
+
+        result = _link_global_command(self.TARGET_DIR, self.SOURCE)
+
+        expected_target = self.TARGET_DIR / "deile"
+        assert result == expected_target
+        mock_symlink.assert_called_once_with(self.SOURCE)
+
+    # -- POSIX: force overwrite --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.Path.is_symlink", return_value=True)
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.Path.unlink")
+    @patch("deile.cli.Path.symlink_to")
+    @patch("deile.cli.os.readlink", return_value="/old/path")
+    @patch("builtins.input", return_value="y")
+    def test_posix_force_overwrite(self, mock_input, mock_readlink,
+                                    mock_symlink, mock_unlink,
+                                    mock_exists, mock_is_symlink, mock_mkdir):
+        """POSIX: existing symlink removed and recreated when user agrees."""
+        from deile.cli import _link_global_command
+
+        link_target = _link_global_command(self.TARGET_DIR, self.SOURCE)
+        assert link_target == self.TARGET_DIR / "deile"
+        mock_unlink.assert_called_once()
+        mock_symlink.assert_called_once_with(self.SOURCE)
+
+    # -- POSIX: refuses overwrite --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.Path.is_symlink", return_value=True)
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("builtins.input", return_value="n")
+    def test_posix_refuses_overwrite(self, mock_input, mock_exists,
+                                      mock_is_symlink, mock_mkdir):
+        """POSIX: user says no -> RuntimeError."""
+        from deile.cli import _link_global_command
+
+        with pytest.raises(RuntimeError, match="refusing to overwrite"):
+            _link_global_command(self.TARGET_DIR, self.SOURCE)
+
+    # -- Windows: .cmd shim creation --
+
+    @patch("deile.cli.os.name", "nt")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.Path.is_symlink", return_value=False)
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.write_text")
+    def test_windows_creates_cmd_shim(self, mock_write, mock_exists,
+                                       mock_is_symlink, mock_mkdir):
+        """Windows: creates deile.cmd with @echo off."""
+        from deile.cli import _link_global_command
+
+        result = _link_global_command(self.TARGET_DIR, self.SOURCE)
+
+        expected_target = self.TARGET_DIR / "deile.cmd"
+        assert result == expected_target
+        written = mock_write.call_args[0][0]
+        assert "@echo off" in written
+        assert str(self.SOURCE) in written
+
+
+# ===================================================================
+# _create_venv_with_deile  (mocked venv + subprocess)
+# ===================================================================
+
+@pytest.mark.unit
+class TestCreateVenvWithDeile:
+    """_create_venv_with_deile() — mocks venv creation and pip subprocesses."""
+
+    VENV_DIR = Path("/tmp/test-venv")
+    REPO_ROOT = Path("/tmp/test-repo")
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.exists")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.subprocess.run")
+    def test_creates_venv_and_installs(self, mock_run, mock_mkdir,
+                                        mock_exists):
+        """Full pipeline: create venv -> upgrade pip -> install reqs -> editable."""
+        from deile.cli import _create_venv_with_deile
+
+        # _create_venv_with_deile calls .exists() 3 times:
+        #   1. venv_py.exists()      -> False (trigger creation)
+        #   2. requirements.exists() -> True  (pip install -r)
+        #   3. deile_script.exists() -> True  (verify script was created)
+        mock_exists.side_effect = [False, True, True]
+
+        # subprocess.run is called 3 times; all must return success (rc=0)
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+        deile_script = self.VENV_DIR / "bin/deile"
+
+        # Mock the actual _venv.EnvBuilder.create
+        with patch("deile.cli._venv.EnvBuilder") as mock_env_builder:
+            mock_env_builder_instance = MagicMock()
+            mock_env_builder.return_value = mock_env_builder_instance
+
+            result = _create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test")
+
+        # Verify venv was created
+        mock_env_builder_instance.create.assert_called_once_with(str(self.VENV_DIR))
+
+        # Verify subprocess calls
+        pip_calls = [c[0][0] for c in mock_run.call_args_list]
+        assert len(pip_calls) >= 3  # upgrade pip, -r requirements, --no-deps -e
+
+        # First: upgrade pip
+        assert "--upgrade" in str(pip_calls[0])
+        assert "pip" in str(pip_calls[0])
+
+        # Second: install requirements.txt
+        assert "-r" in str(pip_calls[1])
+
+        # Third: editable install without deps
+        assert "--no-deps" in str(pip_calls[2])
+        assert "-e" in str(pip_calls[2])
+
+        assert result == deile_script
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.subprocess.run")
+    def test_reuses_existing_venv(self, mock_run, mock_exists):
+        """If venv python already exists, skips creation."""
+        from deile.cli import _create_venv_with_deile
+
+        # subprocess.run is called 3 times; all must return success (rc=0)
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+        with patch("deile.cli._venv.EnvBuilder") as mock_env_builder:
+            _create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test")
+
+        # EnvBuilder.create should NOT be called
+        mock_env_builder.assert_not_called()
+        pip_calls = [c[0][0] for c in mock_run.call_args_list]
+        assert len(pip_calls) >= 2  # still upgrades pip and installs
+
+
+# ===================================================================
+# _run_self_install  (integration-style with all helpers mocked)
+# ===================================================================
+
+@pytest.mark.unit
+class TestRunSelfInstall:
+    """_run_self_install() — end-to-end with all helpers mocked."""
+
+    @patch("deile.cli._prompt_install_mode", return_value="global")
+    @patch("deile.cli._create_venv_with_deile")
+    @patch("deile.cli._wrapper_target_dir")
+    @patch("deile.cli._link_global_command")
+    @patch("deile.cli._ensure_scripts_dir_on_path", return_value=(True, Path("/home/user/.zshrc"), ""))
+    @patch("deile.cli.subprocess.run")
+    @patch("builtins.print")
+    def test_global_mode_full_flow(
+        self, mock_print, mock_subprocess, mock_ensure_path,
+        mock_link, mock_wrapper_dir, mock_create_venv, mock_prompt,
+    ):
+        """Global mode w/ mode=None (interactive prompt) -> all helpers called."""
+        from deile.cli import _run_self_install
+
+        mock_create_venv.return_value = Path("/home/user/.deile/venv/bin/deile")
+        mock_wrapper_dir.return_value = Path("/home/user/.local/bin")
+        mock_link.return_value = Path("/home/user/.local/bin/deile")
+        mock_subprocess.return_value = MagicMock(returncode=0, stdout="")
+
+        result = _run_self_install(mode=None)
+
+        assert result == 0
+        mock_prompt.assert_called_once()
+        mock_create_venv.assert_called_once()
+        mock_link.assert_called_once()
+        # ensure_scripts_dir_on_path should be called since which deile won't match
+        mock_ensure_path.assert_called_once()
+
+    @patch("deile.cli._prompt_install_mode", return_value=None)
+    @patch("builtins.print")
+    def test_cancelled_returns_1(self, mock_print, mock_prompt):
+        """User cancels prompt -> returns 1."""
+        from deile.cli import _run_self_install
+
+        assert _run_self_install(mode=None) == 1
+
+    @patch("deile.cli._create_venv_with_deile",
+           side_effect=RuntimeError("venv creation failed"))
+    @patch("builtins.print")
+    def test_venv_error_returns_1(self, mock_print, mock_create_venv):
+        """RuntimeError from _create_venv_with_deile -> returns 1."""
+        from deile.cli import _run_self_install
+
+        assert _run_self_install(mode="global") == 1
+
+    @patch("deile.cli._create_venv_with_deile")
+    @patch("deile.cli._wrapper_target_dir")
+    @patch("deile.cli._link_global_command",
+           side_effect=RuntimeError("refusing to overwrite"))
+    @patch("builtins.print")
+    def test_link_error_returns_1(
+        self, mock_print, mock_link, mock_wrapper_dir, mock_create_venv,
+    ):
+        """RuntimeError from _link_global_command -> returns 1."""
+        from deile.cli import _run_self_install
+
+        mock_create_venv.return_value = Path("/tmp/venv/bin/deile")
+        mock_wrapper_dir.return_value = Path("/home/user/.local/bin")
+
+        assert _run_self_install(mode="global") == 1
+
+    @patch("deile.cli._create_venv_with_deile")
+    @patch("deile.cli._wrapper_target_dir")
+    @patch("deile.cli._link_global_command")
+    @patch("deile.cli._ensure_scripts_dir_on_path",
+           return_value=(True, Path("/home/user/.zshrc"), ""))
+    @patch("deile.cli.subprocess.run")
+    @patch("builtins.print")
+    def test_local_mode(
+        self, mock_print, mock_subprocess, mock_ensure_path,
+        mock_link, mock_wrapper_dir, mock_create_venv,
+    ):
+        """Local mode with mode='local' -> .venv in repo root."""
+        from deile.cli import _run_self_install
+
+        mock_create_venv.return_value = Path("/tmp/repo/.venv/bin/deile")
+        mock_wrapper_dir.return_value = Path("/home/user/.local/bin")
+        mock_link.return_value = Path("/home/user/.local/bin/deile")
+        mock_subprocess.return_value = MagicMock(returncode=0, stdout="")
+
+        result = _run_self_install(mode="local")
+
+        assert result == 0
+        # Verify venv was created in repo_root/.venv
+        venv_dir_arg = mock_create_venv.call_args[0][0]
+        assert venv_dir_arg.name == ".venv"
+
+    def test_unknown_mode_returns_2(self):
+        """Unknown mode string -> returns 2."""
+        from deile.cli import _run_self_install
+
+        assert _run_self_install(mode="invalid") == 2

--- a/deile/tests/test_install_functions.py
+++ b/deile/tests/test_install_functions.py
@@ -666,3 +666,319 @@ class TestRunSelfInstall:
         from deile.cli import _run_self_install
 
         assert _run_self_install(mode="invalid") == 2
+
+
+# ===================================================================
+# Additional _link_global_command edge cases (MINOR 13)
+# ===================================================================
+
+@pytest.mark.unit
+class TestLinkGlobalCommandEdgeCases:
+    """Edge cases for _link_global_command that were missing coverage."""
+
+    SOURCE = Path("/home/user/.deile/venv/bin/deile")
+    TARGET_DIR = Path("/home/user/.local/bin")
+
+    # -- POSIX: symlink_to raises OSError -> DEILEInstallError --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.Path.is_symlink", return_value=False)
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.symlink_to", side_effect=OSError("permission denied"))
+    def test_posix_symlink_oserror_raises(self, mock_symlink, mock_exists,
+                                           mock_is_symlink, mock_mkdir):
+        """POSIX: OSError from symlink_to -> DEILEInstallError."""
+        from deile.cli import _link_global_command
+
+        with pytest.raises(DEILEInstallError, match="could not create symlink"):
+            _link_global_command(self.TARGET_DIR, self.SOURCE)
+
+    # -- POSIX: unlink raises OSError -> DEILEInstallError --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.Path.is_symlink", return_value=True)
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.Path.unlink", side_effect=OSError("read-only filesystem"))
+    @patch("builtins.input", return_value="y")
+    def test_posix_unlink_oserror_raises(self, mock_input, mock_unlink,
+                                          mock_exists, mock_is_symlink, mock_mkdir):
+        """POSIX: OSError from unlink -> DEILEInstallError."""
+        from deile.cli import _link_global_command
+
+        with pytest.raises(DEILEInstallError, match="could not remove existing shim"):
+            _link_global_command(self.TARGET_DIR, self.SOURCE)
+
+    # -- POSIX: force=True skips prompt, replaces silently --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.Path.is_symlink", return_value=True)
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.Path.unlink")
+    @patch("deile.cli.Path.symlink_to")
+    @patch("builtins.input")
+    def test_posix_force_true_skips_prompt(self, mock_input, mock_symlink,
+                                            mock_unlink, mock_exists,
+                                            mock_is_symlink, mock_mkdir):
+        """POSIX: force=True replaces existing shim without prompting."""
+        from deile.cli import _link_global_command
+
+        result = _link_global_command(self.TARGET_DIR, self.SOURCE, force=True)
+
+        assert result == self.TARGET_DIR / "deile"
+        # input() must not be called when force=True
+        mock_input.assert_not_called()
+        mock_unlink.assert_called_once()
+        mock_symlink.assert_called_once_with(self.SOURCE)
+
+
+# ===================================================================
+# Additional _create_venv_with_deile edge cases (MINOR 12 + 16)
+# ===================================================================
+
+@pytest.mark.unit
+class TestCreateVenvEdgeCases:
+    """Missing edge cases for _create_venv_with_deile."""
+
+    VENV_DIR = Path("/tmp/test-venv")
+    REPO_ROOT = Path("/tmp/test-repo")
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.resolve")
+    @patch("deile.cli.Path.exists")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.asyncio.create_subprocess_exec")
+    def test_pip_upgrade_failure_raises(self, mock_subproc, mock_mkdir,
+                                         mock_exists, mock_resolve):
+        """If pip upgrade fails (rc != 0), DEILEInstallError is raised."""
+        from deile.cli import _create_venv_with_deile
+
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, Path("/tmp")]
+        # venv_py does NOT exist (trigger creation), then upgrade pip is called
+        mock_exists.side_effect = [False]
+
+        failing_proc = MagicMock()
+        failing_proc.returncode = 1
+        failing_proc.communicate = AsyncMock(return_value=(b"", b"error output"))
+        mock_subproc.return_value = failing_proc
+
+        with patch("deile.cli._venv.EnvBuilder"):
+            with patch("deile.cli.asyncio.to_thread"):
+                with pytest.raises(DEILEInstallError, match="pip upgrade_pip failed"):
+                    asyncio.run(_create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test"))
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.resolve")
+    @patch("deile.cli.Path.exists")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.asyncio.create_subprocess_exec")
+    def test_missing_console_script_raises(self, mock_subproc, mock_mkdir,
+                                            mock_exists, mock_resolve):
+        """If console script missing after install, DEILEInstallError raised."""
+        from deile.cli import _create_venv_with_deile
+
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, Path("/tmp")]
+        # venv_py absent, requirements.txt present, deile_script absent
+        mock_exists.side_effect = [False, True, False]
+
+        ok_proc = MagicMock()
+        ok_proc.returncode = 0
+        ok_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_subproc.return_value = ok_proc
+
+        with patch("deile.cli._venv.EnvBuilder"):
+            with patch("deile.cli.asyncio.to_thread"):
+                with pytest.raises(DEILEInstallError, match="console script not created"):
+                    asyncio.run(_create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test"))
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.resolve")
+    @patch("deile.cli.Path.exists")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.asyncio.create_subprocess_exec")
+    def test_editable_install_failure_raises(self, mock_subproc, mock_mkdir,
+                                              mock_exists, mock_resolve):
+        """If editable install (--no-deps -e) fails, DEILEInstallError raised."""
+        from deile.cli import _create_venv_with_deile
+
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, Path("/tmp")]
+        # venv_py absent, requirements.txt present, but deile_script won't matter
+        # because pip install -e fails before we get to the exists() check
+        mock_exists.side_effect = [False, True]
+
+        # First two pip calls succeed (upgrade, install deps), third fails (editable)
+        ok_proc = MagicMock()
+        ok_proc.returncode = 0
+        ok_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        fail_proc = MagicMock()
+        fail_proc.returncode = 1
+        fail_proc.communicate = AsyncMock(return_value=(b"", b"editable install error"))
+
+        mock_subproc.side_effect = [ok_proc, ok_proc, fail_proc]
+
+        with patch("deile.cli._venv.EnvBuilder"):
+            with patch("deile.cli.asyncio.to_thread"):
+                with pytest.raises(DEILEInstallError, match="pip install_editable failed"):
+                    asyncio.run(_create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test"))
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.resolve")
+    @patch("deile.cli.Path.exists")
+    @patch("deile.cli.Path.mkdir")
+    @patch("deile.cli.asyncio.create_subprocess_exec")
+    def test_requirements_absent_skips_dep_install(self, mock_subproc, mock_mkdir,
+                                                    mock_exists, mock_resolve):
+        """If requirements.txt is absent, dep install is skipped (no assert on warning)."""
+        from deile.cli import _create_venv_with_deile
+
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, Path("/tmp")]
+        # venv_py exists (reuse), requirements.txt absent, deile_script exists
+        mock_exists.side_effect = [True, False, True]
+
+        ok_proc = MagicMock()
+        ok_proc.returncode = 0
+        ok_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_subproc.return_value = ok_proc
+
+        with patch("deile.cli._venv.EnvBuilder"):
+            with patch("deile.cli.asyncio.to_thread"):
+                result = asyncio.run(_create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test"))
+
+        # Only 2 pip calls: upgrade pip + editable (no -r requirements)
+        assert mock_subproc.call_count == 2
+        pip_args = [c[0] for c in mock_subproc.call_args_list]
+        assert not any("-r" in args for args in pip_args)
+        assert result == self.VENV_DIR / "bin/deile"
+
+
+# ===================================================================
+# Additional _create_venv_with_deile assertion fix (MINOR 14)
+# ===================================================================
+
+@pytest.mark.unit
+class TestReuseVenvAssertionStrength:
+    """Verify that test_reuses_existing_venv checks .create() not called (MINOR 14)."""
+
+    VENV_DIR = Path("/tmp/test-venv")
+    REPO_ROOT = Path("/tmp/test-repo")
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.resolve")
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.asyncio.create_subprocess_exec")
+    def test_reuses_venv_create_not_called(self, mock_subproc, mock_exists, mock_resolve):
+        """When venv python already exists, EnvBuilder.create must NOT be called."""
+        from deile.cli import _create_venv_with_deile
+
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, Path("/tmp")]
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_subproc.return_value = mock_proc
+
+        with patch("deile.cli._venv.EnvBuilder") as mock_env_builder:
+            with patch("deile.cli.asyncio.to_thread") as mock_to_thread:
+                asyncio.run(_create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test"))
+
+        # The critical assertion: .create() must not be called (not just EnvBuilder())
+        mock_env_builder.return_value.create.assert_not_called()
+        mock_to_thread.assert_not_called()
+
+
+# ===================================================================
+# Additional _ensure_scripts_dir_on_path: rc file content preservation (MINOR 16)
+# ===================================================================
+
+@pytest.mark.unit
+class TestEnsureScriptsDirRcContentPreservation:
+    """Verify rc file pre-existing content is preserved after edit."""
+
+    SCRIPTS_DIR = Path("/home/user/.local/bin")
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.zshrc"))
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.Path.read_text")
+    @patch("deile.cli.tempfile.mkstemp")
+    @patch("deile.cli.os.write")
+    @patch("deile.cli.os.close")
+    @patch("deile.cli.os.replace")
+    @patch("deile.cli.Path.mkdir")
+    def test_pre_existing_content_preserved(
+        self, mock_mkdir, mock_replace, mock_close, mock_write,
+        mock_mkstemp, mock_read, mock_exists, mock_resolve, mock_home,
+        mock_environ,
+    ):
+        """Pre-existing .zshrc content is included in the written output."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user").resolve()
+        existing_content = "# my zshrc\nalias ll='ls -la'\n"
+        mock_read.return_value = existing_content
+        mock_mkstemp.return_value = (999, "/home/user/.deile_rc_abc123.tmp")
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+
+        assert modified is True
+        written_bytes = mock_write.call_args[0][1]
+        written_text = written_bytes.decode("utf-8")
+
+        # Original content must be preserved
+        assert "# my zshrc" in written_text
+        assert "alias ll='ls -la'" in written_text
+        # New export line appended
+        assert 'export PATH="/home/user/.local/bin:$PATH"' in written_text
+        # Atomic rename used
+        mock_replace.assert_called_once()
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.zshrc"))
+    @patch("deile.cli.Path.exists", return_value=False)
+    @patch("deile.cli.Path.read_text")
+    def test_path_with_double_quote_returns_hint(self, mock_read, mock_exists,
+                                                   mock_resolve, mock_home, mock_environ):
+        """scripts_dir with double-quote -> returns manual hint instead of writing."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user").resolve()
+
+        bad_dir = Path('/home/user"evil/.local/bin')
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(bad_dir)
+
+        assert modified is False
+        assert rc_path is None
+        assert "unsupported characters" in hint
+
+
+# ===================================================================
+# NIT 20: --install-mode without --install validation order
+# ===================================================================
+
+@pytest.mark.unit
+class TestInstallModeValidationOrder:
+    """--install-mode without --install must error before running install."""
+
+    def test_install_mode_without_install_flag_errors(self):
+        """--install-mode without --install -> exit 2 with error message."""
+        import io
+        from unittest.mock import patch as _patch
+
+        from deile.cli import main
+
+        captured = io.StringIO()
+        with _patch("sys.stderr", captured):
+            with _patch("deile.cli._run_self_install") as mock_install:
+                result = main(["--install-mode", "global"])
+
+        assert result == 2
+        # _run_self_install must NOT have been called
+        mock_install.assert_not_called()
+        assert "--install-mode requires --install" in captured.getvalue()

--- a/deile/tests/test_install_functions.py
+++ b/deile/tests/test_install_functions.py
@@ -4,7 +4,7 @@ Functions under test:
   * _ensure_scripts_dir_on_path(scripts_dir)
   * _user_scripts_dir()
   * _wrapper_target_dir()
-  * _create_venv_with_deile(venv_dir, repo_root, mode_label)
+  * _create_venv_with_deile(venv_dir, repo_root, mode_label)  [async]
   * _link_global_command(target_dir, source_script, *, force=False)
   * _prompt_install_mode()
   * _run_self_install(mode=None)
@@ -15,10 +15,13 @@ Venv creation is mocked via unittest.mock — we never call real `venv` or `pip`
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from deile.core.exceptions import DEILEInstallError
 
 # ===================================================================
 # _user_scripts_dir
@@ -77,6 +80,7 @@ class TestEnsureScriptsDirOnPath:
     """_ensure_scripts_dir_on_path() — shell detection and rc file editing.
 
     Returns tuple[bool, Optional[Path], str].
+    Security: uses atomic write (tempfile + os.replace), line-by-line check.
     """
 
     SCRIPTS_DIR = Path("/home/user/.local/bin")
@@ -108,19 +112,20 @@ class TestEnsureScriptsDirOnPath:
         assert rc_path is None
         assert "Add to your shell rc" in hint
 
-    # -- Zsh: already configured --
+    # -- Zsh: already configured (line-by-line check) --
 
     @patch("deile.cli.os.name", "posix")
     @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
     @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.zshrc"))
     @patch("deile.cli.Path.exists", return_value=True)
     @patch("deile.cli.Path.read_text")
-    def test_zsh_already_configured(self, mock_read, mock_exists, mock_home,
-                                     mock_environ):
+    def test_zsh_already_configured(self, mock_read, mock_exists, mock_resolve,
+                                     mock_home, mock_environ):
         """Zsh with scripts_dir already in .zshrc -> (False, rc, '')."""
         from deile.cli import _ensure_scripts_dir_on_path
 
-        mock_home.return_value = Path("/home/user")
+        mock_home.return_value = Path("/home/user").resolve()
         mock_read.return_value = 'export PATH="/home/user/.local/bin:$PATH"\n'
 
         modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
@@ -128,33 +133,74 @@ class TestEnsureScriptsDirOnPath:
         assert rc_path == Path("/home/user/.zshrc")
         assert hint == ""
 
-    # -- Bash (Linux): edits .bashrc --
+    # -- Zsh: commented-out line is NOT treated as configured --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
+    @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.zshrc"))
+    @patch("deile.cli.Path.exists", return_value=True)
+    @patch("deile.cli.Path.read_text")
+    @patch("deile.cli.tempfile.mkstemp")
+    @patch("deile.cli.os.write")
+    @patch("deile.cli.os.close")
+    @patch("deile.cli.os.replace")
+    @patch("deile.cli.Path.mkdir")
+    def test_zsh_commented_line_is_not_configured(
+        self, mock_mkdir, mock_replace, mock_close, mock_write,
+        mock_mkstemp, mock_read, mock_exists, mock_resolve, mock_home,
+        mock_environ,
+    ):
+        """Commented-out PATH line is not treated as configured."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user").resolve()
+        # Scripts dir appears but commented out — should NOT match
+        mock_read.return_value = '# export PATH="/home/user/.local/bin:$PATH"\n'
+        mock_mkstemp.return_value = (999, "/home/user/.deile_rc_abc123.tmp")
+
+        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+        assert modified is True
+        assert rc_path == Path("/home/user/.zshrc")
+        assert hint == ""
+
+    # -- Bash (Linux): edits .bashrc (atomic write) --
 
     @patch("deile.cli.os.name", "posix")
     @patch("deile.cli.sys.platform", "linux")
     @patch("deile.cli.os.environ.get", return_value="/bin/bash")
     @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.bashrc"))
     @patch("deile.cli.Path.exists", return_value=False)
     @patch("deile.cli.Path.read_text")
-    @patch("deile.cli.Path.write_text")
+    @patch("deile.cli.tempfile.mkstemp")
+    @patch("deile.cli.os.write")
+    @patch("deile.cli.os.close")
+    @patch("deile.cli.os.replace")
     @patch("deile.cli.Path.mkdir")
-    def test_bash_linux_edits_bashrc(self, mock_mkdir, mock_write, mock_read,
-                                      mock_exists, mock_home, mock_environ):
-        """Bash on Linux -> edits .bashrc with export line."""
+    def test_bash_linux_edits_bashrc(
+        self, mock_mkdir, mock_replace, mock_close, mock_write,
+        mock_mkstemp, mock_read, mock_exists, mock_resolve, mock_home,
+        mock_environ,
+    ):
+        """Bash on Linux -> edits .bashrc with export line (atomic write)."""
         from deile.cli import _ensure_scripts_dir_on_path
 
-        mock_home.return_value = Path("/home/user")
+        mock_home.return_value = Path("/home/user").resolve()
         mock_read.return_value = ""
+        mock_mkstemp.return_value = (999, "/home/user/.deile_rc_abc123.tmp")
 
         modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
         assert modified is True
         assert rc_path == Path("/home/user/.bashrc")
         assert hint == ""
 
-        # Verify the marker and export line were written
-        written = mock_write.call_args[0][0]
-        assert "# Added by `deile --install`" in written
-        assert self.EXPORT_LINE in written
+        # Verify atomic write: content written to tempfile, then os.replace
+        written_bytes = mock_write.call_args[0][1]
+        written_text = written_bytes.decode("utf-8")
+        assert "# Added by `deile --install`" in written_text
+        assert self.EXPORT_LINE in written_text
+        mock_replace.assert_called_once()
 
     # -- Bash (macOS): edits .bash_profile --
 
@@ -162,18 +208,25 @@ class TestEnsureScriptsDirOnPath:
     @patch("deile.cli.sys.platform", "darwin")
     @patch("deile.cli.os.environ.get", return_value="/bin/bash")
     @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.bash_profile"))
     @patch("deile.cli.Path.exists", return_value=False)
     @patch("deile.cli.Path.read_text")
-    @patch("deile.cli.Path.write_text")
+    @patch("deile.cli.tempfile.mkstemp")
+    @patch("deile.cli.os.write")
+    @patch("deile.cli.os.close")
+    @patch("deile.cli.os.replace")
     @patch("deile.cli.Path.mkdir")
-    def test_bash_macos_edits_bash_profile(self, mock_mkdir, mock_write,
-                                            mock_read, mock_exists, mock_home,
-                                            mock_environ):
+    def test_bash_macos_edits_bash_profile(
+        self, mock_mkdir, mock_replace, mock_close, mock_write,
+        mock_mkstemp, mock_read, mock_exists, mock_resolve, mock_home,
+        mock_environ,
+    ):
         """Bash on macOS -> edits .bash_profile with export line."""
         from deile.cli import _ensure_scripts_dir_on_path
 
-        mock_home.return_value = Path("/home/user")
+        mock_home.return_value = Path("/home/user").resolve()
         mock_read.return_value = ""
+        mock_mkstemp.return_value = (999, "/home/user/.deile_rc_abc123.tmp")
 
         modified, rc_path, _hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
         assert modified is True
@@ -184,63 +237,93 @@ class TestEnsureScriptsDirOnPath:
     @patch("deile.cli.os.name", "posix")
     @patch("deile.cli.os.environ.get", return_value="/usr/bin/fish")
     @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.config/fish/config.fish"))
     @patch("deile.cli.Path.exists", return_value=False)
     @patch("deile.cli.Path.read_text")
-    @patch("deile.cli.Path.write_text")
+    @patch("deile.cli.tempfile.mkstemp")
+    @patch("deile.cli.os.write")
+    @patch("deile.cli.os.close")
+    @patch("deile.cli.os.replace")
     @patch("deile.cli.Path.mkdir")
-    def test_fish_edits_config_fish(self, mock_mkdir, mock_write, mock_read,
-                                     mock_exists, mock_home, mock_environ):
+    def test_fish_edits_config_fish(
+        self, mock_mkdir, mock_replace, mock_close, mock_write,
+        mock_mkstemp, mock_read, mock_exists, mock_resolve, mock_home,
+        mock_environ,
+    ):
         """Fish shell -> edits config.fish with set -gx PATH."""
         from deile.cli import _ensure_scripts_dir_on_path
 
-        mock_home.return_value = Path("/home/user")
+        mock_home.return_value = Path("/home/user").resolve()
         mock_read.return_value = ""
+        mock_mkstemp.return_value = (999, "/home/user/.deile_rc_abc123.tmp")
 
         modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
         assert modified is True
         assert rc_path == Path("/home/user/.config/fish/config.fish")
-        assert "set -gx PATH" in mock_write.call_args[0][0]
+        written_text = mock_write.call_args[0][1].decode("utf-8")
+        assert "set -gx PATH" in written_text
 
     # -- Read error --
 
     @patch("deile.cli.os.name", "posix")
     @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
     @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.zshrc"))
     @patch("deile.cli.Path.exists", return_value=True)
     @patch("deile.cli.Path.read_text", side_effect=OSError("Permission denied"))
-    def test_read_error_returns_hint(self, mock_read, mock_exists, mock_home,
-                                      mock_environ):
+    def test_read_error_returns_hint(self, mock_read, mock_exists, mock_resolve,
+                                      mock_home, mock_environ):
         """OSError on read -> (False, rc, hint)."""
         from deile.cli import _ensure_scripts_dir_on_path
 
-        mock_home.return_value = Path("/home/user")
+        mock_home.return_value = Path("/home/user").resolve()
 
         modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
         assert modified is False
         assert rc_path == Path("/home/user/.zshrc")
         assert "Could not read" in hint
 
-    # -- Write error --
+    # -- Write error (raises DEILEInstallError) --
 
     @patch("deile.cli.os.name", "posix")
     @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
     @patch("deile.cli.Path.home")
+    @patch("deile.cli.Path.resolve", return_value=Path("/home/user/.zshrc"))
     @patch("deile.cli.Path.exists", return_value=False)
     @patch("deile.cli.Path.read_text")
-    @patch("deile.cli.Path.write_text", side_effect=OSError("Read-only"))
     @patch("deile.cli.Path.mkdir")
-    def test_write_error_returns_hint(self, mock_mkdir, mock_write, mock_read,
-                                       mock_exists, mock_home, mock_environ):
-        """OSError on write -> (False, rc, hint)."""
+    @patch("deile.cli.tempfile.mkstemp", side_effect=OSError("Read-only filesystem"))
+    def test_write_error_raises_deile_install_error(
+        self, mock_mkstemp, mock_mkdir, mock_read, mock_exists,
+        mock_resolve, mock_home, mock_environ,
+    ):
+        """OSError on tempfile creation -> DEILEInstallError."""
+        from deile.cli import _ensure_scripts_dir_on_path
+
+        mock_home.return_value = Path("/home/user").resolve()
+        mock_read.return_value = ""
+
+        with pytest.raises(DEILEInstallError, match="Could not write"):
+            _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
+
+    # -- Symlink traversal blocked --
+
+    @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.os.environ.get", return_value="/bin/zsh")
+    @patch("deile.cli.Path.home")
+    def test_symlink_outside_home_blocked(self, mock_home, mock_environ):
+        """If rc resolves outside $HOME, raises DEILEInstallError."""
         from deile.cli import _ensure_scripts_dir_on_path
 
         mock_home.return_value = Path("/home/user")
-        mock_read.return_value = ""
 
-        modified, rc_path, hint = _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
-        assert modified is False
-        assert rc_path == Path("/home/user/.zshrc")
-        assert "Could not write" in hint
+        # resolve() is called twice inside the function:
+        #   1. home = Path.home().resolve()   → /home/user (canonical home)
+        #   2. rc   = (home / ".zshrc").resolve() → /etc/.zshrc (symlink outside home)
+        # side_effect gives a different value per call so the security check triggers.
+        with patch("deile.cli.Path.resolve", side_effect=[Path("/home/user"), Path("/etc/.zshrc")]):
+            with pytest.raises(DEILEInstallError, match="outside of home"):
+                _ensure_scripts_dir_on_path(self.SCRIPTS_DIR)
 
 
 # ===================================================================
@@ -345,10 +428,8 @@ class TestLinkGlobalCommand:
     @patch("deile.cli.Path.exists", return_value=True)
     @patch("deile.cli.Path.unlink")
     @patch("deile.cli.Path.symlink_to")
-    @patch("deile.cli.os.readlink", return_value="/old/path")
     @patch("builtins.input", return_value="y")
-    def test_posix_force_overwrite(self, mock_input, mock_readlink,
-                                    mock_symlink, mock_unlink,
+    def test_posix_force_overwrite(self, mock_input, mock_symlink, mock_unlink,
                                     mock_exists, mock_is_symlink, mock_mkdir):
         """POSIX: existing symlink removed and recreated when user agrees."""
         from deile.cli import _link_global_command
@@ -358,7 +439,7 @@ class TestLinkGlobalCommand:
         mock_unlink.assert_called_once()
         mock_symlink.assert_called_once_with(self.SOURCE)
 
-    # -- POSIX: refuses overwrite --
+    # -- POSIX: refuses overwrite (DEILEInstallError) --
 
     @patch("deile.cli.os.name", "posix")
     @patch("deile.cli.Path.mkdir")
@@ -367,10 +448,10 @@ class TestLinkGlobalCommand:
     @patch("builtins.input", return_value="n")
     def test_posix_refuses_overwrite(self, mock_input, mock_exists,
                                       mock_is_symlink, mock_mkdir):
-        """POSIX: user says no -> RuntimeError."""
+        """POSIX: user says no -> DEILEInstallError."""
         from deile.cli import _link_global_command
 
-        with pytest.raises(RuntimeError, match="refusing to overwrite"):
+        with pytest.raises(DEILEInstallError, match="refusing to overwrite"):
             _link_global_command(self.TARGET_DIR, self.SOURCE)
 
     # -- Windows: .cmd shim creation --
@@ -395,24 +476,35 @@ class TestLinkGlobalCommand:
 
 
 # ===================================================================
-# _create_venv_with_deile  (mocked venv + subprocess)
+# _create_venv_with_deile  (mocked venv + asyncio subprocess)
 # ===================================================================
 
 @pytest.mark.unit
 class TestCreateVenvWithDeile:
-    """_create_venv_with_deile() — mocks venv creation and pip subprocesses."""
+    """_create_venv_with_deile() [async] — mocks venv creation and pip subprocesses."""
 
     VENV_DIR = Path("/tmp/test-venv")
     REPO_ROOT = Path("/tmp/test-repo")
 
+    async def _run_async(self, coro):
+        """Helper to run async function in sync test."""
+        return await coro
+
     @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.resolve")
     @patch("deile.cli.Path.exists")
     @patch("deile.cli.Path.mkdir")
-    @patch("deile.cli.subprocess.run")
-    def test_creates_venv_and_installs(self, mock_run, mock_mkdir,
-                                        mock_exists):
+    @patch("deile.cli.asyncio.create_subprocess_exec")
+    def test_creates_venv_and_installs(self, mock_subproc, mock_mkdir,
+                                        mock_exists, mock_resolve):
         """Full pipeline: create venv -> upgrade pip -> install reqs -> editable."""
         from deile.cli import _create_venv_with_deile
+
+        # Path.resolve is called 3 times inside the function:
+        #   1. venv_dir.resolve()        → VENV_DIR
+        #   2. repo_root.resolve()       → REPO_ROOT
+        #   3. Path.home().resolve()     → /tmp (satisfies venv_dir startswith check)
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, Path("/tmp")]
 
         # _create_venv_with_deile calls .exists() 3 times:
         #   1. venv_py.exists()      -> False (trigger creation)
@@ -420,54 +512,58 @@ class TestCreateVenvWithDeile:
         #   3. deile_script.exists() -> True  (verify script was created)
         mock_exists.side_effect = [False, True, True]
 
-        # subprocess.run is called 3 times; all must return success (rc=0)
-        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        # asyncio.create_subprocess_exec is a coroutine — use AsyncMock so
+        # `await asyncio.create_subprocess_exec(...)` returns mock_proc correctly.
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_subproc.return_value = mock_proc
 
         deile_script = self.VENV_DIR / "bin/deile"
 
-        # Mock the actual _venv.EnvBuilder.create
         with patch("deile.cli._venv.EnvBuilder") as mock_env_builder:
-            mock_env_builder_instance = MagicMock()
-            mock_env_builder.return_value = mock_env_builder_instance
+            mock_env_builder.return_value = MagicMock()
+            with patch("deile.cli.asyncio.to_thread") as mock_to_thread:
+                result = asyncio.run(_create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test"))
 
-            result = _create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test")
+        mock_to_thread.assert_called_once()
+        assert mock_subproc.call_count >= 3
 
-        # Verify venv was created
-        mock_env_builder_instance.create.assert_called_once_with(str(self.VENV_DIR))
+        call_args_0 = mock_subproc.call_args_list[0][0]
+        assert "--upgrade" in call_args_0
+        assert "pip" in call_args_0
 
-        # Verify subprocess calls
-        pip_calls = [c[0][0] for c in mock_run.call_args_list]
-        assert len(pip_calls) >= 3  # upgrade pip, -r requirements, --no-deps -e
+        call_args_1 = mock_subproc.call_args_list[1][0]
+        assert "-r" in call_args_1
 
-        # First: upgrade pip
-        assert "--upgrade" in str(pip_calls[0])
-        assert "pip" in str(pip_calls[0])
-
-        # Second: install requirements.txt
-        assert "-r" in str(pip_calls[1])
-
-        # Third: editable install without deps
-        assert "--no-deps" in str(pip_calls[2])
-        assert "-e" in str(pip_calls[2])
+        call_args_2 = mock_subproc.call_args_list[2][0]
+        assert "--no-deps" in call_args_2
+        assert "-e" in call_args_2
 
         assert result == deile_script
 
     @patch("deile.cli.os.name", "posix")
+    @patch("deile.cli.Path.resolve")
     @patch("deile.cli.Path.exists", return_value=True)
-    @patch("deile.cli.subprocess.run")
-    def test_reuses_existing_venv(self, mock_run, mock_exists):
+    @patch("deile.cli.asyncio.create_subprocess_exec")
+    def test_reuses_existing_venv(self, mock_subproc, mock_exists, mock_resolve):
         """If venv python already exists, skips creation."""
         from deile.cli import _create_venv_with_deile
 
-        # subprocess.run is called 3 times; all must return success (rc=0)
-        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        # 3 resolve() calls: venv_dir, repo_root, Path.home()
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, Path("/tmp")]
 
-        with patch("deile.cli._venv.EnvBuilder") as mock_env_builder:
-            _create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test")
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_subproc.return_value = mock_proc
 
-        # EnvBuilder.create should NOT be called
-        mock_env_builder.assert_not_called()
-        pip_calls = [c[0][0] for c in mock_run.call_args_list]
+        with patch("deile.cli._venv.EnvBuilder"):
+            with patch("deile.cli.asyncio.to_thread") as mock_to_thread:
+                asyncio.run(_create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test"))
+
+        mock_to_thread.assert_not_called()
+        pip_calls = [c[0] for c in mock_subproc.call_args_list]
         assert len(pip_calls) >= 2  # still upgrades pip and installs
 
 
@@ -504,7 +600,6 @@ class TestRunSelfInstall:
         mock_prompt.assert_called_once()
         mock_create_venv.assert_called_once()
         mock_link.assert_called_once()
-        # ensure_scripts_dir_on_path should be called since which deile won't match
         mock_ensure_path.assert_called_once()
 
     @patch("deile.cli._prompt_install_mode", return_value=None)
@@ -516,10 +611,10 @@ class TestRunSelfInstall:
         assert _run_self_install(mode=None) == 1
 
     @patch("deile.cli._create_venv_with_deile",
-           side_effect=RuntimeError("venv creation failed"))
+           side_effect=DEILEInstallError("venv creation failed", step="create_venv"))
     @patch("builtins.print")
     def test_venv_error_returns_1(self, mock_print, mock_create_venv):
-        """RuntimeError from _create_venv_with_deile -> returns 1."""
+        """DEILEInstallError from _create_venv_with_deile -> returns 1."""
         from deile.cli import _run_self_install
 
         assert _run_self_install(mode="global") == 1
@@ -527,12 +622,12 @@ class TestRunSelfInstall:
     @patch("deile.cli._create_venv_with_deile")
     @patch("deile.cli._wrapper_target_dir")
     @patch("deile.cli._link_global_command",
-           side_effect=RuntimeError("refusing to overwrite"))
+           side_effect=DEILEInstallError("refusing to overwrite", step="link_command"))
     @patch("builtins.print")
     def test_link_error_returns_1(
         self, mock_print, mock_link, mock_wrapper_dir, mock_create_venv,
     ):
-        """RuntimeError from _link_global_command -> returns 1."""
+        """DEILEInstallError from _link_global_command -> returns 1."""
         from deile.cli import _run_self_install
 
         mock_create_venv.return_value = Path("/tmp/venv/bin/deile")

--- a/deile/tests/test_install_functions.py
+++ b/deile/tests/test_install_functions.py
@@ -63,7 +63,7 @@ class TestWrapperTargetDir:
         """On Windows, delegates to _user_scripts_dir()."""
         from deile.cli import _wrapper_target_dir
 
-        mock_user_scripts.return_value = Path("C:/Users/test/AppData/Roaming/Python/Scripts")
+        mock_user_scripts.return_value = MagicMock()
         result = _wrapper_target_dir()
         assert result == mock_user_scripts.return_value
 


### PR DESCRIPTION
## Resumo

Refatora completamente o sistema de auto-instalação (`deile --install`) substituindo o antigo `pip install --user -e .` por um pipeline robusto que cria um **venv isolado** e um **shim global** em `~/.local/bin/deile`.

## O que mudou

### Novos helpers (modularizados)

| Função | Papel |
|---|---|
| `_create_venv_with_deile()` | Pipeline idempotente: cria venv → upgrade pip → instala `requirements.txt` → registra pacote editable com `--no-deps` |
| `_wrapper_target_dir()` / `_user_scripts_dir()` | Detecta o diretório correto para o shim cross-platform (sysconfig) |
| `_link_global_command()` | Cria symlink (POSIX) ou `.cmd` shim (Windows) no diretório alvo |
| `_ensure_scripts_dir_on_path()` | Edita `.zshrc` / `.bashrc` / `.bash_profile` / `config.fish` para adicionar o diretório ao PATH |
| `_prompt_install_mode()` | Menu interativo g/l/q |

### Modos de instalação

- **Global** (recomendado): venv em `~/.deile/venv/` — deps do DEILE não tocam no sistema nem no user-site.
- **Local**: venv em `<repo>/.venv/` — útil para contribuidores que já estão no clone.

### CLI

- `--install` sem argumentos → prompt interativo (retrocompatível).
- `--install-mode {global,local}` → não-interativo para CI/scripts.
- `--install-mode` sem `--install` → erro claro (exit 2).

### PATH

Após a instalação, se o diretório do shim não estiver no PATH, o script detecta o shell ativo e edita o rc file automaticamente, com mensagem clara de `source` para o usuário.

## Testado

- Commit: `6d21d6e`
- Branch: `feat/self-install-isolated-venv`
- 300 inserções / 66 deleções em `deile/cli.py`

---

By [DEILE One](mailto:deile@deile.info)