### PR TITLE
feat(pipeline): fill 4 dispatch gaps — CronRunner, PR triage, post-merge memory, mention handling (issue #164)

### DIFF
--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -179,15 +179,44 @@ class PipelineCommand(DirectCommand):
                 )
                 agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
             await monitor.start()
+
+            # Wire CronRunner so scheduled tasks fire alongside the pipeline.
+            from deile.cron.agent_bridge import \
+                make_fire_callback as _make_cron_cb
+            from deile.cron.runner import CronRunner  # noqa: PLC0415
+            from deile.cron.store import CronStore, resolve_db_path
+
+            _cron_store = CronStore(resolve_db_path())
+
+            async def _cron_agent_provider():
+                return agent
+
+            cron_runner = CronRunner(
+                _cron_store,
+                fire_callback=_make_cron_cb(_cron_agent_provider),
+            )
+            await cron_runner.start()
+            if agent is not None:
+                try:
+                    agent.cron_runner = cron_runner  # type: ignore[attr-defined]
+                except (AttributeError, TypeError):
+                    pass
+            logger.info("cron runner started (db=%s)", _cron_store.db_path)
+
             return CommandResult(
                 success=True,
                 content=(
                     f"✅ pipeline iniciado (repo={monitor.config.repo}, "
                     f"interval={monitor.config.poll_interval_seconds}s, "
-                    f"identity={monitor.identity.monitor_id})"
+                    f"identity={monitor.identity.monitor_id}) | "
+                    f"cron iniciado (db={_cron_store.db_path})"
                 ),
             )
         if sub == "stop":
+            _cron_runner = getattr(agent, "cron_runner", None) if agent is not None else None
+            if _cron_runner is not None and _cron_runner.is_running:
+                await _cron_runner.stop()
+                logger.info("cron runner stopped")
             await monitor.stop()
             return CommandResult(success=True, content="🛑 pipeline parado")
         if sub == "tick":
@@ -219,6 +248,11 @@ class PipelineCommand(DirectCommand):
         # default: status
         s = monitor.stats
         running = monitor.is_running
+        cron_runner = getattr(agent, "cron_runner", None) if agent is not None else None
+        cron_state = ""
+        if cron_runner is not None:
+            state = "rodando" if cron_runner.is_running else "parado"
+            cron_state = f"\n  cron={state} fired={cron_runner.fired_count}"
         return CommandResult(
             success=True,
             content=(
@@ -226,6 +260,7 @@ class PipelineCommand(DirectCommand):
                 f"  ticks={s.ticks}  reviewed={s.issues_reviewed}  "
                 f"implemented={s.issues_implemented}  prs={s.prs_reviewed}  "
                 f"errors={s.errors}  gh_errors={s.gh_errors}  claude_errors={s.claude_errors}"
+                f"{cron_state}"
             ),
         )
 

--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -121,6 +121,8 @@ class PipelineCommand(DirectCommand):
 
         if monitor is None:
             from deile.config.settings import get_settings
+            from deile.orchestration.pipeline.post_merge_callback import \
+                make_post_merge_callback
             from deile.orchestration.pipeline.review_callback import \
                 make_review_callback
 
@@ -129,7 +131,11 @@ class PipelineCommand(DirectCommand):
                 base_repo_path=_resolve_base_path(),
                 notify_user_id=get_settings().pipeline_notify_user_id,
             )
-            monitor = PipelineMonitor(cfg, review_callback=make_review_callback(agent))
+            monitor = PipelineMonitor(
+                cfg,
+                review_callback=make_review_callback(agent),
+                post_merge_callback=make_post_merge_callback(agent),
+            )
             # Persist on agent so subsequent invocations reuse the instance.
             # When invoked from CLI one-shot mode (#126) agent may be None —
             # the monitor is single-use in that case, no caching needed.
@@ -147,6 +153,8 @@ class PipelineCommand(DirectCommand):
                 from deile.config.settings import get_settings
                 from deile.orchestration.pipeline.identity import \
                     MonitorIdentity
+                from deile.orchestration.pipeline.post_merge_callback import \
+                    make_post_merge_callback
                 from deile.orchestration.pipeline.review_callback import \
                     make_review_callback
                 from deile.orchestration.pipeline.scheduler import \
@@ -176,6 +184,7 @@ class PipelineCommand(DirectCommand):
                     identity=identity,
                     schedule_store=schedule_store,
                     review_callback=make_review_callback(agent),
+                    post_merge_callback=make_post_merge_callback(agent),
                 )
                 agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
             await monitor.start()

--- a/deile/orchestration/pipeline/claude_dispatcher.py
+++ b/deile/orchestration/pipeline/claude_dispatcher.py
@@ -204,3 +204,17 @@ def render_implement_prompt(repo: str, number: int, title: str, issue_body: str)
 
 def render_review_prompt(repo: str, number: int, title: str) -> str:
     return REVIEW_PROMPT_TEMPLATE.format(repo=repo, number=number, title=title)
+
+
+def render_mention_prompt(repo: str, context_url: str, comment_body: str, author: str) -> str:
+    """Build a prompt for the agent to respond to a @deile-one mention."""
+    return (
+        f"Você foi mencionado por @{author} em {context_url} "
+        f"(repositório: {repo}).\n\n"
+        f"Mensagem recebida:\n{comment_body}\n\n"
+        f"Responda diretamente ao que foi solicitado com uma ação concreta. "
+        f"Se for pedido de revisão de código, analise e comente. "
+        f"Se for uma pergunta, responda com precisão e clareza. "
+        f"Ao final, poste sua resposta como comentário em {context_url} "
+        f"usando a ferramenta gh (ex: gh issue comment ou gh pr review)."
+    )

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -18,6 +18,7 @@ import logging
 import re
 import shutil
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Iterable, List, Optional, Sequence, Tuple
 
 from deile.core.exceptions import DEILEError
@@ -78,6 +79,18 @@ class PrRef:
             if is_batch_label(label):
                 return batch_id_from_label(label)
         return None
+
+
+@dataclass(frozen=True)
+class CommentRef:
+    """A comment on an issue or PR, returned by list_*_comments_since()."""
+
+    comment_id: int
+    body: str
+    html_url: str
+    issue_url: str  # API URL of the parent issue or PR (issues/comments) or pull_request_url (pr review comments)
+    author: str
+    kind: str  # "issue" | "pr_review"
 
 
 def compute_batch_id(title: str) -> str:
@@ -520,6 +533,86 @@ class GitHubClient:
             )
             for item in data
         ]
+
+    async def list_unclassified_prs(self) -> List[PrRef]:
+        """Return open, non-draft PRs with no pipeline labels (no ``~*``).
+
+        Candidates for automatic PR triage (Stage 0 for PRs).
+        """
+        try:
+            prs = await self.list_open_prs()
+        except GhCommandError:
+            raise
+        return [
+            pr for pr in prs
+            if not pr.is_draft
+            and not any(lb.startswith("~") for lb in pr.labels)
+        ]
+
+    async def list_issue_comments_since(self, since: datetime) -> List[CommentRef]:
+        """Return all issue comments posted after *since* (UTC).
+
+        Uses the GitHub REST API via ``gh api``. Returns empty list on error.
+        """
+        since_iso = since.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            out = await self._run_checked(
+                "api",
+                f"repos/{self.repo}/issues/comments",
+                "--field", f"since={since_iso}",
+                "--field", "per_page=100",
+            )
+        except GhCommandError as exc:
+            logger.warning("list_issue_comments_since failed: %s", exc)
+            return []
+        data = json.loads(out or "[]")
+        result: List[CommentRef] = []
+        for item in data:
+            try:
+                result.append(CommentRef(
+                    comment_id=int(item["id"]),
+                    body=str(item.get("body") or ""),
+                    html_url=str(item.get("html_url", "")),
+                    issue_url=str(item.get("issue_url", "")),
+                    author=str((item.get("user") or {}).get("login", "")),
+                    kind="issue",
+                ))
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning("skipping malformed issue comment payload: %s", exc)
+        return result
+
+    async def list_pr_review_comments_since(self, since: datetime) -> List[CommentRef]:
+        """Return all PR review comments posted after *since* (UTC).
+
+        Uses the GitHub REST API via ``gh api``. Returns empty list on error.
+        """
+        since_iso = since.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            out = await self._run_checked(
+                "api",
+                f"repos/{self.repo}/pulls/comments",
+                "--field", f"since={since_iso}",
+                "--field", "per_page=100",
+            )
+        except GhCommandError as exc:
+            logger.warning("list_pr_review_comments_since failed: %s", exc)
+            return []
+        data = json.loads(out or "[]")
+        result: List[CommentRef] = []
+        for item in data:
+            try:
+                pr_url = str(item.get("pull_request_url", ""))
+                result.append(CommentRef(
+                    comment_id=int(item["id"]),
+                    body=str(item.get("body") or ""),
+                    html_url=str(item.get("html_url", "")),
+                    issue_url=pr_url,
+                    author=str((item.get("user") or {}).get("login", "")),
+                    kind="pr_review",
+                ))
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning("skipping malformed PR review comment payload: %s", exc)
+        return result
 
     async def clear_batch_label(self, kind: str, number: int) -> None:
         """Remove all ``~batch:*`` labels from an issue or PR (gap #9).

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -24,16 +24,19 @@ import asyncio
 import logging
 import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Awaitable, Callable, Optional
 
 from deile.orchestration.pipeline.claude_dispatcher import (
-    ClaudeDispatcher, render_implement_prompt, render_review_prompt)
+    ClaudeDispatcher, render_implement_prompt, render_mention_prompt,
+    render_review_prompt)
 from deile.orchestration.pipeline.constants import (
     PIPELINE_MSG_TRUNCATE_CHARS, PIPELINE_POLL_INTERVAL_SECONDS,
     PIPELINE_STOP_TIMEOUT_SECONDS)
 from deile.orchestration.pipeline.follow_up_detector import detect_follow_ups
-from deile.orchestration.pipeline.github_client import (GhCommandError,
+from deile.orchestration.pipeline.github_client import (CommentRef,
+                                                        GhCommandError,
                                                         GitHubClient, IssueRef)
 from deile.orchestration.pipeline.identity import MonitorIdentity
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
@@ -82,6 +85,9 @@ class PipelineConfig:
         {"intent", "bug", "refactor", "feature_request", "security"}
     )
     classify_skip_labels: frozenset = frozenset({"infra"})
+    enable_pr_triage: bool = True
+    enable_mention_handling: bool = True
+    mention_handle: str = "@deile-one"
     # Default True: two simultaneous /pipeline start on the same host fail fast.
     use_pid_lock: bool = True
     # When True, Stage 3 reviews any non-draft PR regardless of head branch origin.
@@ -110,6 +116,8 @@ class _Stats:
     follow_ups_skipped: int = 0
     # Incremented when a scheduled action is disabled via enable_* config.
     skipped_runs: int = 0
+    prs_classified: int = 0
+    mentions_processed: int = 0
 
 
 class PipelineMonitor:
@@ -124,6 +132,7 @@ class PipelineMonitor:
         claude: Optional[ClaudeDispatcher] = None,
         notifier: Optional[DiscordNotifier] = None,
         review_callback: Optional[Callable[[IssueRef], Awaitable[str]]] = None,
+        post_merge_callback: Optional[Callable[[int, str, str], Awaitable[None]]] = None,
         identity: Optional[MonitorIdentity] = None,
         schedule_store: Optional[ScheduleStore] = None,
     ) -> None:
@@ -142,6 +151,9 @@ class PipelineMonitor:
         self._stop_event = asyncio.Event()
         self._task: Optional[asyncio.Task] = None
         self._held_lock: Optional[Path] = None
+        self._post_merge_cb = post_merge_callback
+        self._mention_cursor_path = Path(config.base_repo_path) / "data" / "mention_cursor.txt"
+        self._mention_cursor: Optional[datetime] = None
         # Schedule store — when present, schedule entries drive when each
         # action fires (instead of the fixed poll interval). On startup the
         # monitor first drains any catch-up queue (entries whose run time
@@ -286,6 +298,8 @@ class PipelineMonitor:
             "implement": self.config.enable_implement,
             "pr_review": self.config.enable_pr_review,
             "follow_ups": self.config.enable_follow_ups,
+            "pr_triage": self.config.enable_pr_triage,
+            "mention_handling": self.config.enable_mention_handling,
         }
         flag = _ENABLE_FLAGS.get(run.action)
         if flag is False:
@@ -308,6 +322,10 @@ class PipelineMonitor:
             await self._review_one_open_pr()
         elif run.action == "follow_ups":
             await self._standalone_follow_ups()
+        elif run.action == "pr_triage":
+            await self._classify_new_prs()
+        elif run.action == "mention_handling":
+            await self._process_mentions()
         else:
             logger.debug("scheduled action %s unknown; skipped", run.action)
 
@@ -396,6 +414,10 @@ class PipelineMonitor:
                 if self.config.enable_pr_review and "pr_review" not in scheduled_actions:
                     logger.debug("pr_review not in schedule; running legacy fallback")
                     await self._review_one_open_pr()
+                if self.config.enable_pr_triage:
+                    await self._classify_new_prs()
+                if self.config.enable_mention_handling:
+                    await self._process_mentions()
             return
 
         if self.config.enable_classify:
@@ -406,6 +428,10 @@ class PipelineMonitor:
             await self._implement_one_reviewed_issue()
         if self.config.enable_pr_review:
             await self._review_one_open_pr()
+        if self.config.enable_pr_triage:
+            await self._classify_new_prs()
+        if self.config.enable_mention_handling:
+            await self._process_mentions()
 
     # ----- stage 0: auto-classify new issues -----------------------
 
@@ -494,6 +520,103 @@ class PipelineMonitor:
                 await self.github.comment_on_issue(issue.number, comment)
             except Exception as exc:  # noqa: BLE001 — comment is best-effort; label already applied
                 logger.warning("auto-classify comment #%s failed (label applied): %s", issue.number, exc)
+
+    # ----- PR triage: classify open non-draft PRs with no pipeline labels ----
+
+    async def _classify_new_prs(self) -> None:
+        """Apply ``~review:pendente`` to open non-draft PRs that have no pipeline labels."""
+        try:
+            prs = await self.github.list_unclassified_prs()
+        except GhCommandError as exc:
+            self._stats.errors += 1
+            self._stats.gh_errors += 1
+            logger.error("could not list unclassified PRs (gh error): %s", exc)
+            await self.notifier.error("pr_triage/list", str(exc))
+            return
+        except Exception as exc:  # noqa: BLE001
+            self._stats.errors += 1
+            logger.error("could not list unclassified PRs: %s", exc)
+            return
+
+        for pr in prs:
+            if any(lb.startswith("~") for lb in pr.labels):
+                continue
+            try:
+                batch = await self.github.claim_with_batch("pr", pr.number, pr.title)
+            except GhCommandError as exc:
+                self._stats.errors += 1
+                self._stats.gh_errors += 1
+                logger.error("pr_triage claim #%s failed: %s", pr.number, exc)
+                continue
+            if batch is None:
+                logger.debug("PR #%s already claimed; skipping pr_triage", pr.number)
+                continue
+            try:
+                await self.github.add_labels("pr", pr.number, [REVIEW_PENDING])
+            except GhCommandError as exc:
+                self._stats.errors += 1
+                self._stats.gh_errors += 1
+                logger.error("pr_triage label #%s failed: %s", pr.number, exc)
+                await self.notifier.error(f"pr_triage #{pr.number}", str(exc))
+                continue
+            self._stats.prs_classified += 1
+            logger.info("pr_triage: classified PR #%s with %s", pr.number, REVIEW_PENDING)
+            await self.notifier.pr_auto_classified(pr.number, pr.title, pr.url)
+
+    # ----- mention handling: dispatch @deile-one comments to Claude ----------
+
+    def _load_mention_cursor(self) -> datetime:
+        try:
+            if self._mention_cursor is not None:
+                return self._mention_cursor
+            if self._mention_cursor_path.exists():
+                raw = self._mention_cursor_path.read_text().strip()
+                return datetime.fromisoformat(raw).astimezone(timezone.utc)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("mention cursor load failed; using 30-min lookback: %s", exc)
+        return datetime.now(tz=timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=30)
+
+    def _save_mention_cursor(self, ts: datetime) -> None:
+        try:
+            self._mention_cursor_path.parent.mkdir(parents=True, exist_ok=True)
+            self._mention_cursor_path.write_text(ts.isoformat())
+            self._mention_cursor = ts
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("mention cursor save failed: %s", exc)
+
+    async def _process_mentions(self) -> None:
+        """Poll issue/PR comments since cursor, dispatch @deile-one mentions to Claude."""
+        since = self._load_mention_cursor()
+        handle = self.config.mention_handle.lower()
+        try:
+            issue_comments = await self.github.list_issue_comments_since(since)
+            pr_comments = await self.github.list_pr_review_comments_since(since)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("mention poll failed: %s", exc)
+            return
+        all_comments: list[CommentRef] = issue_comments + pr_comments
+        now = datetime.now(tz=timezone.utc)
+        for ref in all_comments:
+            if handle not in ref.body.lower():
+                continue
+            prompt = render_mention_prompt(
+                self.config.repo, ref.html_url, ref.body, ref.author
+            )
+            try:
+                result = await self.claude.run(prompt, cwd=self.config.base_repo_path)
+                if not result.ok:
+                    logger.warning(
+                        "mention dispatch failed (rc=%d) for %s",
+                        result.returncode, ref.html_url,
+                    )
+                    continue
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("mention dispatch error for %s: %s", ref.html_url, exc)
+                continue
+            self._stats.mentions_processed += 1
+            logger.info("mention processed: %s by @%s", ref.html_url, ref.author)
+            await self.notifier.mention_processed(ref.html_url, ref.author)
+        self._save_mention_cursor(now)
 
     # ----- stage 1: review ------------------------------------------
 
@@ -706,7 +829,11 @@ class PipelineMonitor:
         await self.notifier.pr_reviewed(target.number, target.title, target.url, merged=merged)
         if merged and self.config.enable_follow_ups:
             await self._stage4_follow_ups(target.number, target.title, target.url)
-
+        if merged and self._post_merge_cb is not None:
+            try:
+                await self._post_merge_cb(target.number, target.title, target.url)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("post_merge_callback failed for PR #%d: %s", target.number, exc)
 
     # ----- stage 4: follow-up issues from merged PR ----------------
 

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -559,6 +559,8 @@ class PipelineMonitor:
                 logger.error("pr_triage label #%s failed: %s", pr.number, exc)
                 await self.notifier.error(f"pr_triage #{pr.number}", str(exc))
                 continue
+            # Release the batch claim so Stage 3 can pick this PR up via its own claim.
+            await self.github.clear_batch_label("pr", pr.number)
             self._stats.prs_classified += 1
             logger.info("pr_triage: classified PR #%s with %s", pr.number, REVIEW_PENDING)
             await self.notifier.pr_auto_classified(pr.number, pr.title, pr.url)

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -138,3 +138,13 @@ class DiscordNotifier:
 
     async def error(self, where: str, detail: str) -> None:
         await self._send(f"⚠️ **Pipeline error** em `{where}`:\n```\n{detail[:PIPELINE_MSG_TRUNCATE_CHARS]}\n```")
+
+    async def pr_auto_classified(self, number: int, title: str, url: str) -> None:
+        await self._send(
+            f"🏷️ **PR auto-triaged** #{number}: {title[:100]}\n🔗 {url}"
+        )
+
+    async def mention_processed(self, context_url: str, author: str) -> None:
+        await self._send(
+            f"💬 **Menção de @{author} processada**\n🔗 {context_url}"
+        )

--- a/deile/orchestration/pipeline/post_merge_callback.py
+++ b/deile/orchestration/pipeline/post_merge_callback.py
@@ -1,0 +1,37 @@
+"""Factory for the post-merge episodic memory callback."""
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def make_post_merge_callback(agent) -> Optional[Callable[[int, str, str], Awaitable[None]]]:
+    """Return an async callback that stores a PR-merged episode in the agent's episodic memory.
+
+    Returns None when agent is None (e.g. CLI one-shot mode) so callers can guard
+    with ``if cb is not None``.
+    """
+    if agent is None:
+        return None
+
+    async def _cb(pr_number: int, pr_title: str, pr_url: str) -> None:
+        mem = getattr(agent, "memory_manager", None)
+        if mem is None:
+            return
+        episodic = getattr(mem, "episodic_memory", None)
+        if episodic is None:
+            return
+        try:
+            await episodic.store_episode(
+                user_input=f"PR #{pr_number} merged: {pr_title}",
+                agent_response="[pipeline:merge]",
+                context={"type": "pr_merged", "pr_number": pr_number, "pr_url": pr_url},
+                session_id=f"pipeline-merge-{pr_number}",
+            )
+            logger.debug("post-merge episodic memory stored for PR #%d", pr_number)
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning("post_merge_callback: episodic store failed for PR #%d: %s", pr_number, exc)
+
+    return _cb

--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -53,12 +53,15 @@ def _make_monitor(*, unclassified: list | None = None) -> tuple[PipelineMonitor,
     github.add_labels = AsyncMock()
     github.comment_on_issue = AsyncMock()
     github.comment_on_pr = AsyncMock()
+    github.list_unclassified_prs = AsyncMock(return_value=[])
+    github.list_issue_comments_since = AsyncMock(return_value=[])
+    github.list_pr_review_comments_since = AsyncMock(return_value=[])
 
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
         "implementation_finished", "pr_picked_up", "pr_reviewed",
-        "issue_auto_classified", "error",
+        "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
     ):
         setattr(notifier, attr, AsyncMock())
 
@@ -388,11 +391,15 @@ class TestSchedulerClassifyAction:
         github.transition_issue = AsyncMock()
         github.transition_pr = AsyncMock()
 
+        github.list_unclassified_prs = AsyncMock(return_value=[])
+        github.list_issue_comments_since = AsyncMock(return_value=[])
+        github.list_pr_review_comments_since = AsyncMock(return_value=[])
+
         notifier = MagicMock()
         for attr in (
             "issue_picked_up", "issue_reviewed", "implementation_started",
             "implementation_finished", "pr_picked_up", "pr_reviewed",
-            "issue_auto_classified", "error",
+            "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
         ):
             setattr(notifier, attr, AsyncMock())
 

--- a/deile/tests/orchestration/pipeline/test_cron_runner_wiring.py
+++ b/deile/tests/orchestration/pipeline/test_cron_runner_wiring.py
@@ -1,0 +1,100 @@
+"""Tests for Gap 1 — CronRunner wired into /pipeline start/stop (issue #164)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from deile.commands.base import CommandContext
+from deile.commands.builtin.pipeline_command import PipelineCommand
+
+
+def _make_context(args: str = "start") -> tuple[CommandContext, MagicMock]:
+    agent = MagicMock()
+    agent.pipeline_monitor = None
+    agent.cron_runner = None
+    ctx = CommandContext(agent=agent, args=args, user_input=f"/{args}")
+    return ctx, agent
+
+
+class TestCronRunnerStart:
+    async def test_start_creates_and_starts_cron_runner(self):
+        ctx, agent = _make_context("start")
+        cmd = PipelineCommand()
+
+        cron_store_mock = MagicMock()
+        cron_store_mock.db_path = Path("/tmp/cron.db")
+        with patch("deile.commands.builtin.pipeline_command._resolve_repo", return_value="o/r"), \
+             patch("deile.commands.builtin.pipeline_command._resolve_base_path", return_value=Path("/tmp/x")), \
+             patch("deile.commands.builtin.pipeline_command.PipelineMonitor") as MockMonitor, \
+             patch("deile.orchestration.pipeline.review_callback.make_review_callback", return_value=AsyncMock()), \
+             patch("deile.cron.store.CronStore", return_value=cron_store_mock), \
+             patch("deile.cron.store.resolve_db_path", return_value=Path("/tmp/cron.db")), \
+             patch("deile.cron.runner.CronRunner.start", new_callable=AsyncMock), \
+             patch("deile.cron.runner.CronRunner.is_running", new_callable=lambda: property(lambda self: True)):
+            monitor_instance = MagicMock()
+            monitor_instance.start = AsyncMock()
+            monitor_instance.config.repo = "o/r"
+            monitor_instance.config.poll_interval_seconds = 60
+            monitor_instance.identity.monitor_id = "default"
+            MockMonitor.return_value = monitor_instance
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        assert "cron" in result.content.lower()
+
+    async def test_stop_stops_cron_runner(self):
+        ctx, agent = _make_context("stop")
+        cron_runner = MagicMock()
+        cron_runner.is_running = True
+        cron_runner.stop = AsyncMock()
+        agent.cron_runner = cron_runner
+
+        monitor_mock = MagicMock()
+        monitor_mock.is_running = True
+        monitor_mock.stop = AsyncMock()
+        agent.pipeline_monitor = monitor_mock
+
+        cmd = PipelineCommand()
+        result = await cmd.execute(ctx)
+
+        cron_runner.stop.assert_awaited_once()
+        assert result.success
+
+    async def test_stop_noop_when_no_cron_runner(self):
+        ctx, agent = _make_context("stop")
+        agent.cron_runner = None
+        monitor_mock = MagicMock()
+        monitor_mock.is_running = True
+        monitor_mock.stop = AsyncMock()
+        agent.pipeline_monitor = monitor_mock
+
+        cmd = PipelineCommand()
+        result = await cmd.execute(ctx)
+        assert result.success
+
+    async def test_status_shows_cron_info(self):
+        ctx, agent = _make_context("status")
+        cron_runner = MagicMock()
+        cron_runner.is_running = True
+        cron_runner.fired_count = 3
+        agent.cron_runner = cron_runner
+
+        monitor_mock = MagicMock()
+        monitor_mock.is_running = True
+        monitor_mock.stats.ticks = 5
+        monitor_mock.stats.issues_reviewed = 0
+        monitor_mock.stats.issues_implemented = 0
+        monitor_mock.stats.prs_reviewed = 0
+        monitor_mock.stats.errors = 0
+        monitor_mock.stats.gh_errors = 0
+        monitor_mock.stats.claude_errors = 0
+        monitor_mock.config.repo = "o/r"
+        agent.pipeline_monitor = monitor_mock
+
+        cmd = PipelineCommand()
+        result = await cmd.execute(ctx)
+
+        assert result.success
+        assert "cron" in result.content.lower()
+        assert "3" in result.content  # fired_count

--- a/deile/tests/orchestration/pipeline/test_dispatcher_gaps.py
+++ b/deile/tests/orchestration/pipeline/test_dispatcher_gaps.py
@@ -1,0 +1,33 @@
+"""Tests for render_mention_prompt added for issue #164 (gap 4)."""
+from __future__ import annotations
+
+from deile.orchestration.pipeline.claude_dispatcher import render_mention_prompt
+
+
+class TestRenderMentionPrompt:
+    def test_contains_author(self):
+        p = render_mention_prompt("o/r", "https://github.com/o/r/issues/1", "hello", "alice")
+        assert "alice" in p
+
+    def test_contains_context_url(self):
+        url = "https://github.com/o/r/issues/1"
+        p = render_mention_prompt("o/r", url, "msg", "bob")
+        assert url in p
+
+    def test_contains_comment_body(self):
+        p = render_mention_prompt("o/r", "url", "please do X", "user")
+        assert "please do X" in p
+
+    def test_contains_repo(self):
+        p = render_mention_prompt("owner/name", "url", "msg", "user")
+        assert "owner/name" in p
+
+    def test_is_nonempty_string(self):
+        p = render_mention_prompt("o/r", "https://github.com/o/r/issues/1", "body", "author")
+        assert isinstance(p, str)
+        assert len(p) > 0
+
+    def test_instructs_to_post_response(self):
+        p = render_mention_prompt("o/r", "https://github.com/o/r/issues/1", "body", "author")
+        # The prompt should instruct the agent to post a response
+        assert "gh" in p.lower() or "comment" in p.lower() or "responda" in p.lower()

--- a/deile/tests/orchestration/pipeline/test_dispatcher_gaps.py
+++ b/deile/tests/orchestration/pipeline/test_dispatcher_gaps.py
@@ -1,7 +1,8 @@
 """Tests for render_mention_prompt added for issue #164 (gap 4)."""
 from __future__ import annotations
 
-from deile.orchestration.pipeline.claude_dispatcher import render_mention_prompt
+from deile.orchestration.pipeline.claude_dispatcher import \
+    render_mention_prompt
 
 
 class TestRenderMentionPrompt:

--- a/deile/tests/orchestration/pipeline/test_github_client_gaps.py
+++ b/deile/tests/orchestration/pipeline/test_github_client_gaps.py
@@ -7,10 +7,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from deile.orchestration.pipeline.github_client import (
-    GhCommandError,
-    GitHubClient,
-)
+from deile.orchestration.pipeline.github_client import (GhCommandError,
+                                                        GitHubClient)
 
 
 class TestListUnclassifiedPrs:

--- a/deile/tests/orchestration/pipeline/test_github_client_gaps.py
+++ b/deile/tests/orchestration/pipeline/test_github_client_gaps.py
@@ -1,0 +1,259 @@
+"""Tests for new GitHubClient methods added for issue #164 (gaps 2+4)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.github_client import (
+    GhCommandError,
+    GitHubClient,
+)
+
+
+class TestListUnclassifiedPrs:
+    async def test_returns_prs_without_pipeline_labels(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 1,
+                "title": "pr 1",
+                "url": "https://g/o/r/pull/1",
+                "labels": [],
+                "headRefName": "feat/x",
+                "baseRefName": "main",
+                "state": "open",
+                "isDraft": False,
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_prs()
+        assert len(result) == 1
+        assert result[0].number == 1
+
+    async def test_filters_prs_with_pipeline_labels(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 2,
+                "title": "pr 2",
+                "url": "https://g/o/r/pull/2",
+                "labels": [{"name": "~review:pendente"}],
+                "headRefName": "b",
+                "baseRefName": "main",
+                "state": "open",
+                "isDraft": False,
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_prs()
+        assert result == []
+
+    async def test_filters_draft_prs(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 3,
+                "title": "pr 3",
+                "url": "https://g/o/r/pull/3",
+                "labels": [],
+                "headRefName": "b",
+                "baseRefName": "main",
+                "state": "open",
+                "isDraft": True,
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_prs()
+        assert result == []
+
+    async def test_returns_mixed_list_filtered_correctly(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {
+                "number": 10,
+                "title": "clean pr",
+                "url": "https://g/o/r/pull/10",
+                "labels": [],
+                "headRefName": "feat/a",
+                "baseRefName": "main",
+                "state": "open",
+                "isDraft": False,
+            },
+            {
+                "number": 11,
+                "title": "labelled pr",
+                "url": "https://g/o/r/pull/11",
+                "labels": [{"name": "~workflow:new"}],
+                "headRefName": "feat/b",
+                "baseRefName": "main",
+                "state": "open",
+                "isDraft": False,
+            },
+            {
+                "number": 12,
+                "title": "draft pr",
+                "url": "https://g/o/r/pull/12",
+                "labels": [],
+                "headRefName": "feat/c",
+                "baseRefName": "main",
+                "state": "open",
+                "isDraft": True,
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_unclassified_prs()
+        assert len(result) == 1
+        assert result[0].number == 10
+
+    async def test_gh_error_propagates(self):
+        client = GitHubClient("owner/name")
+        with patch.object(
+            client,
+            "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("pr", "list"), 1, "", "err")),
+        ):
+            with pytest.raises(GhCommandError):
+                await client.list_unclassified_prs()
+
+
+class TestListIssueCommentsSince:
+    async def test_returns_comments_after_since(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        payload = json.dumps([
+            {
+                "id": 42,
+                "body": "hello @deile-one",
+                "html_url": "https://github.com/o/r/issues/1#issuecomment-42",
+                "issue_url": "https://api.github.com/repos/o/r/issues/1",
+                "user": {"login": "alice"},
+            }
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_issue_comments_since(since)
+        assert len(result) == 1
+        assert result[0].comment_id == 42
+        assert result[0].author == "alice"
+        assert result[0].kind == "issue"
+
+    async def test_returns_empty_on_empty_list(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value="[]")):
+            result = await client.list_issue_comments_since(since)
+        assert result == []
+
+    async def test_returns_empty_on_gh_error(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        with patch.object(
+            client,
+            "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("api",), 1, "", "err")),
+        ):
+            result = await client.list_issue_comments_since(since)
+        assert result == []
+
+    async def test_skips_malformed_items(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        payload = json.dumps([
+            {"no_id_field": "bad"},
+            {
+                "id": 7,
+                "body": "good comment",
+                "html_url": "https://github.com/o/r/issues/2#c7",
+                "issue_url": "https://api.github.com/repos/o/r/issues/2",
+                "user": {"login": "bob"},
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_issue_comments_since(since)
+        assert len(result) == 1
+        assert result[0].comment_id == 7
+
+    async def test_issue_url_field_populated(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        issue_url = "https://api.github.com/repos/o/r/issues/5"
+        payload = json.dumps([
+            {
+                "id": 99,
+                "body": "msg",
+                "html_url": "https://github.com/o/r/issues/5#c99",
+                "issue_url": issue_url,
+                "user": {"login": "carol"},
+            }
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_issue_comments_since(since)
+        assert result[0].issue_url == issue_url
+
+
+class TestListPrReviewCommentsSince:
+    async def test_returns_pr_review_comments(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        payload = json.dumps([
+            {
+                "id": 99,
+                "body": "@deile-one revise isso",
+                "html_url": "https://github.com/o/r/pull/5#discussion_r99",
+                "pull_request_url": "https://api.github.com/repos/o/r/pulls/5",
+                "user": {"login": "bob"},
+            }
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_pr_review_comments_since(since)
+        assert len(result) == 1
+        assert result[0].kind == "pr_review"
+        assert result[0].author == "bob"
+
+    async def test_issue_url_set_to_pull_request_url(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        pr_url = "https://api.github.com/repos/o/r/pulls/8"
+        payload = json.dumps([
+            {
+                "id": 55,
+                "body": "review comment",
+                "html_url": "https://github.com/o/r/pull/8#discussion_r55",
+                "pull_request_url": pr_url,
+                "user": {"login": "dave"},
+            }
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_pr_review_comments_since(since)
+        assert result[0].issue_url == pr_url
+
+    async def test_returns_empty_on_gh_error(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        with patch.object(
+            client,
+            "_run_checked",
+            new=AsyncMock(side_effect=GhCommandError(("api",), 1, "", "err")),
+        ):
+            result = await client.list_pr_review_comments_since(since)
+        assert result == []
+
+    async def test_skips_malformed_items(self):
+        client = GitHubClient("owner/name")
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        payload = json.dumps([
+            {"no_id_field": "bad"},
+            {
+                "id": 22,
+                "body": "valid",
+                "html_url": "https://github.com/o/r/pull/3#discussion_r22",
+                "pull_request_url": "https://api.github.com/repos/o/r/pulls/3",
+                "user": {"login": "eve"},
+            },
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            result = await client.list_pr_review_comments_since(since)
+        assert len(result) == 1
+        assert result[0].comment_id == 22

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -1,0 +1,165 @@
+"""Tests for mention handling: _process_mentions() in PipelineMonitor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import CommentRef
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+
+
+def _comment(
+    comment_id: int,
+    body: str,
+    *,
+    author: str = "user1",
+    kind: str = "issue",
+) -> CommentRef:
+    return CommentRef(
+        comment_id=comment_id,
+        body=body,
+        html_url=f"https://github.com/o/r/issues/1#issuecomment-{comment_id}",
+        issue_url="https://api.github.com/repos/o/r/issues/1",
+        author=author,
+        kind=kind,
+    )
+
+
+def _make_monitor(
+    *,
+    issue_comments: list | None = None,
+    pr_comments: list | None = None,
+    claude_ok: bool = True,
+) -> tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+        mention_handle="@deile-one",
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(return_value=[])
+    github.list_open_prs = AsyncMock(return_value=[])
+    github.list_unclassified_issues = AsyncMock(return_value=[])
+    github.list_unclassified_prs = AsyncMock(return_value=[])
+    github.list_issue_comments_since = AsyncMock(return_value=list(issue_comments or []))
+    github.list_pr_review_comments_since = AsyncMock(return_value=list(pr_comments or []))
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up", "issue_reviewed", "implementation_started",
+        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    worktrees = MagicMock()
+    claude = MagicMock()
+    claude.run = AsyncMock(return_value=ClaudeRunResult(
+        returncode=0 if claude_ok else 1,
+        stdout="done",
+        stderr="",
+        duration_seconds=0.1,
+        cmd=("claude", "-p", "x"),
+    ))
+
+    monitor = PipelineMonitor(cfg, github=github, worktrees=worktrees, claude=claude, notifier=notifier)
+    return monitor, github, notifier
+
+
+class TestProcessMentions:
+    async def test_no_comments_no_dispatch(self):
+        monitor, github, notifier = _make_monitor()
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_not_called()
+        assert monitor.stats.mentions_processed == 0
+
+    async def test_comment_with_mention_dispatches(self):
+        comment = _comment(1, "Hey @deile-one can you help?")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_called_once_with(comment.html_url, comment.author)
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_comment_without_mention_skipped(self):
+        comment = _comment(2, "Just a regular comment, no mention here")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_not_called()
+        assert monitor.stats.mentions_processed == 0
+
+    async def test_mention_in_pr_review_comment_dispatches(self):
+        pr_comment = _comment(3, "@deile-one please review this", kind="pr_review")
+        monitor, github, notifier = _make_monitor(pr_comments=[pr_comment])
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_called_once()
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_both_issue_and_pr_comments_polled(self):
+        ic = _comment(10, "@deile-one issue mention")
+        pc = _comment(11, "@deile-one pr mention", kind="pr_review")
+        monitor, github, notifier = _make_monitor(issue_comments=[ic], pr_comments=[pc])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 2
+        assert notifier.mention_processed.call_count == 2
+
+    async def test_claude_run_fails_mention_not_counted(self):
+        """When claude.run returns non-ok, the mention is NOT counted."""
+        comment = _comment(4, "@deile-one do something")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment], claude_ok=False)
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_not_called()
+        assert monitor.stats.mentions_processed == 0
+
+    async def test_cursor_saved_after_processing(self, tmp_path):
+        """After _process_mentions(), the cursor file must exist."""
+        cfg = PipelineConfig(
+            repo="owner/name",
+            base_repo_path=tmp_path,
+            notify_user_id="42",
+        )
+        github = MagicMock()
+        github.list_issue_comments_since = AsyncMock(return_value=[])
+        github.list_pr_review_comments_since = AsyncMock(return_value=[])
+        notifier = MagicMock()
+        for attr in ("mention_processed", "error"):
+            setattr(notifier, attr, AsyncMock())
+        claude = MagicMock()
+        claude.run = AsyncMock(return_value=ClaudeRunResult(
+            returncode=0, stdout="", stderr="", duration_seconds=0.0, cmd=("claude",)
+        ))
+        monitor = PipelineMonitor(cfg, github=github, worktrees=MagicMock(), claude=claude, notifier=notifier)
+        await monitor._process_mentions()
+        assert monitor._mention_cursor_path.exists()
+
+    async def test_cursor_case_insensitive_match(self):
+        """Mention matching must be case-insensitive."""
+        comment = _comment(5, "Hello @DEILE-ONE, please help")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_poll_exception_does_not_crash(self):
+        """Exception during GitHub poll must be caught; loop continues cleanly."""
+        monitor, github, notifier = _make_monitor()
+        github.list_issue_comments_since = AsyncMock(side_effect=RuntimeError("network error"))
+        # Should not raise
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 0
+
+    async def test_mention_handling_disabled_skips_on_tick(self):
+        """When enable_mention_handling=False, _process_mentions is not called on tick."""
+        comment = _comment(6, "@deile-one ignored")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        monitor.config.enable_mention_handling = False
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        await monitor.tick()
+        github.list_issue_comments_since.assert_not_called()

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -66,12 +66,16 @@ def _make_monitor(
     github.list_pr_comments = AsyncMock(return_value=[])
     github.create_issue = AsyncMock(return_value=0)
     github.clear_batch_label = AsyncMock()
+    github.list_unclassified_prs = AsyncMock(return_value=[])
+    github.list_issue_comments_since = AsyncMock(return_value=[])
+    github.list_pr_review_comments_since = AsyncMock(return_value=[])
 
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
         "implementation_finished", "pr_picked_up", "pr_reviewed",
         "issue_auto_classified", "follow_ups_processed", "error",
+        "pr_auto_classified", "mention_processed",
     ):
         setattr(notifier, attr, AsyncMock())
 
@@ -315,6 +319,9 @@ def _make_minimal_monitor(
     github.list_issues_with_label = AsyncMock(return_value=[])
     github.list_open_prs = AsyncMock(return_value=[])
     github.list_unclassified_issues = AsyncMock(return_value=[])
+    github.list_unclassified_prs = AsyncMock(return_value=[])
+    github.list_issue_comments_since = AsyncMock(return_value=[])
+    github.list_pr_review_comments_since = AsyncMock(return_value=[])
 
     worktrees = MagicMock()
     worktrees.create_branch_worktree = AsyncMock(
@@ -324,7 +331,8 @@ def _make_minimal_monitor(
     notifier = MagicMock()
     for attr in ("issue_picked_up", "issue_reviewed", "implementation_started",
                  "implementation_finished", "pr_picked_up", "pr_reviewed",
-                 "issue_auto_classified", "follow_ups_processed", "error"):
+                 "issue_auto_classified", "follow_ups_processed", "error",
+                 "pr_auto_classified", "mention_processed"):
         setattr(notifier, attr, AsyncMock())
 
     schedule_store = MagicMock()

--- a/deile/tests/orchestration/pipeline/test_notifier_gaps.py
+++ b/deile/tests/orchestration/pipeline/test_notifier_gaps.py
@@ -1,0 +1,105 @@
+"""Tests for new DiscordNotifier methods added for issue #164 (gaps 2+4)."""
+from __future__ import annotations
+
+from deile.orchestration.pipeline.notifier import DiscordNotifier
+
+
+class TestPrAutoClassified:
+    async def test_sends_dm_with_pr_number(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.pr_auto_classified(7, "My PR title", "https://github.com/o/r/pull/7")
+        assert len(sent) == 1
+        assert "#7" in sent[0][1] or "7" in sent[0][1]
+
+    async def test_sends_dm_with_title(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.pr_auto_classified(3, "My Feature PR", "https://github.com/o/r/pull/3")
+        assert len(sent) == 1
+        assert "My Feature PR" in sent[0][1]
+
+    async def test_sends_dm_with_url(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        url = "https://github.com/o/r/pull/5"
+        await n.pr_auto_classified(5, "title", url)
+        assert url in sent[0][1]
+
+    async def test_noop_when_disabled(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="", dm_fn=fake_dm)
+        await n.pr_auto_classified(1, "t", "u")
+        assert sent == []
+
+    async def test_truncates_long_title(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append(text)
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        long_title = "A" * 200
+        await n.pr_auto_classified(1, long_title, "https://github.com/o/r/pull/1")
+        assert len(sent) == 1
+        # Title is truncated to 100 chars in the message
+        assert long_title[:100] in sent[0]
+        assert long_title[:101] not in sent[0]
+
+
+class TestMentionProcessed:
+    async def test_sends_dm_with_author(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.mention_processed("https://github.com/o/r/issues/3#c1", "alice")
+        assert len(sent) == 1
+        assert "alice" in sent[0][1]
+
+    async def test_sends_dm_with_context_url(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        url = "https://github.com/o/r/issues/3#c1"
+        await n.mention_processed(url, "alice")
+        assert url in sent[0][1]
+
+    async def test_noop_when_disabled(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append((uid, text))
+
+        n = DiscordNotifier(user_id="", dm_fn=fake_dm)
+        await n.mention_processed("url", "user")
+        assert sent == []
+
+    async def test_dm_failure_swallowed(self):
+        async def failing_dm(uid, text):
+            raise RuntimeError("network error")
+
+        n = DiscordNotifier(user_id="42", dm_fn=failing_dm)
+        # Must not raise
+        await n.mention_processed("https://github.com/o/r/issues/1", "bob")

--- a/deile/tests/orchestration/pipeline/test_post_merge_callback.py
+++ b/deile/tests/orchestration/pipeline/test_post_merge_callback.py
@@ -1,0 +1,182 @@
+"""Tests for make_post_merge_callback() factory and PipelineMonitor integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import PrRef
+from deile.orchestration.pipeline.labels import REVIEW_PENDING
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+from deile.orchestration.pipeline.post_merge_callback import \
+    make_post_merge_callback
+
+
+class TestMakePostMergeCallback:
+    def test_returns_none_when_agent_is_none(self):
+        cb = make_post_merge_callback(None)
+        assert cb is None
+
+    def test_returns_callable_when_agent_provided(self):
+        agent = MagicMock()
+        cb = make_post_merge_callback(agent)
+        assert callable(cb)
+
+    async def test_callback_calls_store_episode_with_correct_args(self):
+        episodic = MagicMock()
+        episodic.store_episode = AsyncMock()
+        mem = MagicMock()
+        mem.episodic_memory = episodic
+        agent = MagicMock()
+        agent.memory_manager = mem
+
+        cb = make_post_merge_callback(agent)
+        assert cb is not None
+        await cb(99, "fix: parser edge case", "https://github.com/o/r/pull/99")
+
+        episodic.store_episode.assert_called_once()
+        call_kwargs = episodic.store_episode.call_args.kwargs
+        assert "PR #99" in call_kwargs["user_input"]
+        assert "fix: parser edge case" in call_kwargs["user_input"]
+        assert call_kwargs["agent_response"] == "[pipeline:merge]"
+        assert call_kwargs["context"]["type"] == "pr_merged"
+        assert call_kwargs["context"]["pr_number"] == 99
+        assert call_kwargs["context"]["pr_url"] == "https://github.com/o/r/pull/99"
+        assert call_kwargs["session_id"] == "pipeline-merge-99"
+
+    async def test_callback_noop_when_memory_manager_missing(self):
+        agent = MagicMock(spec=[])  # no memory_manager attribute
+        cb = make_post_merge_callback(agent)
+        assert cb is not None
+        # Should not raise
+        await cb(1, "title", "url")
+
+    async def test_callback_noop_when_episodic_memory_missing(self):
+        mem = MagicMock(spec=[])  # no episodic_memory attribute
+        agent = MagicMock()
+        agent.memory_manager = mem
+        cb = make_post_merge_callback(agent)
+        assert cb is not None
+        # Should not raise
+        await cb(2, "title", "url")
+
+    async def test_callback_swallows_store_episode_exception(self):
+        episodic = MagicMock()
+        episodic.store_episode = AsyncMock(side_effect=RuntimeError("db error"))
+        mem = MagicMock()
+        mem.episodic_memory = episodic
+        agent = MagicMock()
+        agent.memory_manager = mem
+
+        cb = make_post_merge_callback(agent)
+        assert cb is not None
+        # Must not raise — best-effort
+        await cb(3, "title", "url")
+
+
+# ---------------------------------------------------------------------------
+# Integration: PipelineMonitor calls post_merge_callback after PR merge
+# ---------------------------------------------------------------------------
+
+def _make_monitor_with_cb(
+    *,
+    claude_stdout: str = "merged.",
+    claude_rc: int = 0,
+    post_merge_callback=None,
+) -> tuple[PipelineMonitor, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(return_value=[])
+    github.list_open_prs = AsyncMock(return_value=[
+        PrRef(
+            number=77, title="feat: something", url="https://github.com/o/r/pull/77",
+            labels=(REVIEW_PENDING,), head_ref="auto/issue-5",
+        )
+    ])
+    github.list_unclassified_issues = AsyncMock(return_value=[])
+    github.list_unclassified_prs = AsyncMock(return_value=[])
+    github.list_issue_comments_since = AsyncMock(return_value=[])
+    github.list_pr_review_comments_since = AsyncMock(return_value=[])
+    github.claim_with_batch = AsyncMock(return_value="abc12345")
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.clear_batch_label = AsyncMock()
+    github.get_pr_body = AsyncMock(return_value="")
+    github.list_pr_comments = AsyncMock(return_value=[])
+    github.create_issue = AsyncMock(return_value=0)
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up", "issue_reviewed", "implementation_started",
+        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "issue_auto_classified", "follow_ups_processed", "error",
+        "pr_auto_classified", "mention_processed",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    worktrees = MagicMock()
+    from deile.orchestration.pipeline.worktree_manager import Worktree
+    worktrees.create_branch_worktree = AsyncMock(
+        return_value=Worktree(path=Path("/tmp/fake/.wt"), branch="x", base_repo=Path("/tmp/fake"))
+    )
+
+    claude = MagicMock()
+    claude.run = AsyncMock(return_value=ClaudeRunResult(
+        returncode=claude_rc,
+        stdout=claude_stdout,
+        stderr="",
+        duration_seconds=0.1,
+        cmd=("claude", "-p", "x"),
+    ))
+
+    monitor = PipelineMonitor(
+        cfg,
+        github=github,
+        worktrees=worktrees,
+        claude=claude,
+        notifier=notifier,
+        post_merge_callback=post_merge_callback,
+    )
+    monitor.config.enable_review = False
+    monitor.config.enable_implement = False
+    return monitor, notifier
+
+
+class TestMonitorCallsPostMergeCallback:
+    async def test_callback_called_after_merge(self):
+        called_with: list = []
+
+        async def _cb(pr_number: int, pr_title: str, pr_url: str) -> None:
+            called_with.append((pr_number, pr_title, pr_url))
+
+        monitor, _ = _make_monitor_with_cb(claude_stdout="merged.", post_merge_callback=_cb)
+        await monitor.tick()
+        assert len(called_with) == 1
+        assert called_with[0][0] == 77
+        assert called_with[0][1] == "feat: something"
+
+    async def test_callback_not_called_when_not_merged(self):
+        called_with: list = []
+
+        async def _cb(pr_number: int, pr_title: str, pr_url: str) -> None:
+            called_with.append((pr_number, pr_title, pr_url))
+
+        monitor, _ = _make_monitor_with_cb(claude_stdout="review done", post_merge_callback=_cb)
+        await monitor.tick()
+        assert called_with == []
+
+    async def test_callback_failure_does_not_propagate(self):
+        async def _cb(pr_number: int, pr_title: str, pr_url: str) -> None:
+            raise RuntimeError("episodic db unavailable")
+
+        monitor, _ = _make_monitor_with_cb(claude_stdout="merged.", post_merge_callback=_cb)
+        # Must not raise
+        await monitor.tick()
+        assert monitor.stats.prs_reviewed == 1

--- a/deile/tests/orchestration/pipeline/test_pr_triage.py
+++ b/deile/tests/orchestration/pipeline/test_pr_triage.py
@@ -40,6 +40,7 @@ def _make_monitor(*, unclassified_prs: list | None = None) -> tuple[PipelineMoni
     github.add_labels = AsyncMock()
     github.comment_on_issue = AsyncMock()
     github.comment_on_pr = AsyncMock()
+    github.clear_batch_label = AsyncMock()
     github.list_issue_comments_since = AsyncMock(return_value=[])
     github.list_pr_review_comments_since = AsyncMock(return_value=[])
 
@@ -73,6 +74,7 @@ class TestClassifyNewPrs:
         monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
         await monitor._classify_new_prs()
         github.add_labels.assert_called_once_with("pr", 42, [REVIEW_PENDING])
+        github.clear_batch_label.assert_called_once_with("pr", 42)
         notifier.pr_auto_classified.assert_called_once_with(42, pr.title, pr.url)
         assert monitor.stats.prs_classified == 1
 

--- a/deile/tests/orchestration/pipeline/test_pr_triage.py
+++ b/deile/tests/orchestration/pipeline/test_pr_triage.py
@@ -1,0 +1,155 @@
+"""Tests for PR triage: _classify_new_prs() in PipelineMonitor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import GhCommandError, PrRef
+from deile.orchestration.pipeline.labels import REVIEW_PENDING
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+
+
+def _pr(number: int, labels: tuple = ()) -> PrRef:
+    return PrRef(
+        number=number,
+        title=f"PR #{number}",
+        url=f"https://github.com/o/r/pull/{number}",
+        labels=labels,
+        head_ref=f"feat/pr-{number}",
+    )
+
+
+def _make_monitor(*, unclassified_prs: list | None = None) -> tuple[PipelineMonitor, MagicMock, MagicMock]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+    )
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(return_value=[])
+    github.list_open_prs = AsyncMock(return_value=[])
+    github.list_unclassified_issues = AsyncMock(return_value=[])
+    github.list_unclassified_prs = AsyncMock(return_value=list(unclassified_prs or []))
+    github.claim_with_batch = AsyncMock(return_value="abc12345")
+    github.transition_issue = AsyncMock()
+    github.transition_pr = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+    github.list_issue_comments_since = AsyncMock(return_value=[])
+    github.list_pr_review_comments_since = AsyncMock(return_value=[])
+
+    notifier = MagicMock()
+    for attr in (
+        "issue_picked_up", "issue_reviewed", "implementation_started",
+        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
+    ):
+        setattr(notifier, attr, AsyncMock())
+
+    worktrees = MagicMock()
+    claude = MagicMock()
+    claude.run = AsyncMock(return_value=ClaudeRunResult(
+        returncode=0, stdout="", stderr="", duration_seconds=0.1, cmd=("claude", "-p", "x")
+    ))
+
+    monitor = PipelineMonitor(cfg, github=github, worktrees=worktrees, claude=claude, notifier=notifier)
+    return monitor, github, notifier
+
+
+class TestClassifyNewPrs:
+    async def test_no_unclassified_prs_noop(self):
+        monitor, github, notifier = _make_monitor(unclassified_prs=[])
+        await monitor._classify_new_prs()
+        github.add_labels.assert_not_called()
+        notifier.pr_auto_classified.assert_not_called()
+
+    async def test_one_unclassified_pr_gets_label(self):
+        pr = _pr(42)
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
+        await monitor._classify_new_prs()
+        github.add_labels.assert_called_once_with("pr", 42, [REVIEW_PENDING])
+        notifier.pr_auto_classified.assert_called_once_with(42, pr.title, pr.url)
+        assert monitor.stats.prs_classified == 1
+
+    async def test_pr_with_tilde_label_skipped(self):
+        """PR that already has a pipeline label (starts with ~) must be skipped."""
+        pr = _pr(43, labels=("~workflow:nova",))
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
+        await monitor._classify_new_prs()
+        github.add_labels.assert_not_called()
+        assert monitor.stats.prs_classified == 0
+
+    async def test_claim_returns_none_skips_pr(self):
+        """When claim_with_batch returns None (already claimed), PR is skipped."""
+        pr = _pr(44)
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
+        github.claim_with_batch = AsyncMock(return_value=None)
+        await monitor._classify_new_prs()
+        github.add_labels.assert_not_called()
+        assert monitor.stats.prs_classified == 0
+
+    async def test_claim_raises_gh_error_counts_error_and_continues(self):
+        """GhCommandError during claim increments error counter and continues loop."""
+        pr1 = _pr(45)
+        pr2 = _pr(46)
+
+        async def _claim(kind, number, title):
+            if number == 45:
+                raise GhCommandError(["gh"], 1, "", "network")
+            return "abc"
+
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr1, pr2])
+        github.claim_with_batch = AsyncMock(side_effect=_claim)
+        await monitor._classify_new_prs()
+        assert monitor.stats.errors == 1
+        assert monitor.stats.gh_errors == 1
+        # pr2 should still be classified
+        github.add_labels.assert_called_once_with("pr", 46, [REVIEW_PENDING])
+
+    async def test_add_labels_raises_counts_error_and_notifies(self):
+        """GhCommandError in add_labels increments error counter and calls notifier.error."""
+        pr = _pr(47)
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
+        github.add_labels = AsyncMock(side_effect=GhCommandError(["gh"], 1, "", "label error"))
+        await monitor._classify_new_prs()
+        assert monitor.stats.errors == 1
+        assert monitor.stats.gh_errors == 1
+        notifier.error.assert_called_once()
+        assert monitor.stats.prs_classified == 0
+
+    async def test_list_unclassified_prs_gh_error_notifies(self):
+        """GhCommandError in list_unclassified_prs increments counters and calls notifier.error."""
+        monitor, github, notifier = _make_monitor()
+        github.list_unclassified_prs = AsyncMock(
+            side_effect=GhCommandError(["gh"], 1, "", "network error")
+        )
+        await monitor._classify_new_prs()
+        assert monitor.stats.errors == 1
+        assert monitor.stats.gh_errors == 1
+        notifier.error.assert_called_once()
+
+    async def test_list_unclassified_prs_generic_error_no_crash(self):
+        """Generic exception in list_unclassified_prs is caught and increments error counter."""
+        monitor, github, notifier = _make_monitor()
+        github.list_unclassified_prs = AsyncMock(side_effect=RuntimeError("unexpected"))
+        await monitor._classify_new_prs()
+        assert monitor.stats.errors == 1
+        notifier.error.assert_not_called()
+
+    async def test_pr_triage_disabled_skips_all(self):
+        """When enable_pr_triage=False, _classify_new_prs is not called on tick."""
+        pr = _pr(50)
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_mention_handling = False
+        await monitor.tick()
+        github.list_unclassified_prs.assert_not_called()


### PR DESCRIPTION
## Summary

- **Gap 1 — CronRunner dead code**: `/pipeline start` now instantiates `CronStore` + `CronRunner`, wires it via `make_fire_callback`, starts it alongside the pipeline, and stops/status it in the `stop`/`status` sub-commands.
- **Gap 2 — PR triage (Stage 0-B)**: `GitHubClient.list_unclassified_prs()` + `PipelineMonitor._classify_new_prs()` apply `~review:pendente` to open non-draft PRs without pipeline labels; `DiscordNotifier.pr_auto_classified()` fires on each.
- **Gap 3 — Post-merge episodic memory**: `make_post_merge_callback(agent)` stores a `pr_merged` episode in `episodic_memory` after every merge; wired into `_review_one_open_pr()` and both `PipelineMonitor` construction sites in `pipeline_command.py`.
- **Gap 4 — @deile-one mention handling**: `GitHubClient` gains `CommentRef`, `list_issue_comments_since(since)`, `list_pr_review_comments_since(since)`; `ClaudeDispatcher` gains `render_mention_prompt()`; `PipelineMonitor._process_mentions()` polls since a file-backed cursor, dispatches matching comments to Claude, and advances the cursor.

## Files changed (15)

- `pipeline_command.py` — CronRunner wiring + `post_merge_callback` injection
- `github_client.py` — `CommentRef`, 3 new query methods
- `monitor.py` — 3 new `PipelineConfig` flags, 2 new `_Stats` counters, 4 new methods, `post_merge_callback` param
- `notifier.py` — `pr_auto_classified`, `mention_processed`
- `claude_dispatcher.py` — `render_mention_prompt`
- `post_merge_callback.py` — new file, factory for episodic callback
- 9 test files (4 new, 5 updated) — 68 new tests

## Test plan

- [ ] `python3 -m pytest deile/tests/orchestration/pipeline/ -q` → all pass
- [ ] Full suite (excluding deilebot tests): 1934 passed, 14 skipped, 0 failed
- [ ] `ruff check deile/` → clean
- [ ] `isort --check-only deile/` → clean
- [ ] CronRunner starts/stops alongside pipeline (manual: `/pipeline start` / `/pipeline stop`)
- [ ] PR triage: open non-draft PR with no `~` labels → gets `~review:pendente` on next tick
- [ ] Mention: comment `@deile-one please do X` → Claude dispatched, notifier fires
- [ ] Post-merge: PR merge → episodic memory entry appears in SQLite

Closes #164

By [DEILE One](mailto:deile@deile.info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)