### PR TITLE
fix(commands): wire real data for /context, /cost, /export

### DIFF
--- a/deile/commands/builtin/context_command.py
+++ b/deile/commands/builtin/context_command.py
@@ -1,5 +1,6 @@
 """Context Command — exibe informações reais do contexto LLM"""
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -12,15 +13,13 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ..base import CommandResult, DirectCommand
 
-_INDISPONIVEL = {"status": "indisponível"}
-
 
 def _indisponivel(motivo: str = "") -> Dict[str, Any]:
     return {"status": "indisponível", "motivo": motivo}
 
 
-def _est_tokens(text: str) -> int:
-    return max(1, len(text) // 4)
+def _est_tokens(char_count: int) -> int:
+    return max(1, char_count // 4)
 
 
 class ContextCommand(DirectCommand):
@@ -101,6 +100,15 @@ class ContextCommand(DirectCommand):
         agent = getattr(context, "agent", None)
         session = getattr(context, "session", None)
 
+        # Fan out the two independent async subsystems in parallel
+        mm = getattr(agent, "memory_manager", None) if agent else None
+        ctx_mgr = getattr(agent, "context_manager", None) if agent else None
+        raw_memory, raw_stats = await asyncio.gather(
+            mm.get_memory_usage() if mm else asyncio.sleep(0),
+            ctx_mgr.get_stats() if ctx_mgr else asyncio.sleep(0),
+            return_exceptions=True,
+        )
+
         # --- Persona ---
         persona_data: Dict[str, Any]
         try:
@@ -118,15 +126,12 @@ class ContextCommand(DirectCommand):
 
         # --- Memória ---
         memory_data: Dict[str, Any]
-        try:
-            mm = getattr(agent, "memory_manager", None) if agent else None
-            if mm:
-                usage = await mm.get_memory_usage()
-                memory_data = usage
-            else:
-                memory_data = _indisponivel("memory_manager não disponível")
-        except Exception as exc:
-            memory_data = _indisponivel(str(exc))
+        if not mm:
+            memory_data = _indisponivel("memory_manager não disponível")
+        elif isinstance(raw_memory, Exception):
+            memory_data = _indisponivel(str(raw_memory))
+        else:
+            memory_data = raw_memory
 
         # --- Histórico de conversa ---
         conv_data: Dict[str, Any]
@@ -180,7 +185,7 @@ class ContextCommand(DirectCommand):
                 provider_names = list(providers.keys())
                 model_data = {
                     "providers": provider_names,
-                    "strategy": getattr(mr, "strategy", _INDISPONIVEL),
+                    "strategy": getattr(mr, "strategy", _indisponivel("strategy não disponível")),
                 }
             else:
                 model_data = _indisponivel("model_router não disponível")
@@ -208,20 +213,17 @@ class ContextCommand(DirectCommand):
 
         # --- Instruções do sistema (estimativa) ---
         instructions_data: Dict[str, Any]
-        try:
-            ctx_mgr = getattr(agent, "context_manager", None) if agent else None
-            if ctx_mgr:
-                stats = await ctx_mgr.get_stats()
-                instr_len = stats.get("system_instructions_length", 0)
-                instructions_data = {
-                    "length": instr_len,
-                    "tokens": _est_tokens(" " * instr_len),
-                    "token_count_method": "estimated",
-                }
-            else:
-                instructions_data = _indisponivel("context_manager não disponível")
-        except Exception as exc:
-            instructions_data = _indisponivel(str(exc))
+        if not ctx_mgr:
+            instructions_data = _indisponivel("context_manager não disponível")
+        elif isinstance(raw_stats, Exception):
+            instructions_data = _indisponivel(str(raw_stats))
+        else:
+            instr_len = raw_stats.get("system_instructions_length", 0)
+            instructions_data = {
+                "length": instr_len,
+                "tokens": _est_tokens(instr_len),
+                "token_count_method": "estimated",
+            }
 
         return {
             "system_instructions": instructions_data,

--- a/deile/commands/builtin/context_command.py
+++ b/deile/commands/builtin/context_command.py
@@ -218,12 +218,20 @@ class ContextCommand(DirectCommand):
         elif isinstance(raw_stats, Exception):
             instructions_data = _indisponivel(str(raw_stats))
         else:
-            instr_len = raw_stats.get("system_instructions_length", 0)
-            instructions_data = {
-                "length": instr_len,
-                "tokens": _est_tokens(instr_len),
-                "token_count_method": "estimated",
-            }
+            instr_len = raw_stats.get("system_instructions_length")
+            if instr_len is not None:
+                instructions_data = {
+                    "length": instr_len,
+                    "tokens": _est_tokens(instr_len),
+                    "token_count_method": "estimated",
+                }
+            else:
+                # context_manager.get_stats() exposes context window limit, not instruction length
+                instructions_data = {
+                    "max_context_tokens": raw_stats.get("max_context_tokens", "indisponível"),
+                    "context_builds": raw_stats.get("context_builds", 0),
+                    "token_count_method": "not_available",
+                }
 
         return {
             "system_instructions": instructions_data,
@@ -340,10 +348,10 @@ class ContextCommand(DirectCommand):
             f"**Estratégia**: {model.get('strategy', 'indisponível')}",
             "",
             "**Instruções do Sistema**:",
-            f"  Tamanho: {instr.get('length', 'indisponível')} chars",
+            f"  Tamanho: {instr.get('length', instr.get('max_context_tokens', 'indisponível'))} chars",
         ]
         if show_tokens:
-            model_content.append(f"  Tokens: {instr.get('tokens', 'indisponível')}")
+            model_content.append(f"  Tokens: {instr.get('tokens', instr.get('token_count_method', 'indisponível'))}")
         panels.append(Panel("\n".join(model_content), title="🤖 Modelo", border_style="green"))
 
         memory = data.get("memory", {})

--- a/deile/commands/builtin/context_command.py
+++ b/deile/commands/builtin/context_command.py
@@ -1,6 +1,8 @@
-"""Context Command - Display LLM context information"""
+"""Context Command — exibe informações reais do contexto LLM"""
 
 import json
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from rich.columns import Columns
@@ -10,288 +12,391 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ..base import CommandResult, DirectCommand
 
+_INDISPONIVEL = {"status": "indisponível"}
+
+
+def _indisponivel(motivo: str = "") -> Dict[str, Any]:
+    return {"status": "indisponível", "motivo": motivo}
+
+
+def _est_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
 
 class ContextCommand(DirectCommand):
-    """Display complete LLM context: system instructions, memory, history, tools and token usage breakdown"""
-    
+    """Exibe contexto LLM completo: instruções, memória, histórico, tools e tokens"""
+
     def __init__(self):
         from ...config.manager import CommandConfig
         config = CommandConfig(
             name="context",
-            description="Display complete LLM context: system instructions, memory, history, tools and token usage breakdown.",
+            description="Exibe o contexto LLM completo: instruções, memória, histórico, tools e uso de tokens.",
         )
         super().__init__(config)
-    
+
     async def execute(self, context) -> CommandResult:
-        """Execute context command"""
-        args = context.args if hasattr(context, 'args') else ""
-        
+        args = context.args if hasattr(context, "args") else ""
+
         try:
-            # Parse arguments
             parts = args.strip().split() if args.strip() else []
-            format_type = "summary"  # default
-            _export = False
+            format_type = "summary"
+            export_format: Optional[str] = None
             show_tokens = False
-            
+
             i = 0
             while i < len(parts):
-                if parts[i] in ["--format", "-f"]:
-                    if i + 1 < len(parts):
-                        format_type = parts[i + 1]
-                        i += 2
-                    else:
-                        raise CommandError("--format requires a value (summary, detailed, json)")
-                elif parts[i] in ["--export", "-e"]:
-                    _export = True
+                p = parts[i]
+                if p in ("--format", "-f") and i + 1 < len(parts):
+                    format_type = parts[i + 1]
+                    i += 2
+                elif p in ("--export", "-e") and i + 1 < len(parts):
+                    export_format = parts[i + 1]
+                    i += 2
+                elif p in ("--export", "-e"):
+                    export_format = "json"
                     i += 1
-                elif parts[i] in ["--show-tokens", "-t"]:
+                elif p in ("--show-tokens", "-t"):
                     show_tokens = True
                     i += 1
-                else:
-                    format_type = parts[i]  # Positional argument
+                elif p in ("summary", "detailed", "json"):
+                    format_type = p
                     i += 1
-            
-            if format_type not in ["summary", "detailed", "json"]:
-                raise CommandError("Format must be one of: summary, detailed, json")
-            
-            # Get context from agent (this would be injected in real implementation)
-            context_data = self._get_context_data(context)
-            
+                else:
+                    i += 1
+
+            if format_type not in ("summary", "detailed", "json"):
+                raise CommandError("Formato deve ser um de: summary, detailed, json")
+
+            context_data = await self._get_context_data(context)
+
+            if export_format:
+                return await self._do_export(context_data, export_format)
+
             if format_type == "json":
                 return CommandResult.success_result(
                     content=json.dumps(context_data, indent=2, default=str),
                     content_type="json",
                     command_name="context",
-                    format="json"
+                    format="json",
                 )
-            
-            # Create Rich display
+
             if format_type == "summary":
                 display = self._create_summary_display(context_data, show_tokens)
-            else:  # detailed
+            else:
                 display = self._create_detailed_display(context_data, show_tokens)
-            
+
             return CommandResult.success_result(
                 content=display,
                 content_type="rich",
                 command_name="context",
-                format=format_type
+                format=format_type,
             )
-            
-        except Exception as e:
-            raise CommandError(f"Failed to display context: {str(e)}")
-    
-    def _get_context_data(self, context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-        """Get context data from agent (mock implementation)"""
-        
-        # In real implementation, this would get data from the agent
-        return {
-            "system_instructions": {
-                "length": 2500,
-                "tokens": 625,
-                "content_preview": "You are DEILE, an AI assistant specialized in software development..."
-            },
-            "persona": {
-                "active": True,
-                "length": 800,
-                "tokens": 200,
-                "name": "Developer Assistant"
-            },
-            "memory": {
-                "short_term": {
-                    "entries": 15,
-                    "tokens": 1200,
-                    "last_update": "2025-09-06T18:45:00"
-                },
-                "long_term": {
-                    "entries": 45,
-                    "tokens": 3500,
-                    "indexed": True
+
+        except CommandError:
+            raise
+        except Exception as exc:
+            raise CommandError(f"Falha ao exibir contexto: {exc}") from exc
+
+    async def _get_context_data(self, context) -> Dict[str, Any]:
+        agent = getattr(context, "agent", None)
+        session = getattr(context, "session", None)
+
+        # --- Persona ---
+        persona_data: Dict[str, Any]
+        try:
+            pm = getattr(agent, "persona_manager", None) if agent else None
+            persona = pm.get_active_persona() if pm else None
+            if persona:
+                persona_data = {
+                    "name": getattr(persona, "name", "desconhecida"),
+                    "active": True,
                 }
-            },
-            "conversation_history": {
-                "messages": 23,
-                "tokens": 8500,
-                "oldest_message": "2025-09-06T15:30:00",
-                "newest_message": "2025-09-06T18:44:30"
-            },
-            "tools": {
-                "total": 12,
-                "enabled": 11,
-                "categories": ["file", "execution", "search", "network"],
-                "total_tokens": 2400
-            },
-            "model": {
-                "name": "gemini-2.5-pro",
-                "max_tokens": 2048000,
-                "temperature": 0.7,
-                "provider": "Google GenAI"
-            },
-            "token_usage": {
-                "total": 16225,
-                "percentage": 0.79,
-                "breakdown": {
-                    "system": 625,
-                    "persona": 200,
-                    "memory": 4700,
-                    "history": 8500,
-                    "tools": 2400
-                }
-            },
-            "session": {
-                "id": "session_20250906_184500",
-                "started": "2025-09-06T15:30:00",
-                "duration": "3h 15m",
-                "requests": 23
+            else:
+                persona_data = {"name": "nenhuma", "active": False}
+        except Exception as exc:
+            persona_data = _indisponivel(str(exc))
+
+        # --- Memória ---
+        memory_data: Dict[str, Any]
+        try:
+            mm = getattr(agent, "memory_manager", None) if agent else None
+            if mm:
+                usage = await mm.get_memory_usage()
+                memory_data = usage
+            else:
+                memory_data = _indisponivel("memory_manager não disponível")
+        except Exception as exc:
+            memory_data = _indisponivel(str(exc))
+
+        # --- Histórico de conversa ---
+        conv_data: Dict[str, Any]
+        try:
+            history = getattr(session, "conversation_history", []) if session else []
+            created_at = getattr(session, "created_at", None) if session else None
+            last_activity = getattr(session, "last_activity", None) if session else None
+
+            oldest = (
+                datetime.fromtimestamp(created_at, tz=timezone.utc).isoformat()
+                if created_at
+                else None
+            )
+            newest = (
+                datetime.fromtimestamp(last_activity, tz=timezone.utc).isoformat()
+                if last_activity
+                else None
+            )
+            conv_data = {
+                "messages": len(history),
+                "oldest_message": oldest,
+                "newest_message": newest,
             }
+        except Exception as exc:
+            conv_data = _indisponivel(str(exc))
+
+        # --- Tools ---
+        tools_data: Dict[str, Any]
+        try:
+            tr = getattr(agent, "tool_registry", None) if agent else None
+            if tr:
+                all_tools = tr.list_all()
+                enabled_tools = tr.list_enabled()
+                categories = list({getattr(t, "category", "other") for t in all_tools})
+                tools_data = {
+                    "total": len(all_tools),
+                    "enabled": len(enabled_tools),
+                    "categories": categories,
+                }
+            else:
+                tools_data = _indisponivel("tool_registry não disponível")
+        except Exception as exc:
+            tools_data = _indisponivel(str(exc))
+
+        # --- Modelo ---
+        model_data: Dict[str, Any]
+        try:
+            mr = getattr(agent, "model_router", None) if agent else None
+            if mr:
+                providers = getattr(mr, "providers", {})
+                provider_names = list(providers.keys())
+                model_data = {
+                    "providers": provider_names,
+                    "strategy": getattr(mr, "strategy", _INDISPONIVEL),
+                }
+            else:
+                model_data = _indisponivel("model_router não disponível")
+        except Exception as exc:
+            model_data = _indisponivel(str(exc))
+
+        # --- Sessão ---
+        session_data: Dict[str, Any]
+        try:
+            if session:
+                session_id = getattr(session, "session_id", "desconhecido")
+                created_at = getattr(session, "created_at", None)
+                session_data = {
+                    "id": session_id,
+                    "started": (
+                        datetime.fromtimestamp(created_at, tz=timezone.utc).isoformat()
+                        if created_at
+                        else None
+                    ),
+                }
+            else:
+                session_data = _indisponivel("sessão não disponível")
+        except Exception as exc:
+            session_data = _indisponivel(str(exc))
+
+        # --- Instruções do sistema (estimativa) ---
+        instructions_data: Dict[str, Any]
+        try:
+            ctx_mgr = getattr(agent, "context_manager", None) if agent else None
+            if ctx_mgr:
+                stats = await ctx_mgr.get_stats()
+                instr_len = stats.get("system_instructions_length", 0)
+                instructions_data = {
+                    "length": instr_len,
+                    "tokens": _est_tokens(" " * instr_len),
+                    "token_count_method": "estimated",
+                }
+            else:
+                instructions_data = _indisponivel("context_manager não disponível")
+        except Exception as exc:
+            instructions_data = _indisponivel(str(exc))
+
+        return {
+            "system_instructions": instructions_data,
+            "persona": persona_data,
+            "memory": memory_data,
+            "conversation_history": conv_data,
+            "tools": tools_data,
+            "model": model_data,
+            "session": session_data,
         }
-    
+
+    async def _do_export(self, context_data: Dict[str, Any], fmt: str) -> CommandResult:
+        if fmt not in ("json", "md"):
+            return CommandResult.error_result(
+                f"Formato de export inválido: '{fmt}'. Use 'json' ou 'md'."
+            )
+
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        fname = f"context_export_{ts}.{fmt}"
+
+        try:
+            if fmt == "json":
+                content = json.dumps(context_data, indent=2, default=str)
+                Path(fname).write_text(content, encoding="utf-8")
+            else:
+                lines = ["# Exportação de Contexto DEILE", ""]
+                session = context_data.get("session", {})
+                lines.append(f"**Sessão:** {session.get('id', 'indisponível')}")
+                lines.append(f"**Iniciado:** {session.get('started', 'indisponível')}")
+                lines.append("")
+
+                persona = context_data.get("persona", {})
+                lines.append(f"## Persona\n- **Nome:** {persona.get('name', 'indisponível')}")
+                lines.append("")
+
+                model = context_data.get("model", {})
+                providers = model.get("providers", "indisponível")
+                lines.append(f"## Modelo\n- **Provedores:** {providers}")
+                lines.append("")
+
+                tools = context_data.get("tools", {})
+                lines.append(
+                    f"## Tools\n- **Total:** {tools.get('total', 'indisponível')}"
+                    f"\n- **Habilitadas:** {tools.get('enabled', 'indisponível')}"
+                )
+                lines.append("")
+
+                conv = context_data.get("conversation_history", {})
+                lines.append(
+                    f"## Histórico\n- **Mensagens:** {conv.get('messages', 'indisponível')}"
+                )
+                content = "\n".join(lines)
+                Path(fname).write_text(content, encoding="utf-8")
+
+            return CommandResult.success_result(
+                content=Panel(
+                    Text(f"✅ Exportado: {fname}", style="green"),
+                    title="📤 Export de Contexto",
+                    border_style="green",
+                ),
+                content_type="rich",
+                command_name="context",
+                exported_file=fname,
+            )
+        except Exception as exc:
+            return CommandResult.error_result(f"Falha ao exportar: {exc}", error=exc)
+
     def _create_summary_display(self, data: Dict[str, Any], show_tokens: bool) -> Panel:
-        """Create summary display"""
-        
-        # Token usage summary
-        token_data = data.get("token_usage", {})
-        total_tokens = token_data.get("total", 0)
-        percentage = token_data.get("percentage", 0) * 100
-        
-        # Create content
-        content_lines = [
-            "📊 **Context Overview**",
-            "",
-            f"🤖 **Model**: {data.get('model', {}).get('name', 'Unknown')}",
-            f"⏱️  **Session**: {data.get('session', {}).get('duration', 'Unknown')}",
-            f"💬 **Messages**: {data.get('conversation_history', {}).get('messages', 0)}",
-            f"🔧 **Tools**: {data.get('tools', {}).get('enabled', 0)}/{data.get('tools', {}).get('total', 0)} enabled"
-        ]
-        
-        if show_tokens:
-            content_lines.extend([
-                "",
-                f"🎯 **Token Usage**: {total_tokens:,} ({percentage:.1f}%)",
-                f"   • System: {token_data.get('breakdown', {}).get('system', 0):,}",
-                f"   • Memory: {token_data.get('breakdown', {}).get('memory', 0):,}",
-                f"   • History: {token_data.get('breakdown', {}).get('history', 0):,}",
-                f"   • Tools: {token_data.get('breakdown', {}).get('tools', 0):,}"
-            ])
-        
-        content = "\n".join(content_lines)
-        
-        return Panel(
-            Text(content, style="white"),
-            title="🧠 LLM Context",
-            border_style="blue",
-            padding=(1, 2)
-        )
-    
-    def _create_detailed_display(self, data: Dict[str, Any], show_tokens: bool) -> Columns:
-        """Create detailed display with multiple panels"""
-        
-        panels = []
-        
-        # System & Model Panel
-        model_info = data.get("model", {})
-        system_info = data.get("system_instructions", {})
-        
-        model_content = [
-            f"**Model**: {model_info.get('name', 'Unknown')}",
-            f"**Provider**: {model_info.get('provider', 'Unknown')}",
-            f"**Max Tokens**: {model_info.get('max_tokens', 0):,}",
-            f"**Temperature**: {model_info.get('temperature', 0.7)}",
-            "",
-            "**System Instructions**:",
-            f"  Length: {system_info.get('length', 0)} chars",
-            f"  Tokens: {system_info.get('tokens', 0):,}"
-        ]
-        
-        panels.append(Panel(
-            "\n".join(model_content),
-            title="🤖 Model & System",
-            border_style="green"
-        ))
-        
-        # Memory Panel
-        memory = data.get("memory", {})
-        short_term = memory.get("short_term", {})
-        long_term = memory.get("long_term", {})
-        
-        memory_content = [
-            "**Short-term Memory**:",
-            f"  Entries: {short_term.get('entries', 0)}",
-            f"  Tokens: {short_term.get('tokens', 0):,}",
-            f"  Updated: {short_term.get('last_update', 'Never')[:16]}",
-            "",
-            "**Long-term Memory**:",
-            f"  Entries: {long_term.get('entries', 0)}",
-            f"  Tokens: {long_term.get('tokens', 0):,}",
-            f"  Indexed: {'Yes' if long_term.get('indexed') else 'No'}"
-        ]
-        
-        panels.append(Panel(
-            "\n".join(memory_content),
-            title="🧠 Memory",
-            border_style="yellow"
-        ))
-        
-        # Tools Panel
+        persona = data.get("persona", {})
+        conv = data.get("conversation_history", {})
         tools = data.get("tools", {})
-        
-        tools_content = [
-            f"**Available Tools**: {tools.get('total', 0)}",
-            f"**Enabled**: {tools.get('enabled', 0)}",
-            f"**Categories**: {', '.join(tools.get('categories', []))}",
-            f"**Schema Tokens**: {tools.get('total_tokens', 0):,}"
+        model = data.get("model", {})
+        session = data.get("session", {})
+
+        providers = model.get("providers", ["indisponível"])
+        model_str = ", ".join(providers) if isinstance(providers, list) else str(providers)
+
+        lines = [
+            "📊 **Visão Geral do Contexto**",
+            "",
+            f"🤖 **Modelo/Provedores**: {model_str}",
+            f"👤 **Persona**: {persona.get('name', 'indisponível')}",
+            f"🆔 **Sessão**: {session.get('id', 'indisponível')}",
+            f"💬 **Mensagens**: {conv.get('messages', 'indisponível')}",
+            f"🔧 **Tools**: {tools.get('enabled', '?')}/{tools.get('total', '?')} habilitadas",
         ]
-        
-        panels.append(Panel(
-            "\n".join(tools_content),
-            title="🔧 Tools",
-            border_style="cyan"
-        ))
-        
+
         if show_tokens:
-            # Token Usage Panel
-            token_data = data.get("token_usage", {})
-            breakdown = token_data.get("breakdown", {})
-            
-            token_content = [
-                f"**Total**: {token_data.get('total', 0):,} tokens",
-                f"**Usage**: {token_data.get('percentage', 0) * 100:.1f}%",
+            instr = data.get("system_instructions", {})
+            lines.extend([
                 "",
-                "**Breakdown**:",
-                f"  System: {breakdown.get('system', 0):,}",
-                f"  Persona: {breakdown.get('persona', 0):,}",
-                f"  Memory: {breakdown.get('memory', 0):,}", 
-                f"  History: {breakdown.get('history', 0):,}",
-                f"  Tools: {breakdown.get('tools', 0):,}"
-            ]
-            
-            panels.append(Panel(
-                "\n".join(token_content),
-                title="🎯 Token Usage",
-                border_style="red"
-            ))
-        
+                "🎯 **Tokens (estimativa)**:",
+                f"   • Instruções: {instr.get('tokens', 'indisponível')}",
+                f"   • Método: {instr.get('token_count_method', 'indisponível')}",
+            ])
+
+        return Panel(
+            Text("\n".join(lines), style="white"),
+            title="🧠 Contexto LLM",
+            border_style="blue",
+            padding=(1, 2),
+        )
+
+    def _create_detailed_display(self, data: Dict[str, Any], show_tokens: bool) -> Columns:
+        panels = []
+
+        model = data.get("model", {})
+        instr = data.get("system_instructions", {})
+        providers = model.get("providers", ["indisponível"])
+        model_str = ", ".join(providers) if isinstance(providers, list) else str(providers)
+
+        model_content = [
+            f"**Provedores**: {model_str}",
+            f"**Estratégia**: {model.get('strategy', 'indisponível')}",
+            "",
+            "**Instruções do Sistema**:",
+            f"  Tamanho: {instr.get('length', 'indisponível')} chars",
+        ]
+        if show_tokens:
+            model_content.append(f"  Tokens: {instr.get('tokens', 'indisponível')}")
+        panels.append(Panel("\n".join(model_content), title="🤖 Modelo", border_style="green"))
+
+        memory = data.get("memory", {})
+        if memory.get("status") == "indisponível":
+            mem_content = [f"**Status**: {memory.get('motivo', 'indisponível')}"]
+        else:
+            mem_total = memory.get("total_memory_mb", "indisponível")
+            components = memory.get("components", {})
+            mem_content = [f"**Total**: {mem_total} MB", ""]
+            for layer, stats in components.items():
+                entries = stats.get("total_entries", stats.get("count", "?"))
+                mem_content.append(f"  {layer}: {entries} entradas")
+        panels.append(Panel("\n".join(mem_content), title="🧠 Memória", border_style="yellow"))
+
+        tools = data.get("tools", {})
+        cats = tools.get("categories", [])
+        tools_content = [
+            f"**Total**: {tools.get('total', 'indisponível')}",
+            f"**Habilitadas**: {tools.get('enabled', 'indisponível')}",
+            f"**Categorias**: {', '.join(cats) if cats else 'indisponível'}",
+        ]
+        panels.append(Panel("\n".join(tools_content), title="🔧 Tools", border_style="cyan"))
+
+        conv = data.get("conversation_history", {})
+        persona = data.get("persona", {})
+        session = data.get("session", {})
+        session_content = [
+            f"**ID**: {session.get('id', 'indisponível')}",
+            f"**Iniciado**: {session.get('started', 'indisponível')}",
+            "",
+            f"**Persona**: {persona.get('name', 'indisponível')}",
+            f"**Mensagens**: {conv.get('messages', 'indisponível')}",
+            f"**Última msg**: {conv.get('newest_message', 'indisponível')}",
+        ]
+        panels.append(Panel("\n".join(session_content), title="📋 Sessão", border_style="magenta"))
+
         return Columns(panels, equal=True, expand=True)
-    
+
     def get_help(self) -> str:
-        """Get command help"""
-        return """Display LLM context information
+        return """Exibe informações do contexto LLM
 
-Usage:
-  /context [format] [options]
+Uso:
+  /context [formato] [opções]
 
-Formats:
-  summary   Show summary view (default)
-  detailed  Show detailed breakdown
-  json      Export as JSON
+Formatos:
+  summary   Visão resumida (padrão)
+  detailed  Detalhamento por componente
+  json      Exportar como JSON no terminal
 
-Options:
-  --show-tokens, -t    Show detailed token usage
-  --export, -e         Export context to file
-  --format FORMAT, -f  Specify output format
+Opções:
+  --show-tokens, -t         Exibe estimativa de tokens
+  --export json|md, -e      Exporta contexto para arquivo
+  --format FORMATO, -f      Especifica o formato de saída
 
-Examples:
-  /context                    Show summary
-  /context detailed -t        Show detailed view with tokens
-  /context json               Export as JSON
-  /context --show-tokens      Show summary with token breakdown"""
+Exemplos:
+  /context                         Resumo
+  /context detailed -t             Detalhado com tokens
+  /context --export json           Exporta contexto para JSON"""

--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -4,7 +4,8 @@ Comando /cost — rastreamento de custos, orçamentos e análise financeira
 
 import logging
 from datetime import datetime, timedelta
-from typing import List
+from pathlib import Path
+from typing import List, Tuple
 
 from rich.console import Group
 from rich.panel import Panel
@@ -18,6 +19,13 @@ from deile.infrastructure.monitoring.cost_tracker import get_cost_tracker
 logger = logging.getLogger(__name__)
 
 _FORECAST_MIN_DAYS = 7
+
+
+def _safe_summary_values(summary) -> Tuple[int, float]:
+    """Extract (entry_count, total_amount) safely from a CostSummary."""
+    count = getattr(summary, "entry_count", 0) or 0
+    total = float(summary.total_amount) if summary.total_amount else 0.0
+    return count, total
 
 
 class CostCommand(DirectCommand):
@@ -133,8 +141,7 @@ EXEMPLOS:
             summary = self.cost_tracker.get_cost_summary(start_time, end_time)
             session_cost = self.cost_tracker.get_current_session_cost()
 
-            entry_count = getattr(summary, "entry_count", 0) or 0
-            total_amount = float(summary.total_amount) if summary.total_amount else 0.0
+            entry_count, total_amount = _safe_summary_values(summary)
             session_cost_f = float(session_cost) if session_cost else 0.0
 
             summary_table = Table(
@@ -263,17 +270,14 @@ EXEMPLOS:
             )
             table.add_column("Categoria", style="cyan", width=24)
             table.add_column("Valor", style="green", width=14)
-            table.add_column("Transações", style="white", width=14)
+            table.add_column("Percentual", style="white", width=12)
 
-            total_amount = float(summary.total_amount) if summary.total_amount else 0.0
+            _, total_amount = _safe_summary_values(summary)
 
             for category in sorted(summary.categories, key=lambda c: summary.categories[c], reverse=True):
-                cat_summary = self.cost_tracker.get_cost_summary(
-                    start_time, end_time, category=category
-                )
-                cat_count = getattr(cat_summary, "entry_count", 0) or 0
                 cat_amount = float(summary.categories[category])
-                table.add_row(category, f"${cat_amount:.4f}", str(cat_count))
+                pct = cat_amount / total_amount * 100 if total_amount > 0 else 0.0
+                table.add_row(category, f"${cat_amount:.4f}", f"{pct:.1f}%")
 
             return CommandResult.success_result(table, "rich", total=total_amount)
 
@@ -352,10 +356,8 @@ EXEMPLOS:
             hist_start = hist_end - timedelta(days=30)
             summary = self.cost_tracker.get_cost_summary(hist_start, hist_end)
 
-            entry_count = getattr(summary, "entry_count", 0) or 0
-            total_amount = float(summary.total_amount) if summary.total_amount else 0.0
+            entry_count, total_amount = _safe_summary_values(summary)
 
-            # Verifica se há dados históricos suficientes (ao menos _FORECAST_MIN_DAYS de dados)
             if entry_count == 0 or total_amount == 0.0:
                 return CommandResult.success_result(
                     Panel(
@@ -417,7 +419,6 @@ EXEMPLOS:
             ts = datetime.now().strftime("%Y%m%d_%H%M%S")
             ext = "csv" if fmt == "csv" else "json"
             fname = f"costs_export_{ts}.{ext}"
-            from pathlib import Path
             Path(fname).write_text(data, encoding="utf-8")
 
             msg = (

--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -1,11 +1,5 @@
 """
-Cost Command for DEILE
-===========================
-
-Command for managing cost tracking, budgets, and financial analytics
-with comprehensive reporting and budget management features.
-
-Author: DEILE
+Comando /cost — rastreamento de custos, orçamentos e análise financeira
 """
 
 import logging
@@ -17,82 +11,67 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from deile.__version__ import __version__
 from deile.commands.base import CommandResult, DirectCommand
-from deile.core.context_manager import ContextManager
 from deile.infrastructure.monitoring.cost_tracker import get_cost_tracker
 
 logger = logging.getLogger(__name__)
 
+_FORECAST_MIN_DAYS = 7
+
 
 class CostCommand(DirectCommand):
-    """
-    Command for comprehensive cost management and analytics
-
-    Features:
-    - Current session and total cost tracking
-    - Budget management and alerts
-    - Cost forecasting and analysis
-    - Detailed cost breakdowns by category
-    - Export capabilities
-    - Real-time cost monitoring
-    """
+    """Rastreamento de custos, orçamentos e análise financeira"""
 
     cli_flag = "--cost"
-    cli_help = "Show accumulated session costs and exit."
+    cli_help = "Exibe custos acumulados da sessão e encerra."
     cli_requires_provider = False
 
     def __init__(self):
         super().__init__()
-        self.config.description = "Cost tracking, budgets, and financial analytics"
+        self.config.description = "Rastreamento de custos, orçamentos e análise financeira"
         self.help_text = """
-Cost Command - Financial Management and Analytics
+Comando /cost — Gestão Financeira e Análise
 
-USAGE:
-    /cost [action] [options]
+USO:
+    /cost [ação] [opções]
 
-ACTIONS:
-    summary [days]           Show cost summary (default: 30 days)
-    session                  Show current session costs
-    categories               Show costs by category
-    budget list              List all budget limits
-    budget set <category> <period> <amount>  Set budget limit
-    budget check             Check budget status
-    forecast [days]          Forecast costs (default: 7 days)
-    export [format] [days]   Export cost data (json, csv)
-    estimate <provider> <model> <tokens>  Estimate API call cost
-    top [count]              Show top expenses
-    alerts                   Show budget alerts
-    
-PERIODS:
+AÇÕES:
+    summary [dias]                   Resumo de custos (padrão: 30 dias)
+    session                          Custos da sessão atual
+    categories                       Custos por categoria real do banco
+    budget list                      Lista limites de orçamento
+    budget set <cat> <período> <val> Define limite de orçamento
+    forecast [dias]                  Previsão de custos (padrão: 7 dias)
+    export [formato] [dias]          Exporta dados (json, csv)
+    estimate <prov> <model> <tokens> Estima custo de chamada API
+    top [n]                          Exibe top-N despesas
+    alerts                           Exibe alertas de orçamento
+
+PERÍODOS:
     daily, weekly, monthly, yearly
 
-CATEGORIES:
-    api_calls, compute, storage, network, model_usage, 
+CATEGORIAS (reais do banco):
+    api_calls, compute, storage, network, model_usage,
     sandbox, infrastructure, external_services
 
-EXAMPLES:
-    /cost summary                           # Last 30 days summary
-    /cost summary 7                         # Last 7 days
-    /cost session                           # Current session costs
-    /cost budget set api_calls monthly 100  # Set $100/month for API calls
-    /cost forecast 14                       # 14-day forecast
-    /cost export json 90                    # Export last 90 days as JSON
-    /cost estimate gemini pro 5000          # Estimate cost for 5000 tokens
+EXEMPLOS:
+    /cost summary                           # Últimos 30 dias
+    /cost summary 7                         # Últimos 7 dias
+    /cost session                           # Custos da sessão atual
+    /cost budget set api_calls monthly 100  # $100/mês para API
+    /cost forecast 14                       # Previsão 14 dias
+    /cost export json 90                    # Exporta últimos 90 dias
+    /cost estimate gemini pro 5000          # Estima 5000 tokens
 """
-        
         self.cost_tracker = get_cost_tracker()
-        self.context_manager = ContextManager()
 
     async def execute(self, context=None) -> "CommandResult":
-        """Execute the cost command.
-
-        Reads :class:`CommandContext.args`, dispatches to a sub-action, and
-        returns a :class:`CommandResult`. The internal ``_show_*`` helpers
-        return ``CommandResult`` directly.
-        """
-
         args_str = getattr(context, "args", "") or "" if context is not None else ""
         args_list: List[str] = args_str.split() if args_str else []
+
+        session = getattr(context, "session", None) if context else None
+        session_id = getattr(session, "session_id", None) if session else None
 
         try:
             if not args_list:
@@ -104,216 +83,488 @@ EXAMPLES:
                 days = int(args_list[1]) if len(args_list) > 1 else 30
                 return self._show_cost_summary(days)
             if action == "session":
-                return self._show_session_costs()
+                return self._show_session_costs(session_id)
+            if action == "categories":
+                return self._show_categories()
+            if action == "budget":
+                sub = args_list[1].lower() if len(args_list) > 1 else "list"
+                if sub == "list":
+                    return self._show_budget_list()
+                if sub == "set":
+                    if len(args_list) < 5:
+                        return CommandResult.error_result(
+                            "Uso: /cost budget set <categoria> <período> <valor>"
+                        )
+                    return self._set_budget(args_list[2], args_list[3], args_list[4])
+                return CommandResult.error_result(f"Subcomando de budget desconhecido: {sub}")
+            if action == "forecast":
+                days = int(args_list[1]) if len(args_list) > 1 else 7
+                return self._show_forecast(days)
+            if action == "export":
+                fmt = args_list[1] if len(args_list) > 1 else "json"
+                days = int(args_list[2]) if len(args_list) > 2 else 30
+                return self._export_costs(fmt, days)
             if action == "estimate":
                 if len(args_list) < 4:
                     return CommandResult.error_result(
-                        "Usage: /cost estimate <provider> <model> <tokens>"
+                        "Uso: /cost estimate <provedor> <modelo> <tokens>"
                     )
                 provider, model, tokens = args_list[1], args_list[2], int(args_list[3])
                 return self._show_cost_estimate(provider, model, tokens)
-            return CommandResult.error_result(f"Unknown action: {action}")
+            if action == "top":
+                n = int(args_list[1]) if len(args_list) > 1 else 5
+                return self._show_top(n)
+            if action == "alerts":
+                return self._show_alerts()
+
+            return CommandResult.error_result(f"Ação desconhecida: {action}")
 
         except ValueError as exc:
-            return CommandResult.error_result(f"Invalid parameter: {exc}")
+            return CommandResult.error_result(f"Parâmetro inválido: {exc}")
         except Exception as exc:
-            logger.error("CostCommand execution error: %s", exc)
-            return CommandResult.error_result(
-                f"Command execution failed: {exc}", error=exc
-            )
+            logger.error("Erro na execução do CostCommand: %s", exc)
+            return CommandResult.error_result(f"Falha na execução: {exc}", error=exc)
 
     def _show_cost_summary(self, days: int = 30) -> "CommandResult":
-        """Show comprehensive cost summary"""
         try:
             end_time = datetime.now()
             start_time = end_time - timedelta(days=days)
 
-            # Get cost summary
             summary = self.cost_tracker.get_cost_summary(start_time, end_time)
             session_cost = self.cost_tracker.get_current_session_cost()
-            
-            # Create main summary table
-            summary_table = Table(title=f"💰 Cost Summary ({days} days)", show_header=True, header_style="bold cyan")
-            summary_table.add_column("Metric", style="white", width=20)
-            summary_table.add_column("Value", style="green", width=20)
-            summary_table.add_column("Details", style="dim", width=30)
-            
+
+            entry_count = getattr(summary, "entry_count", 0) or 0
+            total_amount = float(summary.total_amount) if summary.total_amount else 0.0
+            session_cost_f = float(session_cost) if session_cost else 0.0
+
+            summary_table = Table(
+                title=f"💰 Resumo de Custos ({days} dias)",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            summary_table.add_column("Métrica", style="white", width=22)
+            summary_table.add_column("Valor", style="green", width=20)
+            summary_table.add_column("Detalhes", style="dim", width=30)
+
             summary_table.add_row(
-                "Total Spent",
-                f"${summary.total_amount:.4f}",
-                f"{summary.entry_count} transactions"
+                "Total Gasto",
+                f"${total_amount:.4f}",
+                f"{entry_count} transações",
+            )
+            daily_avg = total_amount / days if days > 0 else 0.0
+            summary_table.add_row(
+                "Média Diária",
+                f"${daily_avg:.4f}",
+                f"Baseado em {days} dias",
             )
             summary_table.add_row(
-                "Daily Average",
-                f"${summary.total_amount / days:.4f}",
-                f"Based on {days} days"
+                "Sessão Atual",
+                f"${session_cost_f:.6f}",
+                "Custo da sessão ativa",
             )
-            summary_table.add_row(
-                "Current Session",
-                f"${session_cost:.4f}",
-                "Active session cost"
-            )
-            
-            if summary.total_amount > 0:
+            if total_amount > 0 and entry_count > 0:
+                avg_per = total_amount / entry_count
                 summary_table.add_row(
-                    "Avg per Transaction",
-                    f"${summary.total_amount / summary.entry_count:.6f}",
-                    "Per cost entry"
+                    "Média por Transação",
+                    f"${avg_per:.6f}",
+                    "Por entrada de custo",
                 )
-            
-            # Category breakdown
+
             if summary.categories:
-                category_table = Table(title="📊 Costs by Category", show_header=True, header_style="bold yellow")
-                category_table.add_column("Category", style="cyan", width=20)
-                category_table.add_column("Amount", style="green", width=15)
-                category_table.add_column("Percentage", style="white", width=15)
+                category_table = Table(
+                    title="📊 Custos por Categoria",
+                    show_header=True,
+                    header_style="bold yellow",
+                )
+                category_table.add_column("Categoria", style="cyan", width=22)
+                category_table.add_column("Valor", style="green", width=14)
+                category_table.add_column("Percentual", style="white", width=14)
                 category_table.add_column("Visual", style="blue", width=20)
-                
-                for category, amount in sorted(summary.categories.items(), key=lambda x: x[1], reverse=True):
-                    percentage = (amount / summary.total_amount * 100) if summary.total_amount > 0 else 0
-                    bar_width = int(percentage / 5)  # Scale for display
-                    visual_bar = "█" * min(bar_width, 20)
-                    
-                    category_table.add_row(
-                        category,
-                        f"${amount:.4f}",
-                        f"{percentage:.1f}%",
-                        visual_bar
-                    )
-                
+
+                for category, amount in sorted(
+                    summary.categories.items(), key=lambda x: x[1], reverse=True
+                ):
+                    pct = float(amount) / total_amount * 100 if total_amount > 0 else 0
+                    bar = "█" * min(int(pct / 5), 20)
+                    category_table.add_row(category, f"${float(amount):.4f}", f"{pct:.1f}%", bar)
+
                 content = Group(summary_table, "", category_table)
             else:
                 no_data = Panel(
-                    Text("No cost data found for the selected period.", style="yellow"),
-                    title="📊 Categories",
-                    border_style="yellow"
+                    Text("Nenhum dado de custo no período selecionado.", style="yellow"),
+                    title="📊 Categorias",
+                    border_style="yellow",
                 )
                 content = Group(summary_table, "", no_data)
-            
+
             return CommandResult.success_result(
                 content,
                 "rich",
-                total_amount=float(summary.total_amount),
-                session_cost=float(session_cost),
+                total_amount=total_amount,
+                session_cost=session_cost_f,
                 period_days=days,
-                entry_count=summary.entry_count,
+                entry_count=entry_count,
                 categories={k: float(v) for k, v in summary.categories.items()},
             )
 
         except Exception as exc:
-            logger.error("Failed to show cost summary: %s", exc)
-            return CommandResult.error_result(
-                f"Failed to show cost summary: {exc}", error=exc
-            )
+            logger.error("Falha ao exibir resumo de custos: %s", exc)
+            return CommandResult.error_result(f"Falha ao exibir resumo: {exc}", error=exc)
 
-    def _show_session_costs(self) -> "CommandResult":
-        """Show current session costs"""
+    def _show_session_costs(self, session_id=None) -> "CommandResult":
         try:
-            session_cost = self.cost_tracker.get_current_session_cost()
-            
-            # Create session info panel
-            session_info = (
-                f"💰 **Current Session Cost**: ${session_cost:.6f}\n\n"
-                "This represents the cost of API calls and resource usage\n"
-                "in your current DEILE session.\n\n"
-                "📊 **What's included**:\n"
-                "• API calls to language models\n"
-                "• Compute resource usage\n" 
-                "• Sandbox container costs\n"
-                "• Network and storage usage\n\n"
-                "💡 **Cost will reset when you start a new session**"
+            session_cost = self.cost_tracker.get_current_session_cost(session_id)
+            session_cost_f = float(session_cost) if session_cost else 0.0
+
+            info = (
+                f"💰 **Custo da Sessão Atual**: ${session_cost_f:.6f}\n\n"
+                "Representa o custo de chamadas de API e uso de recursos\n"
+                "na sessão DEILE atual.\n\n"
+                "📊 **Incluído**:\n"
+                "• Chamadas a modelos de linguagem\n"
+                "• Uso de recursos de computação\n"
+                "• Uso de rede e armazenamento\n\n"
+                "💡 **Custo resetado ao iniciar nova sessão**"
             )
-            
-            if session_cost > 0:
-                session_info += "\n\n📈 **Session is active with costs**"
-                style = "green"
-            else:
-                session_info += "\n\n🎉 **No costs yet in this session!**"
-                style = "blue"
-            
-            content = Panel(Text(session_info, style=style),
-                          title="💰 Session Costs",
-                          border_style=style)
-            
+            style = "green" if session_cost_f > 0 else "blue"
+            suffix = "\n\n📈 **Sessão ativa com custos**" if session_cost_f > 0 else "\n\n🎉 **Sem custos nesta sessão!**"
+
+            content = Panel(
+                Text(info + suffix, style=style),
+                title="💰 Custos da Sessão",
+                border_style=style,
+            )
+            return CommandResult.success_result(content, "rich", session_cost=session_cost_f)
+
+        except Exception as exc:
+            logger.error("Falha ao exibir custos da sessão: %s", exc)
+            return CommandResult.error_result(f"Falha ao exibir sessão: {exc}", error=exc)
+
+    def _show_categories(self) -> "CommandResult":
+        try:
+            end_time = datetime.now()
+            start_time = end_time - timedelta(days=30)
+            summary = self.cost_tracker.get_cost_summary(start_time, end_time)
+
+            if not summary.categories:
+                return CommandResult.success_result(
+                    Panel(
+                        Text("Nenhuma categoria encontrada nos últimos 30 dias.", style="yellow"),
+                        title="📊 Custos por Categoria",
+                        border_style="yellow",
+                    ),
+                    "rich",
+                )
+
+            table = Table(
+                title="📊 Custos por Categoria (30 dias)",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            table.add_column("Categoria", style="cyan", width=24)
+            table.add_column("Valor", style="green", width=14)
+            table.add_column("Transações", style="white", width=14)
+
+            total_amount = float(summary.total_amount) if summary.total_amount else 0.0
+
+            for category in sorted(summary.categories, key=lambda c: summary.categories[c], reverse=True):
+                cat_summary = self.cost_tracker.get_cost_summary(
+                    start_time, end_time, category=category
+                )
+                cat_count = getattr(cat_summary, "entry_count", 0) or 0
+                cat_amount = float(summary.categories[category])
+                table.add_row(category, f"${cat_amount:.4f}", str(cat_count))
+
+            return CommandResult.success_result(table, "rich", total=total_amount)
+
+        except Exception as exc:
+            logger.error("Falha ao exibir categorias: %s", exc)
+            return CommandResult.error_result(f"Falha ao exibir categorias: {exc}", error=exc)
+
+    def _show_budget_list(self) -> "CommandResult":
+        try:
+            self.cost_tracker._load_budget_limits()
+            budgets = self.cost_tracker.budget_limits
+
+            if not budgets:
+                return CommandResult.success_result(
+                    Panel(
+                        Text("Nenhum limite de orçamento configurado.", style="yellow"),
+                        title="📋 Orçamentos",
+                        border_style="yellow",
+                    ),
+                    "rich",
+                )
+
+            table = Table(
+                title="📋 Limites de Orçamento",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            table.add_column("Categoria", style="cyan", width=22)
+            table.add_column("Período", style="white", width=12)
+            table.add_column("Limite", style="green", width=12)
+            table.add_column("Alerta em", style="yellow", width=10)
+            table.add_column("Rígido", style="red", width=8)
+
+            for budget in budgets.values():
+                table.add_row(
+                    budget.category,
+                    budget.period,
+                    f"${float(budget.limit_amount):.2f}",
+                    f"{budget.alert_threshold * 100:.0f}%",
+                    "Sim" if budget.hard_limit else "Não",
+                )
+
+            return CommandResult.success_result(table, "rich")
+
+        except Exception as exc:
+            logger.error("Falha ao listar orçamentos: %s", exc)
+            return CommandResult.error_result(f"Falha ao listar orçamentos: {exc}", error=exc)
+
+    def _set_budget(self, category: str, period: str, amount_str: str) -> "CommandResult":
+        try:
+            amount = float(amount_str)
+            if amount < 0:
+                return CommandResult.error_result("O valor do limite deve ser positivo.")
+
+            ok = self.cost_tracker.set_budget_limit(category, period, amount)
+            if ok:
+                msg = f"✅ Limite definido: {category}/{period} = ${amount:.2f}"
+                return CommandResult.success_result(
+                    Panel(Text(msg, style="green"), title="💾 Orçamento Salvo", border_style="green"),
+                    "rich",
+                    category=category,
+                    period=period,
+                    amount=amount,
+                )
+            return CommandResult.error_result("Falha ao salvar limite de orçamento.")
+
+        except ValueError:
+            return CommandResult.error_result(f"Valor inválido: '{amount_str}'. Use número decimal.")
+        except Exception as exc:
+            logger.error("Falha ao definir orçamento: %s", exc)
+            return CommandResult.error_result(f"Falha ao definir orçamento: {exc}", error=exc)
+
+    def _show_forecast(self, forecast_days: int = 7) -> "CommandResult":
+        try:
+            hist_end = datetime.now()
+            hist_start = hist_end - timedelta(days=30)
+            summary = self.cost_tracker.get_cost_summary(hist_start, hist_end)
+
+            entry_count = getattr(summary, "entry_count", 0) or 0
+            total_amount = float(summary.total_amount) if summary.total_amount else 0.0
+
+            # Verifica se há dados históricos suficientes (ao menos _FORECAST_MIN_DAYS de dados)
+            if entry_count == 0 or total_amount == 0.0:
+                return CommandResult.success_result(
+                    Panel(
+                        Text(
+                            f"Dados insuficientes para previsão — mínimo {_FORECAST_MIN_DAYS} dias necessários.\n"
+                            "Nenhuma entrada de custo encontrada nos últimos 30 dias.",
+                            style="yellow",
+                        ),
+                        title="📈 Previsão de Custos",
+                        border_style="yellow",
+                    ),
+                    "rich",
+                )
+
+            daily_avg = total_amount / 30
+            projected = daily_avg * forecast_days
+
+            table = Table(
+                title=f"📈 Previsão de Custos ({forecast_days} dias)",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            table.add_column("Métrica", style="white", width=28)
+            table.add_column("Valor", style="green", width=20)
+
+            table.add_row("Média diária (30 dias)", f"${daily_avg:.4f}")
+            table.add_row(f"Previsão ({forecast_days} dias)", f"${projected:.4f}")
+            table.add_row("Método", "Projeção linear (média × dias)")
+            table.add_row("Observações históricas", str(entry_count))
+
             return CommandResult.success_result(
-                content, "rich", session_cost=float(session_cost)
+                table,
+                "rich",
+                daily_avg=daily_avg,
+                projected=projected,
+                forecast_days=forecast_days,
             )
 
         except Exception as exc:
-            logger.error("Failed to show session costs: %s", exc)
-            return CommandResult.error_result(
-                f"Failed to show session costs: {exc}", error=exc
+            logger.error("Falha ao calcular previsão: %s", exc)
+            return CommandResult.error_result(f"Falha ao calcular previsão: {exc}", error=exc)
+
+    def _export_costs(self, fmt: str = "json", days: int = 30) -> "CommandResult":
+        try:
+            end_time = datetime.now()
+            start_time = end_time - timedelta(days=days)
+            data = self.cost_tracker.export_costs(start_time, end_time, format_type=fmt)
+
+            if not data:
+                return CommandResult.success_result(
+                    Panel(
+                        Text("Nenhum dado de custo encontrado no período.", style="yellow"),
+                        title="📤 Export de Custos",
+                        border_style="yellow",
+                    ),
+                    "rich",
+                )
+
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            ext = "csv" if fmt == "csv" else "json"
+            fname = f"costs_export_{ts}.{ext}"
+            from pathlib import Path
+            Path(fname).write_text(data, encoding="utf-8")
+
+            msg = (
+                f"✅ Exportado: {fname}\n"
+                f"Período: {start_time.strftime('%Y-%m-%d')} → {end_time.strftime('%Y-%m-%d')}\n"
+                f"Versão DEILE: {__version__}"
+            )
+            return CommandResult.success_result(
+                Panel(Text(msg, style="green"), title="📤 Export de Custos", border_style="green"),
+                "rich",
+                file=fname,
             )
 
+        except Exception as exc:
+            logger.error("Falha ao exportar custos: %s", exc)
+            return CommandResult.error_result(f"Falha ao exportar: {exc}", error=exc)
+
+    def _show_top(self, n: int = 5) -> "CommandResult":
+        try:
+            end_time = datetime.now()
+            start_time = end_time - timedelta(days=30)
+            summary = self.cost_tracker.get_cost_summary(start_time, end_time)
+
+            top = summary.top_expenses[:n] if summary.top_expenses else []
+
+            if not top:
+                return CommandResult.success_result(
+                    Panel(
+                        Text("Nenhuma despesa encontrada nos últimos 30 dias.", style="yellow"),
+                        title=f"🏆 Top {n} Despesas",
+                        border_style="yellow",
+                    ),
+                    "rich",
+                )
+
+            table = Table(
+                title=f"🏆 Top {n} Despesas (30 dias)",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            table.add_column("#", style="dim", width=4)
+            table.add_column("Categoria", style="cyan", width=20)
+            table.add_column("Subcategoria", style="white", width=20)
+            table.add_column("Valor", style="green", width=14)
+            table.add_column("Descrição", style="dim", width=30)
+
+            for idx, entry in enumerate(top, 1):
+                table.add_row(
+                    str(idx),
+                    entry.get("category", "—"),
+                    entry.get("subcategory", "—"),
+                    f"${entry.get('amount', 0):.6f}",
+                    (entry.get("description", "—") or "—")[:28],
+                )
+
+            return CommandResult.success_result(table, "rich", top_count=len(top))
+
+        except Exception as exc:
+            logger.error("Falha ao listar top despesas: %s", exc)
+            return CommandResult.error_result(f"Falha ao listar top despesas: {exc}", error=exc)
+
+    def _show_alerts(self) -> "CommandResult":
+        try:
+            alerts = getattr(self.cost_tracker, "cost_alerts", []) or []
+
+            if not alerts:
+                return CommandResult.success_result(
+                    Panel(
+                        Text("Nenhum alerta de orçamento ativo.", style="green"),
+                        title="🔔 Alertas de Orçamento",
+                        border_style="green",
+                    ),
+                    "rich",
+                )
+
+            table = Table(
+                title="🔔 Alertas de Orçamento",
+                show_header=True,
+                header_style="bold red",
+            )
+            table.add_column("Tipo", style="red", width=20)
+            table.add_column("Categoria", style="cyan", width=18)
+            table.add_column("Uso Atual", style="yellow", width=14)
+            table.add_column("% Limite", style="white", width=10)
+
+            for alert in alerts:
+                table.add_row(
+                    alert.get("alert_type", "—"),
+                    alert.get("category", "—"),
+                    f"${float(alert.get('current_usage', 0)):.4f}",
+                    f"{alert.get('percentage', 0) * 100:.1f}%",
+                )
+
+            return CommandResult.success_result(table, "rich", alert_count=len(alerts))
+
+        except Exception as exc:
+            logger.error("Falha ao listar alertas: %s", exc)
+            return CommandResult.error_result(f"Falha ao listar alertas: {exc}", error=exc)
+
     def _show_cost_estimate(self, provider: str, model: str, tokens: int) -> "CommandResult":
-        """Show cost estimate for API call"""
         try:
             estimate = self.cost_tracker.get_pricing_estimate(provider, model, tokens)
 
             if "error" in estimate:
                 return CommandResult.error_result(estimate["error"])
-            
-            # Create estimate table
-            estimate_table = Table(title="💰 Cost Estimate", show_header=True, header_style="bold cyan")
-            estimate_table.add_column("Component", style="white", width=20)
-            estimate_table.add_column("Tokens", style="yellow", width=15)
-            estimate_table.add_column("Cost", style="green", width=15)
-            estimate_table.add_column("Rate", style="dim", width=20)
-            
-            estimate_table.add_row(
-                "Input Tokens",
-                f"{estimate['estimated_input_tokens']:,}",
-                f"${estimate['estimated_input_cost']:.6f}",
-                f"${estimate['estimated_input_cost'] / estimate['estimated_input_tokens'] * 1000:.4f}/1K" if estimate['estimated_input_tokens'] > 0 else "N/A"
+
+            table = Table(
+                title="💰 Estimativa de Custo",
+                show_header=True,
+                header_style="bold cyan",
             )
-            
-            estimate_table.add_row(
-                "Output Tokens", 
-                f"{estimate['estimated_output_tokens']:,}",
-                f"${estimate['estimated_output_cost']:.6f}",
-                f"${estimate['estimated_output_cost'] / estimate['estimated_output_tokens'] * 1000:.4f}/1K" if estimate['estimated_output_tokens'] > 0 else "N/A"
+            table.add_column("Componente", style="white", width=20)
+            table.add_column("Tokens", style="yellow", width=14)
+            table.add_column("Custo", style="green", width=14)
+
+            input_t = estimate.get("estimated_input_tokens", 0)
+            output_t = estimate.get("estimated_output_tokens", 0)
+            total_t = estimate.get("estimated_total_tokens", 0)
+            input_c = estimate.get("estimated_input_cost", 0)
+            output_c = estimate.get("estimated_output_cost", 0)
+            total_c = estimate.get("estimated_total_cost", 0)
+
+            table.add_row("Tokens de entrada", f"{input_t:,}", f"${input_c:.6f}")
+            table.add_row("Tokens de saída", f"{output_t:,}", f"${output_c:.6f}")
+            table.add_row("**Total**", f"**{total_t:,}**", f"**${total_c:.6f}**")
+
+            details = Panel(
+                Text(
+                    f"Provedor: {estimate.get('provider', provider)}\n"
+                    f"Modelo: {estimate.get('model', model)}\n"
+                    f"Moeda: {estimate.get('currency', 'USD')}\n\n"
+                    "💡 Estimativa baseada em padrões típicos de uso.",
+                    style="blue",
+                ),
+                title="🔍 Detalhes",
+                border_style="blue",
             )
-            
-            estimate_table.add_row(
-                "**Total**",
-                f"**{estimate['estimated_total_tokens']:,}**",
-                f"**${estimate['estimated_total_cost']:.6f}**",
-                f"**${estimate['cost_per_token'] * 1000:.4f}/1K**"
-            )
-            
-            # Estimate details
-            details_text = (
-                f"🔍 **Estimate Details**\n\n"
-                f"Provider: {estimate['provider']}\n"
-                f"Model: {estimate['model']}\n"
-                f"Currency: {estimate['currency']}\n\n"
-                f"📊 **Token Distribution**\n"
-                f"• Input: {estimate['estimated_input_tokens']:,} tokens (70%)\n"
-                f"• Output: {estimate['estimated_output_tokens']:,} tokens (30%)\n\n"
-                f"💡 **Note**: This is an estimate based on typical usage patterns.\n"
-                f"Actual costs may vary depending on the specific request."
-            )
-            
-            details_panel = Panel(
-                Text(details_text, style="blue"),
-                title="🔍 Details",
-                border_style="blue"
-            )
-            
-            content = Group(estimate_table, "", details_panel)
-            
+
             return CommandResult.success_result(
-                content, "rich", estimate=estimate
+                Group(table, "", details), "rich", estimate=estimate
             )
 
         except Exception as exc:
-            logger.error("Failed to show cost estimate: %s", exc)
-            return CommandResult.error_result(
-                f"Failed to show cost estimate: {exc}", error=exc
-            )
+            logger.error("Falha ao calcular estimativa: %s", exc)
+            return CommandResult.error_result(f"Falha ao calcular estimativa: {exc}", error=exc)
 
 
-# Register the command
 from deile.commands.registry import StaticCommandRegistry  # noqa: E402
 
 StaticCommandRegistry.register("cost", CostCommand)

--- a/deile/commands/builtin/export_command.py
+++ b/deile/commands/builtin/export_command.py
@@ -1,556 +1,453 @@
-"""Export Command - Export conversation, artifacts and session data"""
+"""Comando /export — exporta histórico de conversa e dados da sessão"""
 
 import json
-from datetime import datetime
+import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from rich.panel import Panel
 from rich.text import Text
+
+from deile.__version__ import __version__
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
 
 
 class ExportCommand(DirectCommand):
-    """Export conversation history, artifacts, plans and session data in various formats"""
+    """Exporta histórico de conversa, planos e dados da sessão em vários formatos"""
 
     cli_flag = "--export"
     cli_takes_arg = True
-    cli_arg_metavar = "PATH"
-    cli_help = "Export session data to PATH (forwards args to /export)."
+    cli_arg_metavar = "CAMINHO"
+    cli_help = "Exporta dados da sessão para CAMINHO (repassa args ao /export)."
     cli_requires_provider = False
 
     def __init__(self):
         from ...config.manager import CommandConfig
         super().__init__(CommandConfig(
             name="export",
-            description="Export conversation history, artifacts, plans and session data in various formats.",
+            description="Exporta histórico de conversa, planos e dados da sessão em vários formatos.",
         ))
-    
-    async def execute(self, context: Optional[CommandContext] = None) -> CommandResult:
-        """Execute export command.
 
-        Reads :class:`CommandContext.args` (the registry contract), parses
-        ``--format``/``--path``/inclusion flags, and writes the export.
-        Returns a :class:`CommandResult` whose content is a Rich summary panel.
-        """
+    async def execute(self, context: Optional[CommandContext] = None) -> CommandResult:
         args = (getattr(context, "args", "") or "") if context is not None else ""
 
         try:
-            # Parse arguments
             parts = args.strip().split() if args.strip() else []
-            format_type = "md"  # default
+            format_type = "md"
             export_path = None
             include_artifacts = True
             include_plans = True
             include_session = True
-            
+
             i = 0
             while i < len(parts):
-                if parts[i] in ["--format", "-f"]:
-                    if i + 1 < len(parts):
-                        format_type = parts[i + 1]
-                        i += 2
-                    else:
-                        raise CommandError("--format requires a value (txt, md, json, zip)")
-                elif parts[i] in ["--path", "-p"]:
-                    if i + 1 < len(parts):
-                        export_path = parts[i + 1]
-                        i += 2
-                    else:
-                        raise CommandError("--path requires a directory path")
-                elif parts[i] == "--no-artifacts":
+                p = parts[i]
+                if p in ("--format", "-f") and i + 1 < len(parts):
+                    format_type = parts[i + 1]
+                    i += 2
+                elif p in ("--path", "-p") and i + 1 < len(parts):
+                    export_path = parts[i + 1]
+                    i += 2
+                elif p == "--no-artifacts":
                     include_artifacts = False
                     i += 1
-                elif parts[i] == "--no-plans":
+                elif p == "--no-plans":
                     include_plans = False
                     i += 1
-                elif parts[i] == "--no-session":
+                elif p == "--no-session":
                     include_session = False
                     i += 1
-                elif parts[i].startswith("--"):
-                    raise CommandError(f"Unknown option: {parts[i]}")
+                elif p.startswith("--"):
+                    raise CommandError(f"Opção desconhecida: {p}")
                 else:
-                    # Positional argument - format or path
-                    if format_type == "md" and parts[i] in ["txt", "md", "json", "zip"]:
-                        format_type = parts[i]
+                    if format_type == "md" and p in ("txt", "md", "json", "zip"):
+                        format_type = p
                     else:
-                        export_path = parts[i]
+                        export_path = p
                     i += 1
-            
-            if format_type not in ["txt", "md", "json", "zip"]:
-                raise CommandError("Format must be one of: txt, md, json, zip")
-            
-            # Set default path if not provided
+
+            if format_type not in ("txt", "md", "json", "zip"):
+                raise CommandError("Formato deve ser um de: txt, md, json, zip")
+
             if not export_path:
-                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                export_path = f"./EXPORTS/deile_export_{timestamp}"
-            
-            # Perform export
-            panel = self._perform_export(
-                format_type, export_path, include_artifacts,
-                include_plans, include_session, context,
+                ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                export_path = f"./EXPORTS/deile_export_{ts}"
+
+            panel = await self._perform_export(
+                format_type, export_path, include_artifacts, include_plans, include_session, context
             )
             return CommandResult.success_result(panel, "rich")
 
-        except Exception as e:
-            return CommandResult.error_result(
-                f"Failed to export data: {str(e)}", error=e
-            )
-    
-    def _perform_export(self, format_type: str, export_path: str,
-                       include_artifacts: bool, include_plans: bool,
-                       include_session: bool, context: Optional[Dict[str, Any]]) -> Panel:
-        """Perform the actual export operation"""
-        
-        # Get export data
-        export_data = self._get_export_data(context, include_artifacts, 
-                                          include_plans, include_session)
-        
-        # Create export directory
+        except CommandError:
+            raise
+        except Exception as exc:
+            return CommandResult.error_result(f"Falha ao exportar dados: {exc}", error=exc)
+
+    async def _perform_export(
+        self,
+        format_type: str,
+        export_path: str,
+        include_artifacts: bool,
+        include_plans: bool,
+        include_session: bool,
+        context: Optional[Any],
+    ) -> Panel:
+        export_data = await self._get_export_data(
+            context, include_artifacts, include_plans, include_session
+        )
         export_dir = Path(export_path)
         export_dir.mkdir(parents=True, exist_ok=True)
-        
-        exported_files = []
-        
+
         if format_type == "zip":
-            # Create comprehensive zip export
-            zip_path = self._create_zip_export(export_data, export_dir)
-            exported_files.append(str(zip_path))
+            exported_files = [str(self._create_zip_export(export_data, export_dir))]
         else:
-            # Create individual files
-            exported_files = self._create_individual_exports(
-                export_data, export_dir, format_type
-            )
-        
-        # Generate summary
+            exported_files = self._create_individual_exports(export_data, export_dir, format_type)
+
         return self._create_export_summary(exported_files, export_data, format_type)
-    
-    def _get_export_data(self, context: Optional[Dict[str, Any]], 
-                        include_artifacts: bool, include_plans: bool,
-                        include_session: bool) -> Dict[str, Any]:
-        """Get data to export (mock implementation)"""
-        
-        data = {
+
+    async def _get_export_data(
+        self,
+        context: Optional[Any],
+        include_artifacts: bool,
+        include_plans: bool,
+        include_session: bool,
+    ) -> Dict[str, Any]:
+        agent = getattr(context, "agent", None) if context else None
+        session = getattr(context, "session", None) if context else None
+
+        # --- Sessão e histórico ---
+        session_id = getattr(session, "session_id", None) if session else None
+        history: List[Dict[str, Any]] = getattr(session, "conversation_history", []) if session else []
+        created_at = getattr(session, "created_at", None) if session else None
+
+        messages: List[Dict[str, Any]] = []
+        for idx, msg in enumerate(history):
+            messages.append({
+                "id": idx + 1,
+                "role": msg.get("role", "unknown"),
+                "content": msg.get("content", ""),
+                "timestamp": msg.get("timestamp", None),
+            })
+
+        data: Dict[str, Any] = {
             "export_metadata": {
-                "timestamp": datetime.now().isoformat(),
-                "deile_version": "4.0.0",
-                "export_id": f"export_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
-                "format_version": "1.0"
+                "generated_at": datetime.now(tz=timezone.utc).isoformat(),
+                "deile_version": __version__,
+                "session_id": session_id or "indisponível",
+                "format_version": "2.0",
+                "data_sources": ["AgentSession"],
             },
             "conversation": {
-                "session_id": "session_20250906_184500",
-                "started": "2025-09-06T15:30:00",
-                "total_messages": 23,
-                "messages": [
-                    {
-                        "id": 1,
-                        "timestamp": "2025-09-06T15:30:00",
-                        "role": "user",
-                        "content": "Analyze the current architecture and implement improvements",
-                        "tokens": 12
-                    },
-                    {
-                        "id": 2,
-                        "timestamp": "2025-09-06T15:30:15",
-                        "role": "assistant", 
-                        "content": "I'll analyze the architecture and implement the requested improvements...",
-                        "tokens": 156,
-                        "tool_calls": [
-                            {"tool": "read_file", "params": {"path": "docs/2.md"}, "result": "success"}
-                        ]
-                    },
-                    # More messages would be here in real implementation
-                ],
-                "total_tokens": {
-                    "prompt": 12500,
-                    "completion": 3725,
-                    "total": 16225
-                }
-            }
+                "session_id": session_id or "indisponível",
+                "started": (
+                    datetime.fromtimestamp(created_at, tz=timezone.utc).isoformat()
+                    if created_at
+                    else "indisponível"
+                ),
+                "total_messages": len(messages),
+                "messages": messages,
+            },
         }
-        
+
         if include_session:
+            # Modelo ativo
+            model_name = "indisponível"
+            try:
+                mr = getattr(agent, "model_router", None)
+                if mr:
+                    providers = getattr(mr, "providers", {})
+                    model_name = ", ".join(providers.keys()) if providers else "indisponível"
+            except Exception:
+                pass
+
+            # Persona ativa
+            persona_name = "indisponível"
+            try:
+                pm = getattr(agent, "persona_manager", None)
+                if pm:
+                    persona = pm.get_active_persona()
+                    if persona:
+                        persona_name = getattr(persona, "name", "indisponível")
+            except Exception:
+                pass
+
+            # Memória
+            memory_stats: Dict[str, Any] = {"status": "indisponível"}
+            try:
+                mm = getattr(agent, "memory_manager", None)
+                if mm:
+                    memory_stats = await mm.get_memory_usage()
+            except Exception:
+                pass
+
             data["session_info"] = {
-                "model": "gemini-2.5-pro",
-                "temperature": 0.7,
-                "system_instructions": "You are DEILE, an AI assistant specialized in software development...",
-                "persona": {
-                    "active": True,
-                    "name": "Developer Assistant",
-                    "description": "Expert in Python, software architecture, and best practices"
-                },
-                "memory": {
-                    "short_term_entries": 15,
-                    "long_term_entries": 45,
-                    "total_memory_tokens": 4700
-                }
+                "model": model_name,
+                "persona": {"name": persona_name},
+                "memory": memory_stats,
             }
-        
+            data["export_metadata"]["data_sources"].append("PersonaManager")
+            data["export_metadata"]["data_sources"].append("MemoryManager")
+
         if include_artifacts:
+            artifacts: List[Dict[str, Any]] = []
+            try:
+                artifacts_dir = Path("ARTIFACTS")
+                if artifacts_dir.exists():
+                    for run_dir in sorted(artifacts_dir.iterdir()):
+                        if run_dir.is_dir():
+                            for af in run_dir.glob("*.json"):
+                                artifacts.append({"path": str(af), "size": af.stat().st_size})
+                data["export_metadata"]["data_sources"].append("ArtifactManager")
+            except Exception:
+                pass
             data["artifacts"] = {
-                "total_artifacts": 8,
-                "artifacts": [
-                    {
-                        "id": "artifact_001",
-                        "name": "bash_execute_output.txt",
-                        "tool": "bash_execute",
-                        "timestamp": "2025-09-06T16:45:00",
-                        "size": 1024,
-                        "path": "ARTIFACTS/session_20250906_184500/artifact_001.txt"
-                    },
-                    {
-                        "id": "artifact_002", 
-                        "name": "file_list_output.json",
-                        "tool": "list_files",
-                        "timestamp": "2025-09-06T17:15:00", 
-                        "size": 512,
-                        "path": "ARTIFACTS/session_20250906_184500/artifact_002.json"
-                    }
-                ]
+                "count": len(artifacts),
+                "items": artifacts,
+                "note": "nenhum artifact nesta sessão" if not artifacts else "",
             }
-        
+
         if include_plans:
+            plans: List[Dict[str, Any]] = []
+            try:
+                from deile.orchestration.plan_manager import get_plan_manager
+                pm_inst = get_plan_manager()
+                raw_plans = await pm_inst.list_plans()
+                plans = raw_plans if raw_plans else []
+                data["export_metadata"]["data_sources"].append("PlanManager")
+            except Exception:
+                pass
             data["plans"] = {
-                "total_plans": 3,
-                "plans": [
-                    {
-                        "id": "plan_001",
-                        "name": "Architecture Improvements",
-                        "created": "2025-09-06T15:45:00",
-                        "status": "completed",
-                        "steps": 8,
-                        "path": "PLANS/plan_001.json"
-                    }
-                ]
+                "count": len(plans),
+                "items": plans,
+                "note": "nenhum plano nesta sessão" if not plans else "",
             }
-        
+
         return data
-    
-    def _create_individual_exports(self, data: Dict[str, Any], 
-                                 export_dir: Path, format_type: str) -> list:
-        """Create individual export files"""
-        
-        exported_files = []
-        
+
+    def _create_individual_exports(
+        self, data: Dict[str, Any], export_dir: Path, format_type: str
+    ) -> List[str]:
+        exported = []
+
         if format_type == "json":
-            # Single JSON file with all data
-            json_file = export_dir / "deile_export_complete.json"
-            with open(json_file, 'w', encoding='utf-8') as f:
-                json.dump(data, f, indent=2, default=str)
-            exported_files.append(str(json_file))
-        
-        elif format_type in ["txt", "md"]:
-            # Create separate readable files
-            
-            # Conversation export
+            jf = export_dir / "deile_export_complete.json"
+            jf.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+            exported.append(str(jf))
+        else:
             conv_file = export_dir / f"conversation.{format_type}"
-            self._write_conversation_file(data.get("conversation", {}), conv_file, format_type)
-            exported_files.append(str(conv_file))
-            
-            # Session info
+            conv_file.write_text(
+                self._format_conversation(data.get("conversation", {}), format_type),
+                encoding="utf-8",
+            )
+            exported.append(str(conv_file))
+
             if "session_info" in data:
-                session_file = export_dir / f"session_info.{format_type}"
-                self._write_session_file(data["session_info"], session_file, format_type)
-                exported_files.append(str(session_file))
-            
-            # Artifacts manifest
-            if "artifacts" in data:
-                artifacts_file = export_dir / f"artifacts_manifest.{format_type}"
-                self._write_artifacts_file(data["artifacts"], artifacts_file, format_type)
-                exported_files.append(str(artifacts_file))
-            
-            # Plans manifest
-            if "plans" in data:
-                plans_file = export_dir / f"plans_manifest.{format_type}"
-                self._write_plans_file(data["plans"], plans_file, format_type)
-                exported_files.append(str(plans_file))
-        
-        return exported_files
-    
+                sf = export_dir / f"session_info.{format_type}"
+                sf.write_text(
+                    self._format_session(data["session_info"], format_type), encoding="utf-8"
+                )
+                exported.append(str(sf))
+
+            if "artifacts" in data and data["artifacts"].get("count", 0) > 0:
+                af = export_dir / f"artifacts_manifest.{format_type}"
+                af.write_text(
+                    self._format_artifacts(data["artifacts"], format_type), encoding="utf-8"
+                )
+                exported.append(str(af))
+
+            if "plans" in data and data["plans"].get("count", 0) > 0:
+                pf = export_dir / f"plans_manifest.{format_type}"
+                pf.write_text(
+                    self._format_plans(data["plans"], format_type), encoding="utf-8"
+                )
+                exported.append(str(pf))
+
+        return exported
+
     def _create_zip_export(self, data: Dict[str, Any], export_dir: Path) -> Path:
-        """Create comprehensive zip export"""
-        import zipfile
-        
         zip_path = export_dir / "deile_complete_export.zip"
-        
-        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-            # Add JSON data
-            zipf.writestr("data/complete_export.json", 
-                         json.dumps(data, indent=2, default=str))
-            
-            # Add readable formats
-            conv_content = self._format_conversation_content(data.get("conversation", {}), "md")
-            zipf.writestr("conversation.md", conv_content)
-            
+
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("data/complete_export.json", json.dumps(data, indent=2, default=str))
+            zf.writestr("conversation.md", self._format_conversation(data.get("conversation", {}), "md"))
             if "session_info" in data:
-                session_content = self._format_session_content(data["session_info"], "md")
-                zipf.writestr("session_info.md", session_content)
-            
-            # Add manifest
-            manifest = self._create_export_manifest(data)
-            zipf.writestr("MANIFEST.json", json.dumps(manifest, indent=2, default=str))
-        
+                zf.writestr("session_info.md", self._format_session(data["session_info"], "md"))
+            manifest = {
+                "generated_at": data["export_metadata"]["generated_at"],
+                "deile_version": __version__,
+                "session_id": data["export_metadata"]["session_id"],
+                "data_sources": data["export_metadata"].get("data_sources", []),
+            }
+            zf.writestr("MANIFEST.json", json.dumps(manifest, indent=2, default=str))
+
         return zip_path
-    
-    def _write_conversation_file(self, conv_data: Dict[str, Any], 
-                               file_path: Path, format_type: str):
-        """Write conversation to file"""
-        content = self._format_conversation_content(conv_data, format_type)
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.write(content)
-    
-    def _format_conversation_content(self, conv_data: Dict[str, Any], format_type: str) -> str:
-        """Format conversation content"""
-        if format_type == "md":
+
+    def _format_conversation(self, conv: Dict[str, Any], fmt: str) -> str:
+        session_id = conv.get("session_id", "indisponível")
+        started = conv.get("started", "indisponível")
+        total = conv.get("total_messages", 0)
+        messages = conv.get("messages", [])
+
+        if fmt == "md":
             lines = [
-                "# DEILE Conversation Export",
+                "# Exportação de Conversa DEILE",
                 "",
-                f"**Session ID:** {conv_data.get('session_id', 'Unknown')}",
-                f"**Started:** {conv_data.get('started', 'Unknown')}",
-                f"**Total Messages:** {conv_data.get('total_messages', 0)}",
-                f"**Total Tokens:** {conv_data.get('total_tokens', {}).get('total', 0):,}",
+                f"**ID da Sessão:** {session_id}",
+                f"**Início:** {started}",
+                f"**Total de Mensagens:** {total}",
                 "",
-                "## Messages",
-                ""
+                "## Mensagens",
+                "",
             ]
-        else:  # txt
+            for msg in messages:
+                lines += [
+                    f"### Mensagem {msg.get('id', '')} — {msg.get('role', '').title()}",
+                    f"**Momento:** {msg.get('timestamp', 'desconhecido')}",
+                    "",
+                    str(msg.get("content", "")),
+                    "",
+                ]
+        else:
             lines = [
-                "DEILE CONVERSATION EXPORT",
+                "EXPORTAÇÃO DE CONVERSA DEILE",
                 "=" * 50,
                 "",
-                f"Session ID: {conv_data.get('session_id', 'Unknown')}",
-                f"Started: {conv_data.get('started', 'Unknown')}",
-                f"Total Messages: {conv_data.get('total_messages', 0)}",
-                f"Total Tokens: {conv_data.get('total_tokens', {}).get('total', 0):,}",
+                f"ID da Sessão: {session_id}",
+                f"Início: {started}",
+                f"Total de Mensagens: {total}",
                 "",
-                "MESSAGES:",
+                "MENSAGENS:",
                 "-" * 20,
-                ""
+                "",
             ]
-        
-        # Add messages
-        for msg in conv_data.get("messages", []):
-            if format_type == "md":
-                lines.extend([
-                    f"### Message {msg.get('id', '')} - {msg.get('role', '').title()}",
-                    f"**Time:** {msg.get('timestamp', '')}",
-                    f"**Tokens:** {msg.get('tokens', 0)}",
-                    "",
-                    msg.get('content', ''),
-                    ""
-                ])
-            else:  # txt
-                lines.extend([
+            for msg in messages:
+                lines += [
                     f"[{msg.get('timestamp', '')}] {msg.get('role', '').upper()}:",
-                    msg.get('content', ''),
-                    f"(Tokens: {msg.get('tokens', 0)})",
+                    str(msg.get("content", "")),
                     "",
-                ])
-        
+                ]
+
         return "\n".join(lines)
-    
-    def _write_session_file(self, session_data: Dict[str, Any], 
-                          file_path: Path, format_type: str):
-        """Write session info to file"""
-        content = self._format_session_content(session_data, format_type)
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.write(content)
-    
-    def _format_session_content(self, session_data: Dict[str, Any], format_type: str) -> str:
-        """Format session content"""
-        if format_type == "md":
-            return f"""# Session Information
 
-## Model Configuration
-- **Model:** {session_data.get('model', 'Unknown')}
-- **Temperature:** {session_data.get('temperature', 0.7)}
+    def _format_session(self, session_info: Dict[str, Any], fmt: str) -> str:
+        model = session_info.get("model", "indisponível")
+        persona = session_info.get("persona", {}).get("name", "indisponível")
+        memory = session_info.get("memory", {})
+        total_mb = memory.get("total_memory_mb", "indisponível") if isinstance(memory, dict) else "indisponível"
 
-## System Instructions
-```
-{session_data.get('system_instructions', 'No system instructions')}
-```
-
-## Persona
-- **Active:** {session_data.get('persona', {}).get('active', False)}
-- **Name:** {session_data.get('persona', {}).get('name', 'None')}
-- **Description:** {session_data.get('persona', {}).get('description', 'None')}
-
-## Memory Statistics
-- **Short-term entries:** {session_data.get('memory', {}).get('short_term_entries', 0)}
-- **Long-term entries:** {session_data.get('memory', {}).get('long_term_entries', 0)}
-- **Total memory tokens:** {session_data.get('memory', {}).get('total_memory_tokens', 0):,}
-"""
-        else:  # txt
-            return f"""SESSION INFORMATION
-==================
-
-Model: {session_data.get('model', 'Unknown')}
-Temperature: {session_data.get('temperature', 0.7)}
-
-System Instructions:
-{session_data.get('system_instructions', 'No system instructions')}
-
-Persona:
-- Active: {session_data.get('persona', {}).get('active', False)}
-- Name: {session_data.get('persona', {}).get('name', 'None')}
-- Description: {session_data.get('persona', {}).get('description', 'None')}
-
-Memory Statistics:
-- Short-term entries: {session_data.get('memory', {}).get('short_term_entries', 0)}
-- Long-term entries: {session_data.get('memory', {}).get('long_term_entries', 0)}
-- Total memory tokens: {session_data.get('memory', {}).get('total_memory_tokens', 0):,}
-"""
-    
-    def _write_artifacts_file(self, artifacts_data: Dict[str, Any], 
-                            file_path: Path, format_type: str):
-        """Write artifacts manifest to file"""
-        content = "# Artifacts Manifest\n\n" if format_type == "md" else "ARTIFACTS MANIFEST\n=================\n\n"
-        
-        content += f"Total artifacts: {artifacts_data.get('total_artifacts', 0)}\n\n"
-        
-        for artifact in artifacts_data.get('artifacts', []):
-            if format_type == "md":
-                content += f"""## {artifact.get('name', 'Unknown')}
-- **ID:** {artifact.get('id', '')}
-- **Tool:** {artifact.get('tool', '')}
-- **Created:** {artifact.get('timestamp', '')}
-- **Size:** {artifact.get('size', 0)} bytes
-- **Path:** {artifact.get('path', '')}
-
-"""
-            else:
-                content += f"""Artifact: {artifact.get('name', 'Unknown')}
-  ID: {artifact.get('id', '')}
-  Tool: {artifact.get('tool', '')}
-  Created: {artifact.get('timestamp', '')}
-  Size: {artifact.get('size', 0)} bytes
-  Path: {artifact.get('path', '')}
-
-"""
-        
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.write(content)
-    
-    def _write_plans_file(self, plans_data: Dict[str, Any], 
-                         file_path: Path, format_type: str):
-        """Write plans manifest to file"""
-        content = "# Plans Manifest\n\n" if format_type == "md" else "PLANS MANIFEST\n==============\n\n"
-        
-        content += f"Total plans: {plans_data.get('total_plans', 0)}\n\n"
-        
-        for plan in plans_data.get('plans', []):
-            if format_type == "md":
-                content += f"""## {plan.get('name', 'Unknown')}
-- **ID:** {plan.get('id', '')}
-- **Created:** {plan.get('created', '')}
-- **Status:** {plan.get('status', '')}
-- **Steps:** {plan.get('steps', 0)}
-- **Path:** {plan.get('path', '')}
-
-"""
-            else:
-                content += f"""Plan: {plan.get('name', 'Unknown')}
-  ID: {plan.get('id', '')}
-  Created: {plan.get('created', '')}
-  Status: {plan.get('status', '')}
-  Steps: {plan.get('steps', 0)}
-  Path: {plan.get('path', '')}
-
-"""
-        
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.write(content)
-    
-    def _create_export_manifest(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Create export manifest"""
-        return {
-            "export_info": data.get("export_metadata", {}),
-            "contents": {
-                "conversation": "conversation.md",
-                "session_info": "session_info.md" if "session_info" in data else None,
-                "artifacts": "artifacts_manifest.md" if "artifacts" in data else None,
-                "plans": "plans_manifest.md" if "plans" in data else None,
-                "raw_data": "data/complete_export.json"
-            },
-            "statistics": {
-                "total_messages": data.get("conversation", {}).get("total_messages", 0),
-                "total_tokens": data.get("conversation", {}).get("total_tokens", {}).get("total", 0),
-                "total_artifacts": data.get("artifacts", {}).get("total_artifacts", 0),
-                "total_plans": data.get("plans", {}).get("total_plans", 0)
-            }
-        }
-    
-    def _create_export_summary(self, exported_files: list, 
-                             export_data: Dict[str, Any], format_type: str) -> Panel:
-        """Create export summary panel"""
-        
-        metadata = export_data.get("export_metadata", {})
-        conv_data = export_data.get("conversation", {})
-        
-        content_lines = [
-            "✅ **Export Completed Successfully**",
-            "",
-            "📊 **Export Statistics**:",
-            f"  • Messages: {conv_data.get('total_messages', 0)}",
-            f"  • Total Tokens: {conv_data.get('total_tokens', {}).get('total', 0):,}",
-            f"  • Artifacts: {export_data.get('artifacts', {}).get('total_artifacts', 0)}",
-            f"  • Plans: {export_data.get('plans', {}).get('total_plans', 0)}",
-            "",
-            f"📁 **Exported Files ({len(exported_files)}):**"
-        ]
-        
-        for file_path in exported_files:
-            file_name = Path(file_path).name
-            try:
-                file_size = Path(file_path).stat().st_size
-                content_lines.append(f"  • {file_name} ({file_size:,} bytes)")
-            except Exception:
-                content_lines.append(f"  • {file_name}")
-        
-        content_lines.extend([
-            "",
-            "🎯 **Export Details**:",
-            f"  • Format: {format_type.upper()}",
-            f"  • Export ID: {metadata.get('export_id', 'Unknown')}",
-            f"  • Timestamp: {metadata.get('timestamp', 'Unknown')[:19]}",
-            f"  • Location: {Path(exported_files[0]).parent if exported_files else 'Unknown'}"
-        ])
-        
-        content = "\n".join(content_lines)
-        
-        return Panel(
-            Text(content, style="green"),
-            title="📤 Export Complete",
-            border_style="green",
-            padding=(1, 2)
+        if fmt == "md":
+            return (
+                "# Informações da Sessão\n\n"
+                f"## Modelo\n- **Provedores:** {model}\n\n"
+                f"## Persona\n- **Nome:** {persona}\n\n"
+                f"## Memória\n- **Total:** {total_mb} MB\n"
+            )
+        return (
+            "INFORMAÇÕES DA SESSÃO\n"
+            "====================\n\n"
+            f"Provedores: {model}\n"
+            f"Persona: {persona}\n"
+            f"Memória Total: {total_mb} MB\n"
         )
-    
+
+    def _format_artifacts(self, artifacts: Dict[str, Any], fmt: str) -> str:
+        count = artifacts.get("count", 0)
+        items = artifacts.get("items", [])
+        header = "# Manifesto de Artifacts\n\n" if fmt == "md" else "MANIFESTO DE ARTIFACTS\n=====================\n\n"
+        content = header + f"Total: {count}\n\n"
+        for af in items:
+            path = af.get("path", "—")
+            size = af.get("size", 0)
+            if fmt == "md":
+                content += f"- **{path}** ({size} bytes)\n"
+            else:
+                content += f"Arquivo: {path} ({size} bytes)\n"
+        return content
+
+    def _format_plans(self, plans: Dict[str, Any], fmt: str) -> str:
+        count = plans.get("count", 0)
+        items = plans.get("items", [])
+        header = "# Manifesto de Planos\n\n" if fmt == "md" else "MANIFESTO DE PLANOS\n===================\n\n"
+        content = header + f"Total: {count}\n\n"
+        for plan in items:
+            name = plan.get("name", plan.get("id", "—"))
+            status = plan.get("status", "—")
+            if fmt == "md":
+                content += f"- **{name}** (status: {status})\n"
+            else:
+                content += f"Plano: {name} (status: {status})\n"
+        return content
+
+    def _create_export_summary(
+        self, exported_files: List[str], export_data: Dict[str, Any], format_type: str
+    ) -> Panel:
+        metadata = export_data.get("export_metadata", {})
+        conv = export_data.get("conversation", {})
+        artifacts = export_data.get("artifacts", {})
+        plans = export_data.get("plans", {})
+
+        lines = [
+            "✅ **Exportação Concluída**",
+            "",
+            "📊 **Estatísticas**:",
+            f"  • Mensagens: {conv.get('total_messages', 0)}",
+            f"  • Artifacts: {artifacts.get('count', 0)}",
+            f"  • Planos: {plans.get('count', 0)}",
+            f"  • Versão DEILE: {metadata.get('deile_version', __version__)}",
+            f"  • ID da Sessão: {metadata.get('session_id', 'indisponível')}",
+            "",
+            f"📁 **Arquivos exportados ({len(exported_files)}):**",
+        ]
+
+        for fp in exported_files:
+            fname = Path(fp).name
+            try:
+                size = Path(fp).stat().st_size
+                lines.append(f"  • {fname} ({size:,} bytes)")
+            except Exception:
+                lines.append(f"  • {fname}")
+
+        lines += [
+            "",
+            "🎯 **Detalhes**:",
+            f"  • Formato: {format_type.upper()}",
+            f"  • Gerado em: {metadata.get('generated_at', '')[:19]}",
+            f"  • Fontes: {', '.join(metadata.get('data_sources', []))}",
+        ]
+
+        return Panel(
+            Text("\n".join(lines), style="green"),
+            title="📤 Export Concluído",
+            border_style="green",
+            padding=(1, 2),
+        )
+
     def get_help(self) -> str:
-        """Get command help"""
-        return """Export conversation history, artifacts, plans and session data
+        return """Exporta histórico de conversa e dados da sessão
 
-Usage:
-  /export [format] [options]
+Uso:
+  /export [formato] [opções]
 
-Formats:
-  txt      Export as plain text files
-  md       Export as Markdown files (default) 
-  json     Export as JSON file
-  zip      Export as comprehensive zip archive
+Formatos:
+  txt      Texto simples
+  md       Markdown (padrão)
+  json     JSON completo
+  zip      Arquivo zip com todos os dados
 
-Options:
-  --path PATH, -p PATH     Export directory path
-  --no-artifacts           Exclude artifacts from export
-  --no-plans               Exclude plans from export  
-  --no-session             Exclude session info from export
-  --format FORMAT, -f      Specify export format
+Opções:
+  --path CAMINHO, -p CAMINHO   Diretório de destino
+  --no-artifacts               Exclui artifacts
+  --no-plans                   Exclui planos
+  --no-session                 Exclui info da sessão
+  --format FORMATO, -f         Especifica o formato
 
-Examples:
-  /export                           Export as Markdown to default location
-  /export zip                       Export as comprehensive zip
-  /export json --path ./backups     Export JSON to custom path
-  /export md --no-artifacts         Export without artifacts
-  
-Default path: ./EXPORTS/deile_export_TIMESTAMP/"""
+Exemplos:
+  /export                           Exporta Markdown para caminho padrão
+  /export zip                       Zip completo
+  /export json --path ./backups     JSON em diretório customizado
+  /export md --no-artifacts         Sem artifacts
+
+Caminho padrão: ./EXPORTS/deile_export_TIMESTAMP/"""

--- a/deile/tests/commands/test_context_command.py
+++ b/deile/tests/commands/test_context_command.py
@@ -1,0 +1,232 @@
+"""Testes do comando /context — dados reais e flag --export"""
+
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deile.commands.base import CommandContext
+from deile.commands.builtin.context_command import ContextCommand
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_context(
+    args: str = "",
+    session_id: str = "test-session",
+    history: Optional[List[Dict[str, Any]]] = None,
+    agent=None,
+    session=None,
+) -> CommandContext:
+    if session is None:
+        session = MagicMock()
+        session.session_id = session_id
+        session.conversation_history = history or []
+        session.created_at = 1700000000.0
+        session.last_activity = 1700000100.0
+    ctx = CommandContext(user_input=f"/context {args}", args=args)
+    ctx.agent = agent
+    ctx.session = session
+    return ctx
+
+
+def _make_agent(
+    tools: int = 5,
+    enabled: int = 4,
+    persona_name: str = "developer",
+    memory_usage: Optional[Dict] = None,
+) -> MagicMock:
+    agent = MagicMock()
+
+    tool_mocks = [MagicMock(category="file") for _ in range(tools)]
+    enabled_mocks = tool_mocks[:enabled]
+    agent.tool_registry.list_all.return_value = tool_mocks
+    agent.tool_registry.list_enabled.return_value = enabled_mocks
+
+    persona = MagicMock()
+    persona.name = persona_name
+    agent.persona_manager.get_active_persona.return_value = persona
+
+    default_mem = {"total_memory_mb": 12.5, "components": {}}
+    agent.memory_manager.get_memory_usage = AsyncMock(return_value=memory_usage or default_mem)
+
+    agent.model_router.providers = {"openai": MagicMock()}
+    agent.model_router.strategy = MagicMock()
+    agent.context_manager.get_stats = AsyncMock(return_value={"system_instructions_length": 1000})
+
+    return agent
+
+
+def _render_rich(obj) -> str:
+    """Render a Rich renderable to plain text."""
+    from rich.console import Console
+    buf = StringIO()
+    console = Console(file=buf, highlight=False, markup=False, width=200)
+    console.print(obj)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_summary_shows_real_persona_name():
+    agent = _make_agent(persona_name="architect")
+    ctx = _make_context(agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "architect" in rendered
+
+
+@pytest.mark.unit
+async def test_summary_shows_real_message_count():
+    history = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+    agent = _make_agent()
+    ctx = _make_context(args="", history=history, agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "2" in rendered
+
+
+@pytest.mark.unit
+async def test_summary_shows_real_tool_counts():
+    agent = _make_agent(tools=8, enabled=6)
+    ctx = _make_context(agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "6" in rendered
+    assert "8" in rendered
+
+
+@pytest.mark.unit
+async def test_json_format_no_hardcoded_values():
+    history = [{"role": "user", "content": "msg"}]
+    agent = _make_agent(persona_name="custom-persona", tools=3, enabled=2)
+    ctx = _make_context(args="json", history=history, agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    data = json.loads(result.content)
+    assert data["persona"]["name"] == "custom-persona"
+    assert data["tools"]["total"] == 3
+    assert data["tools"]["enabled"] == 2
+    assert data["conversation_history"]["messages"] == 1
+
+
+@pytest.mark.unit
+async def test_no_hardcoded_numbers_in_summary():
+    agent = _make_agent()
+    ctx = _make_context(args="json", agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    data_str = result.content
+    hardcoded = [
+        "2500", "8500", "16225", "session_20250906_184500",
+        "gemini-2.5-pro", "Developer Assistant",
+    ]
+    for val in hardcoded:
+        assert val not in data_str, f"Valor hardcoded encontrado: {val}"
+
+
+@pytest.mark.unit
+async def test_subsystem_unavailable_shows_indisponivel():
+    agent = MagicMock()
+    agent.tool_registry.list_all.side_effect = RuntimeError("not initialized")
+    agent.tool_registry.list_enabled.side_effect = RuntimeError("not initialized")
+    agent.persona_manager.get_active_persona.side_effect = RuntimeError("pm down")
+    agent.memory_manager.get_memory_usage = AsyncMock(side_effect=RuntimeError("mm down"))
+    agent.model_router.providers = {}
+    agent.context_manager.get_stats = AsyncMock(side_effect=RuntimeError("cm down"))
+
+    ctx = _make_context(args="json", agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    data = json.loads(result.content)
+    assert data["tools"]["status"] == "indisponível"
+    assert data["persona"]["status"] == "indisponível"
+    assert data["memory"]["status"] == "indisponível"
+    assert data["system_instructions"]["status"] == "indisponível"
+
+
+@pytest.mark.unit
+async def test_no_agent_gracefully_returns_indisponivel():
+    ctx = _make_context(agent=None, session=None)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    # JSON format reveals indisponível values without Rich rendering
+    ctx2 = _make_context(args="json", agent=None, session=None)
+    result2 = await cmd.execute(ctx2)
+    assert result2.success
+    data = json.loads(result2.content)
+    assert data["tools"].get("status") == "indisponível" or data["tools"].get("total") is None
+
+
+@pytest.mark.unit
+async def test_export_json_writes_valid_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    agent = _make_agent()
+    ctx = _make_context(args="--export json", agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    exported = result.metadata.get("exported_file", "")
+    assert exported.endswith(".json")
+    content = json.loads(Path(exported).read_text())
+    assert "conversation_history" in content
+
+
+@pytest.mark.unit
+async def test_export_md_writes_valid_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    agent = _make_agent()
+    ctx = _make_context(args="--export md", agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    exported = result.metadata.get("exported_file", "")
+    assert exported.endswith(".md")
+    md = Path(exported).read_text()
+    assert "# Exportação de Contexto DEILE" in md
+
+
+@pytest.mark.unit
+async def test_token_count_method_declared():
+    agent = _make_agent()
+    ctx = _make_context(args="json", agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    data = json.loads(result.content)
+    instr = data.get("system_instructions", {})
+    assert "token_count_method" in instr or instr.get("status") == "indisponível"
+
+
+@pytest.mark.unit
+async def test_detailed_format_no_crash():
+    agent = _make_agent()
+    ctx = _make_context(args="detailed", agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+
+
+@pytest.mark.unit
+async def test_invalid_export_format_returns_error():
+    agent = _make_agent()
+    ctx = _make_context(args="--export xml", agent=agent)
+    cmd = ContextCommand()
+    result = await cmd.execute(ctx)
+    assert not result.success

--- a/deile/tests/commands/test_context_command.py
+++ b/deile/tests/commands/test_context_command.py
@@ -56,7 +56,12 @@ def _make_agent(
 
     agent.model_router.providers = {"openai": MagicMock()}
     agent.model_router.strategy = MagicMock()
-    agent.context_manager.get_stats = AsyncMock(return_value={"system_instructions_length": 1000})
+    agent.context_manager.get_stats = AsyncMock(return_value={
+        "context_builds": 3,
+        "max_context_tokens": 200000,
+        "chat_session_mode": True,
+        "simplified": True,
+    })
 
     return agent
 

--- a/deile/tests/commands/test_cost_command.py
+++ b/deile/tests/commands/test_cost_command.py
@@ -1,0 +1,269 @@
+"""Testes do comando /cost — bugs de runtime e subcomandos reais"""
+
+from decimal import Decimal
+from io import StringIO
+from typing import Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deile.commands.base import CommandContext
+from deile.commands.builtin.cost_command import CostCommand
+
+
+def _render_rich(obj) -> str:
+    from rich.console import Console
+    buf = StringIO()
+    console = Console(file=buf, highlight=False, markup=False, width=200)
+    console.print(obj)
+    return buf.getvalue()
+
+
+def _make_context(args: str = "", session_id: str = "test") -> CommandContext:
+    session = MagicMock()
+    session.session_id = session_id
+    ctx = CommandContext(user_input=f"/cost {args}", args=args)
+    ctx.session = session
+    return ctx
+
+
+def _make_summary(
+    total: str = "0",
+    entry_count: int = 0,
+    categories: Dict = None,
+    top_expenses: List[Dict] = None,
+):
+    s = MagicMock()
+    s.total_amount = Decimal(total)
+    s.entry_count = entry_count
+    s.categories = categories or {}
+    s.top_expenses = top_expenses or []
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Bug fixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_summary_empty_database_no_crash():
+    cmd = CostCommand()
+    empty_summary = _make_summary()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=empty_summary):
+        with patch.object(cmd.cost_tracker, "get_current_session_cost", return_value=Decimal("0")):
+            result = await cmd.execute(_make_context("summary"))
+    assert result.success
+
+
+@pytest.mark.unit
+async def test_summary_populated_database_shows_real_data():
+    cats = {"api_calls": Decimal("1.23"), "compute": Decimal("0.45")}
+    summary = _make_summary(total="1.68", entry_count=10, categories=cats)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        with patch.object(cmd.cost_tracker, "get_current_session_cost", return_value=Decimal("0.1")):
+            result = await cmd.execute(_make_context("summary"))
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "10" in rendered or "1.68" in rendered
+
+
+@pytest.mark.unit
+async def test_decimal_formatting_no_exception():
+    summary = _make_summary(total="1.234567890")
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        with patch.object(cmd.cost_tracker, "get_current_session_cost", return_value=Decimal("0")):
+            result = await cmd.execute(_make_context("summary"))
+    assert result.success
+
+
+@pytest.mark.unit
+async def test_version_from_version_module():
+    from deile.__version__ import __version__
+    export_data = '{"entries": []}'
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
+        result = await cmd.execute(_make_context("export json"))
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "4.0.0" not in rendered, "Versão hardcoded 4.0.0 encontrada"
+    assert __version__ in rendered
+
+
+# ---------------------------------------------------------------------------
+# Subcomandos
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_categories_from_real_database():
+    cats = {"api_calls": Decimal("2.0"), "model_usage": Decimal("1.0")}
+    summary = _make_summary(total="3.0", categories=cats)
+    cat_summary = _make_summary(total="2.0", entry_count=3)
+
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", side_effect=[summary, cat_summary, cat_summary]):
+        result = await cmd.execute(_make_context("categories"))
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "api_calls" in rendered or "model_usage" in rendered
+
+
+@pytest.mark.unit
+async def test_categories_empty_database_no_crash():
+    summary = _make_summary()
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        result = await cmd.execute(_make_context("categories"))
+    assert result.success
+
+
+@pytest.mark.unit
+async def test_budget_list_reads_real_limits():
+    budget = MagicMock()
+    budget.category = "api_calls"
+    budget.period = "monthly"
+    budget.limit_amount = Decimal("100")
+    budget.alert_threshold = 0.8
+    budget.hard_limit = False
+
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "_load_budget_limits"):
+        cmd.cost_tracker.budget_limits = {"api_calls_monthly": budget}
+        result = await cmd.execute(_make_context("budget list"))
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "api_calls" in rendered
+
+
+@pytest.mark.unit
+async def test_budget_list_empty_no_crash():
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "_load_budget_limits"):
+        cmd.cost_tracker.budget_limits = {}
+        result = await cmd.execute(_make_context("budget list"))
+    assert result.success
+
+
+@pytest.mark.unit
+async def test_budget_set_persists():
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "set_budget_limit", return_value=True) as mock_set:
+        result = await cmd.execute(_make_context("budget set api_calls monthly 50"))
+    assert result.success
+    mock_set.assert_called_once_with("api_calls", "monthly", 50.0)
+
+
+@pytest.mark.unit
+async def test_budget_set_invalid_amount_returns_error():
+    cmd = CostCommand()
+    result = await cmd.execute(_make_context("budget set api_calls monthly abc"))
+    assert not result.success
+
+
+@pytest.mark.unit
+async def test_top_n_returns_most_expensive():
+    top = [
+        {"category": "api_calls", "subcategory": "gpt4", "amount": 0.5, "description": "call"},
+        {"category": "compute", "subcategory": "gpu", "amount": 0.3, "description": "run"},
+    ]
+    summary = _make_summary(total="0.8", entry_count=2, top_expenses=top)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        result = await cmd.execute(_make_context("top 2"))
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "api_calls" in rendered
+
+
+@pytest.mark.unit
+async def test_top_empty_no_crash():
+    summary = _make_summary()
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        result = await cmd.execute(_make_context("top 5"))
+    assert result.success
+
+
+@pytest.mark.unit
+async def test_export_json_writes_valid_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    export_data = '{"entries": [], "period_start": "2026-01-01", "period_end": "2026-01-31"}'
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
+        result = await cmd.execute(_make_context("export json 30"))
+    assert result.success
+    json_files = list(tmp_path.glob("costs_export_*.json"))
+    assert len(json_files) == 1
+    import json
+    data = json.loads(json_files[0].read_text())
+    assert "entries" in data
+
+
+@pytest.mark.unit
+async def test_forecast_insufficient_data_message():
+    summary = _make_summary(total="0", entry_count=0)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        result = await cmd.execute(_make_context("forecast"))
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "insuficiente" in rendered.lower() or "insufficient" in rendered.lower() or "Dados" in rendered
+
+
+@pytest.mark.unit
+async def test_forecast_with_data_returns_projection():
+    summary = _make_summary(total="30.0", entry_count=100)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        result = await cmd.execute(_make_context("forecast 14"))
+    assert result.success
+    rendered = _render_rich(result.content)
+    assert "14" in rendered
+
+
+@pytest.mark.unit
+async def test_alerts_no_crash_when_empty():
+    cmd = CostCommand()
+    cmd.cost_tracker.cost_alerts = []
+    result = await cmd.execute(_make_context("alerts"))
+    assert result.success
+
+
+@pytest.mark.unit
+async def test_all_subcommands_dispatched():
+    """Nenhum subcomando declarado deve retornar 'Ação desconhecida'"""
+    cmd = CostCommand()
+    declared = [
+        ("summary", {}),
+        ("session", {}),
+        ("categories", {}),
+        ("budget list", {}),
+        ("forecast", {}),
+        ("export json", {"export_costs": '{"entries": []}'}),
+        ("estimate gemini pro 100", {}),
+        ("top 5", {}),
+        ("alerts", {}),
+    ]
+    for args, extra_patches in declared:
+        ctx = _make_context(args)
+        summary = _make_summary()
+        with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+            with patch.object(cmd.cost_tracker, "get_current_session_cost", return_value=Decimal("0")):
+                with patch.object(cmd.cost_tracker, "export_costs", return_value=extra_patches.get("export_costs", "{}")):
+                    with patch.object(cmd.cost_tracker, "_load_budget_limits"):
+                        cmd.cost_tracker.budget_limits = {}
+                        cmd.cost_tracker.cost_alerts = []
+                        with patch.object(cmd.cost_tracker, "get_pricing_estimate", return_value={"error": "no pricing"}):
+                            result = await cmd.execute(ctx)
+        rendered = _render_rich(result.content) if result.content else ""
+        assert "desconhecida" not in rendered.lower(), f"Subcomando '{args}' sem dispatch real"
+
+
+@pytest.mark.unit
+async def test_unknown_action_returns_error():
+    cmd = CostCommand()
+    result = await cmd.execute(_make_context("nonexistent_action"))
+    assert not result.success

--- a/deile/tests/commands/test_cost_command.py
+++ b/deile/tests/commands/test_cost_command.py
@@ -101,10 +101,9 @@ async def test_version_from_version_module():
 async def test_categories_from_real_database():
     cats = {"api_calls": Decimal("2.0"), "model_usage": Decimal("1.0")}
     summary = _make_summary(total="3.0", categories=cats)
-    cat_summary = _make_summary(total="2.0", entry_count=3)
 
     cmd = CostCommand()
-    with patch.object(cmd.cost_tracker, "get_cost_summary", side_effect=[summary, cat_summary, cat_summary]):
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
         result = await cmd.execute(_make_context("categories"))
     assert result.success
     rendered = _render_rich(result.content)

--- a/deile/tests/commands/test_export_command.py
+++ b/deile/tests/commands/test_export_command.py
@@ -1,0 +1,209 @@
+"""Testes do comando /export — dados reais, sem mock hardcoded"""
+
+import json
+import zipfile
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deile.__version__ import __version__
+from deile.commands.base import CommandContext
+from deile.commands.builtin.export_command import ExportCommand
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(
+    session_id: str = "real-session-123",
+    history: Optional[List[Dict[str, Any]]] = None,
+    created_at: float = 1700000000.0,
+) -> MagicMock:
+    session = MagicMock()
+    session.session_id = session_id
+    session.conversation_history = history or []
+    session.created_at = created_at
+    return session
+
+
+def _make_agent(persona_name: str = "developer") -> MagicMock:
+    agent = MagicMock()
+    agent.model_router.providers = {"openai": MagicMock()}
+    persona = MagicMock()
+    persona.name = persona_name
+    agent.persona_manager.get_active_persona.return_value = persona
+    agent.memory_manager.get_memory_usage = AsyncMock(return_value={"total_memory_mb": 5.0})
+    return agent
+
+
+def _make_context(
+    args: str = "",
+    session: Optional[Any] = None,
+    agent: Optional[Any] = None,
+) -> CommandContext:
+    ctx = CommandContext(user_input=f"/export {args}", args=args)
+    ctx.session = session or _make_session()
+    ctx.agent = agent or _make_agent()
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Rastreabilidade de dados reais
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_session_id_matches_real_session():
+    session = _make_session(session_id="my-unique-session-abc")
+    ctx = _make_context(args="json", session=session)
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=False)
+    assert data["conversation"]["session_id"] == "my-unique-session-abc"
+    assert data["export_metadata"]["session_id"] == "my-unique-session-abc"
+
+
+@pytest.mark.unit
+async def test_message_count_matches_session():
+    history = [
+        {"role": "user", "content": "oi"},
+        {"role": "assistant", "content": "olá"},
+        {"role": "user", "content": "tudo bem?"},
+    ]
+    session = _make_session(history=history)
+    ctx = _make_context(session=session)
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=False)
+    assert data["conversation"]["total_messages"] == 3
+    assert len(data["conversation"]["messages"]) == 3
+
+
+@pytest.mark.unit
+async def test_version_from_version_module():
+    ctx = _make_context()
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=False)
+    assert data["export_metadata"]["deile_version"] == __version__
+    assert data["export_metadata"]["deile_version"] != "4.0.0"
+
+
+@pytest.mark.unit
+async def test_empty_session_exports_empty_lists():
+    session = _make_session(history=[])
+    ctx = _make_context(session=session)
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=True, include_plans=True, include_session=True)
+    assert data["conversation"]["total_messages"] == 0
+    assert data["conversation"]["messages"] == []
+    assert data["artifacts"]["count"] == 0
+    assert data["plans"]["count"] == 0
+
+
+@pytest.mark.unit
+async def test_no_hardcoded_session_id():
+    ctx = _make_context()
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=False)
+    assert data["conversation"]["session_id"] != "session_20250906_184500"
+    assert data["export_metadata"]["session_id"] != "session_20250906_184500"
+
+
+@pytest.mark.unit
+async def test_no_hardcoded_version():
+    ctx = _make_context()
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=False)
+    assert data["export_metadata"]["deile_version"] != "4.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Integridade do arquivo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_json_output_is_valid(tmp_path):
+    ctx = _make_context(args=f"json --path {tmp_path}")
+    cmd = ExportCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    json_files = list(tmp_path.glob("*.json"))
+    assert len(json_files) == 1
+    data = json.loads(json_files[0].read_text())
+    assert "conversation" in data
+    assert "export_metadata" in data
+
+
+@pytest.mark.unit
+async def test_md_output_has_correct_headings(tmp_path):
+    ctx = _make_context(args=f"md --path {tmp_path}")
+    cmd = ExportCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    md_files = list(tmp_path.glob("*.md"))
+    assert len(md_files) >= 1
+    content = md_files[0].read_text()
+    assert content.startswith("# ")
+
+
+@pytest.mark.unit
+async def test_zip_output_is_valid(tmp_path):
+    ctx = _make_context(args=f"zip --path {tmp_path}")
+    cmd = ExportCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    zip_files = list(tmp_path.glob("*.zip"))
+    assert len(zip_files) == 1
+    assert zipfile.is_zipfile(zip_files[0])
+    with zipfile.ZipFile(zip_files[0]) as zf:
+        names = zf.namelist()
+    assert "MANIFEST.json" in names
+    assert any("complete_export.json" in n for n in names)
+
+
+@pytest.mark.unit
+async def test_no_artifacts_flag_excludes_artifacts(tmp_path):
+    history = [{"role": "user", "content": "x"}]
+    session = _make_session(history=history)
+    ctx = _make_context(args=f"json --path {tmp_path} --no-artifacts", session=session)
+    cmd = ExportCommand()
+    result = await cmd.execute(ctx)
+    assert result.success
+    json_files = list(tmp_path.glob("*.json"))
+    data = json.loads(json_files[0].read_text())
+    assert "artifacts" not in data
+
+
+@pytest.mark.unit
+async def test_export_metadata_has_data_sources():
+    ctx = _make_context()
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=True)
+    sources = data["export_metadata"]["data_sources"]
+    assert isinstance(sources, list)
+    assert len(sources) > 0
+    assert "AgentSession" in sources
+
+
+@pytest.mark.unit
+async def test_message_timestamps_are_from_session():
+    history = [
+        {"role": "user", "content": "msg1", "timestamp": "2026-01-01T10:00:00"},
+    ]
+    session = _make_session(history=history)
+    ctx = _make_context(session=session)
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=False)
+    msgs = data["conversation"]["messages"]
+    assert msgs[0]["timestamp"] == "2026-01-01T10:00:00"
+
+
+@pytest.mark.unit
+async def test_no_agent_graceful_degradation():
+    ctx = _make_context(session=_make_session(), agent=None)
+    ctx.agent = None
+    cmd = ExportCommand()
+    data = await cmd._get_export_data(ctx, include_artifacts=False, include_plans=False, include_session=True)
+    # Should not crash; session_info should exist but model is indisponível
+    assert "session_info" in data
+    assert data["session_info"]["model"] == "indisponível"

--- a/deile/tests/config/test_enterprise_profile.py
+++ b/deile/tests/config/test_enterprise_profile.py
@@ -9,19 +9,13 @@ from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from deile.config.settings import (
-    Settings,
-    _apply_nested_dict,
-    _apply_profile_layer,
-    reset_settings,
-)
+from deile.config.settings import (Settings, _apply_nested_dict,
+                                   _apply_profile_layer)
 from deile.security.audit_logger import AuditLogger
-
 
 # ---------------------------------------------------------------------------
 # Settings: profile fields land in Settings

--- a/deile/tests/test_model_command.py
+++ b/deile/tests/test_model_command.py
@@ -11,7 +11,8 @@ import pytest
 
 from deile.commands.builtin.model_command import ModelCommand
 from deile.core.interfaces.selector import (InteractiveSelector,
-                                         SelectorNotSupported, SelectorOption)
+                                            SelectorNotSupported,
+                                            SelectorOption)
 
 _YAML_PATH = Path(__file__).parents[2] / "deile" / "config" / "model_providers.yaml"
 


### PR DESCRIPTION
## Summary

- **#168 — /context hardcoded data**: `_get_context_data()` now reads live subsystems (PersonaManager, MemoryManager, ToolRegistry, ModelRouter, ContextManager, AgentSession) with graceful `{"status": "indisponível"}` fallback per subsystem. `--export json|md` writes real files.
- **#169 — /cost dead subcommands + runtime bugs**: All 9 subcommands are now dispatched (`categories`, `budget list/set`, `forecast`, `export`, `top`, `alerts`). Fixed Decimal formatting, empty-DB crashes, and hardcoded version "4.0.0".
- **#170 — /export invented data**: `_get_export_data()` reads session_id, conversation_history, version, model, persona, memory from real objects. ZIP includes `MANIFEST.json`. No hardcoded session IDs or message counts.

## Key decisions

- Every subsystem wrapped in individual `try/except` so one failure doesn't break the whole display.
- `asyncio.gather()` fans out `mm.get_memory_usage()` and `ctx_mgr.get_stats()` in parallel (Principle: Async by design).
- `/cost categories` removed N+1 DB queries (was 1+N per category); now shows % breakdown from the single summary query.
- `_safe_summary_values(summary)` helper centralises the `entry_count`/`total_amount` null-safe extraction used in 3 methods.

## Test plan

- [x] 43 new unit tests across `test_context_command.py` (12), `test_cost_command.py` (18), `test_export_command.py` (13)
- [x] All 305 command tests green (`pytest deile/tests/commands/ -q`)
- [x] 2147 non-SDK tests pass (failures are pre-existing `ModuleNotFoundError: openai/anthropic`)
- [x] `ruff check deile/` — clean
- [x] `isort --check-only deile/` — clean
- [x] No hardcoded values: `"session_20250906_184500"`, `"4.0.0"`, `"gemini-2.5-pro"`, `"Developer Assistant"` absent from all outputs

Closes #168
Closes #169
Closes #170

https://claude.ai/code/session_01F9htVRG2AnZ1t8W8HBieJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9htVRG2AnZ1t8W8HBieJn)_