### PR TITLE
feat(messaging): whatsapp_send_template tool (deile side of #157)

### DIFF
--- a/deile/integrations/bot/client.py
+++ b/deile/integrations/bot/client.py
@@ -121,6 +121,9 @@ class BotClientFacade:
     async def get_user(self, user_id: str):
         return await self._ensure_client().get_user_profile(user_id)
 
+    async def whatsapp_send_template(self, **kwargs):
+        return await self._ensure_client().whatsapp_send_template(**kwargs)
+
 
 def get_bot_client(settings: Optional[BotIntegrationSettings] = None) -> BotClientFacade:
     """Process-wide singleton. Pass settings only to override (tests)."""

--- a/deile/tests/tools/messaging/conftest.py
+++ b/deile/tests/tools/messaging/conftest.py
@@ -105,6 +105,33 @@ class FakeBotClient:
             is_bot=False,
         )
 
+    async def whatsapp_send_template(
+        self,
+        *,
+        to,
+        template_name,
+        language,
+        body_params=None,
+        header_params=None,
+        category="utility",
+    ):
+        self._record(
+            "whatsapp_send_template",
+            to=to,
+            template_name=template_name,
+            language=language,
+            body_params=list(body_params or []),
+            header_params=list(header_params or []),
+            category=category,
+        )
+        return _DummyResp(
+            message_id=f"wamid.tpl-{len(self.calls)}",
+            to=to,
+            template_name=template_name,
+            language=language,
+            sent_at=_now(),
+        )
+
 
 class FakePermissionManager:
     def __init__(self, allow: bool = True):

--- a/deile/tests/tools/messaging/test_auto_discover.py
+++ b/deile/tests/tools/messaging/test_auto_discover.py
@@ -3,7 +3,7 @@
 Three scenarios:
   1. deilebot missing       → 0 tools registered, no warning
   2. settings unconfigured          → 0 tools registered
-  3. both available + configured    → 7 tools registered
+  3. both available + configured    → 8 tools registered (7 Discord + WhatsApp)
 """
 
 from __future__ import annotations
@@ -65,7 +65,7 @@ def test_unconfigured_registers_zero(monkeypatch):
     assert len(registry) == 0
 
 
-def test_full_setup_registers_all_seven(monkeypatch):
+def test_full_setup_registers_all_eight(monkeypatch):
     monkeypatch.setattr(
         "deile.integrations.bot.BOT_CLIENT_AVAILABLE", True, raising=True
     )
@@ -74,7 +74,7 @@ def test_full_setup_registers_all_seven(monkeypatch):
     reset_bot_settings_cache()
     registry = ToolRegistry()
     n = register_messaging_tools(registry)
-    assert n == 7
+    assert n == 8
     expected = {
         "discord_send_message",
         "discord_send_dm",
@@ -83,6 +83,7 @@ def test_full_setup_registers_all_seven(monkeypatch):
         "discord_pin_message",
         "discord_mention_role",
         "discord_get_user_profile",
+        "whatsapp_send_template",
     }
     assert {t.name for t in registry.list_all()} >= expected
 
@@ -98,6 +99,6 @@ def test_idempotent(monkeypatch):
     registry = ToolRegistry()
     n1 = register_messaging_tools(registry)
     n2 = register_messaging_tools(registry)
-    assert n1 == 7
+    assert n1 == 8
     assert n2 == 0
-    assert len(registry) == 7
+    assert len(registry) == 8

--- a/deile/tests/tools/messaging/test_schemas.py
+++ b/deile/tests/tools/messaging/test_schemas.py
@@ -8,7 +8,8 @@ from deile.tools.messaging import (DiscordGetUserProfileTool,
                                    DiscordMentionRoleTool,
                                    DiscordPinMessageTool, DiscordReactTool,
                                    DiscordSendDMTool, DiscordSendMessageTool,
-                                   DiscordStartThreadTool)
+                                   DiscordStartThreadTool,
+                                   WhatsAppSendTemplateTool)
 
 ALL_TOOLS = [
     DiscordSendMessageTool,
@@ -18,6 +19,7 @@ ALL_TOOLS = [
     DiscordPinMessageTool,
     DiscordMentionRoleTool,
     DiscordGetUserProfileTool,
+    WhatsAppSendTemplateTool,
 ]
 
 

--- a/deile/tests/tools/messaging/test_whatsapp_send_template.py
+++ b/deile/tests/tools/messaging/test_whatsapp_send_template.py
@@ -1,0 +1,259 @@
+"""whatsapp_send_template — template send tool requires explicit approval.
+
+The tool is the DEILE-side surface for the deilebot control-plane endpoint
+``POST /v1/outbound/whatsapp/send_template``. It is DANGEROUS because each
+send costs Meta-tier money; ApprovalSystem gates every call.
+"""
+
+from __future__ import annotations
+
+from deile.security.audit_logger import AuditEventType
+from deile.tools.base import SecurityLevel
+from deile.tools.messaging import WhatsAppSendTemplateTool
+
+from .conftest import make_context
+
+
+async def test_security_level_is_dangerous():
+    tool = WhatsAppSendTemplateTool()
+    assert tool.schema.security_level == SecurityLevel.DANGEROUS
+    assert tool.require_approval is True
+    assert tool.approval_risk == "high"
+
+
+async def test_required_params():
+    tool = WhatsAppSendTemplateTool()
+    required = set(tool.schema.required)
+    assert {"to", "template_name", "language"}.issubset(required)
+
+
+async def test_approval_denied_blocks_send(
+    fake_client, fake_permission, fake_audit, fake_approval_deny
+):
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={
+            "to": "5511999998888",
+            "template_name": "hello_world",
+            "language": "en_US",
+        },
+        fake_client=fake_client,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_deny,
+    )
+    result = await tool.execute(ctx)
+    assert result.is_error
+    assert result.metadata.get("error_code") == "APPROVAL_REQUIRED"
+    assert fake_client.calls == []  # facade never called
+    # approval system was consulted with the correct risk
+    assert len(fake_approval_deny.requests) == 1
+    assert fake_approval_deny.requests[0]["risk_level"] == "high"
+
+
+async def test_approval_grant_sends_template(
+    fake_client, fake_permission, fake_audit, fake_approval_grant
+):
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={
+            "to": "5511999998888",
+            "template_name": "appointment_reminder",
+            "language": "pt_BR",
+            "body_params": ["Maria", "10:00"],
+            "category": "utility",
+        },
+        fake_client=fake_client,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    result = await tool.execute(ctx)
+    assert result.is_success, result.message
+    call = fake_client.calls[0]
+    assert call["op"] == "whatsapp_send_template"
+    assert call["to"] == "5511999998888"
+    assert call["template_name"] == "appointment_reminder"
+    assert call["language"] == "pt_BR"
+    assert call["body_params"] == ["Maria", "10:00"]
+    assert call["category"] == "utility"
+    # response payload propagated through
+    assert result.data["template_name"] == "appointment_reminder"
+    assert result.data["to"] == "5511999998888"
+    # audit shows APPROVAL_GRANTED + TOOL_EXECUTION success
+    types = [e.get("event_type") for e in fake_audit.events]
+    assert AuditEventType.APPROVAL_GRANTED in types
+    assert AuditEventType.TOOL_EXECUTION in types
+
+
+async def test_permission_denied_skips_approval_and_send(
+    fake_client, fake_denied_permission, fake_audit, fake_approval_grant
+):
+    """Permission gate runs before approval — denied perm short-circuits."""
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={
+            "to": "5511999998888",
+            "template_name": "hi",
+            "language": "en_US",
+        },
+        fake_client=fake_client,
+        permission=fake_denied_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    result = await tool.execute(ctx)
+    assert result.is_error
+    assert result.metadata.get("error_code") == "PERMISSION_DENIED"
+    assert fake_approval_grant.requests == []
+    assert fake_client.calls == []
+
+
+async def test_audit_redacts_phone_number(
+    fake_client, fake_permission, fake_audit, fake_approval_grant
+):
+    """Phone numbers are PII — must never hit the audit log in plaintext."""
+    tool = WhatsAppSendTemplateTool()
+    phone = "5511987654321"
+    ctx = make_context(
+        args={
+            "to": phone,
+            "template_name": "hi",
+            "language": "en_US",
+        },
+        fake_client=fake_client,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    await tool.execute(ctx)
+    for evt in fake_audit.events:
+        assert phone not in str(evt), (
+            f"phone leaked into audit event: {evt}"
+        )
+
+
+async def test_audit_keeps_template_name_and_category(
+    fake_client, fake_permission, fake_audit, fake_approval_grant
+):
+    """Template name + category are operator config (not PII) — keep visible."""
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={
+            "to": "5511999",
+            "template_name": "appointment_reminder",
+            "language": "pt_BR",
+            "category": "utility",
+        },
+        fake_client=fake_client,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    await tool.execute(ctx)
+    success_events = [
+        e for e in fake_audit.events
+        if e.get("event_type") == AuditEventType.TOOL_EXECUTION
+        and e.get("result") == "success"
+    ]
+    assert success_events, "expected one success TOOL_EXECUTION event"
+    details = success_events[0].get("details") or {}
+    assert details.get("template_name") == "appointment_reminder"
+    assert details.get("category") == "utility"
+    assert details.get("language") == "pt_BR"
+
+
+async def test_param_counts_recorded_in_audit(
+    fake_client, fake_permission, fake_audit, fake_approval_grant
+):
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={
+            "to": "5511999",
+            "template_name": "appt",
+            "language": "pt_BR",
+            "body_params": ["a", "b", "c"],
+            "header_params": ["x"],
+        },
+        fake_client=fake_client,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    await tool.execute(ctx)
+    success = [
+        e for e in fake_audit.events
+        if e.get("event_type") == AuditEventType.TOOL_EXECUTION
+        and e.get("result") == "success"
+    ]
+    details = success[0]["details"]
+    assert details["body_param_count"] == 3
+    assert details["header_param_count"] == 1
+
+
+async def test_default_category_is_utility(
+    fake_client, fake_permission, fake_audit, fake_approval_grant
+):
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={
+            "to": "5511999",
+            "template_name": "hi",
+            "language": "en_US",
+        },
+        fake_client=fake_client,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    await tool.execute(ctx)
+    assert fake_client.calls[0]["category"] == "utility"
+
+
+async def test_upstream_error_maps_to_bot_upstream(
+    fake_permission, fake_audit, fake_approval_grant
+):
+    """Meta 132001 (template not found) lands at the tool as BotClientUpstreamError."""
+    from deile.integrations.bot.client import BotClientUpstreamError
+
+    from .conftest import FakeBotClient
+    fake = FakeBotClient(raise_on={
+        "whatsapp_send_template": BotClientUpstreamError(
+            "Template name does not exist",
+            status_code=400,
+            code="UPSTREAM_ERROR",
+            details={"meta_code": 132001},
+        ),
+    })
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={"to": "5511999", "template_name": "ghost", "language": "en_US"},
+        fake_client=fake,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    result = await tool.execute(ctx)
+    assert result.is_error
+    assert result.metadata.get("error_code") == "BOT_UPSTREAM"
+
+
+async def test_integration_disabled_short_circuits(
+    fake_permission, fake_audit, fake_approval_grant
+):
+    """When facade is unavailable, no approval prompt and no send."""
+    from .conftest import FakeBotClient
+    fake = FakeBotClient()
+    fake.disable()
+    tool = WhatsAppSendTemplateTool()
+    ctx = make_context(
+        args={"to": "5511999", "template_name": "hi", "language": "en_US"},
+        fake_client=fake,
+        permission=fake_permission,
+        audit=fake_audit,
+        approval=fake_approval_grant,
+    )
+    result = await tool.execute(ctx)
+    assert result.is_error
+    assert result.metadata.get("error_code") == "BOT_INTEGRATION_DISABLED"
+    assert fake_approval_grant.requests == []

--- a/deile/tools/messaging/__init__.py
+++ b/deile/tools/messaging/__init__.py
@@ -22,6 +22,7 @@ from .discord_react import DiscordReactTool
 from .discord_send_dm import DiscordSendDMTool
 from .discord_send_message import DiscordSendMessageTool
 from .discord_start_thread import DiscordStartThreadTool
+from .whatsapp_send_template import WhatsAppSendTemplateTool
 
 __all__ = [
     "MessagingTool",
@@ -32,5 +33,6 @@ __all__ = [
     "DiscordPinMessageTool",
     "DiscordMentionRoleTool",
     "DiscordGetUserProfileTool",
+    "WhatsAppSendTemplateTool",
     "register_messaging_tools",
 ]

--- a/deile/tools/messaging/auto_discover.py
+++ b/deile/tools/messaging/auto_discover.py
@@ -34,6 +34,7 @@ _TOOL_CLASSES = (
     "DiscordPinMessageTool",
     "DiscordMentionRoleTool",
     "DiscordGetUserProfileTool",
+    "WhatsAppSendTemplateTool",
 )
 
 
@@ -59,7 +60,8 @@ def register_messaging_tools(registry: "ToolRegistry") -> int:
     # deilebot never breaks the deile import chain.
     from . import (DiscordGetUserProfileTool, DiscordMentionRoleTool,
                    DiscordPinMessageTool, DiscordReactTool, DiscordSendDMTool,
-                   DiscordSendMessageTool, DiscordStartThreadTool)
+                   DiscordSendMessageTool, DiscordStartThreadTool,
+                   WhatsAppSendTemplateTool)
 
     candidates = [
         DiscordSendMessageTool(),
@@ -69,6 +71,7 @@ def register_messaging_tools(registry: "ToolRegistry") -> int:
         DiscordPinMessageTool(),
         DiscordMentionRoleTool(),
         DiscordGetUserProfileTool(),
+        WhatsAppSendTemplateTool(),
     ]
 
     registered = 0

--- a/deile/tools/messaging/whatsapp_send_template.py
+++ b/deile/tools/messaging/whatsapp_send_template.py
@@ -1,0 +1,135 @@
+"""messaging.whatsapp_send_template — send an approved WhatsApp template.
+
+Templates are required for any WhatsApp send outside the 24h conversation
+window. Each call costs Meta-tier money (utility/marketing/authentication
+have different prices) so the tool runs at SecurityLevel.DANGEROUS with
+explicit ApprovalSystem gating, like the Discord DM tool.
+
+The template name + language must match an entry the operator has both:
+1. Submitted to and had approved by Meta in WhatsApp Business Manager.
+2. Mirrored in the bot's `config/whatsapp_templates.yaml` catalog.
+
+Mismatch surfaces as a ProviderError 132001 from the bot, mapped here to
+``BOT_UPSTREAM`` so the operator can correct the catalog or chase the
+Meta approval queue.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..base import SecurityLevel
+from ._base import MessagingTool
+
+
+class WhatsAppSendTemplateTool(MessagingTool):
+    tool_name = "whatsapp_send_template"
+    description_text = (
+        "Send an approved WhatsApp Cloud API template message via the deilebot "
+        "daemon. Use this when the conversation window is closed (>24h since "
+        "the user's last inbound), or to initiate a new conversation. The "
+        "template must already be approved in WhatsApp Business Manager and "
+        "mirrored in the bot's catalog. Each send is metered against the "
+        "Meta pricing tier of the chosen category. Requires explicit operator "
+        "approval — a confirmation prompt is raised."
+    )
+    parameters: Dict[str, Any] = {
+        "to": {
+            "type": "string",
+            "description": (
+                "Recipient WhatsApp ID — E.164 phone number without leading '+', "
+                "e.g. '5511999998888'."
+            ),
+        },
+        "template_name": {
+            "type": "string",
+            "description": (
+                "Exact template name as registered in WhatsApp Business Manager "
+                "(snake_case). Must also exist in the bot's catalog when the "
+                "template has body or header parameters."
+            ),
+        },
+        "language": {
+            "type": "string",
+            "description": (
+                "Meta locale code for the template (e.g. 'pt_BR', 'en_US', 'es_ES'). "
+                "Each language is a separate Meta approval — the catalog enforces "
+                "the (name, language) pair."
+            ),
+        },
+        "body_params": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Ordered values for the template body placeholders ({{1}}, {{2}}, ...). "
+                "Empty list when the template has no body params. Must match the "
+                "count declared in the catalog."
+            ),
+        },
+        "header_params": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Ordered values for the template header placeholders. Empty list "
+                "when the template has no header params."
+            ),
+        },
+        "category": {
+            "type": "string",
+            "enum": ["utility", "marketing", "authentication", "service"],
+            "description": (
+                "Meta pricing category of the template. Drives the "
+                "bot_whatsapp_conversations_total metric the operator uses to "
+                "track spend. Must match the category registered with Meta."
+            ),
+        },
+    }
+    required_params = ["to", "template_name", "language"]
+    security_level = SecurityLevel.DANGEROUS
+    require_approval = True
+    approval_risk = "high"
+
+    async def _perform(self, facade, args):
+        result = await facade.whatsapp_send_template(
+            to=str(args["to"]),
+            template_name=str(args["template_name"]),
+            language=str(args["language"]),
+            body_params=list(args.get("body_params") or []),
+            header_params=list(args.get("header_params") or []),
+            category=str(args.get("category") or "utility"),
+        )
+        return {
+            "message_id": result.message_id,
+            "to": result.to,
+            "template_name": result.template_name,
+            "language": result.language,
+            "sent_at": result.sent_at.isoformat(),
+        }
+
+    def _build_audit_payload(self, args):
+        # WhatsApp recipient is a phone number — sensitive PII. Do NOT
+        # plaintext it in the audit log; hash via the inherited _sha8.
+        # Template name + language are operator config (not PII), keep them.
+        from ._base import _sha8
+
+        payload = {"tool": self.tool_name}
+        if isinstance(args, dict):
+            if args.get("to"):
+                payload["to_hash"] = _sha8(str(args["to"]))
+            if args.get("template_name"):
+                payload["template_name"] = args["template_name"]
+            if args.get("language"):
+                payload["language"] = args["language"]
+            if args.get("category"):
+                payload["category"] = args["category"]
+            body = args.get("body_params") or []
+            header = args.get("header_params") or []
+            payload["body_param_count"] = len(body)
+            payload["header_param_count"] = len(header)
+        return payload
+
+    def _success_message(self, data, args):
+        return (
+            f"sent template {data['template_name']} ({data['language']}) "
+            f"to {data['to']} as {data['message_id']}"
+        )

--- a/docs/future/deilebot/whatsapp/05-E2E-RESULTADOS.md
+++ b/docs/future/deilebot/whatsapp/05-E2E-RESULTADOS.md
@@ -1,0 +1,64 @@
+# Fase E2E — resultados
+
+> **Estado: PENDENTE — aguardando operador humano com credenciais Meta Business.**
+>
+> Os 10 cenários listados aqui só podem ser executados contra um número
+> WhatsApp Business sandbox real (verificação de negócio + templates aprovados).
+> O agente não tem acesso às credenciais e não pode rodar esta bateria.
+>
+> Runbook completo (provisionamento, webhook, templates, validação):
+> [`elimarcavalli/deilebot:docs/whatsapp/SETUP.md`](https://github.com/elimarcavalli/deilebot/blob/main/docs/whatsapp/SETUP.md)
+> (mergeada via PR de Phase 2 — issue #157).
+
+## Pré-requisitos antes de rodar
+
+1. Conta Meta Business com WABA criada
+2. Pelo menos 1 número WhatsApp Business (sandbox serve)
+3. Token de System User permanente
+4. Webhook HTTPS público apontando para o bot
+5. Pelo menos 2 templates aprovados pela Meta:
+   - Um `utility` sem parâmetros (ex.: `hello_world`)
+   - Um `utility` com 2 parâmetros body (ex.: `appointment_reminder`)
+6. `config/whatsapp_templates.yaml` espelhando os templates aprovados
+7. Bot rodando com control plane HTTP exposto
+8. DEILE com `DEILE_BOT_ENDPOINT` + `DEILE_BOT_AUTH_TOKEN` configurados
+
+## Bateria
+
+Spec dos cenários: [`03-FASE-E2E.md`](03-FASE-E2E.md). Operator preenche a coluna **Resultado** após cada execução.
+
+| # | Cenário | Critério de aprovação | Resultado | Data | Notas |
+|---|---|---|---|---|---|
+| 1 | Inbound texto dentro da janela → reply texto livre | Mensagem visível no cliente WhatsApp | ⏳ pendente | — | — |
+| 2 | Inbound imagem → adapter recebe `Attachment(IMAGE)` | Tool vê mime + url | ⏳ pendente | — | — |
+| 3 | Reply Button click → `interactive.button_reply` parsed → `env.text == title`, `env.raw["interactive"]["id"] == callback_data` | Mensagem com botão enviada via tool, clique processado | ⏳ pendente | — | — |
+| 4 | List selection → `interactive.list_reply` parsed identicamente | Idem | ⏳ pendente | — | — |
+| 5 | Texto livre fora da janela 24h → adapter rejeita (ou pipeline roteia para template) | Sem envio silencioso | ⏳ pendente | — | — |
+| 6 | Send template (utility, sem params) | Mensagem chega; `bot_whatsapp_conversations_total{category=utility,status=ok}` incrementa | ⏳ pendente | — | — |
+| 7 | Send template (utility, 2 params body) | Variáveis substituídas corretamente | ⏳ pendente | — | — |
+| 8 | Template name não aprovado → `BOT_UPSTREAM` (132001) chega ao operador | Tool retorna erro, sem cobrança | ⏳ pendente | — | — |
+| 9 | Param-count mismatch → `ProviderError` antes da chamada HTTP | Erro nomeia o template + contagem esperada | ⏳ pendente | — | — |
+| 10 | Send template (marketing, após business verification) | Meta aceita; `category=marketing` incrementa | ⏳ pendente | — | — |
+
+## Como reportar resultados
+
+Para cada cenário executado:
+
+1. Rodar e observar.
+2. Marcar **Resultado** como ✅ (passou), ❌ (falhou) ou ⚠️ (parcial).
+3. Preencher **Data** com YYYY-MM-DD.
+4. Em **Notas**, registrar:
+   - Output relevante do bot log (sem token!)
+   - Snapshot da métrica `bot_whatsapp_conversations_total`
+   - Qualquer divergência do critério
+
+## Critério de fechamento da Fase E2E
+
+A Fase E2E só está concluída quando:
+
+- [ ] Todos os 10 cenários estão ✅ ou ⚠️ (com nota explicativa de por que ⚠️ é aceitável).
+- [ ] Cenário #5 está ✅ (proteção de janela é o controle de gasto crítico).
+- [ ] Cenário #6 está ✅ (template send é o caminho feliz primário).
+- [ ] Snapshot final da métrica anexado a este doc.
+
+Falhas em #1–#4 são bloqueantes (capacidade básica). Falha em #8/#9 indica que algo no catálogo ou no adapter está silenciando erros — também bloqueante.


### PR DESCRIPTION
## Summary

Adds the DEILE-side surface for WhatsApp Cloud API templates. The tool calls a new control-plane endpoint shipped in [elimarcavalli/deilebot#14](https://github.com/elimarcavalli/deilebot/pull/14) (foundation + adapter + templates + metric + endpoint).

Closes deile-side of #157.

## What ships

- \`deile/tools/messaging/whatsapp_send_template.py\` — \`WhatsAppSendTemplateTool\`. Required: \`to\` (E.164), \`template_name\`, \`language\`. Optional: \`body_params\`, \`header_params\`, \`category\` (utility/marketing/authentication/service, default utility). \`SecurityLevel.DANGEROUS\` + \`require_approval=True\` (each send costs Meta-tier money).
- \`deile/integrations/bot/client.py\` — \`BotClientFacade.whatsapp_send_template\` pass-through.
- \`deile/tools/messaging/__init__.py\` + \`auto_discover.py\` — registered. Auto-loads when \`deilebot\` is importable AND \`DEILE_BOT_*\` env vars are set; otherwise zero impact (count goes 7 → 8 with both gates met).
- \`docs/future/deilebot/whatsapp/05-E2E-RESULTADOS.md\` — placeholder for the 10 sandbox scenarios. Marked operator-pending; links the runbook in \`deilebot/docs/whatsapp/SETUP.md\`.

## Privacy

The audit payload **hashes the recipient phone number** via the existing \`_sha8\` helper (PII), but keeps \`template_name\` + \`language\` + \`category\` + body/header param counts in plaintext (operator config — needed for spend tracing).

## Tests

+10 new tests (in \`deile/tests/tools/messaging/test_whatsapp_send_template.py\`):
- security level + required params
- approval-deny blocks send and never reaches the facade
- approval-grant succeeds with correct call args + audit emissions
- permission-denied short-circuits before approval
- phone redaction (audit never plaintexts the recipient)
- template_name / language / category preserved in audit details
- param counts recorded in audit
- default category = utility
- upstream 132001 → \`BOT_UPSTREAM\` error code mapping
- integration-disabled short-circuits

Plus updates to \`test_auto_discover.py\` (count 7 → 8), \`test_schemas.py\` (Anthropic/OpenAI/Gemini schemas), \`conftest.py\` (FakeBotClient.whatsapp_send_template).

\`\`\`
1929 passed, 15 skipped, 3 warnings in 52.39s
\`\`\`

## Dependency

This PR's runtime path **requires** the deilebot PR ([elimarcavalli/deilebot#14](https://github.com/elimarcavalli/deilebot/pull/14)) to be merged + deployed. Until that lands, calling the tool returns \`BOT_UPSTREAM\` (404 from the bot — endpoint doesn't exist yet). Tests don't depend on it (they use \`FakeBotClient\`).

## Test plan

- [ ] Tests green locally + CI.
- [ ] Operator follows \`deilebot/docs/whatsapp/SETUP.md\` to provision Meta + templates.
- [ ] Operator runs the 10 sandbox scenarios and updates \`docs/future/deilebot/whatsapp/05-E2E-RESULTADOS.md\` (this PR creates the empty template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)