### PR TITLE
feat(env): exportar vars de ambiente via settings.json, elimina .env em disco

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -74,6 +74,21 @@ def _silence_genai_shutdown_noise() -> None:
     _gc.Client.__del__ = _safe_del
 
 
+
+def _load_exported_env_vars() -> None:
+    """Load env vars from ~/.deile/settings.json env.exports into os.environ.
+
+    Preferred alternative to .env files: variables stored via /env set KEY=VALUE
+    are exported here, before provider bootstrap.
+    Missing or malformed settings are silently ignored.
+    """
+    try:
+        from deile.config.env_store import load_exported_vars
+        load_exported_vars()
+    except Exception:
+        pass
+
+
 def _run_env_recovery() -> bool:
     """Interactive wizard: prompt for API keys, write .env, reload os.environ.
 
@@ -665,6 +680,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     Returns exit code (0 = success, 1 = error).
     """
     _load_dotenv()
+    _load_exported_env_vars()
     _silence_genai_shutdown_noise()
 
     # Ensure deile package is importable

--- a/deile/commands/builtin/__init__.py
+++ b/deile/commands/builtin/__init__.py
@@ -9,6 +9,7 @@ from .context_command import ContextCommand
 from .cost_command import CostCommand
 from .debug_command import DebugCommand
 from .diff_command import DiffCommand
+from .env_command import EnvCommand
 from .export_command import ExportCommand
 from .help_command import HelpCommand
 from .model_command import ModelCommand
@@ -55,4 +56,5 @@ __all__ = [
     "WelcomeCommand",
     "PipelineCommand",
     "PipelineScheduleCommand",
+    "EnvCommand",
 ]

--- a/deile/commands/builtin/env_command.py
+++ b/deile/commands/builtin/env_command.py
@@ -1,0 +1,156 @@
+"""Env Command -- manage environment variables exported to the process.
+
+Replaces the .env file approach: variables are stored in
+~/.deile/settings.json under env.exports (0o600, owner-only) and loaded
+into os.environ at startup, so no plaintext .env file lives in the project.
+
+Subcommands:
+    /env set KEY=VALUE      store KEY in ~/.deile/settings.json env.exports
+    /env set KEY VALUE      same with space separator
+    /env list               list stored vars (sensitive values masked)
+    /env unset KEY          remove KEY from the store and os.environ
+"""
+
+from __future__ import annotations
+
+from rich.table import Table
+
+from ..base import CommandContext, CommandResult, DirectCommand
+
+
+class EnvCommand(DirectCommand):
+    """Manage environment variables exported to the process (replaces .env files)."""
+
+    cli_flag = "--env"
+    cli_takes_arg = True
+    cli_arg_metavar = "ACTION [KEY[=VALUE]]"
+    cli_help = (
+        "Manage exported env vars in ~/.deile/settings.json "
+        "(e.g. --env 'set ANTHROPIC_API_KEY=sk-ant-...')."
+    )
+    cli_requires_provider = False
+
+    def __init__(self):
+        from ...config.manager import CommandConfig
+        super().__init__(CommandConfig(
+            name="env",
+            description=(
+                "Manage environment variables stored securely in ~/.deile/settings.json "
+                "(replaces .env files)."
+            ),
+        ))
+
+    async def execute(self, context: CommandContext) -> CommandResult:
+        args = (getattr(context, "args", "") or "").strip()
+        if not args:
+            return CommandResult.success_result(self.get_help(), "text")
+
+        parts = args.split(maxsplit=1)
+        subcommand = parts[0].lower()
+        rest = parts[1].strip() if len(parts) > 1 else ""
+
+        if subcommand == "list":
+            return await self._cmd_list()
+        if subcommand == "set":
+            return await self._cmd_set(rest)
+        if subcommand == "unset":
+            return await self._cmd_unset(rest)
+        return CommandResult.error_result(
+            "Unknown subcommand: {!r}. Use set, list, or unset.".format(subcommand)
+        )
+
+    async def _cmd_list(self) -> CommandResult:
+        from ...config.env_store import list_vars
+
+        stored = list_vars()
+        if not stored:
+            return CommandResult.success_result(
+                "No environment variables stored.\n"
+                "Use `/env set KEY=VALUE` to add one.",
+                "text",
+            )
+        table = Table(
+            title="Stored env vars (~/.deile/settings.json)",
+            show_lines=False,
+        )
+        table.add_column("Variable", style="cyan")
+        table.add_column("Value", style="dim")
+        for key in sorted(stored):
+            table.add_row(key, stored[key])
+        return CommandResult.success_result(table, "rich")
+
+    async def _cmd_set(self, rest: str) -> CommandResult:
+        from ...config.env_store import is_sensitive, store_var
+
+        if "=" in rest:
+            key, _, value = rest.partition("=")
+        else:
+            parts = rest.split(maxsplit=1)
+            if len(parts) < 2:
+                return CommandResult.error_result(
+                    "Usage: /env set KEY=VALUE  or  /env set KEY VALUE"
+                )
+            key, value = parts[0], parts[1]
+
+        key = key.strip()
+        value = value.strip()
+
+        if not key:
+            return CommandResult.error_result("Key must not be empty.")
+
+        try:
+            ok = store_var(key, value)
+        except (ValueError, TypeError) as exc:
+            return CommandResult.error_result("Cannot store variable: {}".format(exc))
+        except Exception as exc:
+            return CommandResult.error_result("Failed to store variable: {}".format(exc))
+
+        if ok:
+            display = "<masked>" if is_sensitive(key) else repr(value)
+            return CommandResult.success_result(
+                "Stored {}={} in ~/.deile/settings.json".format(key, display),
+                "text",
+            )
+        return CommandResult.error_result("Failed to write settings file.")
+
+    async def _cmd_unset(self, rest: str) -> CommandResult:
+        from ...config.env_store import unset_var
+
+        key = rest.strip()
+        if not key:
+            return CommandResult.error_result("Usage: /env unset KEY")
+
+        try:
+            existed = unset_var(key)
+        except ValueError as exc:
+            return CommandResult.error_result("Cannot unset variable: {}".format(exc))
+        except Exception as exc:
+            return CommandResult.error_result("Failed to unset variable: {}".format(exc))
+
+        if existed:
+            return CommandResult.success_result(
+                "Removed {} from env store.".format(key), "text"
+            )
+        return CommandResult.success_result(
+            "{} was not in the env store.".format(key), "text"
+        )
+
+    def get_help(self) -> str:
+        return """Manage environment variables stored in ~/.deile/settings.json
+
+Variables are loaded into os.environ at startup, replacing .env file dependency.
+File is stored with 0o600 (owner-only) permissions -- no risk of accidental commits.
+
+Usage:
+  /env set KEY=VALUE      Store KEY=VALUE securely
+  /env set KEY VALUE      Same with space separator
+  /env list               List stored vars (sensitive values masked)
+  /env unset KEY          Remove KEY from store and os.environ
+
+Examples:
+  /env set ANTHROPIC_API_KEY=sk-ant-...
+  /env set MY_CUSTOM_VAR=hello
+  /env list
+  /env unset OLD_VAR
+
+Variables are stored under the 'env.exports' key in ~/.deile/settings.json."""

--- a/deile/config/env_store.py
+++ b/deile/config/env_store.py
@@ -1,0 +1,193 @@
+"""EnvStore — store environment variables in ~/.deile/settings.json.
+
+Replaces the .env file approach: variables are kept in
+~/.deile/settings.json (0o600, owner-only) under the ``env.exports``
+key and exported into os.environ at process startup.
+
+Security properties:
+  - No .env file in the project directory (no accidental git commits)
+  - File lives in ~/.deile/ -- outside any repo working tree
+  - 0o600 permissions: owner read/write only
+  - Values are only in memory (os.environ) after load
+
+Usage in cli.py main():
+    from deile.config.env_store import load_exported_vars
+    load_exported_vars()   # call before bootstrap_providers()
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_file_lock = threading.Lock()
+
+# Patterns that mark a key as sensitive -- values are masked in list output.
+_SENSITIVE_PATTERNS = ("key", "token", "secret", "password", "api")
+
+
+def _settings_path(home=None):
+    return (home or Path.home()) / ".deile" / "settings.json"
+
+
+def _load_raw(path):
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("env_store: cannot read %s: %s", path, exc)
+        return {}
+
+
+def _save_raw(path, data):
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=".{}.".format(path.name),
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(data, tmp, indent=2)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_name = tmp.name
+        os.replace(tmp_name, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return True
+    except (OSError, TypeError, ValueError) as exc:
+        logger.error("env_store: cannot write %s: %s", path, exc)
+        return False
+
+
+def _get_exports(data):
+    env_section = data.get("env")
+    if not isinstance(env_section, dict):
+        return {}
+    exports = env_section.get("exports")
+    return exports if isinstance(exports, dict) else {}
+
+
+def _set_exports(data, exports):
+    if "env" not in data or not isinstance(data["env"], dict):
+        data["env"] = {}
+    data["env"]["exports"] = exports
+
+
+def is_sensitive(key):
+    """Return True when *key* looks like it holds a secret value."""
+    lower = key.lower()
+    return any(pat in lower for pat in _SENSITIVE_PATTERNS)
+
+
+def load_exported_vars(home=None):
+    """Export vars from ~/.deile/settings.json env.exports into os.environ.
+
+    Existing os.environ values take precedence -- an already-set var is
+    never overwritten. Returns the dict of keys that were actually exported.
+    """
+    path = _settings_path(home)
+    data = _load_raw(path)
+    exports = _get_exports(data)
+
+    loaded = {}
+    for key, value in exports.items():
+        if not isinstance(key, str) or not key:
+            continue
+        if not isinstance(value, str):
+            value = str(value)
+        if key not in os.environ:
+            os.environ[key] = value
+            loaded[key] = value
+
+    if loaded:
+        logger.debug("env_store: exported %d var(s) into os.environ", len(loaded))
+    return loaded
+
+
+def store_var(key, value, home=None):
+    """Persist *key*=*value* in ~/.deile/settings.json under env.exports.
+
+    Also sets os.environ[key] immediately so the value is available for
+    the rest of the current session without a restart.
+    """
+    if not isinstance(key, str) or not key.strip():
+        raise ValueError("key must be a non-empty string")
+    key = key.strip()
+    if not all(c.isalnum() or c == "_" for c in key):
+        raise ValueError(
+            "Invalid key {!r}: only letters, digits and underscores allowed".format(key)
+        )
+    if not isinstance(value, str):
+        raise TypeError("value must be a string")
+
+    path = _settings_path(home)
+    with _file_lock:
+        data = _load_raw(path)
+        exports = dict(_get_exports(data))
+        exports[key] = value
+        _set_exports(data, exports)
+        ok = _save_raw(path, data)
+
+    if ok:
+        os.environ[key] = value
+    return ok
+
+
+def unset_var(key, home=None):
+    """Remove *key* from env.exports and from os.environ.
+
+    Returns True if the key existed in the store.
+    """
+    if not isinstance(key, str) or not key.strip():
+        raise ValueError("key must be a non-empty string")
+    key = key.strip()
+
+    path = _settings_path(home)
+    with _file_lock:
+        data = _load_raw(path)
+        exports = dict(_get_exports(data))
+        existed = key in exports
+        if existed:
+            del exports[key]
+            _set_exports(data, exports)
+            _save_raw(path, data)
+
+    if existed:
+        os.environ.pop(key, None)
+    return existed
+
+
+def list_vars(home=None):
+    """Return stored env vars with sensitive values replaced by ``<masked>``.
+
+    Keys whose names match common secret patterns (api, key, token, secret,
+    password) have their value hidden.
+    """
+    path = _settings_path(home)
+    data = _load_raw(path)
+    exports = _get_exports(data)
+
+    result = {}
+    for key, value in exports.items():
+        if not isinstance(key, str):
+            continue
+        if is_sensitive(key):
+            result[key] = "<masked>"
+        else:
+            result[key] = str(value) if not isinstance(value, str) else value
+    return result

--- a/deile/tests/commands/test_env_command.py
+++ b/deile/tests/commands/test_env_command.py
@@ -1,0 +1,154 @@
+"""Tests for deile.commands.builtin.env_command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_context(args: str = "") -> MagicMock:
+    ctx = MagicMock()
+    ctx.args = args
+    ctx.agent = None
+    ctx.ui_manager = None
+    ctx.config_manager = None
+    return ctx
+
+
+def _write_settings(home: Path, data: dict) -> None:
+    d = home / ".deile"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "settings.json").write_text(json.dumps(data), encoding="utf-8")
+
+@pytest.mark.unit
+class TestEnvCommandSet:
+    async def test_set_key_equals_value(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+        monkeypatch.delenv("MY_ENV_CMD_VAR", raising=False)
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("set MY_ENV_CMD_VAR=hello")
+        result = await cmd.execute(ctx)
+        assert result.success
+        assert "MY_ENV_CMD_VAR" in result.content
+
+    async def test_set_key_space_value(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+        monkeypatch.delenv("SPACE_VAR", raising=False)
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("set SPACE_VAR world")
+        result = await cmd.execute(ctx)
+        assert result.success
+
+    async def test_set_invalid_key(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("set MY-INVALID=value")
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+    async def test_set_missing_value(self, tmp_path):
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("set ONLY_KEY")
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+    async def test_set_sensitive_key_masked_in_output(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+        monkeypatch.delenv("MY_API_KEY", raising=False)
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("set MY_API_KEY=sk-secret-value")
+        result = await cmd.execute(ctx)
+        assert result.success
+        assert "sk-secret-value" not in str(result.content)
+        assert "<masked>" in str(result.content)
+
+@pytest.mark.unit
+class TestEnvCommandList:
+    async def test_list_empty(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("list")
+        result = await cmd.execute(ctx)
+        assert result.success
+
+    async def test_list_shows_vars(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+        monkeypatch.delenv("LIST_VAR", raising=False)
+        _write_settings(tmp_path, {"env": {"exports": {"LIST_VAR": "val"}}})
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("list")
+        result = await cmd.execute(ctx)
+        assert result.success
+
+
+@pytest.mark.unit
+class TestEnvCommandUnset:
+    async def test_unset_existing(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+        monkeypatch.delenv("UNSET_ME", raising=False)
+        _write_settings(tmp_path, {"env": {"exports": {"UNSET_ME": "v"}}})
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("unset UNSET_ME")
+        result = await cmd.execute(ctx)
+        assert result.success
+        assert "Removed" in str(result.content)
+
+    async def test_unset_nonexistent(self, tmp_path, monkeypatch):
+        import deile.config.env_store as es
+        monkeypatch.setattr(es, "_settings_path", lambda home=None: tmp_path / ".deile" / "settings.json")
+
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("unset GHOST_VAR")
+        result = await cmd.execute(ctx)
+        assert result.success
+        assert "not in" in str(result.content)
+
+    async def test_unset_empty_key(self, tmp_path):
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("unset")
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+
+@pytest.mark.unit
+class TestEnvCommandMisc:
+    async def test_no_args_shows_help(self, tmp_path):
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("")
+        result = await cmd.execute(ctx)
+        assert result.success
+
+    async def test_unknown_subcommand(self, tmp_path):
+        from deile.commands.builtin.env_command import EnvCommand
+        cmd = EnvCommand()
+        ctx = _make_context("frobnicate FOO")
+        result = await cmd.execute(ctx)
+        assert not result.success

--- a/deile/tests/test_env_store.py
+++ b/deile/tests/test_env_store.py
@@ -1,0 +1,295 @@
+"""Tests for deile.config.env_store."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+
+def _write_settings(home: Path, data: dict) -> None:
+    d = home / ".deile"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "settings.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _read_settings(home: Path) -> dict:
+    p = home / ".deile" / "settings.json"
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+@pytest.mark.unit
+class TestIsSensitive:
+    def test_api_key(self):
+        from deile.config.env_store import is_sensitive
+        assert is_sensitive("ANTHROPIC_API_KEY")
+
+    def test_token(self):
+        from deile.config.env_store import is_sensitive
+        assert is_sensitive("GITHUB_TOKEN")
+
+    def test_secret(self):
+        from deile.config.env_store import is_sensitive
+        assert is_sensitive("DATABASE_SECRET")
+
+    def test_password(self):
+        from deile.config.env_store import is_sensitive
+        assert is_sensitive("DB_PASSWORD")
+
+    def test_non_sensitive(self):
+        from deile.config.env_store import is_sensitive
+        assert not is_sensitive("MY_CUSTOM_VAR")
+
+    def test_case_insensitive(self):
+        from deile.config.env_store import is_sensitive
+        assert is_sensitive("my_api_key")
+
+@pytest.mark.unit
+class TestLoadExportedVars:
+    def test_missing_file_is_noop(self, tmp_path, monkeypatch):
+        from deile.config.env_store import load_exported_vars
+        monkeypatch.delenv("DEILE_TEST_VAR_LOAD", raising=False)
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded == {}
+
+    def test_loads_into_os_environ(self, tmp_path, monkeypatch):
+        from deile.config.env_store import load_exported_vars
+        monkeypatch.delenv("DEILE_TEST_VAR_LOAD", raising=False)
+        _write_settings(tmp_path, {"env": {"exports": {"DEILE_TEST_VAR_LOAD": "hello"}}})
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded == {"DEILE_TEST_VAR_LOAD": "hello"}
+        assert os.environ["DEILE_TEST_VAR_LOAD"] == "hello"
+
+    def test_existing_env_not_overridden(self, tmp_path, monkeypatch):
+        from deile.config.env_store import load_exported_vars
+        monkeypatch.setenv("DEILE_TEST_VAR_SKIP", "existing")
+        _write_settings(tmp_path, {"env": {"exports": {"DEILE_TEST_VAR_SKIP": "new_value"}}})
+        loaded = load_exported_vars(home=tmp_path)
+        assert "DEILE_TEST_VAR_SKIP" not in loaded
+        assert os.environ["DEILE_TEST_VAR_SKIP"] == "existing"
+
+    def test_empty_exports_section(self, tmp_path):
+        from deile.config.env_store import load_exported_vars
+        _write_settings(tmp_path, {"env": {"exports": {}}})
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded == {}
+
+    def test_non_dict_exports_ignored(self, tmp_path):
+        from deile.config.env_store import load_exported_vars
+        _write_settings(tmp_path, {"env": {"exports": ["not", "a", "dict"]}})
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded == {}
+
+    def test_malformed_json_is_noop(self, tmp_path):
+        from deile.config.env_store import load_exported_vars
+        d = tmp_path / ".deile"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "settings.json").write_text("{broken json", encoding="utf-8")
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded == {}
+
+    def test_non_string_value_coerced(self, tmp_path, monkeypatch):
+        from deile.config.env_store import load_exported_vars
+        monkeypatch.delenv("DEILE_INT_VAR", raising=False)
+        _write_settings(tmp_path, {"env": {"exports": {"DEILE_INT_VAR": 42}}})
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded["DEILE_INT_VAR"] == "42"
+        assert os.environ["DEILE_INT_VAR"] == "42"
+
+    def test_empty_key_skipped(self, tmp_path):
+        from deile.config.env_store import load_exported_vars
+        _write_settings(tmp_path, {"env": {"exports": {"": "value"}}})
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded == {}
+
+    def test_multiple_vars_loaded(self, tmp_path, monkeypatch):
+        from deile.config.env_store import load_exported_vars
+        monkeypatch.delenv("DEILE_A", raising=False)
+        monkeypatch.delenv("DEILE_B", raising=False)
+        _write_settings(tmp_path, {"env": {"exports": {"DEILE_A": "1", "DEILE_B": "2"}}})
+        loaded = load_exported_vars(home=tmp_path)
+        assert set(loaded) == {"DEILE_A", "DEILE_B"}
+
+    def test_other_settings_preserved_on_load(self, tmp_path, monkeypatch):
+        from deile.config.env_store import load_exported_vars
+        monkeypatch.delenv("DEILE_X", raising=False)
+        _write_settings(tmp_path, {
+            "debug": True,
+            "env": {"exports": {"DEILE_X": "x"}},
+        })
+        loaded = load_exported_vars(home=tmp_path)
+        assert loaded == {"DEILE_X": "x"}
+
+@pytest.mark.unit
+class TestStoreVar:
+    def test_creates_settings_file(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        monkeypatch.delenv("MY_VAR", raising=False)
+        ok = store_var("MY_VAR", "hello", home=tmp_path)
+        assert ok is True
+        data = _read_settings(tmp_path)
+        assert data["env"]["exports"]["MY_VAR"] == "hello"
+
+    def test_sets_os_environ(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        monkeypatch.delenv("MY_VAR2", raising=False)
+        store_var("MY_VAR2", "world", home=tmp_path)
+        assert os.environ["MY_VAR2"] == "world"
+
+    def test_overwrite_existing(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        _write_settings(tmp_path, {"env": {"exports": {"MY_VAR3": "old"}}})
+        monkeypatch.setenv("MY_VAR3", "old")
+        store_var("MY_VAR3", "new", home=tmp_path)
+        data = _read_settings(tmp_path)
+        assert data["env"]["exports"]["MY_VAR3"] == "new"
+
+    def test_preserves_other_exports(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        _write_settings(tmp_path, {"env": {"exports": {"OTHER": "kept"}}})
+        monkeypatch.delenv("NEW_VAR", raising=False)
+        store_var("NEW_VAR", "added", home=tmp_path)
+        data = _read_settings(tmp_path)
+        assert data["env"]["exports"]["OTHER"] == "kept"
+        assert data["env"]["exports"]["NEW_VAR"] == "added"
+
+    def test_preserves_other_top_level_settings(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        _write_settings(tmp_path, {"debug": True, "env": {"exports": {}}})
+        monkeypatch.delenv("TOPVAR", raising=False)
+        store_var("TOPVAR", "v", home=tmp_path)
+        data = _read_settings(tmp_path)
+        assert data["debug"] is True
+
+    def test_empty_key_raises(self, tmp_path):
+        from deile.config.env_store import store_var
+        with pytest.raises(ValueError):
+            store_var("", "value", home=tmp_path)
+
+    def test_whitespace_only_key_raises(self, tmp_path):
+        from deile.config.env_store import store_var
+        with pytest.raises(ValueError):
+            store_var("   ", "value", home=tmp_path)
+
+    def test_invalid_char_in_key_raises(self, tmp_path):
+        from deile.config.env_store import store_var
+        with pytest.raises(ValueError, match="Invalid key"):
+            store_var("MY-VAR", "value", home=tmp_path)
+
+    def test_non_string_value_raises(self, tmp_path):
+        from deile.config.env_store import store_var
+        with pytest.raises(TypeError):
+            store_var("MY_VAR4", 42, home=tmp_path)
+
+    def test_file_permissions_600(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        monkeypatch.delenv("PERM_VAR", raising=False)
+        store_var("PERM_VAR", "v", home=tmp_path)
+        path = tmp_path / ".deile" / "settings.json"
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_key_with_underscores(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        monkeypatch.delenv("MY_VALID_KEY_123", raising=False)
+        ok = store_var("MY_VALID_KEY_123", "ok", home=tmp_path)
+        assert ok is True
+
+    def test_spaces_stripped_from_key(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var
+        monkeypatch.delenv("STRIPPED", raising=False)
+        ok = store_var("  STRIPPED  ", "v", home=tmp_path)
+        assert ok is True
+        data = _read_settings(tmp_path)
+        assert "STRIPPED" in data["env"]["exports"]
+
+@pytest.mark.unit
+class TestUnsetVar:
+    def test_returns_true_when_existed(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var, unset_var
+        monkeypatch.delenv("RM_VAR", raising=False)
+        store_var("RM_VAR", "v", home=tmp_path)
+        result = unset_var("RM_VAR", home=tmp_path)
+        assert result is True
+
+    def test_returns_false_when_not_found(self, tmp_path):
+        from deile.config.env_store import unset_var
+        result = unset_var("DOES_NOT_EXIST", home=tmp_path)
+        assert result is False
+
+    def test_removes_from_settings(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var, unset_var
+        monkeypatch.delenv("DEL_VAR", raising=False)
+        store_var("DEL_VAR", "v", home=tmp_path)
+        unset_var("DEL_VAR", home=tmp_path)
+        data = _read_settings(tmp_path)
+        assert "DEL_VAR" not in data.get("env", {}).get("exports", {})
+
+    def test_removes_from_os_environ(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var, unset_var
+        monkeypatch.delenv("ENV_DEL", raising=False)
+        store_var("ENV_DEL", "v", home=tmp_path)
+        assert "ENV_DEL" in os.environ
+        unset_var("ENV_DEL", home=tmp_path)
+        assert "ENV_DEL" not in os.environ
+
+    def test_preserves_other_exports(self, tmp_path, monkeypatch):
+        from deile.config.env_store import store_var, unset_var
+        monkeypatch.delenv("K1", raising=False)
+        monkeypatch.delenv("K2", raising=False)
+        store_var("K1", "v1", home=tmp_path)
+        store_var("K2", "v2", home=tmp_path)
+        unset_var("K1", home=tmp_path)
+        data = _read_settings(tmp_path)
+        assert "K1" not in data["env"]["exports"]
+        assert data["env"]["exports"]["K2"] == "v2"
+
+    def test_empty_key_raises(self, tmp_path):
+        from deile.config.env_store import unset_var
+        with pytest.raises(ValueError):
+            unset_var("", home=tmp_path)
+
+    def test_missing_file_returns_false(self, tmp_path):
+        from deile.config.env_store import unset_var
+        result = unset_var("GHOST", home=tmp_path)
+        assert result is False
+
+
+@pytest.mark.unit
+class TestListVars:
+    def test_empty_when_no_file(self, tmp_path):
+        from deile.config.env_store import list_vars
+        assert list_vars(home=tmp_path) == {}
+
+    def test_sensitive_keys_masked(self, tmp_path, monkeypatch):
+        from deile.config.env_store import list_vars, store_var
+        monkeypatch.delenv("MY_API_KEY", raising=False)
+        store_var("MY_API_KEY", "sk-secret", home=tmp_path)
+        result = list_vars(home=tmp_path)
+        assert result["MY_API_KEY"] == "<masked>"
+
+    def test_non_sensitive_value_shown(self, tmp_path, monkeypatch):
+        from deile.config.env_store import list_vars, store_var
+        monkeypatch.delenv("MY_CUSTOM_VAR", raising=False)
+        store_var("MY_CUSTOM_VAR", "hello", home=tmp_path)
+        result = list_vars(home=tmp_path)
+        assert result["MY_CUSTOM_VAR"] == "hello"
+
+    def test_multiple_vars(self, tmp_path, monkeypatch):
+        from deile.config.env_store import list_vars, store_var
+        monkeypatch.delenv("A_KEY", raising=False)
+        monkeypatch.delenv("B_VAR", raising=False)
+        store_var("A_KEY", "secret", home=tmp_path)
+        store_var("B_VAR", "public", home=tmp_path)
+        result = list_vars(home=tmp_path)
+        assert result["A_KEY"] == "<masked>"
+        assert result["B_VAR"] == "public"
+
+    def test_non_string_key_skipped(self, tmp_path):
+        from deile.config.env_store import list_vars
+        _write_settings(tmp_path, {"env": {"exports": {"VALID": "ok"}}})
+        result = list_vars(home=tmp_path)
+        assert "VALID" in result


### PR DESCRIPTION
## Summary

- Adds `deile/config/env_store.py` (EnvStore): reads `env.exports` from `~/.deile/settings.json` (0o600) and exports vars into `os.environ` at startup, replacing `.env` file dependency
- Adds `/env set KEY=VALUE | list | unset KEY` slash command + `--env` CLI flag for managing the store interactively
- `deile/cli.py` calls `_load_exported_env_vars()` before provider bootstrap so API keys stored via `/env set` work without a `.env` file

**Security properties vs .env:**
- File lives in `~/.deile/` (outside any repo) — no accidental git commits
- Owner-only permissions (0o600)
- Values land in `os.environ` (memory) after startup
- Sensitive key names (`key`, `token`, `secret`, `password`, `api`) are masked in `/env list` output

## Test plan

- [x] 52 new unit tests: `test_env_store.py` (40) + `test_env_command.py` (12), all passing
- [x] Full suite: 1862 passed, 3 pre-existing failures (Gemini API + empirical), 0 regressions
- [x] `ruff check` and `isort` clean

Closes #150

Generated with [Claude Code](https://claude.com/claude-code)