### PR TITLE
fix(tools,persona,loop_guard): bash_execute fail-over hints when path is outside CWD

### DIFF
--- a/deile/core/loop_guard.py
+++ b/deile/core/loop_guard.py
@@ -73,13 +73,21 @@ class AbortReason:
     detail: str
 
     def user_message(self) -> str:
-        """One-paragraph user-visible explanation of the loop break."""
+        """One-paragraph user-visible explanation of the loop break.
+
+        For path-related tool loops we additionally point at ``bash_execute``
+        — observed real failure mode: the model loops on ``list_files`` with
+        a path that the sandbox keeps rejecting, when the user actually
+        wanted a parent-repo / system-absolute path that only ``bash_execute``
+        can reach.
+        """
+        suffix = _bash_failover_hint(self.tool_name, self.args_preview)
         if self.kind is AbortKind.MAX_CALLS:
             return (
                 "I stopped because I exceeded the maximum number of tool calls "
                 f"allowed for a single turn ({self.total_calls}). The last call "
                 f"was {self.tool_name}({self.args_preview}). Please rephrase your "
-                "request or break it into smaller steps."
+                "request or break it into smaller steps." + suffix
             )
         if self.kind is AbortKind.IDENTICAL_REPEAT:
             return (
@@ -87,22 +95,53 @@ class AbortReason:
                 f"same arguments {self.repeat_count} times in a row "
                 f"({self.args_preview}). That is almost certainly a loop, so I "
                 "stopped before wasting more tokens. Please try a different phrasing "
-                "or be more specific about what you want."
+                "or be more specific about what you want." + suffix
             )
         if self.kind is AbortKind.SLIDING_WINDOW:
             return (
                 f"I detected that '{self.tool_name}' had been called {self.repeat_count} "
                 "times with the same arguments in a small window of recent calls "
                 f"({self.args_preview}). That looks like a loop, so I stopped. "
-                "Please rephrase your request."
+                "Please rephrase your request." + suffix
             )
         # NO_PROGRESS
         return (
             f"I made {self.repeat_count} consecutive tool calls without producing "
             "any useful result (the calls returned empty or errored). Rather than "
             "keep retrying, I stopped. Please check the most recent tool errors "
-            "and try a different approach."
+            "and try a different approach." + suffix
         )
+
+
+# Tools whose arguments include a ``path``/``file_path``/``directory`` field
+# and whose loops typically come from a sandbox-rejected path the user actually
+# wanted resolved system-wide. When one of these loops, hint at bash_execute.
+_PATH_TOOL_NAMES = frozenset({
+    "list_files", "read_file", "write_file", "delete_file", "edit_file",
+})
+
+# Substrings in args_preview that indicate the LLM was reaching for a path
+# outside the working_directory — leading slash (system-absolute), parent
+# traversal, or home shorthand.
+_OUTSIDE_PROJECT_MARKERS = ('"/', "'/", '"..', "'..", '"~', "'~")
+
+
+def _bash_failover_hint(tool_name: str, args_preview: str) -> str:
+    """Return a one-line addendum suggesting ``bash_execute`` when the
+    looping call looks like a sandboxed path-tool reaching outside CWD.
+
+    Pure string check — never raises, returns ``""`` when no hint applies.
+    """
+    if tool_name not in _PATH_TOOL_NAMES:
+        return ""
+    if not args_preview or not any(m in args_preview for m in _OUTSIDE_PROJECT_MARKERS):
+        return ""
+    return (
+        " HINT: the path looks like it targets OUTSIDE the project working "
+        "directory. file_tools cannot escape the sandbox — use `bash_execute` "
+        "with the absolute path instead (e.g. `bash_execute(command=\"ls "
+        "<abs_path>\")` or `bash_execute(command=\"cat <abs_path>\")`)."
+    )
 
 
 @dataclass

--- a/deile/personas/instructions/core/DEILE.md
+++ b/deile/personas/instructions/core/DEILE.md
@@ -60,6 +60,18 @@ Use sem pedir permissão:
 
 6. **Não alucine sobre localização.** Reportar "criei em X" sem ter visto X num tool result é mentira.
 
+7. **Fail-over para `bash_execute` quando file_tools rejeita path FORA do projeto.**
+   Quando `list_files` / `read_file` retorna `OUTSIDE the project working directory` OU `Path not found` com nota `leading '/' stripped` / `'~' stripped`, o caminho que o usuário pediu mora **fora** do `working_directory`. **NÃO repita a chamada com a mesma estrutura.** Use `bash_execute` com o path absoluto:
+   - `bash_execute(command="ls /caminho/absoluto/")` para listar
+   - `bash_execute(command="cat /caminho/absoluto/arquivo")` para ler
+   - `bash_execute(command="grep -rn padrão /caminho/absoluto/")` para varrer
+
+   `bash_execute` **não tem** sandbox de working_directory — aceita qualquer path do sistema.
+
+   Casos legítimos típicos: monorepo onde DEILE foi invocado de um subprojeto (ex.: `deile_bot/` dentro de `deile/`) e o usuário quer ler templates/configs do repo-pai; auditoria de paths absolutos que o usuário forneceu literalmente; verificação cross-repo.
+
+   **Anti-padrão proibido**: receber `Path not found: /Users/.../algo` e tentar `list_files(path='.github/...')` — você acabou de remover o prefixo absoluto que era a parte importante. Se o usuário disse `/Users/x/y`, use `bash_execute(command="ls /Users/x/y")`.
+
 ---
 
 ## 🛡️ Segurança (REGRA #5)

--- a/deile/tests/test_loop_detection.py
+++ b/deile/tests/test_loop_detection.py
@@ -255,6 +255,65 @@ def test_user_message_mentions_kind_and_tool():
     assert AbortKind.IDENTICAL_REPEAT.value in formatted
 
 
+def test_user_message_hints_bash_when_path_tool_loops_outside_cwd():
+    """Regression guard for the second-/EVOLVE-run trace.
+
+    When the model loops on a path-tool with arguments that look like they
+    target OUTSIDE the working directory (leading slash, ``..``, ``~``),
+    the loop-break message must point at ``bash_execute`` — that's the only
+    DEILE tool with no working_directory sandbox.
+
+    Without this hint, the model receives the loop-break, "rephrases", and
+    keeps trying the same family of broken paths because nothing told it
+    the sandbox is the actual blocker. With the hint, the next iteration
+    has explicit guidance to switch tools.
+    """
+    guard = ToolLoopGuard()
+    guard.check("list_files", {"path": "/Users/x/parent_repo/.github"})
+    guard.check("list_files", {"path": "/Users/x/parent_repo/.github"})
+    abort = guard.check("list_files", {"path": "/Users/x/parent_repo/.github"})
+    assert abort is not None
+    msg = abort.user_message()
+    assert "bash_execute" in msg
+    assert "OUTSIDE the project working" in msg
+
+
+def test_user_message_hints_bash_for_parent_relative_path_loops():
+    """Same as above but for ``../parent/...`` paths (parent-relative form
+    the user typically uses when redirecting from a subproject)."""
+    guard = ToolLoopGuard()
+    guard.check("read_file", {"file_path": "../parent_repo/README.md"})
+    guard.check("read_file", {"file_path": "../parent_repo/README.md"})
+    abort = guard.check("read_file", {"file_path": "../parent_repo/README.md"})
+    assert abort is not None
+    assert "bash_execute" in abort.user_message()
+
+
+def test_user_message_no_bash_hint_for_clean_relative_path_loops():
+    """When the loop is on a project-relative path (no leading /, no ..,
+    no ~), the bash hint would mislead the model — clean-relative paths
+    that loop usually mean "the file you keep listing doesn't exist", not
+    "use a different tool". Stay quiet on the bash hint there."""
+    guard = ToolLoopGuard()
+    guard.check("list_files", {"path": "src/components"})
+    guard.check("list_files", {"path": "src/components"})
+    abort = guard.check("list_files", {"path": "src/components"})
+    assert abort is not None
+    assert "bash_execute" not in abort.user_message()
+
+
+def test_user_message_no_bash_hint_for_non_path_tool_loops():
+    """The bash failover hint applies only to file/path tools. A loop on
+    e.g. ``http_get`` shouldn't suggest bash — that's a different family
+    of failures (network, auth) where bash isn't the answer."""
+    guard = ToolLoopGuard()
+    guard.check("http_get", {"url": "https://example.com/api"})
+    guard.check("http_get", {"url": "https://example.com/api"})
+    abort = guard.check("http_get", {"url": "https://example.com/api"})
+    assert abort is not None
+    assert "bash_execute" not in abort.user_message()
+
+
 def test_tool_result_made_progress_helper():
     assert tool_result_made_progress(
         ToolResult(status=ToolStatus.SUCCESS, data={"x": 1})

--- a/deile/tests/test_path_normalization.py
+++ b/deile/tests/test_path_normalization.py
@@ -26,8 +26,9 @@ from pathlib import Path
 import pytest
 
 from deile.tools.base import ToolContext
-from deile.tools.file_tools import (LocalFileAccessViolation, ReadFileTool,
-                                    ResolvedPath, WriteFileTool,
+from deile.tools.file_tools import (ListFilesTool, LocalFileAccessViolation,
+                                    ReadFileTool, ResolvedPath, WriteFileTool,
+                                    _looks_like_outside_project,
                                     _resolve_project_path,
                                     _validate_path_within_working_directory)
 
@@ -338,6 +339,139 @@ def test_write_file_blocks_parent_escape_with_clear_message(tmp_path):
     result = tool.execute_sync(ctx)
     assert result.is_error
     assert "OUTSIDE the project" in result.message
+
+
+def test_outside_project_violation_points_to_bash_execute(tmp_path):
+    """Regression guard for the second-/EVOLVE-run trace: when DEILE was
+    launched from ``deile_bot/`` (a subdir of the deile parent repo) and
+    asked to read templates at ``../.github/ISSUE_TEMPLATE/``, the path
+    resolver rejected it with a generic "OUTSIDE the project" message that
+    didn't tell the LLM HOW to recover. The model then looped on the same
+    broken call.
+
+    The fix surfaces, inside the LocalFileAccessViolation message, an
+    explicit pointer to ``bash_execute`` — the only tool in DEILE that has
+    no working-directory sandbox and CAN access parent / sibling repos.
+    """
+    with pytest.raises(LocalFileAccessViolation) as exc:
+        _resolve_project_path("../.github/ISSUE_TEMPLATE/", str(tmp_path))
+    msg = str(exc.value)
+    assert "OUTSIDE the project" in msg
+    assert "bash_execute" in msg
+    # Must include a concrete example so the LLM can copy-paste — `ls` or `cat`
+    assert "`ls " in msg or "`cat " in msg
+    assert "no working-directory sandbox" in msg
+
+
+# ---------------------------------------------------------------------------
+# 2b. _looks_like_outside_project heuristic — pure-string detector that
+#     decides whether to attach a bash_execute hint to "Path not found"
+#     messages from list_files / read_file.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/Users/x/foo.txt",
+        "/etc/passwd",
+        "/tmp/foo",
+        "..",
+        "../sibling/file.py",
+        "../../parent/of/parent.txt",
+        "~",
+        "~/foo.py",
+    ],
+)
+def test_looks_like_outside_project_true(path):
+    assert _looks_like_outside_project(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "foo.py",
+        "src/main.py",
+        "./local.py",
+        "a/../b.py",   # internal .. doesn't trigger heuristic
+        ".github/ISSUE_TEMPLATE/",
+        "",
+        "   ",
+    ],
+)
+def test_looks_like_outside_project_false(path):
+    assert _looks_like_outside_project(path) is False
+
+
+def test_looks_like_outside_project_handles_non_string():
+    assert _looks_like_outside_project(None) is False
+    assert _looks_like_outside_project(42) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 2c. ListFilesTool — surface normalization note + bash_execute hint
+# ---------------------------------------------------------------------------
+
+
+def test_list_files_not_found_for_normalized_absolute_path_hints_bash(tmp_path):
+    """Direct repro of the second-run failure mode.
+
+    User launches DEILE from a subdir, then asks it to read
+    ``/Users/.../parent_repo/.github/ISSUE_TEMPLATE/``. The resolver strips
+    the leading ``/`` (treating it as a project-relative typo), the
+    resulting path doesn't exist inside CWD, and ``list_files`` returns
+    "Path not found".
+
+    Before the fix: the LLM saw only "Path not found: /Users/...", didn't
+    realize the path had been mangled, and looped on the same call.
+
+    After the fix: the message includes (a) the normalization note so the
+    LLM SEES the slash was stripped, and (b) an explicit pointer to
+    ``bash_execute`` so it knows exactly which tool to use instead.
+    """
+    tool = ListFilesTool()
+    nonexistent_abs = "/some/system/path/that/does/not/exist/anywhere"
+    ctx = _ctx(tmp_path, path=nonexistent_abs)
+    result = tool.execute_sync(ctx)
+
+    assert result.is_error
+    assert "Path not found" in result.message
+    # (a) Normalization note must be visible
+    assert "leading '/' stripped" in result.message
+    # (b) bash_execute hint must be visible
+    assert "bash_execute" in result.message
+
+
+def test_list_files_not_found_for_parent_relative_path_hints_bash(tmp_path):
+    """Same idea but for ``../parent_repo/...`` — the resolver raises
+    LocalFileAccessViolation here. The list_files tool catches it and
+    surfaces the violation message, which the resolver enriched with the
+    bash_execute hint.
+    """
+    tool = ListFilesTool()
+    ctx = _ctx(tmp_path, path="../escape/.github")
+    result = tool.execute_sync(ctx)
+
+    assert result.is_error
+    assert "OUTSIDE the project" in result.message
+    assert "bash_execute" in result.message
+
+
+def test_list_files_not_found_for_clean_relative_path_no_bash_hint(tmp_path):
+    """Negative case: when the LLM asks for a non-existent project-relative
+    path (a typo like ``misspelled_dir/``), we still want a clear "Path
+    not found" — but we should NOT spam the bash_execute hint, because
+    the path is conceptually correct (project-scoped) and just doesn't
+    exist yet. Adding the hint here would mislead the LLM into reaching
+    for bash when ``write_file`` / ``mkdir`` is the right answer.
+    """
+    tool = ListFilesTool()
+    ctx = _ctx(tmp_path, path="misspelled_dir/")
+    result = tool.execute_sync(ctx)
+
+    assert result.is_error
+    assert "Path not found" in result.message
+    assert "bash_execute" not in result.message
 
 
 def test_write_file_at_prefix_normalized(tmp_path):

--- a/deile/tools/file_tools.py
+++ b/deile/tools/file_tools.py
@@ -85,6 +85,36 @@ _DANGEROUS_PATH_CHARS = re.compile(r"[\x00<>|*?]")
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]+")
 
 
+def _looks_like_outside_project(path: Optional[str]) -> bool:
+    """Heuristic: did the LLM attempt a path that clearly targets outside the
+    project working directory?
+
+    Used to decide whether ``Path not found`` errors should include a hint
+    pointing at ``bash_execute`` (which has no working-directory sandbox).
+    Triggers on:
+
+    * Leading ``/`` (system-absolute, e.g. ``/Users/...``, ``/etc/...``).
+    * Leading ``..`` (parent-relative, e.g. ``../sibling/file``).
+    * Leading ``~`` (home, e.g. ``~/foo`` — note: file_tools does NOT expand
+      ``~``; we still treat it as a clear "outside" intent).
+
+    Pure-string check, no I/O. Conservative on purpose — false positives just
+    add a helpful hint to a real error message, never block legitimate paths.
+    """
+    if not isinstance(path, str):
+        return False
+    stripped = path.strip()
+    if not stripped:
+        return False
+    if stripped.startswith("/"):
+        return True
+    if stripped.startswith("..") and (len(stripped) == 2 or stripped[2] in ("/", "\\")):
+        return True
+    if stripped.startswith("~"):
+        return True
+    return False
+
+
 def _resolve_absolute_or_strip(
     candidate: str, work_dir: Path, raw: str
 ) -> Tuple[str, Optional[Path], Optional[str]]:
@@ -205,7 +235,11 @@ def _resolve_project_path(file_path: str, working_directory: str) -> ResolvedPat
         raise LocalFileAccessViolation(
             f"path {raw!r} resolves to {target}, which is OUTSIDE the project "
             f"working directory {work_dir}. Use a project-relative path "
-            f"(e.g. drop any leading '..' that escapes the project root)."
+            f"(e.g. drop any leading '..' that escapes the project root). "
+            f"For files OUTSIDE the project (parent repo, sibling project, "
+            f"system paths like /etc/), use `bash_execute` (e.g. "
+            f"`ls {target}` or `cat {target}`) — bash_execute has no "
+            f"working-directory sandbox."
         )
 
     # POSIX-style relative for display (works across platforms in messages)
@@ -1103,45 +1137,68 @@ class ListFilesTool(SyncTool):
                         logger.debug(f"ListFilesTool: Extracted path from user_input: {target_path}")
                         break
         
-        # ROBUSTEZ: Múltiplas tentativas de validação de path
-        validation_attempts = [
-            target_path,
-            ".",  # Fallback para diretório atual
-            context.working_directory,  # Fallback para working_directory explícito
-        ]
-        
+        # Resolve the LLM-supplied target_path through the canonical resolver
+        # so we capture the normalization ``note`` (e.g. "leading '/' stripped"
+        # or "@ prefix stripped") AND surface sandbox violations cleanly.
+        #
+        # IMPORTANT: when the LLM EXPLICITLY supplies a path that violates the
+        # sandbox (``../parent_repo/.github`` or system-absolute outside CWD),
+        # we MUST surface that violation — never silently fall back to CWD,
+        # which would list unrelated content and mislead the model into a
+        # tighter loop. Fallbacks are only useful when the LLM omitted the
+        # argument entirely (target_path stayed at default "." which always
+        # resolves cleanly).
         full_path = None
+        resolved_obj: Optional[ResolvedPath] = None
         working_dir = Path(context.working_directory).resolve()
-        
+
         logger.debug(f"ListFilesTool - target_path: {target_path}, working_directory: {context.working_directory}")
-        
-        for attempt_path in validation_attempts:
-            try:
-                logger.debug(f"ListFilesTool - trying validation for: {attempt_path}")
-                validated_path = _validate_path_within_working_directory(
-                    attempt_path, context.working_directory
-                )
-                full_path = Path(validated_path)
-                logger.debug(f"ListFilesTool - validation successful: {full_path}")
-                break
-            except LocalFileAccessViolation as e:
-                logger.debug(f"ListFilesToool - validation failed for {attempt_path}: {e}")
-                continue
-            except Exception as e:
-                logger.debug(f"ListFilesTool - unexpected error for {attempt_path}: {e}")
-                continue
-        
-        if full_path is None:
-            # ÚLTIMO RECURSO: Usa working_directory diretamente (sem validação)
-            logger.warning("All path validations failed, using working_directory directly")
-            full_path = working_dir
-        
+
         try:
-            
+            resolved_obj = _resolve_project_path(
+                target_path, context.working_directory
+            )
+            full_path = Path(resolved_obj.absolute)
+            logger.debug(f"ListFilesTool - validation successful: {full_path}")
+        except LocalFileAccessViolation as e:
+            logger.debug(f"ListFilesTool - sandbox violation for {target_path!r}: {e}")
+            return ToolResult(
+                status=ToolStatus.ERROR,
+                message=str(e),
+                error=e,
+            )
+        except Exception as e:
+            logger.debug(f"ListFilesTool - unexpected resolver error for {target_path!r}: {e}")
+            # Fall through to the working_directory fallback below — this
+            # branch should be unreachable in normal operation, but keeping
+            # the safety net avoids a hard 500 on resolver bugs.
+            full_path = working_dir
+
+        try:
+
             if not full_path.exists():
+                # Surface the normalization note (e.g. "leading '/' stripped")
+                # AND a bash-execute hint when the user clearly asked for a
+                # system-absolute or parent-relative path. Without this, the
+                # LLM gets only "Path not found: <garbage>" and loops on the
+                # same broken call (observed in the second-run trace).
+                hint = ""
+                if resolved_obj is not None and resolved_obj.note:
+                    hint += (
+                        f" (input was {resolved_obj.input!r} → "
+                        f"{resolved_obj.note})"
+                    )
+                if _looks_like_outside_project(target_path):
+                    hint += (
+                        ". For paths OUTSIDE the project working directory "
+                        "(parent repo, sibling project, /etc/, ~/...), use "
+                        "`bash_execute` (e.g. `ls <abs_path>` or "
+                        "`cat <abs_path>`) — bash_execute has no "
+                        "working-directory sandbox."
+                    )
                 return ToolResult(
                     status=ToolStatus.ERROR,
-                    message=f"Path not found: {target_path}",
+                    message=f"Path not found: {target_path}{hint}",
                     error=FileNotFoundError(f"Path '{target_path}' not found")
                 )
             


### PR DESCRIPTION
## Summary

- Surfaces `bash_execute` fail-over hints in `file_tools` errors and `loop_guard` exit messages so DEILE can recover when the user asks for a path outside the working directory (parent repo / sibling project / system path).
- Adds Path Discipline rule #7 to the DEILE persona: explicit fail-over from sandboxed file_tools to `bash_execute`.
- Stops `ListFilesTool` from silently falling back to `.` when the LLM-supplied path violated the sandbox (was masking the real error).

Closes the path-loop failure-mode of run-2 in #149. Other tiers in #149 follow as separate PRs.

## Test plan

- [x] `python3 -m pytest deile/tests/ -q --no-cov` — **1833 passing** (vs 1805 baseline, +28 new), zero regression. Pre-existing failure in `might/streaming-ui` (real-LLM smoke) unchanged.
- [x] `python3 -m pytest deile/tests/test_path_normalization.py -q` — 80/80 passing (60 existing + 20 new).
- [x] `python3 -m pytest deile/tests/test_loop_detection.py -q` — 26/26 passing (22 existing + 4 new).
- [ ] Empirical smoke: re-run `/EVOLVE` from `deile_bot/` and confirm the agent now reaches for `bash_execute` instead of looping on `list_files` (covered by Tier 4 of #149).

## Files changed

| File | Change |
|---|---|
| `deile/tools/file_tools.py` | `_looks_like_outside_project` helper; `ListFilesTool` surfaces normalization note + bash hint and propagates `LocalFileAccessViolation` instead of misleading fallback; containment-check exception message includes concrete `bash_execute` example. |
| `deile/personas/instructions/core/DEILE.md` | New Path Discipline rule #7 — fail-over to `bash_execute` for paths outside CWD with anti-pattern callout. |
| `deile/core/loop_guard.py` | `_PATH_TOOL_NAMES` set + `_bash_failover_hint` helper; `AbortReason.user_message()` appends bash hint when looping path-tool with outside-CWD args. |
| `deile/tests/test_path_normalization.py` | +20 tests: heuristic coverage, `ListFilesTool` not-found-with-hint scenarios, sibling-path `LocalFileAccessViolation` message contents. |
| `deile/tests/test_loop_detection.py` | +4 tests: bash hint appears for outside-CWD path-tool loops, suppressed for clean-relative or non-path tools. |

## Out of scope (deferred to #149)

- Same hint pattern in `read_file` / `write_file` / `delete_file` / `edit_file` (Tier 1).
- `AbortKind.HARD_STOP` escalation when same hash trips guard twice (Tier 2).
- EVOLVE skill quality-gates (Tier 3).
- Empirical `/EVOLVE` golden harness (Tier 4).
- Persona meta-reasoning rule #8 (Tier 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)