### PR TITLE
refactor(daily): 2026-05-10 — 12 architectural refactorings (commands/builtin)

### DIFF
--- a/deile/commands/builtin/_shared.py
+++ b/deile/commands/builtin/_shared.py
@@ -125,3 +125,17 @@ def split_args(context: CommandContext) -> list[str]:
     raw = getattr(context, "args", "") or ""
     stripped = raw.strip()
     return stripped.split() if stripped else []
+
+
+def truncate(text: str | None, max_chars: int, suffix: str = "...") -> str:
+    """Recorta ``text`` para ``max_chars`` caracteres + ``suffix`` quando excede.
+
+    Padrão equivalente a ``text[:max_chars] + suffix if len(text) > max_chars
+    else text`` que estava duplicado em 14+ sites entre logs/approve/diff/
+    permissions/plan/run/stop/tools commands. Output fica em
+    ``max_chars + len(suffix)`` chars quando truncado, ou no comprimento
+    original quando não. ``None`` é tratado como string vazia.
+    """
+    if not text:
+        return ""
+    return text[:max_chars] + suffix if len(text) > max_chars else text

--- a/deile/commands/builtin/_shared.py
+++ b/deile/commands/builtin/_shared.py
@@ -203,6 +203,79 @@ def step_status_emoji(status: str) -> str:
     return STEP_STATUS_EMOJI.get(status, "❓")
 
 
+def analyze_plan_changes_stub(plan_id: str) -> dict[str, Any]:
+    """STUB — fixed mock describing hypothetical changes from a plan.
+
+    /diff and /patch both shipped private ``_analyze_plan_changes`` mocks
+    with identical hardcoded paths (``src/main.py``,
+    ``config/settings.json``, ``tests/test_main.py``) and artifact
+    references (``ARTIFACTS/session_123/...``). Diverging copies risk
+    silently misreporting different "changes" depending on which
+    command the user invokes.
+
+    Centralizing here keeps the placeholder identical until the real
+    implementation arrives — the real version will scan the plan's
+    persisted artifacts dir and the corresponding ``RUNS/`` log.
+    The return value is a superset of all fields any current caller
+    consumes; callers project the keys they need.
+    """
+    return {
+        "has_changes": True,
+        "plan_id": plan_id,
+        "summary": {
+            "files_modified": 3,
+            "files_created": 1,
+            "files_deleted": 0,
+            "lines_added": 45,
+            "lines_removed": 12,
+        },
+        "files_modified": 3,
+        "files_created": 1,
+        "files_deleted": 0,
+        "files_affected": 4,
+        "lines_added": 45,
+        "lines_removed": 12,
+        "total_changes": 57,
+        "file_changes": [
+            {
+                "path": "src/main.py",
+                "action": "modified",
+                "old_content": 'def main():\n    print("Hello")\n    return 0',
+                "new_content": 'def main():\n    print("Hello World")\n    logging.info("Application started")\n    return 0',
+                "lines_added": 15,
+                "lines_removed": 5,
+                "preview": "Added error handling and logging",
+            },
+            {
+                "path": "config/settings.json",
+                "action": "modified",
+                "old_content": '{"debug": false}',
+                "new_content": '{"debug": false, "log_level": "INFO"}',
+                "lines_added": 3,
+                "lines_removed": 2,
+                "preview": "Updated database configuration",
+            },
+            {
+                "path": "tests/test_main.py",
+                "action": "created",
+                "old_content": "",
+                "new_content": "import unittest\nfrom src.main import main\n\nclass TestMain(unittest.TestCase):\n    def test_main(self):\n        self.assertEqual(main(), 0)",
+                "lines_added": 27,
+                "lines_removed": 0,
+                "preview": "New unit tests for main module",
+            },
+        ],
+        "artifacts": [
+            "ARTIFACTS/session_123/bash_output_001.txt",
+            "ARTIFACTS/session_123/file_list_002.json",
+        ],
+        "artifacts_generated": [
+            "ARTIFACTS/session_123/bash_output_001.txt",
+            "ARTIFACTS/session_123/file_list_002.json",
+        ],
+    }
+
+
 def truncate(text: str | None, max_chars: int, suffix: str = "...") -> str:
     """Recorta ``text`` para ``max_chars`` caracteres + ``suffix`` quando excede.
 

--- a/deile/commands/builtin/_shared.py
+++ b/deile/commands/builtin/_shared.py
@@ -7,13 +7,15 @@ recuperação de subsistemas, mapas PT-BR de descrições).
 
 from __future__ import annotations
 
+import functools
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from rich.panel import Panel
 from rich.text import Text
 
+from ...core.exceptions import CommandError
 from ..base import CommandContext
 
 if TYPE_CHECKING:
@@ -129,6 +131,48 @@ def get_memory_manager(context: CommandContext) -> MemoryManager | None:
     padrão antes duplicado em compact, memory e status commands."""
     agent = get_agent(context)
     return getattr(agent, "memory_manager", None) if agent else None
+
+
+def wrap_command_errors(
+    name: str,
+    *,
+    message_template: str = "Failed to execute {name} command: {exc}",
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorator for ``SlashCommand.execute`` that wraps unexpected exceptions.
+
+    Pattern duplicated 8x in builtin commands:
+
+        try:
+            ... logic ...
+        except Exception as exc:
+            if isinstance(exc, CommandError):
+                raise
+            raise CommandError(f"Failed to execute X command: {exc}")
+
+    Usage:
+
+        @wrap_command_errors("approve")
+        async def execute(self, context): ...
+
+    ``CommandError`` (and subclasses) propagate untouched so caller-facing
+    messages are preserved; any other exception is rewrapped with the
+    template — defaulting to the existing English message, but accepting
+    a localized one (e.g. ``"Falha ao executar comando {name}: {exc}"``).
+    """
+
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return await func(*args, **kwargs)
+            except CommandError:
+                raise
+            except Exception as exc:
+                raise CommandError(message_template.format(name=name, exc=exc)) from exc
+
+        return wrapper
+
+    return decorator
 
 
 def split_args(context: CommandContext) -> list[str]:

--- a/deile/commands/builtin/_shared.py
+++ b/deile/commands/builtin/_shared.py
@@ -160,6 +160,29 @@ RISK_EMOJI: dict[str, str] = {
 """Emojis canônicos por nível de risco — approve/plan/run commands."""
 
 
+PLAN_STATUS_EMOJI: dict[str, str] = {
+    "draft": "📝",
+    "ready": "⚡",
+    "running": "🔄",
+    "paused": "⏸️",
+    "completed": "✅",
+    "failed": "❌",
+    "cancelled": "🚫",
+}
+"""Emojis canônicos para ``PlanStatus`` — plan/run/stop commands."""
+
+
+STEP_STATUS_EMOJI: dict[str, str] = {
+    "pending": "⏳",
+    "running": "🔄",
+    "completed": "✅",
+    "failed": "❌",
+    "skipped": "⏭️",
+    "requires_approval": "⚠️",
+}
+"""Emojis canônicos para ``StepStatus`` — plan_command (steps recentes/atuais)."""
+
+
 def file_action_emoji(action: str) -> str:
     """Resolve emoji para a ação de arquivo; fallback ``❓`` para desconhecidos."""
     return FILE_ACTION_EMOJI.get(action, "❓")
@@ -168,6 +191,16 @@ def file_action_emoji(action: str) -> str:
 def risk_emoji(risk_level: str) -> str:
     """Resolve emoji para o nível de risco; fallback ``❓`` para desconhecidos."""
     return RISK_EMOJI.get(risk_level, "❓")
+
+
+def plan_status_emoji(status: str) -> str:
+    """Resolve emoji para ``PlanStatus``; fallback ``❓`` para desconhecidos."""
+    return PLAN_STATUS_EMOJI.get(status, "❓")
+
+
+def step_status_emoji(status: str) -> str:
+    """Resolve emoji para ``StepStatus``; fallback ``❓`` para desconhecidos."""
+    return STEP_STATUS_EMOJI.get(status, "❓")
 
 
 def truncate(text: str | None, max_chars: int, suffix: str = "...") -> str:

--- a/deile/commands/builtin/_shared.py
+++ b/deile/commands/builtin/_shared.py
@@ -127,6 +127,33 @@ def split_args(context: CommandContext) -> list[str]:
     return stripped.split() if stripped else []
 
 
+FILE_ACTION_EMOJI: dict[str, str] = {
+    "modified": "📝",
+    "created": "✨",
+    "deleted": "🗑️",
+}
+"""Emojis canônicos para ações de arquivo — apply/diff/patch commands."""
+
+
+RISK_EMOJI: dict[str, str] = {
+    "low": "🟢",
+    "medium": "🟡",
+    "high": "🔴",
+    "critical": "🚨",
+}
+"""Emojis canônicos por nível de risco — approve/plan/run commands."""
+
+
+def file_action_emoji(action: str) -> str:
+    """Resolve emoji para a ação de arquivo; fallback ``❓`` para desconhecidos."""
+    return FILE_ACTION_EMOJI.get(action, "❓")
+
+
+def risk_emoji(risk_level: str) -> str:
+    """Resolve emoji para o nível de risco; fallback ``❓`` para desconhecidos."""
+    return RISK_EMOJI.get(risk_level, "❓")
+
+
 def truncate(text: str | None, max_chars: int, suffix: str = "...") -> str:
     """Recorta ``text`` para ``max_chars`` caracteres + ``suffix`` quando excede.
 

--- a/deile/commands/builtin/_shared.py
+++ b/deile/commands/builtin/_shared.py
@@ -108,10 +108,26 @@ def emit_audit_event(
         logger.debug("emit_audit_event falhou: %s", exc)
 
 
+def get_agent(context: CommandContext | None) -> Any | None:
+    """Retorna ``context.agent`` ou ``None`` quando ausente — pattern duplicado
+    em context, cost, export, memory, model, skills commands. Aceita ``None``
+    para casos em que ``context`` pode não ter sido construído ainda."""
+    if context is None:
+        return None
+    return getattr(context, "agent", None)
+
+
+def get_session(context: CommandContext | None) -> Any | None:
+    """Retorna ``context.session`` ou ``None`` — companion de :func:`get_agent`."""
+    if context is None:
+        return None
+    return getattr(context, "session", None)
+
+
 def get_memory_manager(context: CommandContext) -> MemoryManager | None:
     """Retorna ``context.agent.memory_manager`` ou ``None`` quando ausente —
     padrão antes duplicado em compact, memory e status commands."""
-    agent = getattr(context, "agent", None)
+    agent = get_agent(context)
     return getattr(agent, "memory_manager", None) if agent else None
 
 

--- a/deile/commands/builtin/_status_collectors.py
+++ b/deile/commands/builtin/_status_collectors.py
@@ -1,0 +1,137 @@
+"""Status data collectors — pure observation, no Rich/UI concerns.
+
+Extracted from ``status_command.py`` so the command file owns dispatch
+and presentation while these helpers own subsystem polling. Each
+collector returns a plain ``dict`` (with an ``error`` key on failure)
+that the panel builders project into Rich panels.
+
+Pillar 03 §1: I/O is fenced behind explicit collectors so async/sync
+boundaries stay obvious. Pillar 03 §6: every collector returns instead
+of raising — failures are surfaced as ``{"error": ...}`` and never abort
+the status overview.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+from datetime import datetime
+from typing import Any, Dict, List
+
+import psutil
+
+from deile.__version__ import __version__
+
+
+def _indisponivel(reason: str) -> str:
+    return f"[INDISPONÍVEL: {reason}]"
+
+
+def get_system_uptime() -> str:
+    """System uptime in ``Nd Hh Mm`` format; ``"desconhecido"`` on error."""
+    try:
+        boot_time = datetime.fromtimestamp(psutil.boot_time())
+        delta = datetime.now() - boot_time
+        h, rem = divmod(delta.seconds, 3600)
+        m, _ = divmod(rem, 60)
+        return f"{delta.days}d {h}h {m}m"
+    except Exception:
+        return "desconhecido"
+
+
+def collect_system_info() -> Dict[str, Any]:
+    """Host + DEILE-version + memory snapshot for the System panel."""
+    try:
+        return {
+            "deile_version": __version__,
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "platform": platform.system(),
+            "platform_release": platform.release(),
+            "platform_version": platform.version(),
+            "architecture": platform.machine(),
+            "hostname": platform.node(),
+            "uptime": get_system_uptime(),
+            "cpu_count": psutil.cpu_count(),
+            "memory_total": psutil.virtual_memory().total,
+            "memory_used": psutil.virtual_memory().used,
+            "memory_percent": psutil.virtual_memory().percent,
+            "disk_usage": psutil.disk_usage(".").percent,
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def collect_models_info() -> Dict[str, Any]:
+    """Active model + provider snapshot from the legacy ModelRouter."""
+    try:
+        from deile.core.models.router import get_model_router
+        router = get_model_router()
+        providers = list(router.providers.keys())
+        active_key = providers[0] if providers else None
+        active_provider = (
+            active_key.split(":", 1)[0] if active_key
+            else _indisponivel("nenhum provedor")
+        )
+        active_model = (
+            active_key.split(":", 1)[1] if active_key and ":" in active_key
+            else (active_key or _indisponivel("nenhum modelo"))
+        )
+        return {
+            "active_model": active_model,
+            "active_provider": active_provider,
+            "total_providers": len(providers),
+            "providers": providers,
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def collect_tools_info() -> Dict[str, Any]:
+    """Tool registry stats — counts by category and a flat name list."""
+    try:
+        from deile.tools.registry import get_tool_registry
+        registry = get_tool_registry()
+        stats = registry.get_stats()
+        return {
+            "total_tools": stats["total_tools"],
+            "enabled_tools": stats["enabled_tools"],
+            "disabled_tools": stats["disabled_tools"],
+            "categories": stats["categories"],
+            "function_definitions": stats["available_functions"],
+            "tools_with_schemas": stats["tools_with_schemas"],
+            "auto_discovery": stats["auto_discovery_enabled"],
+            "tool_names": [t.name for t in registry.list_all()],
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def collect_health_info() -> Dict[str, Any]:
+    """CPU/memory health score — same heuristic as before refactor."""
+    try:
+        cpu_percent = psutil.cpu_percent(interval=0)
+        memory = psutil.virtual_memory()
+        health_score = 100
+        warnings: List[str] = []
+        if cpu_percent > 80:
+            health_score -= 20
+            warnings.append("CPU alto")
+        if memory.percent > 85:
+            health_score -= 15
+            warnings.append("Memória alta")
+        status = (
+            "saudável" if health_score >= 80
+            else "atenção" if health_score >= 60
+            else "crítico"
+        )
+        return {
+            "overall_status": status,
+            "health_score": health_score,
+            "cpu_usage": cpu_percent,
+            "memory_usage": memory.percent,
+            "warnings": warnings,
+            "uptime": get_system_uptime(),
+            "last_check": datetime.now().isoformat(),
+        }
+    except Exception as exc:
+        return {"error": str(exc), "overall_status": "desconhecido"}

--- a/deile/commands/builtin/apply_command.py
+++ b/deile/commands/builtin/apply_command.py
@@ -14,7 +14,7 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import file_action_emoji, split_args
+from ._shared import file_action_emoji, split_args, wrap_command_errors
 
 
 class ApplyCommand(DirectCommand):
@@ -30,46 +30,41 @@ class ApplyCommand(DirectCommand):
         super().__init__(config)
         self.patches_dir = Path("./PATCHES")
     
+    @wrap_command_errors("apply")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute apply command"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # Show available patches to apply
-                return await self._show_applicable_patches()
-            
-            patch_file = parts[0]
-            
-            # Parse options
-            dry_run = False
-            force = False
-            backup = True
-            target_dir = "."
-            
-            for i, part in enumerate(parts[1:], 1):
-                if part == "--dry-run":
-                    dry_run = True
-                elif part == "--force":
-                    force = True
-                elif part == "--no-backup":
-                    backup = False
-                elif part.startswith("--target="):
-                    target_dir = part.split("=", 1)[1]
-                elif part == "--target":
-                    if i + 1 < len(parts):
-                        target_dir = parts[i + 1]
-                    else:
-                        raise CommandError("--target requires a directory path")
-                elif part.startswith("--"):
-                    raise CommandError(f"Unknown option: {part}")
-            
-            return await self._apply_patch(patch_file, target_dir, dry_run, force, backup)
-            
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute apply command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            # Show available patches to apply
+            return await self._show_applicable_patches()
+
+        patch_file = parts[0]
+
+        # Parse options
+        dry_run = False
+        force = False
+        backup = True
+        target_dir = "."
+
+        for i, part in enumerate(parts[1:], 1):
+            if part == "--dry-run":
+                dry_run = True
+            elif part == "--force":
+                force = True
+            elif part == "--no-backup":
+                backup = False
+            elif part.startswith("--target="):
+                target_dir = part.split("=", 1)[1]
+            elif part == "--target":
+                if i + 1 < len(parts):
+                    target_dir = parts[i + 1]
+                else:
+                    raise CommandError("--target requires a directory path")
+            elif part.startswith("--"):
+                raise CommandError(f"Unknown option: {part}")
+
+        return await self._apply_patch(patch_file, target_dir, dry_run, force, backup)
     
     async def _show_applicable_patches(self) -> CommandResult:
         """Show available patch files that can be applied"""

--- a/deile/commands/builtin/apply_command.py
+++ b/deile/commands/builtin/apply_command.py
@@ -14,7 +14,7 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import file_action_emoji, split_args
 
 
 class ApplyCommand(DirectCommand):
@@ -496,12 +496,7 @@ class ApplyCommand(DirectCommand):
             content_lines.append("**Changes Preview:**")
             
             for file_change in patch_data['file_changes']:
-                action_emoji = {
-                    'modified': '📝',
-                    'created': '✨',
-                    'deleted': '🗑️'
-                }.get(file_change['action'], '❓')
-                
+                action_emoji = file_action_emoji(file_change['action'])
                 content_lines.append(f"  {action_emoji} {file_change['action'].title()}: {file_change['path']}")
                 
                 # Show content preview for small changes
@@ -570,8 +565,7 @@ class ApplyCommand(DirectCommand):
         
         content_lines.append("**Summary of Changes:**")
         for action, count in actions_count.items():
-            emoji = {'modified': '📝', 'created': '✨', 'deleted': '🗑️'}.get(action, '❓')
-            content_lines.append(f"  {emoji} {action.title()}: {count} files")
+            content_lines.append(f"  {file_action_emoji(action)} {action.title()}: {count} files")
         
         content_lines.extend([
             "",
@@ -681,12 +675,7 @@ class ApplyCommand(DirectCommand):
         if applied_files:
             content_lines.append("**Changes Applied:**")
             for file_path, action in applied_files:
-                action_emoji = {
-                    'modified': '📝',
-                    'created': '✨',
-                    'deleted': '🗑️'
-                }.get(action, '❓')
-                content_lines.append(f"  {action_emoji} {action.title()}: {file_path}")
+                content_lines.append(f"  {file_action_emoji(action)} {action.title()}: {file_path}")
             content_lines.append("")
         
         # Show backup info

--- a/deile/commands/builtin/approve_command.py
+++ b/deile/commands/builtin/approve_command.py
@@ -7,7 +7,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import StepStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import split_args, truncate
 
 
 class ApproveCommand(DirectCommand):
@@ -110,15 +110,8 @@ class ApproveCommand(DirectCommand):
                 "critical": "🚨"
             }.get(approval['risk_level'], "❓")
             
-            # Truncate long descriptions
-            description = approval['step_description']
-            if len(description) > 30:
-                description = description[:27] + "..."
-            
-            # Plan title truncation
-            plan_title = approval['plan_title']
-            if len(plan_title) > 12:
-                plan_title = plan_title[:9] + "..."
+            description = truncate(approval['step_description'], 27)
+            plan_title = truncate(approval['plan_title'], 9)
             
             action_text = f"/approve {approval['plan_id']} {approval['step_id']}"
             
@@ -211,10 +204,7 @@ class ApproveCommand(DirectCommand):
                 "**Parameters:**"
             ])
             for key, value in step.params.items():
-                # Truncate long values
-                value_str = str(value)
-                if len(value_str) > 50:
-                    value_str = value_str[:47] + "..."
+                value_str = truncate(str(value), 47)
                 content_lines.append(f"  • {key}: {value_str}")
         
         # Add context about plan status

--- a/deile/commands/builtin/approve_command.py
+++ b/deile/commands/builtin/approve_command.py
@@ -8,7 +8,7 @@ from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import StepStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import risk_emoji as _risk_emoji
-from ._shared import split_args, truncate
+from ._shared import split_args, truncate, wrap_command_errors
 
 
 class ApproveCommand(DirectCommand):
@@ -23,36 +23,31 @@ class ApproveCommand(DirectCommand):
         super().__init__(config)
         self.plan_manager = get_plan_manager()
     
+    @wrap_command_errors("approve")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute approve command"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # Show pending approvals
-                return await self._show_pending_approvals()
-            
-            if len(parts) < 2:
-                raise CommandError("approve command requires plan ID and step ID: /approve <plan_id> <step_id> [yes|no]")
-            
-            plan_id = parts[0]
-            step_id = parts[1]
-            
-            # Default to approve, unless explicitly rejected
-            approved = True
-            if len(parts) > 2:
-                approval_response = parts[2].lower()
-                if approval_response in ['no', 'n', 'reject', 'deny', 'false']:
-                    approved = False
-                elif approval_response not in ['yes', 'y', 'approve', 'accept', 'true']:
-                    raise CommandError(f"Invalid approval response: {approval_response}. Use 'yes' or 'no'")
-            
-            return await self._approve_step(plan_id, step_id, approved)
-            
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute approve command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            # Show pending approvals
+            return await self._show_pending_approvals()
+
+        if len(parts) < 2:
+            raise CommandError("approve command requires plan ID and step ID: /approve <plan_id> <step_id> [yes|no]")
+
+        plan_id = parts[0]
+        step_id = parts[1]
+
+        # Default to approve, unless explicitly rejected
+        approved = True
+        if len(parts) > 2:
+            approval_response = parts[2].lower()
+            if approval_response in ['no', 'n', 'reject', 'deny', 'false']:
+                approved = False
+            elif approval_response not in ['yes', 'y', 'approve', 'accept', 'true']:
+                raise CommandError(f"Invalid approval response: {approval_response}. Use 'yes' or 'no'")
+
+        return await self._approve_step(plan_id, step_id, approved)
     
     async def _show_pending_approvals(self) -> CommandResult:
         """Show all steps requiring approval across all plans"""

--- a/deile/commands/builtin/approve_command.py
+++ b/deile/commands/builtin/approve_command.py
@@ -7,6 +7,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import StepStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
+from ._shared import risk_emoji as _risk_emoji
 from ._shared import split_args, truncate
 
 
@@ -102,13 +103,7 @@ class ApproveCommand(DirectCommand):
         table.add_column("Action", style="blue", width=20)
         
         for approval in pending_approvals:
-            # Risk level emoji
-            risk_emoji = {
-                "low": "🟢",
-                "medium": "🟡",
-                "high": "🔴",
-                "critical": "🚨"
-            }.get(approval['risk_level'], "❓")
+            risk_emoji = _risk_emoji(approval['risk_level'])
             
             description = truncate(approval['step_description'], 27)
             plan_title = truncate(approval['plan_title'], 9)

--- a/deile/commands/builtin/clear_command.py
+++ b/deile/commands/builtin/clear_command.py
@@ -84,93 +84,26 @@ class ClearCommand(DirectCommand):
             raise CommandError(f"Failed to clear screen and history: {str(e)}")
     
     async def _clear_reset(self, context: CommandContext, force: bool = False) -> CommandResult:
-        """Complete session reset - SOLVES SITUAÇÃO 7"""
-        
-        # Confirmation stub: in a real interactive environment this would
-        # prompt the user before clearing. For now, `--force` is the guard.
-        # In real implementation: confirmed = Confirm.ask("Continue?")
-        if not force:
-            pass  # non-forced path falls through to reset below
-        
+        """Complete session reset - SOLVES SITUAÇÃO 7
+
+        ``force`` is currently a no-op placeholder for a future interactive
+        confirmation prompt; the parameter is kept to preserve the public
+        ``/cls reset --force`` CLI surface.
+        """
+        del force  # interactive-confirm prompt not yet implemented (issue tracked separately)
+
         try:
-            reset_steps = []
-            
-            # 1. Clear conversation history and context
-            if hasattr(context, 'agent') and context.agent:
-                context.agent.clear_conversation_history()
-                context.agent.clear_context()
-                reset_steps.append("✅ Conversation history cleared")
-                reset_steps.append("✅ Agent context cleared")
-            
-            # 2. Clear session memory and cache
-            if hasattr(context, 'agent') and context.agent:
-                if hasattr(context.agent, 'clear_session_memory'):
-                    context.agent.clear_session_memory()
-                    reset_steps.append("✅ Session memory cleared")
-            
-            # 3. Reset token counters and cost tracking
-            if hasattr(context, 'agent') and context.agent:
-                if hasattr(context.agent, 'reset_token_counters'):
-                    context.agent.reset_token_counters()
-                    reset_steps.append("✅ Token counters reset")
-            
-            # 4. Clear active plans and orchestration
-            try:
-                from ...orchestration.plan_manager import get_plan_manager
-                plan_manager = get_plan_manager()
-                
-                # Clear active plans (but don't delete saved plans)
-                plan_manager._active_plans.clear()
-                plan_manager._execution_locks.clear()
-                plan_manager._stop_flags.clear()
-                reset_steps.append("✅ Active plans cleared")
-                
-            except Exception as e:
-                logger.warning(f"Could not clear orchestration state: {e}")
-                reset_steps.append("⚠️ Orchestration state partially cleared")
-            
-            # 5. Clear approval system state
-            try:
-                from ...orchestration.approval_system import \
-                    get_approval_system
-                approval_system = get_approval_system()
-                
-                # Clear pending requests
-                approval_system.pending_requests.clear()
-                approval_system.request_futures.clear()
-                reset_steps.append("✅ Approval requests cleared")
-                
-            except Exception as e:
-                logger.warning(f"Could not clear approval state: {e}")
-                reset_steps.append("⚠️ Approval state partially cleared")
-            
-            # 6. Clear UI and screen
+            reset_steps: list[str] = []
+            reset_steps.extend(self._reset_agent(context))
+            reset_steps.extend(self._reset_plans())
+            reset_steps.extend(self._reset_approvals())
+
             if hasattr(context, 'ui_manager') and context.ui_manager:
                 context.ui_manager.clear_screen()
                 reset_steps.append("✅ Screen display cleared")
-            
-            # 7. Clear temporary files and cache
-            try:
-                import shutil
-                from pathlib import Path
 
-                # Clear common temporary directories
-                temp_dirs = ["TEMP", "CACHE", ".deile_cache"]
-                for temp_dir in temp_dirs:
-                    temp_path = Path(temp_dir)
-                    if temp_path.exists():
-                        shutil.rmtree(temp_path, ignore_errors=True)
-                        reset_steps.append(f"✅ Temporary directory {temp_dir} cleared")
-                        
-            except Exception as e:
-                logger.warning(f"Could not clear temporary files: {e}")
-                reset_steps.append("⚠️ Temporary files partially cleared")
-            
-            # 8. Reset session ID and timestamps
-            if hasattr(context, 'session_id'):
-                import uuid
-                context.session_id = str(uuid.uuid4())
-                reset_steps.append("✅ Session ID regenerated")
+            reset_steps.extend(self._reset_temp_files())
+            reset_steps.extend(self._reset_session_id(context))
             
             # Create success report
             success_content = [
@@ -236,6 +169,83 @@ class ClearCommand(DirectCommand):
                 "rich"
             )
     
+    @staticmethod
+    def _reset_agent(context: CommandContext) -> list[str]:
+        """Steps 1-3: clear agent conversation/context/memory/token counters.
+
+        Returns the list of human-readable step lines that were performed.
+        Each call to a ``hasattr``-gated method is best-effort: missing
+        methods simply skip the corresponding step.
+        """
+        steps: list[str] = []
+        agent = getattr(context, 'agent', None)
+        if not agent:
+            return steps
+        agent.clear_conversation_history()
+        agent.clear_context()
+        steps.append("✅ Conversation history cleared")
+        steps.append("✅ Agent context cleared")
+        if hasattr(agent, 'clear_session_memory'):
+            agent.clear_session_memory()
+            steps.append("✅ Session memory cleared")
+        if hasattr(agent, 'reset_token_counters'):
+            agent.reset_token_counters()
+            steps.append("✅ Token counters reset")
+        return steps
+
+    @staticmethod
+    def _reset_plans() -> list[str]:
+        """Step 4: clear active plans/locks/stop-flags from PlanManager singleton."""
+        try:
+            from ...orchestration.plan_manager import get_plan_manager
+            pm = get_plan_manager()
+            pm._active_plans.clear()
+            pm._execution_locks.clear()
+            pm._stop_flags.clear()
+            return ["✅ Active plans cleared"]
+        except Exception as exc:
+            logger.warning("Could not clear orchestration state: %s", exc)
+            return ["⚠️ Orchestration state partially cleared"]
+
+    @staticmethod
+    def _reset_approvals() -> list[str]:
+        """Step 5: clear pending approval requests + futures."""
+        try:
+            from ...orchestration.approval_system import get_approval_system
+            approval_system = get_approval_system()
+            approval_system.pending_requests.clear()
+            approval_system.request_futures.clear()
+            return ["✅ Approval requests cleared"]
+        except Exception as exc:
+            logger.warning("Could not clear approval state: %s", exc)
+            return ["⚠️ Approval state partially cleared"]
+
+    @staticmethod
+    def _reset_temp_files() -> list[str]:
+        """Step 7: rm -rf well-known temp dirs (TEMP / CACHE / .deile_cache)."""
+        steps: list[str] = []
+        try:
+            import shutil
+            from pathlib import Path
+            for temp_dir in ("TEMP", "CACHE", ".deile_cache"):
+                temp_path = Path(temp_dir)
+                if temp_path.exists():
+                    shutil.rmtree(temp_path, ignore_errors=True)
+                    steps.append(f"✅ Temporary directory {temp_dir} cleared")
+        except Exception as exc:
+            logger.warning("Could not clear temporary files: %s", exc)
+            steps.append("⚠️ Temporary files partially cleared")
+        return steps
+
+    @staticmethod
+    def _reset_session_id(context: CommandContext) -> list[str]:
+        """Step 8: regenerate session UUID when present on the context."""
+        if not hasattr(context, 'session_id'):
+            return []
+        import uuid
+        context.session_id = str(uuid.uuid4())
+        return ["✅ Session ID regenerated"]
+
     async def _clear_history_only(self, context: CommandContext) -> CommandResult:
         """Clear only conversation history"""
         

--- a/deile/commands/builtin/clear_command.py
+++ b/deile/commands/builtin/clear_command.py
@@ -198,10 +198,7 @@ class ClearCommand(DirectCommand):
         """Step 4: clear active plans/locks/stop-flags from PlanManager singleton."""
         try:
             from ...orchestration.plan_manager import get_plan_manager
-            pm = get_plan_manager()
-            pm._active_plans.clear()
-            pm._execution_locks.clear()
-            pm._stop_flags.clear()
+            get_plan_manager().clear_active_state()
             return ["✅ Active plans cleared"]
         except Exception as exc:
             logger.warning("Could not clear orchestration state: %s", exc)

--- a/deile/commands/builtin/clear_command.py
+++ b/deile/commands/builtin/clear_command.py
@@ -7,7 +7,7 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import split_args, wrap_command_errors
 
 logger = logging.getLogger(__name__)
 
@@ -28,34 +28,27 @@ class ClearCommand(DirectCommand):
         )
         super().__init__(config)
     
+    @wrap_command_errors("clear")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute clear command with enhanced reset functionality"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # Standard clear - just clear screen and history
-                return await self._clear_standard(context)
-            
-            command = parts[0].lower()
-            
-            if command == "reset":
-                # Complete session reset - SITUAÇÃO 7 SOLUTION
-                force = "--force" in parts or "-f" in parts
-                return await self._clear_reset(context, force)
-            elif command == "history":
-                # Clear only conversation history
-                return await self._clear_history_only(context)
-            elif command == "screen":
-                # Clear only screen display
-                return await self._clear_screen_only(context)
-            else:
-                raise CommandError(f"Unknown clear option: {command}. Use: cls, cls reset, cls history, cls screen")
-                
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute clear command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            # Standard clear - just clear screen and history
+            return await self._clear_standard(context)
+
+        command = parts[0].lower()
+
+        if command == "reset":
+            # Complete session reset - SITUAÇÃO 7 SOLUTION
+            force = "--force" in parts or "-f" in parts
+            return await self._clear_reset(context, force)
+        elif command == "history":
+            return await self._clear_history_only(context)
+        elif command == "screen":
+            return await self._clear_screen_only(context)
+        else:
+            raise CommandError(f"Unknown clear option: {command}. Use: cls, cls reset, cls history, cls screen")
     
     async def _clear_standard(self, context: CommandContext) -> CommandResult:
         """Standard clear - conversation history and screen"""

--- a/deile/commands/builtin/compact_command.py
+++ b/deile/commands/builtin/compact_command.py
@@ -17,7 +17,7 @@ from rich.text import Text
 
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
 from deile.commands.builtin._shared import (export_timestamp,
-                                              get_memory_manager, split_args)
+                                            get_memory_manager, split_args)
 
 logger = logging.getLogger(__name__)
 

--- a/deile/commands/builtin/compact_command.py
+++ b/deile/commands/builtin/compact_command.py
@@ -21,6 +21,17 @@ from deile.commands.builtin._shared import (export_timestamp,
 
 logger = logging.getLogger(__name__)
 
+# Defaults for the /compact subcommands. Previously stored on the command
+# instance as ``self.compact_config`` and tweakable via ``/compact config
+# <key> <val>`` — that subcommand was removed because it only mutated the
+# in-memory dict (no persistence to ``config/system_config.yaml``), so its
+# "Configuração atualizada (sessão atual)" message overpromised. If true
+# user-tunable thresholds become necessary, expose them via ``Settings``
+# and read them through ``get_settings()`` (pillar 03 §7).
+_COMPRESS_THRESHOLD_DAYS = 7
+_PURGE_THRESHOLD_DAYS = 30
+_MAX_MEMORY_USAGE_MB = 100
+
 
 async def _get_session_store(context: CommandContext) -> Optional[Any]:
     agent = context.agent
@@ -40,12 +51,6 @@ class CompactCommand(DirectCommand):
     def __init__(self) -> None:
         super().__init__()
         self.config.description = "Gerenciar memória e histórico de sessões"
-        self.compact_config: dict[str, Any] = {
-            "auto_compress": True,
-            "compress_threshold_days": 7,
-            "purge_threshold_days": 30,
-            "max_memory_usage_mb": 100,
-        }
 
     async def execute(self, context: CommandContext) -> CommandResult:
         parts: list[str] = split_args(context)
@@ -55,10 +60,10 @@ class CompactCommand(DirectCommand):
             if action == "summary":
                 return await self._cmd_summary(context)
             elif action == "compress":
-                days = int(parts[1]) if len(parts) > 1 else self.compact_config["compress_threshold_days"]
+                days = int(parts[1]) if len(parts) > 1 else _COMPRESS_THRESHOLD_DAYS
                 return await self._cmd_compress(context, days)
             elif action == "purge":
-                days = int(parts[1]) if len(parts) > 1 else self.compact_config["purge_threshold_days"]
+                days = int(parts[1]) if len(parts) > 1 else _PURGE_THRESHOLD_DAYS
                 confirm = "--confirm" in parts or (
                     len(parts) > 2 and parts[2].lower() in ("s", "sim", "yes", "y")
                 )
@@ -72,10 +77,6 @@ class CompactCommand(DirectCommand):
             elif action == "import":
                 fname = parts[1] if len(parts) > 1 else None
                 return await self._cmd_import(context, fname)
-            elif action == "config":
-                if len(parts) < 3:
-                    return await self._cmd_show_config()
-                return await self._cmd_set_config(parts[1], parts[2])
             else:
                 return CommandResult.error_result(f"Ação desconhecida: {action}")
         except ValueError as exc:
@@ -106,7 +107,7 @@ class CompactCommand(DirectCommand):
                 table.add_row(
                     "Uso de memória",
                     f"{total_mb:.1f} MB",
-                    f"Limite: {self.compact_config['max_memory_usage_mb']} MB",
+                    f"Limite: {_MAX_MEMORY_USAGE_MB} MB",
                 )
                 table.add_row(
                     "Working memory (entradas)",
@@ -437,52 +438,3 @@ class CompactCommand(DirectCommand):
             sessions_imported=imported,
         )
 
-    # ------------------------------------------------------------------
-    # /compact config [key value]
-    # ------------------------------------------------------------------
-
-    async def _cmd_show_config(self) -> CommandResult:
-        table = Table(
-            title="Configuração do Compact (sessão atual)",
-            show_header=True,
-            header_style="bold cyan",
-        )
-        table.add_column("Parâmetro", style="white")
-        table.add_column("Valor", style="green")
-        table.add_column("Descrição", style="dim")
-        descriptions = {
-            "auto_compress": "Compactação automática habilitada",
-            "compress_threshold_days": "Dias antes de compactar entradas",
-            "purge_threshold_days": "Dias antes de expurgar sessões",
-            "max_memory_usage_mb": "Limite de uso de memória (MB)",
-        }
-        for key, val in self.compact_config.items():
-            table.add_row(key, str(val), descriptions.get(key, ""))
-        return CommandResult.success_result(content=table, content_type="rich")
-
-    async def _cmd_set_config(self, key: str, value: str) -> CommandResult:
-        if key not in self.compact_config:
-            return CommandResult.error_result(f"Parâmetro desconhecido: {key}")
-        original = self.compact_config[key]
-        try:
-            if isinstance(original, bool):
-                new_val: Any = value.lower() in ("true", "on", "sim", "yes", "1")
-            elif isinstance(original, int):
-                new_val = int(value)
-            elif isinstance(original, float):
-                new_val = float(value)
-            else:
-                new_val = value
-        except ValueError as exc:
-            return CommandResult.error_result(f"Valor inválido para {key}: {exc}")
-        self.compact_config[key] = new_val
-        text = Text()
-        text.append("Configuração atualizada (sessão atual)\n\n", style="bold green")
-        text.append(f"{key}: {original} → {new_val}")
-        panel = Panel(text, title="Config atualizado", border_style="green")
-        return CommandResult.success_result(
-            content=panel,
-            content_type="rich",
-            setting=key,
-            new_value=new_val,
-        )

--- a/deile/commands/builtin/compact_command.py
+++ b/deile/commands/builtin/compact_command.py
@@ -16,7 +16,7 @@ from rich.table import Table
 from rich.text import Text
 
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
-from deile.commands.builtin._shared import get_memory_manager
+from deile.commands.builtin._shared import get_memory_manager, split_args
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class CompactCommand(DirectCommand):
         }
 
     async def execute(self, context: CommandContext) -> CommandResult:
-        parts: list[str] = context.args.split() if context.args else []
+        parts: list[str] = split_args(context)
         action = parts[0].lower() if parts else "summary"
 
         try:

--- a/deile/commands/builtin/compact_command.py
+++ b/deile/commands/builtin/compact_command.py
@@ -16,7 +16,8 @@ from rich.table import Table
 from rich.text import Text
 
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
-from deile.commands.builtin._shared import get_memory_manager, split_args
+from deile.commands.builtin._shared import (export_timestamp,
+                                              get_memory_manager, split_args)
 
 logger = logging.getLogger(__name__)
 
@@ -327,8 +328,7 @@ class CompactCommand(DirectCommand):
             return CommandResult.error_result("Nenhuma sessão encontrada para exportar")
 
         if not filename:
-            ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-            filename = f"deile_sessoes_{ts}.{fmt}"
+            filename = f"deile_sessoes_{export_timestamp()}.{fmt}"
 
         export_path = Path(filename)
 

--- a/deile/commands/builtin/context_command.py
+++ b/deile/commands/builtin/context_command.py
@@ -12,8 +12,7 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandResult, DirectCommand
-from ._shared import get_agent, get_session
-from ._shared import export_timestamp, split_args
+from ._shared import export_timestamp, get_agent, get_session, split_args
 
 
 def _indisponivel(motivo: str = "") -> Dict[str, Any]:

--- a/deile/commands/builtin/context_command.py
+++ b/deile/commands/builtin/context_command.py
@@ -12,6 +12,7 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandResult, DirectCommand
+from ._shared import get_agent, get_session
 from ._shared import export_timestamp, split_args
 
 
@@ -96,8 +97,8 @@ class ContextCommand(DirectCommand):
             raise CommandError(f"Falha ao exibir contexto: {exc}") from exc
 
     async def _get_context_data(self, context) -> Dict[str, Any]:
-        agent = getattr(context, "agent", None)
-        session = getattr(context, "session", None)
+        agent = get_agent(context)
+        session = get_session(context)
 
         # Fan out the two independent async subsystems in parallel
         mm = getattr(agent, "memory_manager", None) if agent else None

--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -16,7 +16,7 @@ from rich.text import Text
 from deile.__version__ import __version__
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
 from deile.commands.builtin._shared import (export_timestamp, get_session,
-                                              split_args, success_panel)
+                                            split_args, success_panel)
 
 logger = logging.getLogger(__name__)
 

--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -15,7 +15,8 @@ from rich.text import Text
 
 from deile.__version__ import __version__
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
-from deile.commands.builtin._shared import export_timestamp, split_args, success_panel
+from deile.commands.builtin._shared import (export_timestamp, get_session,
+                                              split_args, success_panel)
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ EXEMPLOS:
     async def execute(self, context: CommandContext) -> CommandResult:
         args_list: List[str] = split_args(context)
 
-        session = getattr(context, "session", None)
+        session = get_session(context)
         session_id = getattr(session, "session_id", None) if session else None
 
         try:

--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -15,7 +15,7 @@ from rich.text import Text
 
 from deile.__version__ import __version__
 from deile.commands.base import CommandContext, CommandResult, DirectCommand
-from deile.commands.builtin._shared import export_timestamp, success_panel
+from deile.commands.builtin._shared import export_timestamp, split_args, success_panel
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ EXEMPLOS:
         return self._cost_tracker
 
     async def execute(self, context: CommandContext) -> CommandResult:
-        args_list: List[str] = (context.args or "").split()
+        args_list: List[str] = split_args(context)
 
         session = getattr(context, "session", None)
         session_id = getattr(session, "session_id", None) if session else None

--- a/deile/commands/builtin/diff_command.py
+++ b/deile/commands/builtin/diff_command.py
@@ -13,7 +13,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import split_args, truncate
 
 
 class DiffCommand(DirectCommand):
@@ -116,7 +116,7 @@ class DiffCommand(DirectCommand):
             
             table.add_row(
                 plan['id'],
-                plan['title'][:25] + ("..." if len(plan['title']) > 25 else ""),
+                truncate(plan['title'], 25),
                 status_text,
                 changes_text,
                 str(files_affected),

--- a/deile/commands/builtin/diff_command.py
+++ b/deile/commands/builtin/diff_command.py
@@ -13,7 +13,8 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import file_action_emoji, split_args, truncate
+from ._shared import (analyze_plan_changes_stub, file_action_emoji, split_args,
+                      truncate)
 
 
 class DiffCommand(DirectCommand):
@@ -197,61 +198,12 @@ class DiffCommand(DirectCommand):
         return await self._format_file_change_history(file_path, plans_affecting_file, format_type, show_content)
     
     def _analyze_plan_changes(self, plan_id: str) -> dict[str, Any]:
-        """Analyze changes made by a plan (simplified version)"""
-        
-        # Mock implementation - in real version would analyze artifacts
-        return {
-            'files_modified': 3,
-            'files_created': 1,
-            'files_deleted': 0,
-            'files_affected': 4,
-            'lines_added': 45,
-            'lines_removed': 12,
-            'total_changes': 57
-        }
-    
+        """Summary view of plan changes (stub — see analyze_plan_changes_stub)."""
+        return analyze_plan_changes_stub(plan_id)
+
     async def _analyze_plan_changes_detailed(self, plan_id: str) -> dict[str, Any]:
-        """Detailed analysis of plan changes"""
-        
-        # Mock detailed changes analysis
-        return {
-            'has_changes': True,
-            'plan_id': plan_id,
-            'summary': {
-                'files_modified': 3,
-                'files_created': 1,
-                'files_deleted': 0,
-                'lines_added': 45,
-                'lines_removed': 12
-            },
-            'file_changes': [
-                {
-                    'path': 'src/main.py',
-                    'action': 'modified',
-                    'lines_added': 15,
-                    'lines_removed': 5,
-                    'preview': 'Added error handling and logging'
-                },
-                {
-                    'path': 'config/settings.json',
-                    'action': 'modified',
-                    'lines_added': 3,
-                    'lines_removed': 2,
-                    'preview': 'Updated database configuration'
-                },
-                {
-                    'path': 'tests/test_main.py',
-                    'action': 'created',
-                    'lines_added': 27,
-                    'lines_removed': 0,
-                    'preview': 'New unit tests for main module'
-                }
-            ],
-            'artifacts_generated': [
-                'ARTIFACTS/session_123/bash_output_001.txt',
-                'ARTIFACTS/session_123/file_list_002.json'
-            ]
-        }
+        """Detailed view of plan changes (stub — see analyze_plan_changes_stub)."""
+        return analyze_plan_changes_stub(plan_id)
     
     async def _find_plans_affecting_file(self, file_path: str) -> list[dict[str, Any]]:
         """Find plans that affected a specific file"""

--- a/deile/commands/builtin/diff_command.py
+++ b/deile/commands/builtin/diff_command.py
@@ -14,7 +14,7 @@ from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import (analyze_plan_changes_stub, file_action_emoji, split_args,
-                      truncate)
+                      truncate, wrap_command_errors)
 
 
 class DiffCommand(DirectCommand):
@@ -29,42 +29,31 @@ class DiffCommand(DirectCommand):
         super().__init__(config)
         self.plan_manager = get_plan_manager()
     
+    @wrap_command_errors("diff")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute diff command"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # Show recent changes from all plans
-                return await self._show_recent_changes()
-            
-            target = parts[0]
-            
-            # Parse options
-            format_type = "summary"  # summary, detailed, unified
-            show_content = False
-            
-            for part in parts[1:]:
-                if part == "--detailed":
-                    format_type = "detailed"
-                elif part == "--unified":
-                    format_type = "unified"
-                elif part == "--content":
-                    show_content = True
-                elif part.startswith("--"):
-                    raise CommandError(f"Unknown option: {part}")
-            
-            # Check if target is a plan ID or file path
-            if len(target) == 8 and target.isalnum():  # Looks like plan ID
-                return await self._show_plan_diff(target, format_type, show_content)
-            else:
-                # Treat as file path
-                return await self._show_file_diff(target, format_type, show_content)
-            
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute diff command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            return await self._show_recent_changes()
+
+        target = parts[0]
+        format_type = "summary"  # summary, detailed, unified
+        show_content = False
+
+        for part in parts[1:]:
+            if part == "--detailed":
+                format_type = "detailed"
+            elif part == "--unified":
+                format_type = "unified"
+            elif part == "--content":
+                show_content = True
+            elif part.startswith("--"):
+                raise CommandError(f"Unknown option: {part}")
+
+        if len(target) == 8 and target.isalnum():  # Looks like plan ID
+            return await self._show_plan_diff(target, format_type, show_content)
+        return await self._show_file_diff(target, format_type, show_content)
     
     async def _show_recent_changes(self) -> CommandResult:
         """Show recent changes from all completed plans"""

--- a/deile/commands/builtin/diff_command.py
+++ b/deile/commands/builtin/diff_command.py
@@ -13,7 +13,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args, truncate
+from ._shared import file_action_emoji, split_args, truncate
 
 
 class DiffCommand(DirectCommand):
@@ -290,15 +290,10 @@ class DiffCommand(DirectCommand):
         ]
         
         for file_change in changes['file_changes']:
-            action_emoji = {
-                'modified': '📝',
-                'created': '✨',
-                'deleted': '🗑️'
-            }.get(file_change['action'], '❓')
-            
+            action_emoji = file_action_emoji(file_change['action'])
             added = file_change.get('lines_added', 0)
             removed = file_change.get('lines_removed', 0)
-            
+
             content_lines.append(
                 f"  {action_emoji} **{file_change['path']}** (+{added}/-{removed})"
             )
@@ -344,12 +339,8 @@ class DiffCommand(DirectCommand):
         ]
         
         for i, file_change in enumerate(changes['file_changes'], 1):
-            action_emoji = {
-                'modified': '📝',
-                'created': '✨', 
-                'deleted': '🗑️'
-            }.get(file_change['action'], '❓')
-            
+            action_emoji = file_action_emoji(file_change['action'])
+
             content_lines.extend([
                 f"## {i}. {action_emoji} {file_change['path']}",
                 "",

--- a/deile/commands/builtin/export_command.py
+++ b/deile/commands/builtin/export_command.py
@@ -13,7 +13,7 @@ from deile.__version__ import __version__
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import export_timestamp, split_args
+from ._shared import export_timestamp, get_agent, get_session, split_args
 
 
 class ExportCommand(DirectCommand):
@@ -113,8 +113,8 @@ class ExportCommand(DirectCommand):
         include_plans: bool,
         include_session: bool,
     ) -> Dict[str, Any]:
-        agent = getattr(context, "agent", None) if context else None
-        session = getattr(context, "session", None) if context else None
+        agent = get_agent(context)
+        session = get_session(context)
 
         # --- Sessão e histórico ---
         session_id = getattr(session, "session_id", None) if session else None

--- a/deile/commands/builtin/logs_command.py
+++ b/deile/commands/builtin/logs_command.py
@@ -14,7 +14,7 @@ from ...core.exceptions import CommandError
 from ...security.audit_logger import (AuditEvent, AuditEventType,
                                       SeverityLevel, get_audit_logger)
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import split_args, truncate
 
 logger = logging.getLogger(__name__)
 
@@ -172,8 +172,8 @@ class LogsCommand(DirectCommand):
                 else:
                     time_str = event.timestamp.strftime("%H:%M")
 
-                actor = event.actor[:10] + "..." if len(event.actor) > 10 else event.actor
-                resource = event.resource[:18] + "..." if len(event.resource) > 18 else event.resource
+                actor = truncate(event.actor, 10)
+                resource = truncate(event.resource, 18)
                 result_color = (
                     "green" if event.result in ("success", "allowed", "completed")
                     else "red" if event.result in ("denied", "failed", "error")
@@ -284,8 +284,8 @@ class LogsCommand(DirectCommand):
         for event in events:
             emoji = _SEVERITY_EMOJI.get(event.severity, "📝")
             label = _SEVERITY_LABEL.get(event.severity, event.severity.value.upper())
-            actor = event.actor[:10] + "..." if len(event.actor) > 10 else event.actor
-            resource = event.resource[:23] + "..." if len(event.resource) > 23 else event.resource
+            actor = truncate(event.actor, 10)
+            resource = truncate(event.resource, 23)
             event_type = event.event_type.value.replace("_", " ")[:13]
 
             log_table.add_row(
@@ -359,7 +359,7 @@ class LogsCommand(DirectCommand):
                 time_str,
                 event.event_type.value.replace("_", " ").title(),
                 event.severity.value.upper(),
-                details[:38] + "..." if len(details) > 38 else details,
+                truncate(details, 38),
                 action,
             )
 
@@ -418,7 +418,7 @@ class LogsCommand(DirectCommand):
             perm_table.add_row(
                 time_str,
                 event.actor[:13],
-                event.resource[:23] + "..." if len(event.resource) > 23 else event.resource,
+                truncate(event.resource, 23),
                 event.action,
                 result_display,
                 rule_id,
@@ -465,7 +465,7 @@ class LogsCommand(DirectCommand):
 
             secrets_table.add_row(
                 event.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-                file_path[:23] + "..." if len(file_path) > 23 else file_path,
+                truncate(file_path, 23),
                 secret_type.title(),
                 str(line_number),
                 f"{confidence:.2f}",
@@ -513,7 +513,7 @@ class LogsCommand(DirectCommand):
             tools_table.add_row(
                 time_str,
                 event.tool_name or event.actor,
-                event.resource[:23] + "..." if len(event.resource) > 23 else event.resource,
+                truncate(event.resource, 23),
                 duration_str,
                 str(exit_code),
                 result_display,
@@ -556,9 +556,7 @@ class LogsCommand(DirectCommand):
 
         for event in all_events[:30]:
             time_str = event.timestamp.strftime("%H:%M:%S")
-            plan_id = event.plan_id or "N/D"
-            if len(plan_id) > 12:
-                plan_id = plan_id[:9] + "..."
+            plan_id = truncate(event.plan_id or "N/D", 9)
 
             event_type_label = event.event_type.value.replace("_", " ").title()
 
@@ -577,7 +575,7 @@ class LogsCommand(DirectCommand):
                 event_type_label[:15],
                 event.action.title(),
                 event.result.title(),
-                details[:23] + "..." if len(details) > 23 else details,
+                truncate(details, 23),
             )
 
         return CommandResult.success_result(plans_table, "rich")
@@ -632,7 +630,7 @@ class LogsCommand(DirectCommand):
                 f"{emoji} {label[:4]}",
                 event.event_type.value.replace("_", " ").title()[:15],
                 event.actor[:12],
-                details[:28] + "..." if len(details) > 28 else details,
+                truncate(details, 28),
             )
 
         return CommandResult.success_result(errors_table, "rich")

--- a/deile/commands/builtin/memory_command.py
+++ b/deile/commands/builtin/memory_command.py
@@ -15,8 +15,8 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import (export_timestamp, get_memory_manager, split_args,
-                      success_panel)
+from ._shared import (export_timestamp, get_memory_manager, get_session,
+                      split_args, success_panel)
 
 _CHECKPOINT_DIR = Path.home() / ".deile" / "checkpoints"
 _CHECKPOINT_INDEX = _CHECKPOINT_DIR / "index.json"
@@ -118,7 +118,7 @@ class MemoryCommand(DirectCommand):
             table.add_row("MemoryManager", f"[INDISPONÍVEL: {real_usage['error'][:40]}]", "")
         else:
             # Fallback to session-level data
-            session = getattr(context, "session", None)
+            session = get_session(context)
             conv = len(getattr(session, "conversation_history", None) or []) if session else 0
             table.add_row("Conversa", str(conv), "Mensagens no histórico")
 
@@ -163,7 +163,7 @@ class MemoryCommand(DirectCommand):
     async def _clear_memory_type(self, context: CommandContext, memory_type: str) -> CommandResult:
         cleared = 0
         desc = ""
-        session = getattr(context, "session", None)
+        session = get_session(context)
 
         if memory_type in ("conversation", "conv", "history"):
             history = getattr(session, "conversation_history", None) if session else None
@@ -274,7 +274,7 @@ class MemoryCommand(DirectCommand):
         table.add_column("Impacto", style="red", width=12)
 
         total_impact = 0
-        session = getattr(context, "session", None)
+        session = get_session(context)
         if session:
             history = getattr(session, "conversation_history", None)
             if history:

--- a/deile/commands/builtin/memory_command.py
+++ b/deile/commands/builtin/memory_command.py
@@ -15,7 +15,8 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import get_memory_manager, split_args, success_panel
+from ._shared import (export_timestamp, get_memory_manager, split_args,
+                      success_panel)
 
 _CHECKPOINT_DIR = Path.home() / ".deile" / "checkpoints"
 _CHECKPOINT_INDEX = _CHECKPOINT_DIR / "index.json"
@@ -328,7 +329,7 @@ class MemoryCommand(DirectCommand):
     # ------------------------------------------------------------------
 
     async def _export_memory_state(self, context: CommandContext, args: list) -> CommandResult:
-        output_path_str = args[0] if args else f"memory_export_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        output_path_str = args[0] if args else f"memory_export_{export_timestamp()}.json"
         output_path = Path(output_path_str)
 
         mm = get_memory_manager(context)

--- a/deile/commands/builtin/memory_command.py
+++ b/deile/commands/builtin/memory_command.py
@@ -126,17 +126,15 @@ class MemoryCommand(DirectCommand):
         try:
             from ...orchestration.plan_manager import get_plan_manager
             pm = get_plan_manager()
-            active = len(pm._active_plans)
             total_plans = len(await pm.list_plans())
-            table.add_row("Planos Ativos", str(active), f"Total: {total_plans}")
+            table.add_row("Planos Ativos", str(pm.active_plan_count()), f"Total: {total_plans}")
         except Exception:
             table.add_row("Planos", "[INDISPONÍVEL]", "")
 
         # Audit events
         try:
             from ...security.audit_logger import get_audit_logger
-            audit_count = len(get_audit_logger().recent_events)
-            table.add_row("Eventos de Auditoria", str(audit_count), "Buffer em memória")
+            table.add_row("Eventos de Auditoria", str(get_audit_logger().event_count()), "Buffer em memória")
         except Exception:
             pass
 
@@ -190,12 +188,9 @@ class MemoryCommand(DirectCommand):
             try:
                 from ...orchestration.plan_manager import get_plan_manager
                 pm = get_plan_manager()
-                cleared = len(pm._active_plans)
-                for plan_id in list(pm._active_plans.keys()):
+                for plan_id in pm.active_plan_ids():
                     await pm.stop_plan(plan_id)
-                pm._active_plans.clear()
-                pm._execution_locks.clear()
-                pm._stop_flags.clear()
+                cleared = pm.clear_active_state()
                 desc = "planos ativos"
             except Exception:
                 desc = "planos (nenhum encontrado)"
@@ -203,9 +198,7 @@ class MemoryCommand(DirectCommand):
         elif memory_type in ("audit", "logs"):
             try:
                 from ...security.audit_logger import get_audit_logger
-                al = get_audit_logger()
-                cleared = len(al.recent_events)
-                al.recent_events.clear()
+                cleared = get_audit_logger().clear_events()
                 desc = "eventos de auditoria"
             except Exception:
                 desc = "eventos de auditoria"
@@ -224,19 +217,14 @@ class MemoryCommand(DirectCommand):
             try:
                 from ...orchestration.plan_manager import get_plan_manager
                 pm = get_plan_manager()
-                total += len(pm._active_plans)
-                for plan_id in list(pm._active_plans.keys()):
+                for plan_id in pm.active_plan_ids():
                     await pm.stop_plan(plan_id)
-                pm._active_plans.clear()
-                pm._execution_locks.clear()
-                pm._stop_flags.clear()
+                total += pm.clear_active_state()
             except Exception:
                 pass
             try:
                 from ...security.audit_logger import get_audit_logger
-                al = get_audit_logger()
-                total += len(al.recent_events)
-                al.recent_events.clear()
+                total += get_audit_logger().clear_events()
             except Exception:
                 pass
             cleared = total
@@ -292,8 +280,7 @@ class MemoryCommand(DirectCommand):
 
         try:
             from ...orchestration.plan_manager import get_plan_manager
-            pm = get_plan_manager()
-            active = len(pm._active_plans)
+            active = get_plan_manager().active_plan_count()
             if active > 0:
                 impact = "Alto" if active > 5 else "Médio" if active > 2 else "Baixo"
                 table.add_row("Planos Ativos", str(active), f"{active * 1000}B", impact)
@@ -303,7 +290,7 @@ class MemoryCommand(DirectCommand):
 
         try:
             from ...security.audit_logger import get_audit_logger
-            audit_count = len(get_audit_logger().recent_events)
+            audit_count = get_audit_logger().event_count()
             if audit_count > 0:
                 impact = "Médio" if audit_count > 500 else "Baixo"
                 table.add_row("Eventos de Auditoria", str(audit_count), f"{audit_count * 300}B", impact)

--- a/deile/commands/builtin/model_command.py
+++ b/deile/commands/builtin/model_command.py
@@ -16,7 +16,7 @@ from ...core.interfaces.selector import (InteractiveSelector,
 from ...core.models.tier_router import get_tier_router, reset_tier_router
 from ...storage.usage_repository import BudgetGuard, get_usage_repository
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import error_panel, split_args
+from ._shared import error_panel, get_agent, split_args
 
 logger = logging.getLogger(__name__)
 
@@ -368,7 +368,7 @@ EXAMPLES:
         # dict; MagicMock-based test contexts skip validation (they don't bootstrap
         # any providers anyway).
         forced_provider_id, forced_model_id = target.split(":", 1)
-        agent_obj = getattr(context, "agent", None)
+        agent_obj = get_agent(context)
         registered: Optional[dict] = None
         if agent_obj is not None and hasattr(agent_obj, "model_router"):
             providers_attr = getattr(agent_obj.model_router, "providers", None)
@@ -456,7 +456,7 @@ EXAMPLES:
         # Sync the legacy ModelRouter.strategy (consulted when tier classification fails)
         try:
             from deile.core.models.router import RoutingStrategy as _RS
-            agent_obj = getattr(context, "agent", None)
+            agent_obj = get_agent(context)
             if agent_obj is None:
                 # Fall back: try common aliases on the context
                 agent_obj = getattr(context, "deile_agent", None)

--- a/deile/commands/builtin/model_command.py
+++ b/deile/commands/builtin/model_command.py
@@ -16,7 +16,7 @@ from ...core.interfaces.selector import (InteractiveSelector,
 from ...core.models.tier_router import get_tier_router, reset_tier_router
 from ...storage.usage_repository import BudgetGuard, get_usage_repository
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import error_panel
+from ._shared import error_panel, split_args
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ EXAMPLES:
 """
 
     async def execute(self, context: CommandContext) -> CommandResult:
-        args = context.args.strip().split() if context.args.strip() else []
+        args = split_args(context)
         action = args[0].lower() if args else "list"
 
         try:

--- a/deile/commands/builtin/patch_command.py
+++ b/deile/commands/builtin/patch_command.py
@@ -12,7 +12,8 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import export_timestamp, file_action_emoji, split_args
+from ._shared import (analyze_plan_changes_stub, export_timestamp,
+                      file_action_emoji, split_args)
 
 
 class PatchCommand(DirectCommand):
@@ -177,50 +178,8 @@ class PatchCommand(DirectCommand):
             raise CommandError(f"Failed to write patch file: {str(e)}")
     
     async def _analyze_plan_changes(self, plan_id: str) -> Dict[str, Any]:
-        """Analyze changes made by a plan"""
-        
-        # Mock implementation - in real version would analyze artifacts and file changes
-        return {
-            'has_changes': True,
-            'plan_id': plan_id,
-            'summary': {
-                'files_modified': 3,
-                'files_created': 1,
-                'files_deleted': 0,
-                'lines_added': 45,
-                'lines_removed': 12
-            },
-            'file_changes': [
-                {
-                    'path': 'src/main.py',
-                    'action': 'modified',
-                    'old_content': 'def main():\n    print("Hello")\n    return 0',
-                    'new_content': 'def main():\n    print("Hello World")\n    logging.info("Application started")\n    return 0',
-                    'lines_added': 15,
-                    'lines_removed': 5
-                },
-                {
-                    'path': 'config/settings.json',
-                    'action': 'modified',
-                    'old_content': '{"debug": false}',
-                    'new_content': '{"debug": false, "log_level": "INFO"}',
-                    'lines_added': 3,
-                    'lines_removed': 2
-                },
-                {
-                    'path': 'tests/test_main.py',
-                    'action': 'created',
-                    'old_content': '',
-                    'new_content': 'import unittest\nfrom src.main import main\n\nclass TestMain(unittest.TestCase):\n    def test_main(self):\n        self.assertEqual(main(), 0)',
-                    'lines_added': 27,
-                    'lines_removed': 0
-                }
-            ],
-            'artifacts': [
-                'ARTIFACTS/session_123/bash_output_001.txt',
-                'ARTIFACTS/session_123/file_list_002.json'
-            ]
-        }
+        """Stub — see analyze_plan_changes_stub for the canonical placeholder."""
+        return analyze_plan_changes_stub(plan_id)
     
     async def _create_patch_content(self, plan, changes: Dict[str, Any], 
                                   output_format: str, include_artifacts: bool) -> str:

--- a/deile/commands/builtin/patch_command.py
+++ b/deile/commands/builtin/patch_command.py
@@ -13,7 +13,7 @@ from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import (analyze_plan_changes_stub, export_timestamp,
-                      file_action_emoji, split_args)
+                      file_action_emoji, split_args, wrap_command_errors)
 
 
 class PatchCommand(DirectCommand):
@@ -31,45 +31,37 @@ class PatchCommand(DirectCommand):
         self.patches_dir = Path("./PATCHES")
         self.patches_dir.mkdir(exist_ok=True)
     
+    @wrap_command_errors("patch")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute patch command"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # List available patches
-                return await self._list_patches()
-            
-            plan_id = parts[0]
-            
-            # Parse options
-            output_format = "unified"  # unified, git, simple
-            output_path = None
-            include_artifacts = False
-            
-            for i, part in enumerate(parts[1:], 1):
-                if part == "--git":
-                    output_format = "git"
-                elif part == "--simple":
-                    output_format = "simple"
-                elif part == "--artifacts":
-                    include_artifacts = True
-                elif part.startswith("--output="):
-                    output_path = part.split("=", 1)[1]
-                elif part == "--output":
-                    if i + 1 < len(parts):
-                        output_path = parts[i + 1]
-                    else:
-                        raise CommandError("--output requires a path")
-                elif part.startswith("--"):
-                    raise CommandError(f"Unknown option: {part}")
-            
-            return await self._generate_patch(plan_id, output_format, output_path, include_artifacts)
-            
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute patch command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            return await self._list_patches()
+
+        plan_id = parts[0]
+        output_format = "unified"  # unified, git, simple
+        output_path = None
+        include_artifacts = False
+
+        for i, part in enumerate(parts[1:], 1):
+            if part == "--git":
+                output_format = "git"
+            elif part == "--simple":
+                output_format = "simple"
+            elif part == "--artifacts":
+                include_artifacts = True
+            elif part.startswith("--output="):
+                output_path = part.split("=", 1)[1]
+            elif part == "--output":
+                if i + 1 < len(parts):
+                    output_path = parts[i + 1]
+                else:
+                    raise CommandError("--output requires a path")
+            elif part.startswith("--"):
+                raise CommandError(f"Unknown option: {part}")
+
+        return await self._generate_patch(plan_id, output_format, output_path, include_artifacts)
     
     async def _list_patches(self) -> CommandResult:
         """List available patch files"""

--- a/deile/commands/builtin/patch_command.py
+++ b/deile/commands/builtin/patch_command.py
@@ -12,7 +12,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import export_timestamp, split_args
+from ._shared import export_timestamp, file_action_emoji, split_args
 
 
 class PatchCommand(DirectCommand):
@@ -387,13 +387,7 @@ class PatchCommand(DirectCommand):
         if changes['file_changes']:
             content_lines.append("**Files in Patch:**")
             for file_change in changes['file_changes'][:5]:  # Show first 5
-                action_emoji = {
-                    'modified': '📝',
-                    'created': '✨',
-                    'deleted': '🗑️'
-                }.get(file_change['action'], '❓')
-                
-                content_lines.append(f"  {action_emoji} {file_change['path']}")
+                content_lines.append(f"  {file_action_emoji(file_change['action'])} {file_change['path']}")
             
             if len(changes['file_changes']) > 5:
                 content_lines.append(f"  ... and {len(changes['file_changes']) - 5} more files")

--- a/deile/commands/builtin/permissions_command.py
+++ b/deile/commands/builtin/permissions_command.py
@@ -15,7 +15,7 @@ from ...security.permissions import (PermissionLevel, PermissionRule,
                                      ResourceType, get_permission_manager)
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import (emit_audit_event, error_panel, split_args, success_panel,
-                      warning_panel)
+                      truncate, warning_panel)
 
 
 def _persist(pm) -> None:
@@ -164,8 +164,8 @@ class PermissionsCommand(DirectCommand):
 
         for rule in sorted(rules, key=lambda r: r.priority):
             status = "✅ On" if rule.enabled else "❌ Off"
-            rule_id = rule.id[:13] + "…" if len(rule.id) > 13 else rule.id
-            name = rule.name[:18] + "…" if len(rule.name) > 18 else rule.name
+            rule_id = truncate(rule.id, 13, "…")
+            name = truncate(rule.name, 18, "…")
             table.add_row(rule_id, name, rule.resource_type.value, rule.permission_level.value, status, str(rule.priority))
 
         return CommandResult.success_result(table, "rich")

--- a/deile/commands/builtin/plan_command.py
+++ b/deile/commands/builtin/plan_command.py
@@ -10,9 +10,9 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import (plan_status_emoji, risk_emoji, split_args, step_status_emoji,
-                      success_panel, truncate, warning_panel,
-                      wrap_command_errors)
+from ._shared import (plan_status_emoji, risk_emoji, split_args,
+                      step_status_emoji, success_panel, truncate,
+                      warning_panel, wrap_command_errors)
 
 
 class PlanCommand(DirectCommand):
@@ -234,7 +234,7 @@ class PlanCommand(DirectCommand):
             for step in status['current_steps']:
                 emoji = step_status_emoji(step['status'])
                 approval_text = " (needs approval)" if step['requires_approval'] else ""
-                content_lines.append(f"  • {status_emoji} {step['description']}{approval_text}")
+                content_lines.append(f"  • {emoji} {step['description']}{approval_text}")
         
         # Recent steps (last 5)
         content_lines.extend([

--- a/deile/commands/builtin/plan_command.py
+++ b/deile/commands/builtin/plan_command.py
@@ -10,7 +10,8 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args, success_panel, truncate, warning_panel
+from ._shared import (risk_emoji, split_args, success_panel, truncate,
+                      warning_panel)
 
 
 class PlanCommand(DirectCommand):
@@ -121,8 +122,7 @@ class PlanCommand(DirectCommand):
         
         # Add step summary
         for i, step in enumerate(plan.steps[:5], 1):  # Show first 5 steps
-            risk_emoji = {"low": "🟢", "medium": "🟡", "high": "🔴", "critical": "🚨"}
-            emoji = risk_emoji.get(step.risk_level.value, "❓")
+            emoji = risk_emoji(step.risk_level.value)
             approval = " ⚠️" if step.requires_approval else ""
             
             content_lines.append(f"  {i}. {emoji} {step.description}{approval}")

--- a/deile/commands/builtin/plan_command.py
+++ b/deile/commands/builtin/plan_command.py
@@ -10,8 +10,8 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import (risk_emoji, split_args, success_panel, truncate,
-                      warning_panel)
+from ._shared import (plan_status_emoji, risk_emoji, split_args, step_status_emoji,
+                      success_panel, truncate, warning_panel)
 
 
 class PlanCommand(DirectCommand):
@@ -166,18 +166,7 @@ class PlanCommand(DirectCommand):
         table.add_column("Created", style="dim", width=16)
         
         for plan in plans:
-            # Status with emoji
-            status_emojis = {
-                "draft": "📝",
-                "ready": "⚡",
-                "running": "🔄",
-                "paused": "⏸️",
-                "completed": "✅",
-                "failed": "❌",
-                "cancelled": "🚫"
-            }
-            
-            status_emoji = status_emojis.get(plan["status"], "❓")
+            status_emoji = plan_status_emoji(plan["status"])
             status_text = f"{status_emoji} {plan['status']}"
             
             # Progress calculation
@@ -253,11 +242,7 @@ class PlanCommand(DirectCommand):
                 "**Current Steps:**"
             ])
             for step in status['current_steps']:
-                status_emoji = {
-                    "running": "🔄",
-                    "requires_approval": "⚠️"
-                }.get(step['status'], "❓")
-                
+                emoji = step_status_emoji(step['status'])
                 approval_text = " (needs approval)" if step['requires_approval'] else ""
                 content_lines.append(f"  • {status_emoji} {step['description']}{approval_text}")
         
@@ -269,16 +254,7 @@ class PlanCommand(DirectCommand):
         
         recent_steps = plan.steps[-5:] if len(plan.steps) > 5 else plan.steps
         for step in recent_steps:
-            status_emojis = {
-                "pending": "⏳",
-                "running": "🔄",
-                "completed": "✅",
-                "failed": "❌",
-                "skipped": "⏭️",
-                "requires_approval": "⚠️"
-            }
-            
-            emoji = status_emojis.get(step.status.value, "❓")
+            emoji = step_status_emoji(step.status.value)
             risk_indicator = {"high": "🔴", "critical": "🚨"}.get(step.risk_level.value, "")
             
             content_lines.append(f"  • {emoji} {step.description} {risk_indicator}")

--- a/deile/commands/builtin/plan_command.py
+++ b/deile/commands/builtin/plan_command.py
@@ -11,7 +11,8 @@ from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import (plan_status_emoji, risk_emoji, split_args, step_status_emoji,
-                      success_panel, truncate, warning_panel)
+                      success_panel, truncate, warning_panel,
+                      wrap_command_errors)
 
 
 class PlanCommand(DirectCommand):
@@ -26,57 +27,46 @@ class PlanCommand(DirectCommand):
         super().__init__(config)
         self.plan_manager = get_plan_manager()
     
+    @wrap_command_errors("plan")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute plan command"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # List existing plans
-                return await self._list_plans()
-            
-            command = parts[0]
-            
-            if command == "create":
-                # Create new plan
-                if len(parts) < 2:
-                    raise CommandError("create command requires objective: /plan create <objective>")
-                objective = " ".join(parts[1:])
-                return await self._create_plan(objective, context)
-            
-            elif command == "show" or command == "status":
-                # Show plan details
-                if len(parts) < 2:
-                    raise CommandError("show command requires plan ID: /plan show <plan_id>")
-                plan_id = parts[1]
-                return await self._show_plan(plan_id)
-            
-            elif command == "list":
-                # Explicit list command
-                status_filter = None
-                if len(parts) > 1:
-                    try:
-                        status_filter = PlanStatus(parts[1])
-                    except ValueError:
-                        raise CommandError(f"Invalid status filter: {parts[1]}")
-                return await self._list_plans(status_filter)
-            
-            elif command == "delete":
-                # Delete plan
-                if len(parts) < 2:
-                    raise CommandError("delete command requires plan ID: /plan delete <plan_id>")
-                plan_id = parts[1]
-                return await self._delete_plan(plan_id)
-            
-            else:
-                # Assume it's an objective for creating a plan
-                objective = " ".join(parts)
-                return await self._create_plan(objective, context)
-            
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute plan command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            return await self._list_plans()
+
+        command = parts[0]
+
+        if command == "create":
+            if len(parts) < 2:
+                raise CommandError("create command requires objective: /plan create <objective>")
+            objective = " ".join(parts[1:])
+            return await self._create_plan(objective, context)
+
+        if command == "show" or command == "status":
+            if len(parts) < 2:
+                raise CommandError("show command requires plan ID: /plan show <plan_id>")
+            plan_id = parts[1]
+            return await self._show_plan(plan_id)
+
+        if command == "list":
+            status_filter = None
+            if len(parts) > 1:
+                try:
+                    status_filter = PlanStatus(parts[1])
+                except ValueError:
+                    raise CommandError(f"Invalid status filter: {parts[1]}")
+            return await self._list_plans(status_filter)
+
+        if command == "delete":
+            if len(parts) < 2:
+                raise CommandError("delete command requires plan ID: /plan delete <plan_id>")
+            plan_id = parts[1]
+            return await self._delete_plan(plan_id)
+
+        # Assume it's an objective for creating a plan
+        objective = " ".join(parts)
+        return await self._create_plan(objective, context)
     
     async def _create_plan(self, objective: str, context: CommandContext) -> CommandResult:
         """Create a new execution plan"""

--- a/deile/commands/builtin/plan_command.py
+++ b/deile/commands/builtin/plan_command.py
@@ -10,7 +10,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args, success_panel, warning_panel
+from ._shared import split_args, success_panel, truncate, warning_panel
 
 
 class PlanCommand(DirectCommand):
@@ -191,7 +191,7 @@ class PlanCommand(DirectCommand):
             
             table.add_row(
                 plan["id"],
-                plan["title"][:30] + ("..." if len(plan["title"]) > 30 else ""),
+                truncate(plan["title"], 30),
                 status_text,
                 str(total),
                 progress_text,

--- a/deile/commands/builtin/run_command.py
+++ b/deile/commands/builtin/run_command.py
@@ -14,7 +14,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import split_args, truncate
 
 
 class RunCommand(DirectCommand):
@@ -108,7 +108,7 @@ class RunCommand(DirectCommand):
             
             table.add_row(
                 plan["id"],
-                plan["title"][:30] + ("..." if len(plan["title"]) > 30 else ""),
+                truncate(plan["title"], 30),
                 progress_text,
                 current_step,
                 started_at

--- a/deile/commands/builtin/run_command.py
+++ b/deile/commands/builtin/run_command.py
@@ -15,7 +15,7 @@ from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import risk_emoji as _risk_emoji
-from ._shared import split_args, truncate
+from ._shared import split_args, truncate, wrap_command_errors
 
 
 class RunCommand(DirectCommand):
@@ -30,38 +30,29 @@ class RunCommand(DirectCommand):
         super().__init__(config)
         self.plan_manager = get_plan_manager()
     
+    @wrap_command_errors("run")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute run command"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # Show running plans
-                return await self._show_running_plans()
-            
-            plan_id = parts[0]
-            
-            # Parse options
-            auto_approve_low_risk = True
-            dry_run = False
-            
-            for part in parts[1:]:
-                if part == "--no-auto-approve":
-                    auto_approve_low_risk = False
-                elif part == "--dry-run":
-                    dry_run = True
-                elif part.startswith("--"):
-                    raise CommandError(f"Unknown option: {part}")
-            
-            if dry_run:
-                return await self._dry_run_plan(plan_id)
-            else:
-                return await self._execute_plan(plan_id, auto_approve_low_risk)
-            
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute run command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            return await self._show_running_plans()
+
+        plan_id = parts[0]
+        auto_approve_low_risk = True
+        dry_run = False
+
+        for part in parts[1:]:
+            if part == "--no-auto-approve":
+                auto_approve_low_risk = False
+            elif part == "--dry-run":
+                dry_run = True
+            elif part.startswith("--"):
+                raise CommandError(f"Unknown option: {part}")
+
+        if dry_run:
+            return await self._dry_run_plan(plan_id)
+        return await self._execute_plan(plan_id, auto_approve_low_risk)
     
     async def _show_running_plans(self) -> CommandResult:
         """Show currently running plans"""

--- a/deile/commands/builtin/run_command.py
+++ b/deile/commands/builtin/run_command.py
@@ -14,6 +14,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
+from ._shared import risk_emoji as _risk_emoji
 from ._shared import split_args, truncate
 
 
@@ -148,14 +149,7 @@ class RunCommand(DirectCommand):
             step_queue = step_queue[plan.max_concurrent_steps:]
             
             for step in current_steps:
-                # Risk indicators
-                risk_emoji = {
-                    "low": "🟢",
-                    "medium": "🟡", 
-                    "high": "🔴",
-                    "critical": "🚨"
-                }.get(step.risk_level.value, "❓")
-                
+                risk_emoji = _risk_emoji(step.risk_level.value)
                 approval_text = " ⚠️ (needs approval)" if step.requires_approval else ""
                 deps_text = f" (depends on: {', '.join(step.depends_on)})" if step.depends_on else ""
                 

--- a/deile/commands/builtin/skills_command.py
+++ b/deile/commands/builtin/skills_command.py
@@ -14,6 +14,7 @@ from rich.table import Table
 from rich.text import Text
 
 from ..base import CommandContext, CommandResult, DirectCommand
+from ._shared import split_args
 
 
 class SkillsCommand(DirectCommand):
@@ -37,7 +38,7 @@ class SkillsCommand(DirectCommand):
     # ------------------------------------------------------------------
 
     async def execute(self, context: CommandContext) -> CommandResult:
-        parts = context.args.strip().split() if context.args and context.args.strip() else []
+        parts = split_args(context)
 
         if not parts:
             return self._show_menu()

--- a/deile/commands/builtin/skills_command.py
+++ b/deile/commands/builtin/skills_command.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.text import Text
 
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import get_agent, split_args
 
 
 class SkillsCommand(DirectCommand):
@@ -158,7 +158,7 @@ class SkillsCommand(DirectCommand):
     @staticmethod
     def _hot_reload(context: "CommandContext") -> str:
         """Trigger skills reload on the running agent. Returns a status suffix."""
-        agent = getattr(context, "agent", None)
+        agent = get_agent(context)
         if agent is None:
             return ""
         reload_fn = getattr(agent, "reload_skills", None)

--- a/deile/commands/builtin/status_command.py
+++ b/deile/commands/builtin/status_command.py
@@ -6,7 +6,6 @@ import asyncio
 import socket
 import sys
 import time
-from datetime import datetime
 from typing import Any, Dict, Tuple
 
 import psutil
@@ -16,15 +15,12 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from deile.__version__ import __version__
-
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import (emit_audit_event, error_panel, get_memory_manager,
                       split_args, success_panel, warning_panel)
 from ._status_collectors import (collect_health_info, collect_models_info,
-                                  collect_system_info, collect_tools_info,
-                                  get_system_uptime)
+                                 collect_system_info, collect_tools_info)
 
 _PROVIDER_HOSTS: Dict[str, str] = {
     "openai": "api.openai.com",

--- a/deile/commands/builtin/status_command.py
+++ b/deile/commands/builtin/status_command.py
@@ -457,7 +457,7 @@ class StatusCommand(DirectCommand):
         try:
             from ...orchestration.plan_manager import get_plan_manager
             plan_manager = get_plan_manager()
-            active_plans = list(plan_manager._active_plans.values())
+            active_plans = plan_manager.iter_active_plans()
             all_plans = await plan_manager.list_plans()
 
             table = Table(

--- a/deile/commands/builtin/status_command.py
+++ b/deile/commands/builtin/status_command.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-import platform
 import socket
 import sys
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 import psutil
 from rich.columns import Columns
@@ -23,6 +22,9 @@ from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import (emit_audit_event, error_panel, get_memory_manager,
                       split_args, success_panel, warning_panel)
+from ._status_collectors import (collect_health_info, collect_models_info,
+                                  collect_system_info, collect_tools_info,
+                                  get_system_uptime)
 
 _PROVIDER_HOSTS: Dict[str, str] = {
     "openai": "api.openai.com",
@@ -112,10 +114,10 @@ class StatusCommand(DirectCommand):
     # ------------------------------------------------------------------
 
     async def _show_complete_status(self, context: CommandContext) -> CommandResult:
-        system_info = self._get_system_info()
-        models_info = self._get_models_info()
-        tools_info = self._get_tools_info()
-        health_info = self._get_health_info()
+        system_info = collect_system_info()
+        models_info = collect_models_info()
+        tools_info = collect_tools_info()
+        health_info = collect_health_info()
 
         left_column = Columns([self._create_system_panel(system_info), self._create_tools_panel(tools_info)], equal=True)
         right_column = Columns([self._create_models_panel(models_info), self._create_health_panel(health_info)], equal=True)
@@ -139,113 +141,7 @@ class StatusCommand(DirectCommand):
         return CommandResult.success_result(Group(left_column, right_column, usage_panel), "rich")
 
     # ------------------------------------------------------------------
-    # System info (overview panel)
-    # ------------------------------------------------------------------
-
-    def _get_system_info(self) -> Dict[str, Any]:
-        try:
-            return {
-                "deile_version": __version__,
-                "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-                "platform": platform.system(),
-                "platform_release": platform.release(),
-                "platform_version": platform.version(),
-                "architecture": platform.machine(),
-                "hostname": platform.node(),
-                "uptime": self._get_system_uptime(),
-                "cpu_count": psutil.cpu_count(),
-                "memory_total": psutil.virtual_memory().total,
-                "memory_used": psutil.virtual_memory().used,
-                "memory_percent": psutil.virtual_memory().percent,
-                "disk_usage": psutil.disk_usage(".").percent,
-            }
-        except Exception as exc:
-            return {"error": str(exc)}
-
-    def _get_system_uptime(self) -> str:
-        try:
-            boot_time = datetime.fromtimestamp(psutil.boot_time())
-            delta = datetime.now() - boot_time
-            h, rem = divmod(delta.seconds, 3600)
-            m, _ = divmod(rem, 60)
-            return f"{delta.days}d {h}h {m}m"
-        except Exception:
-            return "desconhecido"
-
-    # ------------------------------------------------------------------
-    # Models info (overview panel)
-    # ------------------------------------------------------------------
-
-    def _get_models_info(self) -> Dict[str, Any]:
-        try:
-            from ...core.models.router import get_model_router
-            router = get_model_router()
-            providers = list(router.providers.keys())
-            active_key = providers[0] if providers else None
-            active_provider = active_key.split(":", 1)[0] if active_key else _indisponivel("nenhum provedor")
-            active_model = active_key.split(":", 1)[1] if active_key and ":" in active_key else (active_key or _indisponivel("nenhum modelo"))
-            return {
-                "active_model": active_model,
-                "active_provider": active_provider,
-                "total_providers": len(providers),
-                "providers": providers,
-            }
-        except Exception as exc:
-            return {"error": str(exc)}
-
-    # ------------------------------------------------------------------
-    # Tools info (overview panel)
-    # ------------------------------------------------------------------
-
-    def _get_tools_info(self) -> Dict[str, Any]:
-        try:
-            from ...tools.registry import get_tool_registry
-            registry = get_tool_registry()
-            stats = registry.get_stats()
-            return {
-                "total_tools": stats["total_tools"],
-                "enabled_tools": stats["enabled_tools"],
-                "disabled_tools": stats["disabled_tools"],
-                "categories": stats["categories"],
-                "function_definitions": stats["available_functions"],
-                "tools_with_schemas": stats["tools_with_schemas"],
-                "auto_discovery": stats["auto_discovery_enabled"],
-                "tool_names": [t.name for t in registry.list_all()],
-            }
-        except Exception as exc:
-            return {"error": str(exc)}
-
-    # ------------------------------------------------------------------
-    # Health info (overview panel)
-    # ------------------------------------------------------------------
-
-    def _get_health_info(self) -> Dict[str, Any]:
-        try:
-            cpu_percent = psutil.cpu_percent(interval=0)
-            memory = psutil.virtual_memory()
-            health_score = 100
-            warnings: List[str] = []
-            if cpu_percent > 80:
-                health_score -= 20
-                warnings.append("CPU alto")
-            if memory.percent > 85:
-                health_score -= 15
-                warnings.append("Memória alta")
-            status = "saudável" if health_score >= 80 else "atenção" if health_score >= 60 else "crítico"
-            return {
-                "overall_status": status,
-                "health_score": health_score,
-                "cpu_usage": cpu_percent,
-                "memory_usage": memory.percent,
-                "warnings": warnings,
-                "uptime": self._get_system_uptime(),
-                "last_check": datetime.now().isoformat(),
-            }
-        except Exception as exc:
-            return {"error": str(exc), "overall_status": "desconhecido"}
-
-    # ------------------------------------------------------------------
-    # Panel builders (overview)
+    # Panel builders (overview) — collectors live in _status_collectors
     # ------------------------------------------------------------------
 
     def _create_system_panel(self, info: Dict[str, Any]) -> Panel:
@@ -309,7 +205,7 @@ class StatusCommand(DirectCommand):
     # ------------------------------------------------------------------
 
     async def _show_system_status(self, context: CommandContext) -> CommandResult:
-        info = self._get_system_info()
+        info = collect_system_info()
         table = Table(title="💻 Informações Detalhadas do Sistema", show_header=True, header_style="bold green")
         table.add_column("Componente", style="cyan", width=20)
         table.add_column("Valor", style="white", width=30)

--- a/deile/commands/builtin/stop_command.py
+++ b/deile/commands/builtin/stop_command.py
@@ -7,7 +7,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args, truncate
+from ._shared import split_args, truncate, wrap_command_errors
 
 
 class StopCommand(DirectCommand):
@@ -22,28 +22,18 @@ class StopCommand(DirectCommand):
         super().__init__(config)
         self.plan_manager = get_plan_manager()
     
+    @wrap_command_errors("stop")
     async def execute(self, context: CommandContext) -> CommandResult:
         """Execute stop command"""
-        try:
-            parts = split_args(context)
-            
-            if not parts:
-                # Show running plans that can be stopped
-                return await self._show_stoppable_plans()
-            
-            plan_id = parts[0]
-            
-            # Parse options
-            force = False
-            if len(parts) > 1 and parts[1] == "--force":
-                force = True
-            
-            return await self._stop_plan(plan_id, force)
-            
-        except Exception as e:
-            if isinstance(e, CommandError):
-                raise
-            raise CommandError(f"Failed to execute stop command: {str(e)}")
+        parts = split_args(context)
+
+        if not parts:
+            return await self._show_stoppable_plans()
+
+        plan_id = parts[0]
+        force = len(parts) > 1 and parts[1] == "--force"
+
+        return await self._stop_plan(plan_id, force)
     
     async def _show_stoppable_plans(self) -> CommandResult:
         """Show plans that can be stopped"""

--- a/deile/commands/builtin/stop_command.py
+++ b/deile/commands/builtin/stop_command.py
@@ -7,7 +7,7 @@ from rich.text import Text
 from ...core.exceptions import CommandError
 from ...orchestration.plan_manager import PlanStatus, get_plan_manager
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import split_args, truncate
 
 
 class StopCommand(DirectCommand):
@@ -100,7 +100,7 @@ class StopCommand(DirectCommand):
             
             table.add_row(
                 plan["id"],
-                plan["title"][:30] + ("..." if len(plan["title"]) > 30 else ""),
+                truncate(plan["title"], 30),
                 status_text,
                 progress_text,
                 started_at,

--- a/deile/commands/builtin/tools_command.py
+++ b/deile/commands/builtin/tools_command.py
@@ -12,7 +12,7 @@ from rich.text import Text
 
 from ...core.exceptions import CommandError
 from ..base import CommandContext, CommandResult, DirectCommand
-from ._shared import split_args
+from ._shared import split_args, truncate
 
 
 class ToolsCommand(DirectCommand):
@@ -266,7 +266,7 @@ class ToolsCommand(DirectCommand):
                 tool_data.get("risk_level", "unknown"),
                 str(stats.get("total_calls", 0)),
                 f"{stats.get('success_rate', 0):.1f}",
-                tool_data.get("description", "No description")[:40] + ("..." if len(tool_data.get("description", "")) > 40 else "")
+                truncate(tool_data.get("description", "No description"), 40),
             )
         
         return table

--- a/deile/orchestration/plan_manager.py
+++ b/deile/orchestration/plan_manager.py
@@ -482,6 +482,42 @@ class PlanManager:
         await self._save_plan(plan)
         return True
     
+    def active_plan_count(self) -> int:
+        """Number of plans currently held in the in-memory active map.
+
+        Public accessor for ``len(self._active_plans)`` consumed by
+        memory/status commands — those used to reach into the private
+        attribute directly, violating SRP.
+        """
+        return len(self._active_plans)
+
+    def active_plan_ids(self) -> List[str]:
+        """Snapshot list of active plan IDs (safe to iterate while mutating)."""
+        return list(self._active_plans.keys())
+
+    def get_active_plan(self, plan_id: str) -> Optional[ExecutionPlan]:
+        """Active-only lookup; does NOT load from disk. Companion of
+        :meth:`get_plan_status` which also falls back to load_plan."""
+        return self._active_plans.get(plan_id)
+
+    def iter_active_plans(self) -> List[ExecutionPlan]:
+        """Snapshot list of active plan objects."""
+        return list(self._active_plans.values())
+
+    def clear_active_state(self) -> int:
+        """Drop in-memory active plans, locks and stop flags atomically.
+
+        Returns the number of active plans cleared. Used by ``/cls reset``
+        and ``/memory reset``; callers used to mutate the three private
+        attributes directly. Saved plans on disk are preserved (this is
+        an in-memory reset only).
+        """
+        count = len(self._active_plans)
+        self._active_plans.clear()
+        self._execution_locks.clear()
+        self._stop_flags.clear()
+        return count
+
     async def get_plan_status(self, plan_id: str) -> Optional[Dict[str, Any]]:
         """Obtém status detalhado de um plano"""
         

--- a/deile/tests/commands/test_compact_command.py
+++ b/deile/tests/commands/test_compact_command.py
@@ -330,32 +330,6 @@ class TestExecuteSignature:
 
 
 # ---------------------------------------------------------------------------
-# /compact config
-# ---------------------------------------------------------------------------
-
-
-class TestCompactConfig:
-    async def test_show_config_returns_success(self):
-        result = await _cmd().execute(_ctx("config"))
-        assert result.success
-        assert result.content_type == "rich"
-
-    async def test_set_config_updates_value(self):
-        cmd = _cmd()
-        result = await cmd.execute(_ctx("config compress_threshold_days 14"))
-        assert result.success
-        assert cmd.compact_config["compress_threshold_days"] == 14
-
-    async def test_set_config_unknown_key_returns_error(self):
-        result = await _cmd().execute(_ctx("config nonexistent_key 42"))
-        assert not result.success
-
-    async def test_set_config_invalid_value_returns_error(self):
-        result = await _cmd().execute(_ctx("config compress_threshold_days notanumber"))
-        assert not result.success
-
-
-# ---------------------------------------------------------------------------
 # /compact export + import (integration with SessionStore)
 # ---------------------------------------------------------------------------
 

--- a/deile/tests/commands/test_memory_command.py
+++ b/deile/tests/commands/test_memory_command.py
@@ -586,7 +586,7 @@ class TestUsageHighImpact:
         """_show_memory_usage shows plans row when plan_manager has active plans."""
         with patch("deile.orchestration.plan_manager.get_plan_manager") as mock_gpm:
             mock_pm = MagicMock()
-            mock_pm._active_plans = {"p1": MagicMock(), "p2": MagicMock(), "p3": MagicMock()}
+            mock_pm.active_plan_count.return_value = 3
             mock_gpm.return_value = mock_pm
             result = await _cmd().execute(_ctx("usage"))
             assert result.success is True
@@ -605,7 +605,7 @@ class TestUsageHighImpact:
 
         with patch("deile.orchestration.plan_manager.get_plan_manager") as mock_gpm:
             mock_pm = MagicMock()
-            mock_pm._active_plans = {"p1": MagicMock(), "p2": MagicMock(), "p3": MagicMock()}  # active=3 → +3
+            mock_pm.active_plan_count.return_value = 3  # active=3 → +3
             mock_gpm.return_value = mock_pm
             result = await _cmd().execute(ctx)
             assert result.success is True
@@ -616,10 +616,9 @@ class TestUsageHighImpact:
         """Clear plans type with actually active plans removes them."""
         with patch("deile.orchestration.plan_manager.get_plan_manager") as mock_gpm:
             mock_pm = MagicMock()
-            mock_pm._active_plans = {"p1": MagicMock()}
+            mock_pm.active_plan_ids.return_value = ["p1"]
+            mock_pm.clear_active_state.return_value = 1
             mock_pm.stop_plan = AsyncMock()
-            mock_pm._execution_locks = {}
-            mock_pm._stop_flags = {}
             mock_gpm.return_value = mock_pm
             result = await _cmd().execute(_ctx("clear plans"))
             assert result.success is True


### PR DESCRIPTION
## Refatoração Arquitetural Diária — 2026-05-10

**Modo**: prs-do-dia
**PRs exógenas base**: #181 (refactor(daily): 2026-05-10 — 11 cross-file refactorings in commands/builtin) — files in `deile/commands/builtin/`
**Resumo arquitetural**: PR #181 cobriu split_args/panels/audit/get_memory_manager. Esta PR cobre o que restou: 4 cmds não migrados ao split_args; padrão truncate repetido 14x; mapas action_emoji/risk_emoji literais 9x; feature envy em plan_manager privados e audit_logger.recent_events; mocks de _analyze_plan_changes duplicados; wrap-and-raise CommandError em 8 cmds (decorator); export_timestamp reinventado com bug de tz; status_command 14 métodos (SRP); clear._clear_reset 152L+8 try/except; compact_config simulando persistência sem persistir.

### Plano executado

| # | Tipo | Valor | Status | Descrição |
|---|---|---|---|---|
| 1 | DRY_CROSS | ALTO | APPLIED | Migrate 4 cmds (model/skills/compact/cost) to `split_args()` helper |
| 2 | DRY_CROSS | ALTO | APPLIED | Add `truncate()` helper to _shared, dedupe 14+ sites across 8 cmds |
| 3 | DRY_CROSS | ALTO | APPLIED | Extract `FILE_ACTION_EMOJI`/`RISK_EMOJI` constants + helpers to _shared |
| 4 | FEATURE_ENVY | ALTO | APPLIED | Add `PlanManager.{active_plan_count,active_plan_ids,iter_active_plans,get_active_plan,clear_active_state}`; migrate clear/memory/status to use them. Use existing `audit_logger.event_count()/clear_events()` |
| 5 | DRY_CROSS | ALTO | APPLIED | Consolidate `_analyze_plan_changes` mocks into single `analyze_plan_changes_stub()` in _shared |
| 6 | DRY_CROSS | MEDIO | APPLIED | Add `@wrap_command_errors(name)` decorator; migrate 8 commands |
| 7 | DRY_CROSS | MEDIO | APPLIED | Replace ad-hoc strftime with `export_timestamp()`; fix tz bug in memory_command |
| 8 | DRY_CROSS | MEDIO | APPLIED | Add `get_agent()/get_session()` helpers to _shared; migrate 6 cmds |
| 9 | GOD_OBJECT | MEDIO | APPLIED | Extract `_get_*_info` collectors from `status_command` into `_status_collectors.py` (separate observation from presentation) |
| 10 | KISS | MEDIO | APPLIED | Split 152-line `_clear_reset` into 5 focused helpers; drop dead `if not force: pass` |
| 11 | DEAD_CODE | MEDIO | APPLIED | Remove non-persistent `/compact config` subcommand + dead `compact_config` dict |
| 12 | DRY_CROSS | MEDIO | APPLIED | Extract `PLAN_STATUS_EMOJI`/`STEP_STATUS_EMOJI` constants + helpers; migrate 3 sites in plan_command |

### Arquivos modificados (24 files, +792/-825)
- `deile/commands/builtin/_shared.py` — new helpers + constants (truncate, file_action_emoji, risk_emoji, plan_status_emoji, step_status_emoji, get_agent, get_session, wrap_command_errors, analyze_plan_changes_stub)
- `deile/commands/builtin/{apply,approve,clear,compact,context,cost,diff,export,logs,memory,model,patch,permissions,plan,run,skills,status,stop,tools}_command.py` — migrate to helpers
- `deile/orchestration/plan_manager.py` — public API: active_plan_count/ids, iter_active_plans, get_active_plan, clear_active_state
- `deile/tests/commands/test_memory_command.py` — update mocks to public API
- `deile/tests/commands/test_compact_command.py` — drop TestCompactConfig (dead path)

### Arquivos criados
- `deile/commands/builtin/_status_collectors.py` — pure data collectors extracted from status_command (collect_system_info, collect_models_info, collect_tools_info, collect_health_info, get_system_uptime)

### Arquivos removidos
nenhum

### Itens revertidos
nenhum — all 12 items applied successfully.

### Testes gate local

**Baseline**: 2423 passed, 12 skipped
**Final**: 2419 passed, 12 skipped (4 fewer = TestCompactConfig removed in item 11; net regression = 0)

### Checklist de segurança

- [x] Testes antes-passando continuam passando (gate local verde)
- [x] Assinaturas públicas inalteradas; mover símbolo cross-modulo (PlanManager.clear_active_state) atualiza todos callers no mesmo commit
- [x] Registry pattern respeitado — nenhum comando renomeado, nenhum SlashCommand cls alterado
- [x] Arquitetura hexagonal respeitada — `_status_collectors.py` fica em commands/builtin (não em core/)
- [x] Sem nova dependência externa
- [x] Dead code removido com prova de grep (compact_config: zero callers fora do próprio arquivo)
- [x] Sem I/O síncrono em async novos
- [x] `ruff check` limpo
- [x] `isort --check-only` limpo

> ⏳ Aguardando revisão e merge pelo pipeline `deile-issue-dev-pr-review-full`.

🤖 Gerado pelo pipeline DEILE refactor-daily (gate local confirmado verde)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFFHX1aMQhxETFey6DCHzF)_