### PR TITLE
refactor: align bot naming on canonical 'deilebot'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ deilebot.yaml
 config/settings.json
 config/permissions.yaml
 config/persona_config.yaml
-config/deile_bot.yaml
+config/deilebot.yaml
 # Dead duplicates of deile/config/* — code never reads these
 config/api_config.yaml
 config/commands.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Entry point: `python3 deile.py` (CLI shell in `DeileAgentCLI`; all logic lives i
   ```
   Pip detects `deilebot` already installed and ignores the extra. The `deilebot/` folder is gitignored.
 
+  > **Migration note (issue #159):** the canonical clone path is `deilebot/` (no separator). If you have a legacy `deile_bot/` clone, run `mv deile_bot deilebot` and re-run `pip install -e ./deilebot`. Run the bot from the `deile/` repo root (`python3 -m deilebot run --provider discord`) — running from inside the clone shadows the parent `deile.config` package via the partial `deilebot/deile/` overrides.
+
   **Both cases:** configure `DEILE_BOT_ENDPOINT` + `DEILE_BOT_AUTH_TOKEN` (see `.env.example`). The `messaging.discord_*` tools auto-register only when `import deilebot` succeeds and both env vars are set.
 - **If you're touching messaging tools**, open [`08-SEGURANCA.md`](docs/system_design/08-SEGURANCA.md) **before** writing code — DM and role-mention tools are gated by `ApprovalSystem` by design and changes to that gate are non-trivial.
 - **Two `config/` directories**: `./config/` (runtime YAML/JSON) vs `./deile/config/` (package code + `settings.py` + YAML configs like `intent_patterns.yaml`). Don't conflate.

--- a/config/deilebot.yaml
+++ b/config/deilebot.yaml
@@ -1,7 +1,7 @@
-# Example config for deile_bot. Copy to config/deile_bot.yaml and edit.
+# Example config for deilebot. Copy to config/deilebot.yaml and edit.
 
 foundation:
-  sqlite_path: data/deile_bot.sqlite
+  sqlite_path: data/deilebot.sqlite
   sessions_sqlite_path: data/deile_sessions.sqlite
   data_retention_days: 90
   default_persona: developer
@@ -17,7 +17,7 @@ foundation:
   session_strategy: per_user
 
 permissions:
-  # ULIDs from data/deile_bot.sqlite — discord:1475913578648436909 (elimar) + discord:1244112295261503573 (ZeZiNHo_HiPPie)
+  # ULIDs from data/deilebot.sqlite — discord:1475913578648436909 (elimar) + discord:1244112295261503573 (ZeZiNHo_HiPPie)
   owners:
     - "01KQMMWKRHG0HJD6PQ7J2S8JY4"
     - "01KQMNJQ24GNA1X2RQ4VHTQSCH"

--- a/deile/core/context_manager.py
+++ b/deile/core/context_manager.py
@@ -367,7 +367,7 @@ class ContextManager:
                 "logs",
                 ".claude",
                 "cache", ".cache",
-                "deile_bot",           # separate repo, irrelevant to file nav
+                "deilebot", "deile_bot",  # separate repo (canonical + transitional names)
                 "work_items",          # large planning docs, not project code
                 "test-your-might",     # sandbox output dir
                 "dist", "build", "site-packages",

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -6,10 +6,10 @@ log a warning but never abort the pipeline.
 
 Wiring
 ------
-At runtime we rely on ``deile_bot.bridge.dm_tool.send_discord_dm`` (when the
-deile-bot package is importable; that's the standard local-dev configuration)
-or fall back to the ``deilebot.bridge.dm_tool`` import path for the renamed
-package. Either path uses ``DEILE_BOT_DISCORD_TOKEN`` from the environment.
+At runtime we resolve the DM sender from ``deilebot.bridge.dm_tool.send_discord_dm``.
+The ``deilebot`` package must be importable (installed via ``pip install -e .[bot]``
+or the local-dev clone described in CLAUDE.md). The sender uses
+``DEILE_BOT_DISCORD_TOKEN`` from the environment.
 """
 
 from __future__ import annotations
@@ -26,20 +26,13 @@ _DM_FN: Optional[Callable[[str, str], Awaitable[dict]]] = None
 
 
 def _resolve_dm_function() -> Optional[Callable[[str, str], Awaitable[dict]]]:
-    """Pick the best available DM sender.
+    """Resolve the DM sender from ``deilebot.bridge.dm_tool``.
 
-    Tries the new ``deilebot.bridge.dm_tool`` first (current package name),
-    then falls back to the legacy ``deile_bot.bridge.dm_tool`` for older
-    local installs. Returns None if neither is importable — in that case the
+    Returns None if ``deilebot`` is not importable — in that case the
     notifier silently no-ops.
     """
     try:
         from deilebot.bridge.dm_tool import send_discord_dm  # type: ignore
-        return send_discord_dm
-    except Exception:  # noqa: BLE001 — fall back, log later
-        pass
-    try:
-        from deile_bot.bridge.dm_tool import send_discord_dm  # type: ignore
         return send_discord_dm
     except Exception:  # noqa: BLE001
         return None

--- a/deile/personas/instructions/core/DEILE.md
+++ b/deile/personas/instructions/core/DEILE.md
@@ -68,7 +68,7 @@ Use sem pedir permissão:
 
    `bash_execute` **não tem** sandbox de working_directory — aceita qualquer path do sistema.
 
-   Casos legítimos típicos: monorepo onde DEILE foi invocado de um subprojeto (ex.: `deile_bot/` dentro de `deile/`) e o usuário quer ler templates/configs do repo-pai; auditoria de paths absolutos que o usuário forneceu literalmente; verificação cross-repo.
+   Casos legítimos típicos: monorepo onde DEILE foi invocado de um subprojeto (ex.: `deilebot/` dentro de `deile/`) e o usuário quer ler templates/configs do repo-pai; auditoria de paths absolutos que o usuário forneceu literalmente; verificação cross-repo.
 
    **Anti-padrão proibido**: receber `Path not found: /Users/.../algo` e tentar `list_files(path='.github/...')` — você acabou de remover o prefixo absoluto que era a parte importante. Se o usuário disse `/Users/x/y`, use `bash_execute(command="ls /Users/x/y")`.
 

--- a/deile/tests/core/test_file_context_truncation.py
+++ b/deile/tests/core/test_file_context_truncation.py
@@ -84,8 +84,12 @@ def project_with_ignored_dirs(tmp_path: Path) -> Path:
                 },
             },
             "deile_bot/": {
-                "bot.py": "# separate repo",
+                "bot.py": "# legacy clone name (transitional)",
                 "requirements.txt": "discord.py",
+            },
+            "deilebot/": {
+                "daemon.py": "# canonical clone name",
+                "pyproject.toml": "[project]\nname = \"deilebot\"",
             },
             "node_modules/": {
                 "lodash/": {
@@ -146,6 +150,7 @@ async def test_ignored_dirs_are_pruned(
     assert "HEAD" not in result, ".git was not pruned"
     assert "pyvenv.cfg" not in result, "venv was not pruned"
     assert "bot.py" not in result, "deile_bot was not pruned"
+    assert "daemon.py" not in result, "deilebot was not pruned"
     assert "lodash" not in result, "node_modules was not pruned"
     assert "PLAN.md" not in result, "work_items was not pruned"
 

--- a/deile/tests/test_path_normalization.py
+++ b/deile/tests/test_path_normalization.py
@@ -343,7 +343,7 @@ def test_write_file_blocks_parent_escape_with_clear_message(tmp_path):
 
 def test_outside_project_violation_points_to_bash_execute(tmp_path):
     """Regression guard for the second-/EVOLVE-run trace: when DEILE was
-    launched from ``deile_bot/`` (a subdir of the deile parent repo) and
+    launched from ``deilebot/`` (a sibling clone of the deile parent repo) and
     asked to read templates at ``../.github/ISSUE_TEMPLATE/``, the path
     resolver rejected it with a generic "OUTSIDE the project" message that
     didn't tell the LLM HOW to recover. The model then looped on the same

--- a/docs/system_design/09-CONFIGURACAO.md
+++ b/docs/system_design/09-CONFIGURACAO.md
@@ -157,7 +157,7 @@ Configura múltiplas seções tipadas:
 
 > **Status (issue #111):** este diretório foi limpo. As preferências antes
 > ali agora vivem em `.deile/settings.json` (ver §Camadas). Apenas
-> `config/deile_bot.yaml` permanece tracked (operacional do bot).
+> `config/deilebot.yaml` permanece tracked (operacional do bot — carregado por `deilebot/foundation/settings.py` em `_YAML_PATH`).
 
 `config/settings.json` continua reconhecido como **fallback de leitura**
 quando nenhum `.deile/settings.json` existe — emite aviso de depreciação


### PR DESCRIPTION
## Summary

Closes #159. Three sources of confusion eliminated:

- **`notifier.py`**: removes the dead legacy `deile_bot.bridge.dm_tool` fallback. The package rename happened in `deilebot` repo commit `de0a83d`; the fallback is unreachable in any layout produced after that.
- **`config/deile_bot.yaml` → `config/deilebot.yaml`** (`git mv`, no content loss). The bot loader looks for `./config/deilebot.yaml` (`deilebot/foundation/settings.py:_YAML_PATH`), so the old name was silently ignored — the bot ran on defaults instead of the tracked config. `sqlite_path` updated from `data/deile_bot.sqlite` to `data/deilebot.sqlite` (the DB the bot was actually writing to).
- **`context_manager` skip-list**: now covers both `deilebot` and `deile_bot` so users mid-migration don't see the bot subrepo polluting file context.

Plus targeted doc/test updates: CLAUDE.md migration note, `docs/system_design/09-CONFIGURACAO.md` reference, persona instruction example, two test fixtures/docstrings.

## ⚠️ Operator-visible behavior change (positive)

The renamed YAML now actually loads. That activates the `permissions:` block in `config/deilebot.yaml`, which previously never reached the bot:

| Setting | Before (defaults) | After (YAML applied) |
|---|---|---|
| `owners` | `[]` (nobody) | 2 ULIDs (elimar + ZeZiNHo) |
| `per_action.EXECUTE_TOOL` | unrestricted | `owner_only` |
| `per_action.ADMIN_COMMAND` | unrestricted | `owner_only` |
| `per_action.DEBUG_COMMAND` | unrestricted | `owner_only` |
| `per_action.SEND_DM` | unrestricted | `allowlist: ["*"]` (still permissive) |
| `allowlist_invoke_agent` | `["*"]` | `["*"]` (no change) |

This is the configuration the operator wrote into the YAML — pre-PR it was silently no-op due to the filename mismatch. Post-PR it enforces. **If this tightening is not desired, edit `config/deilebot.yaml` before deploying.**

## Out of scope

- Renaming the GitHub repo (canonical is already `elimarcavalli/deilebot`).
- Renaming `DEILE_BOT_*` env vars (operational convention, breaking).
- Cleaning up the empty runtime `./deilebot/{cache,config,logs}` dirs (manual, untracked).

## Test plan

- [x] Targeted tests: `pytest deile/tests/core/test_file_context_truncation.py deile/tests/test_path_normalization.py deile/tests/orchestration/pipeline/test_gap_regressions.py` — 125 passed, 1 skipped
- [x] Full suite: `pytest deile/tests/` — 1904 passed, 15 skipped, zero new failures
- [x] Lint: `ruff check deile/` — 2 pre-existing errors in `test_enterprise_profile.py` (unused imports), unrelated to this PR
- [x] Smoke: `_resolve_dm_function()` returns `deilebot.bridge.dm_tool.send_discord_dm`
- [x] Smoke: renamed YAML parses cleanly with `sqlite_path: data/deilebot.sqlite`

## Migration (operator)

After merge, on local machines that still have the legacy layout:

```bash
mv deile_bot deilebot                  # rename clone folder
rm -rf deilebot/cache deilebot/config deilebot/logs   # drop empty runtime dirs (if any)
pip install -e ./deilebot              # re-link editable install
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)