### PR TITLE
fix(orchestration): corrige wiring WorkflowExecutor — issues #140 #141 #142

### DIFF
--- a/deile/orchestration/sqlite_task_manager.py
+++ b/deile/orchestration/sqlite_task_manager.py
@@ -294,11 +294,25 @@ class SQLiteTaskManager:
         logger.info(f"Created task list {list_id}: {title}")
         return task_list
 
+    async def activate_task_list(self, list_id: str) -> None:
+        """Marca lista como ativa no banco de dados."""
+        async with self._db_lock:
+            async with aiosqlite.connect(self.db_path) as db:
+                await db.execute(
+                    "UPDATE task_lists SET active = TRUE, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (list_id,)
+                )
+                await db.commit()
+        self._invalidate_cache(list_id)
+        logger.info("Activated task list %s", list_id)
+
     async def add_task_to_list(self, list_id: str, title: str, description: str = "",
                               depends_on: Optional[List[str]] = None,
                               priority: TaskPriority = TaskPriority.MEDIUM,
-                              estimated_duration: Optional[timedelta] = None) -> Task:
-        """Adiciona task a uma lista com validação de integridade"""
+                              estimated_duration: Optional[timedelta] = None,
+                              metadata: Optional[Dict[str, Any]] = None,
+                              tags: Optional[List[str]] = None) -> Task:
+        """Adiciona task a uma lista com validação de integridade."""
 
         # Verifica se lista existe
         task_list = await self.load_task_list(list_id)
@@ -312,7 +326,9 @@ class SQLiteTaskManager:
             description=description,
             depends_on=depends_on or [],
             priority=priority,
-            estimated_duration=estimated_duration
+            estimated_duration=estimated_duration,
+            metadata=metadata or {},
+            tags=tags or [],
         )
 
         # Validação de dependências (só valida se as dependências não estão vazias e existem)

--- a/deile/orchestration/workflow_executor.py
+++ b/deile/orchestration/workflow_executor.py
@@ -40,6 +40,10 @@ class WorkflowExecutor:
             'command': self._execute_command_action,
             'validation': self._execute_validation_action,
         }
+        # Keeps background loop tasks alive (prevents GC cancellation)
+        self._running_loops: set = set()
+        # In-memory store for Callables that cannot be JSON-serialized to SQLite
+        self._step_funcs: Dict[str, Dict[str, Optional[Callable]]] = {}
 
     async def create_workflow_from_objective(self, objective: str,
                                            context: Optional[Dict[str, Any]] = None) -> TaskList:
@@ -74,8 +78,9 @@ class WorkflowExecutor:
 
             result = await handler(action_name, params, task)
 
-            if task.metadata.get('validation_func'):
-                validation_result = await self._run_validation(task, result)
+            step_funcs = self._step_funcs.get(task.id, {})
+            if step_funcs.get('validation_func'):
+                validation_result = await self._run_validation(task, result, step_funcs['validation_func'])
                 if not validation_result['success']:
                     raise DEILEError(f"Validation failed: {validation_result['error']}")
 
@@ -88,9 +93,10 @@ class WorkflowExecutor:
         except Exception as e:
             logger.error("Task execution failed: %s", e)
 
-            if task.metadata.get('rollback_func'):
+            step_funcs = self._step_funcs.get(task.id, {})
+            if step_funcs.get('rollback_func'):
                 try:
-                    await self._run_rollback(task)
+                    await self._run_rollback(task, step_funcs['rollback_func'])
                     logger.info("Rollback completed for task %s", task.id)
                 except Exception as rollback_error:
                     logger.error("Rollback failed: %s", rollback_error)
@@ -106,7 +112,9 @@ class WorkflowExecutor:
         """Inicia execução completa de workflow baseado em objetivo."""
         task_list = await self.create_workflow_from_objective(objective, context)
         await self.task_manager.activate_task_list(task_list.id)
-        asyncio.create_task(self._execute_task_list_loop(task_list.id))
+        loop_task = asyncio.create_task(self._execute_task_list_loop(task_list.id))
+        self._running_loops.add(loop_task)
+        loop_task.add_done_callback(self._running_loops.discard)
         return {
             'workflow_id': task_list.id,
             'status': 'started',
@@ -120,29 +128,32 @@ class WorkflowExecutor:
 
     async def _execute_task_list_loop(self, list_id: str) -> None:
         """Executa tasks da lista sequencialmente respeitando dependências."""
-        while True:
-            ready_tasks = await self.task_manager.get_next_tasks(list_id)
-            if not ready_tasks:
-                break
-
-            task = ready_tasks[0]
-            result = await self.execute_task(task)
-
-            await self.task_manager.mark_task_completed(
-                list_id=list_id,
-                task_id=task.id,
-                success=result['success'],
-                result_data=result.get('data') if isinstance(result.get('data'), dict) else None,
-                error_message=result.get('error'),
-            )
-
-            if not result['success']:
-                task_list = await self.task_manager.load_task_list(list_id)
-                if task_list and task_list.stop_on_failure:
-                    logger.info(
-                        "Stopping workflow %s on step failure (stop_on_failure=True)", list_id
-                    )
+        try:
+            while True:
+                ready_tasks = await self.task_manager.get_next_tasks(list_id)
+                if not ready_tasks:
                     break
+
+                task = ready_tasks[0]
+                result = await self.execute_task(task)
+
+                await self.task_manager.mark_task_completed(
+                    list_id=list_id,
+                    task_id=task.id,
+                    success=result['success'],
+                    result_data=result.get('data') if isinstance(result.get('data'), dict) else None,
+                    error_message=result.get('error'),
+                )
+
+                if not result['success']:
+                    task_list = await self.task_manager.load_task_list(list_id)
+                    if task_list and task_list.stop_on_failure:
+                        logger.info(
+                            "Stopping workflow %s on step failure (stop_on_failure=True)", list_id
+                        )
+                        break
+        except Exception as exc:
+            logger.error("Workflow loop %s aborted due to infrastructure error: %s", list_id, exc)
 
     async def monitor_workflow_progress(self, workflow_id: str) -> Dict[str, Any]:
         """Monitora progresso de um workflow."""
@@ -266,11 +277,9 @@ class WorkflowExecutor:
             'params': step.params or {},
             'timeout': step.timeout,
             'retry_count': step.retry_count,
-            'validation_func': step.validation,
-            'rollback_func': step.rollback,
         }
 
-        return await self.task_manager.add_task_to_list(
+        task = await self.task_manager.add_task_to_list(
             list_id=list_id,
             title=step.description or f"Step {index + 1}: {step.action}",
             description=step.description,
@@ -280,6 +289,15 @@ class WorkflowExecutor:
             metadata=task_metadata,
             tags=['workflow', f'action:{step.action}'],
         )
+
+        # Callables cannot be JSON-serialized to SQLite — store in memory keyed by task.id
+        if step.validation is not None or step.rollback is not None:
+            self._step_funcs[task.id] = {
+                'validation_func': step.validation,
+                'rollback_func': step.rollback,
+            }
+
+        return task
 
     async def _execute_tool_action(self, action_name: str, params: Dict[str, Any], task: Task) -> Any:
         """Executa ação usando tool registry."""
@@ -329,12 +347,8 @@ class WorkflowExecutor:
 
         return {'validation_passed': True, 'message': 'All previous steps completed successfully'}
 
-    async def _run_validation(self, task: Task, result: Any) -> Dict[str, Any]:
+    async def _run_validation(self, task: Task, result: Any, validation_func: Callable) -> Dict[str, Any]:
         """Executa validação do resultado de uma task."""
-        validation_func = task.metadata.get('validation_func')
-        if not validation_func:
-            return {'success': True, 'message': 'No validation specified'}
-
         try:
             if asyncio.iscoroutinefunction(validation_func):
                 validation_result = await validation_func(result)
@@ -344,11 +358,8 @@ class WorkflowExecutor:
         except Exception as e:
             return {'success': False, 'error': str(e)}
 
-    async def _run_rollback(self, task: Task) -> None:
+    async def _run_rollback(self, task: Task, rollback_func: Callable) -> None:
         """Executa rollback de uma task."""
-        rollback_func = task.metadata.get('rollback_func')
-        if not rollback_func:
-            return
         if asyncio.iscoroutinefunction(rollback_func):
             await rollback_func(task)
         else:

--- a/deile/orchestration/workflow_executor.py
+++ b/deile/orchestration/workflow_executor.py
@@ -10,7 +10,8 @@ from ..core.exceptions import DEILEError
 from ..tools.base import ToolContext, ToolStatus
 from ..tools.registry import get_tool_registry
 from .sqlite_task_manager import (SQLiteTaskManager, Task, TaskList,
-                                  TaskPriority, get_sqlite_task_manager)
+                                  TaskPriority, TaskStatus,
+                                  get_sqlite_task_manager)
 
 logger = logging.getLogger(__name__)
 
@@ -18,13 +19,13 @@ logger = logging.getLogger(__name__)
 @dataclass
 class WorkflowStep:
     """Representa um step de workflow que será convertido em Task"""
-    action: str  # Ação a ser executada (nome da tool, comando, etc.)
-    params: Dict[str, Any] = None  # Parâmetros para a ação
-    description: str = ""  # Descrição legível
-    validation: Optional[Callable] = None  # Função de validação do resultado
-    rollback: Optional[Callable] = None  # Função de rollback em caso de erro
-    timeout: int = 300  # Timeout em segundos
-    retry_count: int = 0  # Número de tentativas em caso de erro
+    action: str
+    params: Dict[str, Any] = None
+    description: str = ""
+    validation: Optional[Callable] = None
+    rollback: Optional[Callable] = None
+    timeout: int = 300
+    retry_count: int = 0
 
 
 class WorkflowExecutor:
@@ -34,54 +35,45 @@ class WorkflowExecutor:
         self.task_manager = task_manager or get_sqlite_task_manager()
         self.tool_registry = get_tool_registry()
 
-        # Note: SQLiteTaskManager não precisa de set_task_executor
-
-        # Callbacks para diferentes tipos de ações
         self._action_handlers: Dict[str, Callable] = {
             'tool': self._execute_tool_action,
             'command': self._execute_command_action,
             'validation': self._execute_validation_action,
-            'custom': self._execute_custom_action
         }
 
     async def create_workflow_from_objective(self, objective: str,
                                            context: Optional[Dict[str, Any]] = None) -> TaskList:
-        """Cria workflow baseado em objetivo do usuário"""
-
-        # Analisa objetivo e gera steps
+        """Cria workflow baseado em objetivo do usuário."""
         steps = await self._analyze_objective_to_steps(objective, context or {})
 
-        # Cria task list
         task_list = await self.task_manager.create_task_list(
             title=f"Workflow: {objective[:50]}...",
             description=f"Auto-generated workflow for: {objective}",
             sequential=True,
-            auto_start=True
+            auto_start=True,
         )
 
-        # Converte steps em tasks usando SQLiteTaskManager
         for i, step in enumerate(steps):
             await self._add_workflow_step_to_list(step, task_list.id, i)
 
-        logger.info(f"Created workflow with {len(steps)} steps for objective: {objective}")
+        logger.info("Created workflow with %d steps for objective: %s", len(steps), objective)
         return task_list
 
     async def execute_task(self, task: Task) -> Dict[str, Any]:
-        """Executa uma task específica (callback do TaskManager)"""
-
-        logger.info(f"Executing task: {task.title}")
+        """Executa uma task específica."""
+        logger.info("Executing task: %s", task.title)
 
         try:
-            # Extrai informações da task
             action_type = task.metadata.get('action_type', 'tool')
             action_name = task.metadata.get('action_name', '')
             params = task.metadata.get('params', {})
 
-            # Executa baseado no tipo de ação
-            handler = self._action_handlers.get(action_type, self._execute_tool_action)
+            handler = self._action_handlers.get(action_type)
+            if handler is None:
+                raise DEILEError(f"Unknown action type: '{action_type}'")
+
             result = await handler(action_name, params, task)
 
-            # Validação adicional se especificada
             if task.metadata.get('validation_func'):
                 validation_result = await self._run_validation(task, result)
                 if not validation_result['success']:
@@ -90,56 +82,78 @@ class WorkflowExecutor:
             return {
                 'success': True,
                 'data': result,
-                'message': f"Task '{task.title}' completed successfully"
+                'message': f"Task '{task.title}' completed successfully",
             }
 
         except Exception as e:
-            logger.error(f"Task execution failed: {e}")
+            logger.error("Task execution failed: %s", e)
 
-            # Tenta rollback se disponível
             if task.metadata.get('rollback_func'):
                 try:
                     await self._run_rollback(task)
-                    logger.info(f"Rollback completed for task {task.id}")
+                    logger.info("Rollback completed for task %s", task.id)
                 except Exception as rollback_error:
-                    logger.error(f"Rollback failed: {rollback_error}")
+                    logger.error("Rollback failed: %s", rollback_error)
 
             return {
                 'success': False,
                 'error': str(e),
-                'message': f"Task '{task.title}' failed: {str(e)}"
+                'message': f"Task '{task.title}' failed: {str(e)}",
             }
 
     async def start_workflow_execution(self, objective: str,
-                                     context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        """Inicia execução completa de workflow baseado em objetivo"""
-
-        # Cria workflow
+                                      context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Inicia execução completa de workflow baseado em objetivo."""
         task_list = await self.create_workflow_from_objective(objective, context)
-
-        # Inicia execução
-        execution_result = await self.task_manager.start_execution(task_list.id)
-
+        await self.task_manager.activate_task_list(task_list.id)
+        asyncio.create_task(self._execute_task_list_loop(task_list.id))
         return {
             'workflow_id': task_list.id,
             'status': 'started',
             'total_steps': task_list.total_tasks,
-            'execution_info': execution_result
+            'execution_info': {
+                'list_id': task_list.id,
+                'status': 'started',
+                'total_tasks': task_list.total_tasks,
+            },
         }
 
-    async def monitor_workflow_progress(self, workflow_id: str) -> Dict[str, Any]:
-        """Monitora progresso de um workflow"""
+    async def _execute_task_list_loop(self, list_id: str) -> None:
+        """Executa tasks da lista sequencialmente respeitando dependências."""
+        while True:
+            ready_tasks = await self.task_manager.get_next_tasks(list_id)
+            if not ready_tasks:
+                break
 
+            task = ready_tasks[0]
+            result = await self.execute_task(task)
+
+            await self.task_manager.mark_task_completed(
+                list_id=list_id,
+                task_id=task.id,
+                success=result['success'],
+                result_data=result.get('data') if isinstance(result.get('data'), dict) else None,
+                error_message=result.get('error'),
+            )
+
+            if not result['success']:
+                task_list = await self.task_manager.load_task_list(list_id)
+                if task_list and task_list.stop_on_failure:
+                    logger.info(
+                        "Stopping workflow %s on step failure (stop_on_failure=True)", list_id
+                    )
+                    break
+
+    async def monitor_workflow_progress(self, workflow_id: str) -> Dict[str, Any]:
+        """Monitora progresso de um workflow."""
         status = await self.task_manager.get_task_list_status(workflow_id)
         if not status:
             raise DEILEError(f"Workflow {workflow_id} not found")
-
         return status
 
     async def wait_for_workflow_completion(self, workflow_id: str,
-                                         timeout: Optional[timedelta] = None) -> Dict[str, Any]:
-        """Aguarda conclusão de um workflow"""
-
+                                          timeout: Optional[timedelta] = None) -> Dict[str, Any]:
+        """Aguarda conclusão de um workflow."""
         start_time = datetime.now()
         max_wait = timeout or timedelta(hours=1)
 
@@ -150,178 +164,136 @@ class WorkflowExecutor:
                 return {
                     'status': 'completed',
                     'success': not status['has_failures'],
-                    'final_stats': status
+                    'final_stats': status,
                 }
 
             if status['has_failures']:
                 return {
                     'status': 'failed',
                     'success': False,
-                    'final_stats': status
+                    'final_stats': status,
                 }
 
-            # Verifica timeout
             if datetime.now() - start_time > max_wait:
                 return {
                     'status': 'timeout',
                     'success': False,
-                    'message': f"Workflow timed out after {max_wait}"
+                    'message': f"Workflow timed out after {max_wait}",
                 }
 
-            # Aguarda antes de verificar novamente
             await asyncio.sleep(2)
 
     # Métodos privados
 
     async def _analyze_objective_to_steps(self, objective: str,
-                                        context: Dict[str, Any]) -> List[WorkflowStep]:
-        """Analisa objetivo e converte em steps executáveis"""
-
+                                         context: Dict[str, Any]) -> List[WorkflowStep]:
+        """Analisa objetivo e converte em steps executáveis."""
         steps = []
-
-        # Análise básica por palavras-chave (versão simplificada)
         objective_lower = objective.lower()
 
-        # Verificação de arquivos
-        if any(word in objective_lower for word in ['file', 'read', 'analyze', 'check']):
+        if any(w in objective_lower for w in ['file', 'read', 'analyze', 'check']):
             steps.append(WorkflowStep(
                 action='read_file',
                 params={'path': context.get('target_file', 'README.md')},
                 description="Read target file for analysis",
-                timeout=30
+                timeout=30,
             ))
 
-        # Listagem de arquivos
-        if any(word in objective_lower for word in ['list', 'files', 'directory', 'explore']):
+        if any(w in objective_lower for w in ['list', 'files', 'directory', 'explore']):
             steps.append(WorkflowStep(
                 action='list_files',
                 params={'path': context.get('target_dir', '.'), 'recursive': True},
                 description="List files in target directory",
-                timeout=60
+                timeout=60,
             ))
 
-        # Busca em arquivos
-        if any(word in objective_lower for word in ['search', 'find', 'grep', 'pattern']):
+        if any(w in objective_lower for w in ['search', 'find', 'grep', 'pattern']):
             steps.append(WorkflowStep(
                 action='find_in_files',
                 params={
                     'pattern': context.get('search_pattern', 'TODO'),
                     'path': context.get('search_path', '.'),
-                    'max_results': 50
+                    'max_results': 50,
                 },
                 description="Search for pattern in files",
-                timeout=120
+                timeout=120,
             ))
 
-        # Execução de comandos
-        if any(word in objective_lower for word in ['run', 'execute', 'command', 'script']):
+        if any(w in objective_lower for w in ['run', 'execute', 'command', 'script']):
             steps.append(WorkflowStep(
                 action='bash_execute',
                 params={
                     'command': context.get('command', 'echo "Workflow step executed"'),
-                    'show_cli': True
+                    'show_cli': True,
                 },
                 description="Execute command",
-                timeout=300
+                timeout=300,
             ))
 
-        # Validação de resultados
-        if any(word in objective_lower for word in ['validate', 'verify', 'check', 'test']):
+        if any(w in objective_lower for w in ['validate', 'verify', 'check', 'test']):
             steps.append(WorkflowStep(
                 action='validation',
                 params={'validation_type': 'general'},
                 description="Validate workflow results",
-                timeout=60
+                timeout=60,
             ))
 
-        # Se nenhum step específico foi gerado, cria step genérico de análise
         if not steps:
             steps.append(WorkflowStep(
                 action='list_files',
                 params={'path': '.', 'recursive': False},
                 description=f"General analysis step for: {objective}",
-                timeout=60
+                timeout=60,
             ))
 
         return steps
 
     async def _add_workflow_step_to_list(self, step: WorkflowStep, list_id: str, index: int) -> Task:
-        """Adiciona workflow step como task na lista SQLite"""
-
-        # Determina dependências baseado no índice
+        """Adiciona workflow step como task na lista SQLite, persistindo metadata."""
         depends_on = []
         if index > 0:
-            # Busca tasks existentes na lista para determinar dependência
             existing_tasks = await self.task_manager._get_tasks_for_list(list_id)
             if existing_tasks:
-                # Depende da última task adicionada
                 depends_on = [existing_tasks[-1].id]
 
-        # Cria task usando SQLiteTaskManager
-        task = await self.task_manager.add_task_to_list(
+        is_registered_tool = self.tool_registry.get_enabled(step.action) is not None
+        action_type = 'tool' if is_registered_tool else step.action
+
+        task_metadata = {
+            'list_id': list_id,
+            'action_type': action_type,
+            'action_name': step.action,
+            'params': step.params or {},
+            'timeout': step.timeout,
+            'retry_count': step.retry_count,
+            'validation_func': step.validation,
+            'rollback_func': step.rollback,
+        }
+
+        return await self.task_manager.add_task_to_list(
             list_id=list_id,
             title=step.description or f"Step {index + 1}: {step.action}",
             description=step.description,
             depends_on=depends_on,
             priority=TaskPriority.MEDIUM,
-            estimated_duration=timedelta(seconds=step.timeout)
+            estimated_duration=timedelta(seconds=step.timeout),
+            metadata=task_metadata,
+            tags=['workflow', f'action:{step.action}'],
         )
-
-        # Adiciona metadados específicos do workflow como tags
-        task.tags = ['workflow', f'action:{step.action}']
-        task.metadata = {
-            'action_type': 'tool' if self.tool_registry.get_enabled(step.action) is not None else 'custom',
-            'action_name': step.action,
-            'params': step.params or {},
-            'timeout': step.timeout,
-            'retry_count': step.retry_count,
-            'validation_func': step.validation,
-            'rollback_func': step.rollback
-        }
-
-        return task
-
-    async def _convert_step_to_task(self, step: WorkflowStep, list_id: str, index: int) -> Task:
-        """Converte WorkflowStep em Task"""
-
-        task = Task(
-            id=f"{list_id}_{index:03d}",
-            title=step.description or f"Step {index + 1}: {step.action}",
-            description=step.description,
-            priority=TaskPriority.MEDIUM,
-            estimated_duration=timedelta(seconds=step.timeout)
-        )
-
-        # Adiciona metadados específicos do workflow
-        task.metadata = {
-            'action_type': 'tool' if self.tool_registry.get_enabled(step.action) is not None else 'custom',
-            'action_name': step.action,
-            'params': step.params or {},
-            'timeout': step.timeout,
-            'retry_count': step.retry_count,
-            'validation_func': step.validation,
-            'rollback_func': step.rollback
-        }
-
-        return task
 
     async def _execute_tool_action(self, action_name: str, params: Dict[str, Any], task: Task) -> Any:
-        """Executa ação usando tool registry"""
-
-        # Verifica se tool existe
+        """Executa ação usando tool registry."""
         if self.tool_registry.get_enabled(action_name) is None:
-            raise DEILEError(f"Tool '{action_name}' not found")
+            raise DEILEError(f"Tool '{action_name}' not found in registry")
 
-        # Cria contexto para execução
         context = ToolContext(
             user_input=task.description,
             parsed_args=params,
             session_data={},
             working_directory='.',
-            file_list=[]
+            file_list=[],
         )
 
-        # Executa tool
         result = await self.tool_registry.execute_tool(action_name, context)
 
         if result.status != ToolStatus.SUCCESS:
@@ -330,41 +302,35 @@ class WorkflowExecutor:
         return result.output
 
     async def _execute_command_action(self, command: str, params: Dict[str, Any], task: Task) -> Any:
-        """Executa comando do sistema"""
-
-        # Usa bash_execute tool para executar comando
-        return await self._execute_tool_action('bash_execute', {
-            'command': command,
-            **params
-        }, task)
+        """Executa comando do sistema via bash_execute tool."""
+        return await self._execute_tool_action('bash_execute', {'command': command, **params}, task)
 
     async def _execute_validation_action(self, validation_type: str, params: Dict[str, Any], task: Task) -> Any:
-        """Executa validação personalizada"""
+        """Valida resultado dos steps anteriores do workflow.
 
-        # Implementação básica de validação
-        if validation_type == 'general':
-            return {
-                'validation_passed': True,
-                'message': 'General validation completed',
-                'timestamp': datetime.now().isoformat()
-            }
+        'general': falha se qualquer step anterior do mesmo task_list falhou.
+        """
+        if validation_type != 'general':
+            raise DEILEError(
+                f"Unknown validation type: '{validation_type}'. Supported: 'general'"
+            )
 
-        return {'validation_passed': True, 'type': validation_type}
+        list_id = task.metadata.get('list_id')
+        if not list_id:
+            raise DEILEError("Cannot run general validation: list_id missing from task metadata")
 
-    async def _execute_custom_action(self, action_name: str, params: Dict[str, Any], task: Task) -> Any:
-        """Executa ação customizada"""
+        tasks = await self.task_manager._get_tasks_for_list(list_id)
+        failed = [t for t in tasks if t.id != task.id and t.status == TaskStatus.FAILED]
+        if failed:
+            failed_titles = ', '.join(t.title for t in failed)
+            raise DEILEError(
+                f"General validation failed: {len(failed)} step(s) failed — {failed_titles}"
+            )
 
-        logger.warning(f"Custom action '{action_name}' not implemented, returning success")
-        return {
-            'action': action_name,
-            'params': params,
-            'message': f"Custom action '{action_name}' executed (placeholder)",
-            'timestamp': datetime.now().isoformat()
-        }
+        return {'validation_passed': True, 'message': 'All previous steps completed successfully'}
 
     async def _run_validation(self, task: Task, result: Any) -> Dict[str, Any]:
-        """Executa validação do resultado de uma task"""
-
+        """Executa validação do resultado de uma task."""
         validation_func = task.metadata.get('validation_func')
         if not validation_func:
             return {'success': True, 'message': 'No validation specified'}
@@ -374,19 +340,15 @@ class WorkflowExecutor:
                 validation_result = await validation_func(result)
             else:
                 validation_result = validation_func(result)
-
             return {'success': True, 'result': validation_result}
-
         except Exception as e:
             return {'success': False, 'error': str(e)}
 
     async def _run_rollback(self, task: Task) -> None:
-        """Executa rollback de uma task"""
-
+        """Executa rollback de uma task."""
         rollback_func = task.metadata.get('rollback_func')
         if not rollback_func:
             return
-
         if asyncio.iscoroutinefunction(rollback_func):
             await rollback_func(task)
         else:
@@ -398,7 +360,7 @@ _workflow_executor: Optional[WorkflowExecutor] = None
 
 
 def get_workflow_executor() -> WorkflowExecutor:
-    """Retorna instância singleton do WorkflowExecutor"""
+    """Retorna instância singleton do WorkflowExecutor."""
     global _workflow_executor
     if _workflow_executor is None:
         _workflow_executor = WorkflowExecutor()

--- a/deile/tests/orchestration/test_workflow_executor.py
+++ b/deile/tests/orchestration/test_workflow_executor.py
@@ -153,7 +153,7 @@ async def test_execute_task_list_loop_stops_on_failure():
     })
     tl = _make_task_list()
     tl.stop_on_failure = True
-    mgr = _make_task_manager(task_list=tl, tasks_sequence=[[task], []])
+    mgr = _make_task_manager(task_list=tl, tasks_sequence=[[task]])
     executor = _make_executor(task_manager=mgr)
 
     async def failing_execute(t):

--- a/deile/tests/orchestration/test_workflow_executor.py
+++ b/deile/tests/orchestration/test_workflow_executor.py
@@ -1,0 +1,285 @@
+"""Tests for WorkflowExecutor — covers issues #140, #141, #142."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.core.exceptions import DEILEError
+from deile.orchestration.sqlite_task_manager import Task, TaskList, TaskStatus
+from deile.orchestration.workflow_executor import (WorkflowExecutor,
+                                                   WorkflowStep)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_task(task_id="t001", title="Test Task", status=TaskStatus.TODO, metadata=None):
+    t = Task(id=task_id, title=title, status=status, metadata=metadata or {})
+    return t
+
+
+def _make_task_list(list_id="list1", title="Test Workflow", total=1):
+    tl = TaskList(id=list_id, title=title)
+    tl.total_tasks = total
+    tl.stop_on_failure = True
+    return tl
+
+
+def _make_task_manager(
+    task_list=None,
+    tasks_sequence=None,  # list of list-of-tasks returned on successive get_next_tasks calls
+):
+    """Returns a mock SQLiteTaskManager."""
+    mgr = MagicMock()
+    tl = task_list or _make_task_list()
+    mgr.create_task_list = AsyncMock(return_value=tl)
+    mgr.add_task_to_list = AsyncMock(side_effect=lambda **kw: _make_task(
+        task_id="t001", title=kw.get("title", "step"),
+        metadata=kw.get("metadata", {}),
+    ))
+    mgr.activate_task_list = AsyncMock()
+    mgr.mark_task_completed = AsyncMock(return_value=True)
+    mgr.load_task_list = AsyncMock(return_value=tl)
+    mgr._get_tasks_for_list = AsyncMock(return_value=[])
+
+    # get_next_tasks: empty by default (loop exits immediately)
+    if tasks_sequence is not None:
+        mgr.get_next_tasks = AsyncMock(side_effect=tasks_sequence)
+    else:
+        mgr.get_next_tasks = AsyncMock(return_value=[])
+
+    mgr.get_task_list_status = AsyncMock(return_value={
+        "id": "list1",
+        "title": "Test Workflow",
+        "active": True,
+        "progress": 100.0,
+        "total_tasks": 1,
+        "completed_tasks": 1,
+        "failed_tasks": 0,
+        "current_task": None,
+        "is_completed": True,
+        "has_failures": False,
+        "next_tasks": [],
+    })
+    return mgr
+
+
+def _make_executor(task_manager=None, registry_has_tool=False):
+    """Returns WorkflowExecutor with mocked dependencies."""
+    mock_registry = MagicMock()
+    mock_registry.get_enabled = MagicMock(
+        return_value=MagicMock() if registry_has_tool else None
+    )
+    mock_registry.execute_tool = AsyncMock()
+
+    with patch("deile.orchestration.workflow_executor.get_tool_registry", return_value=mock_registry):
+        executor = WorkflowExecutor(task_manager=task_manager or _make_task_manager())
+
+    executor._mock_registry = mock_registry
+    return executor
+
+
+# ---------------------------------------------------------------------------
+# Issue #140 — start_workflow_execution must not call task_manager.start_execution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_start_workflow_execution_no_attribute_error():
+    """start_workflow_execution must not raise AttributeError (#140)."""
+    executor = _make_executor()
+    result = await executor.start_workflow_execution("analyze and list files")
+
+    assert "workflow_id" in result
+    assert result["status"] == "started"
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_start_workflow_execution_calls_activate():
+    """activate_task_list must be called on the task manager (#140)."""
+    mgr = _make_task_manager()
+    executor = _make_executor(task_manager=mgr)
+
+    await executor.start_workflow_execution("list files")
+
+    mgr.activate_task_list.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_execute_task_list_loop_runs_tasks():
+    """_execute_task_list_loop must invoke execute_task for each ready task."""
+    task = _make_task(metadata={
+        'list_id': 'list1',
+        'action_type': 'tool',
+        'action_name': 'read_file',
+        'params': {},
+    })
+    # First call returns one task, second call returns [] to stop the loop
+    mgr = _make_task_manager(tasks_sequence=[[task], []])
+    executor = _make_executor(task_manager=mgr, registry_has_tool=True)
+
+    # Patch execute_task to avoid real tool invocation
+    executed = []
+
+    async def fake_execute(t):
+        executed.append(t.id)
+        return {'success': True, 'data': {}, 'message': 'ok'}
+
+    executor.execute_task = fake_execute
+
+    await executor._execute_task_list_loop("list1")
+
+    assert executed == ["t001"]
+    call_kwargs = mgr.mark_task_completed.call_args.kwargs
+    assert call_kwargs["list_id"] == "list1"
+    assert call_kwargs["task_id"] == "t001"
+    assert call_kwargs["success"] is True
+    assert call_kwargs["error_message"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_execute_task_list_loop_stops_on_failure():
+    """Loop must stop after a failed task when stop_on_failure=True (#140)."""
+    task = _make_task(metadata={
+        'list_id': 'list1',
+        'action_type': 'tool',
+        'action_name': 'read_file',
+        'params': {},
+    })
+    tl = _make_task_list()
+    tl.stop_on_failure = True
+    mgr = _make_task_manager(task_list=tl, tasks_sequence=[[task], []])
+    executor = _make_executor(task_manager=mgr)
+
+    async def failing_execute(t):
+        return {'success': False, 'error': 'boom', 'message': 'fail'}
+
+    executor.execute_task = failing_execute
+
+    await executor._execute_task_list_loop("list1")
+
+    mgr.mark_task_completed.assert_awaited_once_with(
+        list_id="list1", task_id="t001", success=False,
+        result_data=None, error_message="boom",
+    )
+    # get_next_tasks called once (before the failing task); loop exits without a second call
+    assert mgr.get_next_tasks.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_task_metadata_persisted_in_add_task():
+    """metadata dict with list_id must be passed to add_task_to_list upfront (#140)."""
+    mgr = _make_task_manager()
+    executor = _make_executor(task_manager=mgr)
+
+    step = WorkflowStep(action='list_files', params={'path': '.'}, description='List files', timeout=60)
+    await executor._add_workflow_step_to_list(step, 'list1', 0)
+
+    call_kwargs = mgr.add_task_to_list.call_args.kwargs
+    assert 'metadata' in call_kwargs
+    assert call_kwargs['metadata']['list_id'] == 'list1'
+    assert call_kwargs['metadata']['action_name'] == 'list_files'
+
+
+# ---------------------------------------------------------------------------
+# Issue #141 — _execute_validation_action must implement real validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_validation_action_passes_when_no_failures():
+    """General validation passes when all previous steps succeeded (#141)."""
+    task = _make_task(metadata={'list_id': 'list1'})
+    completed = _make_task(task_id="prev", title="Previous Step", status=TaskStatus.COMPLETED)
+
+    mgr = _make_task_manager()
+    mgr._get_tasks_for_list = AsyncMock(return_value=[completed])
+    executor = _make_executor(task_manager=mgr)
+
+    result = await executor._execute_validation_action('general', {}, task)
+
+    assert result['validation_passed'] is True
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_validation_action_fails_when_previous_step_failed():
+    """General validation raises DEILEError when a previous step failed (#141)."""
+    task = _make_task(task_id="validation_task", metadata={'list_id': 'list1'})
+    failed_step = _make_task(task_id="prev", title="Broken Step", status=TaskStatus.FAILED)
+
+    mgr = _make_task_manager()
+    mgr._get_tasks_for_list = AsyncMock(return_value=[failed_step])
+    executor = _make_executor(task_manager=mgr)
+
+    with pytest.raises(DEILEError, match="General validation failed"):
+        await executor._execute_validation_action('general', {}, task)
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_validation_action_unknown_type_raises():
+    """Unknown validation_type must raise DEILEError (#141)."""
+    task = _make_task(metadata={'list_id': 'list1'})
+    executor = _make_executor()
+
+    with pytest.raises(DEILEError, match="Unknown validation type"):
+        await executor._execute_validation_action('nonexistent', {}, task)
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_validation_action_missing_list_id_raises():
+    """General validation without list_id in metadata must raise DEILEError (#141)."""
+    task = _make_task(metadata={})  # no list_id
+    executor = _make_executor()
+
+    with pytest.raises(DEILEError, match="list_id missing"):
+        await executor._execute_validation_action('general', {}, task)
+
+
+# ---------------------------------------------------------------------------
+# Issue #142 — _execute_custom_action must raise instead of fake success
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_unregistered_tool_action_raises():
+    """Tool not in registry must raise DEILEError, not return fake success (#142)."""
+    task = _make_task(metadata={
+        'list_id': 'list1',
+        'action_type': 'tool',
+        'action_name': 'nonexistent_tool',
+        'params': {},
+    })
+    executor = _make_executor(registry_has_tool=False)
+
+    result = await executor.execute_task(task)
+
+    # execute_task catches and returns error dict
+    assert result['success'] is False
+    assert "not found in registry" in result['error']
+
+
+@pytest.mark.unit
+@pytest.mark.orchestration
+async def test_unknown_action_type_raises():
+    """Unknown action_type in metadata must surface as task failure (#142)."""
+    task = _make_task(metadata={
+        'list_id': 'list1',
+        'action_type': 'custom',   # removed handler
+        'action_name': 'something',
+        'params': {},
+    })
+    executor = _make_executor()
+
+    result = await executor.execute_task(task)
+
+    assert result['success'] is False
+    assert "Unknown action type" in result['error']


### PR DESCRIPTION
## Summary

- **#140** — `start_workflow_execution` chamava `task_manager.start_execution()` que não existe em `SQLiteTaskManager`, causando `AttributeError` silenciado e fallback incondicional. Corrigido: `WorkflowExecutor` agora é o dono do loop de execução (`_execute_task_list_loop`), adicionado `activate_task_list` no SQLiteTaskManager, e metadata das tasks passa a ser persistida no INSERT (não em atribuição post-hoc).
- **#141** — `_execute_validation_action` sempre retornava `True` hardcoded. Substituído por validação real: consulta tasks anteriores no banco e falha se alguma estiver com `status=FAILED`.
- **#142** — `_execute_custom_action` retornava sucesso fake para tools não registradas. Removido o handler `'custom'`; action_type desconhecido agora surfaça como `success=False` via `DEILEError`.

## Arquivos alterados

| Arquivo | O que mudou |
|---|---|
| `deile/orchestration/workflow_executor.py` | Loop de execução próprio, validação real, remoção de código morto |
| `deile/orchestration/sqlite_task_manager.py` | `activate_task_list` + params `metadata`/`tags` em `add_task_to_list` |
| `deile/tests/orchestration/test_workflow_executor.py` | 11 novos testes, um por comportamento corrigido |

## Test plan

- [x] `python3 -m pytest deile/tests/orchestration/test_workflow_executor.py -v` → 11/11 passed
- [x] `python3 -m pytest deile/tests/ -q` → 1891 passed, 0 failed
- [x] `ruff check` + `isort --check-only` → sem erros

Closes #140
Closes #141
Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)