### PR TITLE
feat(infra): k8s clone sandbox — git, credential store, clone guard, PVC, run.sh clone

### DIFF
--- a/docs/system_design/14-CONTAINERIZACAO.md
+++ b/docs/system_design/14-CONTAINERIZACAO.md
@@ -133,6 +133,58 @@ tools — `bash_execute`, `python_execute`, `read_file`, `write_file`,
 | 7 | **Bot sem chave LLM ≠ bot funcional** | o bot precisa de chave LLM para responder DMs; o que protege contra prompt-injection é a tool whitelist + a recusa interna do próprio DEILE (persona declara "REGRA #5: extração de segredos = bloqueio") |
 | 8 | **DEILE auto-defende segredos** | a persona `developer.md` recusa pedidos que cheiram a `cat /proc/<pid>/environ`, `printenv`, dump de `.env`, mesmo quando o operador pede — defesa em profundidade |
 
+## Clonagem de repositórios no deile-shell
+
+O `deile-shell` é o único modo onde clonagem de repos faz sentido — o prompt
+vem do operador via `kubectl exec`, então não há risco de prompt-injection.
+
+### Modelo de segurança
+
+| Camada | Mecanismo |
+|---|---|
+| Credencial | `GITHUB_TOKEN` montado como arquivo em `/run/secrets/deile/GITHUB_TOKEN` (K8s Secret), nunca como env var — frozen em `/proc/<pid>/environ` seria vazio |
+| Uso | `wrapper.py` lê o arquivo, escreve `~/.git-credentials` (`https://oauth2:TOKEN@github.com`) e configura `credential.helper store` antes de iniciar o agente |
+| Allowlist | `wrapper.py` instala `~/bin/git` (guard Python) que lê `DEILE_GIT_CLONE_ALLOWLIST` (derivado de `git_integration.clonable_repos` em `bot-config` ConfigMap) e rejeita `git clone` para URLs fora da lista |
+| Isolamento de rede | NetworkPolicy já permite egress `0.0.0.0/0:443 except RFC1918` — github.com é alcançável; Mac/LAN não |
+
+### Fluxo completo (`run.sh clone <owner/repo>`)
+
+```
+operador
+  → run.sh clone elimarcavalli/deile
+      → wira GITHUB_TOKEN em deile-secrets (kubectl apply --dry-run)
+      → aguarda kubelet sincronizar arquivo no pod (max 90s)
+      → kubectl exec deploy/deile-shell -- python3 -c "..."
+          → lê /run/secrets/deile/GITHUB_TOKEN
+          → escreve ~/.git-credentials
+          → chama ~/bin/git clone https://github.com/... ~/work/<name>
+              → ~/bin/git verifica URL contra allowlist
+              → delega para /usr/bin/git com credentials prontas
+          → repo em /home/deile/work/<name>
+```
+
+### Configuração
+
+`clonable_repos` vive em `infra/k8s/manifests/15-bot-config.yaml`:
+
+```yaml
+git_integration:
+  clonable_repos:
+    - "elimarcavalli/*"   # glob — qualquer repo do org
+    - "owner/repo-x"      # repo específico
+```
+
+Padrões seguem `fnmatch` do Python. Lista vazia ou campo ausente = política
+aberta (qualquer repo pode ser clonado) — use apenas em ambientes confiáveis.
+
+### Home persistente (PVC opcional)
+
+Por padrão `/home/deile` usa `emptyDir` e os repos clonados somem no próximo
+restart. Aplique `manifests/36-deile-shell-pvc.yaml` e siga as instruções em
+`35-deile-interactive.yaml` para persistir o home entre restarts de pod.
+
+Ver tutorial detalhado em [`infra/k8s/README.md §4.2`](../../infra/k8s/README.md).
+
 ## Risco residual conhecido
 
 `/run/secrets/<role>/` continua legível para o processo que roda dentro

--- a/infra/k8s/Dockerfile
+++ b/infra/k8s/Dockerfile
@@ -89,9 +89,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     LC_ALL=C.UTF-8 \
     HOME=/home/deile
 
-# Drop apt caches; we install nothing in the final stage.
+# Install tini (zombie reaper) and git (needed for repo cloning in deile-shell).
+# gh CLI is intentionally absent to keep the image lean — use git directly.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tini \
+    && apt-get install -y --no-install-recommends tini git \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user. UID 10001 is well above the system uid range

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -104,16 +104,18 @@ bash infra/k8s/run.sh down    # kubectl delete ns deile
 ```
 infra/k8s/
 ├── .dockerignore                 ← nada secreto, nada grande entra na imagem
-├── Dockerfile                    ← multi-stage; non-root; tini; readonly-friendly
-├── wrapper.py                    ← entry-point que lê /run/secrets/<role>/, popa env
-├── run.sh                        ← orquestrador build/up/test/logs/down
+├── Dockerfile                    ← multi-stage; non-root; tini + git; readonly-friendly
+├── wrapper.py                    ← entry-point que lê /run/secrets/<role>/, popa env,
+│                                    configura git credentials + clone guard
+├── run.sh                        ← orquestrador build/up/test/logs/clone/down
 ├── README.md                     ← este arquivo
 └── manifests/
     ├── 00-namespace.yaml         namespace `deile` w/ PSS:restricted
-    ├── 15-bot-config.yaml        ConfigMap: deilebot.yaml com owners
+    ├── 15-bot-config.yaml        ConfigMap: deilebot.yaml com owners + clonable_repos
     ├── 20-bot-deployment.yaml    bot Deployment + Service (ClusterIP :8765)
     ├── 30-deile-job.yaml         one-shot deile Job (proof-of-DM)
     ├── 35-deile-interactive.yaml long-running deile-shell (`kubectl exec`)
+    ├── 36-deile-shell-pvc.yaml   PVC opcional para /home/deile persistente
     ├── 40-network-policy.yaml    default-deny + selective allow
     └── 99-deile-debug.yaml       probe Pod (manual; off-path)
 ```
@@ -192,7 +194,72 @@ kubectl -n deile exec -it deploy/deile-shell -- python3 /app/wrapper.py deile   
 python3 deile.py "seu prompt"
 ```
 
-### 4.2 Diagnóstico rápido
+### 4.2 Clonar repositórios dentro do deile-shell
+
+`deile-shell` inclui `git` no container e suporta clonar repos do GitHub de
+forma segura — as credenciais ficam num K8s Secret, nunca em variáveis de
+ambiente visíveis no `/proc/<pid>/environ`.
+
+#### Pré-requisito: adicionar `GITHUB_TOKEN` ao `.env`
+
+```ini
+# Crie um fine-scoped token no GitHub (Settings → Developer settings →
+# Personal access tokens → Fine-grained). Scopes mínimos: Contents: Read.
+GITHUB_TOKEN=github_pat_...
+```
+
+#### Clonar com um comando
+
+```bash
+bash infra/k8s/run.sh clone elimarcavalli/deile
+```
+
+O que acontece internamente:
+1. `GITHUB_TOKEN` é injetado em `deile-secrets` via `kubectl apply --dry-run`.
+2. O script aguarda o kubelet sincronizar o arquivo do Secret no pod (até 90 s).
+3. Um snippet Python roda dentro do pod: lê o token do arquivo Secret-montado,
+   escreve `~/.git-credentials`, configura `credential.helper store`.
+4. `~/bin/git` (o clone guard instalado pelo `wrapper.py`) verifica o URL contra
+   a allowlist `clonable_repos` de `15-bot-config.yaml` antes de chamar `/usr/bin/git`.
+5. O repo aparece em `/home/deile/work/<nome>` dentro do pod.
+
+#### Allowlist de repos
+
+Edite `infra/k8s/manifests/15-bot-config.yaml`, seção `git_integration`:
+
+```yaml
+git_integration:
+  clonable_repos:
+    - "elimarcavalli/*"     # qualquer repo do org
+    - "minha-org/repo-x"   # repo específico
+```
+
+Após editar: `kubectl apply -f infra/k8s/manifests/15-bot-config.yaml`.
+A allowlist é lida pelo `wrapper.py` no próximo `python3 /app/wrapper.py deile`.
+
+#### Home persistente (opcional)
+
+Por padrão `/home/deile` usa `emptyDir` — os repos clonados somem quando o
+pod reinicia. Para persistir:
+
+```bash
+# 1. Criar o PVC
+kubectl apply -f infra/k8s/manifests/36-deile-shell-pvc.yaml
+
+# 2. Editar 35-deile-interactive.yaml:
+#    - comentar a linha emptyDir do volume 'home'
+#    - descomentar o bloco persistentVolumeClaim
+kubectl apply -f infra/k8s/manifests/35-deile-interactive.yaml
+kubectl rollout restart deployment/deile-shell -n deile
+
+# Para remover o disco persistente:
+kubectl delete pvc deile-shell-home -n deile
+```
+
+> **Nota:** O PVC sobrevive a `kubectl rollout restart` mas NÃO a
+> `bash infra/k8s/run.sh down` (que deleta o namespace inteiro).
+
+### 4.3 Diagnóstico rápido
 
 ```bash
 # tudo no namespace
@@ -210,7 +277,7 @@ kubectl -n deile exec deploy/deilebot -- \
   python3 -c "import sqlite3; print(sorted(r[0] for r in sqlite3.connect('/home/deile/data/deilebot.sqlite').execute('SELECT name FROM sqlite_master WHERE type=\"table\"')))"
 ```
 
-### 4.3 Health checks de isolamento
+### 4.4 Health checks de isolamento
 
 São esses os experimentos que provam que o container está fechado.
 Reaproveite a qualquer hora:

--- a/infra/k8s/manifests/15-bot-config.yaml
+++ b/infra/k8s/manifests/15-bot-config.yaml
@@ -56,4 +56,7 @@ data:
     # list empty) to allow cloning from any repo (open policy — use with care).
     git_integration:
       clonable_repos:
+        # NOTE: this glob is org-wide and includes private repositories under
+        # the elimarcavalli org. Narrow to specific repos (e.g.
+        # "elimarcavalli/deile") if broader access is undesired.
         - "elimarcavalli/*"

--- a/infra/k8s/manifests/15-bot-config.yaml
+++ b/infra/k8s/manifests/15-bot-config.yaml
@@ -48,3 +48,12 @@ data:
 
     providers:
       enabled_providers: ["discord"]
+
+    # Allowlist of repos that deile-shell is permitted to clone via git.
+    # Globs follow Python fnmatch rules (e.g. "elimarcavalli/*" matches any
+    # repo under that org). The list is enforced by the ~/bin/git guard
+    # installed by wrapper.py at startup. Omit the section (or leave the
+    # list empty) to allow cloning from any repo (open policy — use with care).
+    git_integration:
+      clonable_repos:
+        - "elimarcavalli/*"

--- a/infra/k8s/manifests/35-deile-interactive.yaml
+++ b/infra/k8s/manifests/35-deile-interactive.yaml
@@ -90,7 +90,10 @@ spec:
         #   2. Comment out the emptyDir entry below.
         #   3. Uncomment the persistentVolumeClaim entry.
         #   4. kubectl rollout restart deployment/deile-shell
-        - { name: home, emptyDir: { sizeLimit: "256Mi" } }
+        # WARNING: emptyDir sizeLimit is a soft quota enforced by kubelet eviction.
+        # Exceeding the limit causes silent pod eviction. 1Gi accommodates
+        # typical shallow-cloned repos; use a PVC for larger workloads.
+        - { name: home, emptyDir: { sizeLimit: "1Gi" } }
         # - name: home
         #   persistentVolumeClaim:
         #     claimName: deile-shell-home

--- a/infra/k8s/manifests/35-deile-interactive.yaml
+++ b/infra/k8s/manifests/35-deile-interactive.yaml
@@ -60,6 +60,12 @@ spec:
             - { name: deile-secrets, mountPath: /run/secrets/deile, readOnly: true }
             - { name: home, mountPath: /home/deile }
             - { name: tmp,  mountPath: /tmp }
+            # bot-config provides the clonable_repos allowlist to the wrapper.
+            # subPath pins one file so /home/deile/config stays otherwise empty.
+            - name: bot-config
+              mountPath: /home/deile/config/deilebot.yaml
+              subPath: deilebot.yaml
+              readOnly: true
           resources:
             requests: { cpu: "50m", memory: "256Mi" }
             limits:   { cpu: "2000m", memory: "2Gi" }
@@ -73,5 +79,19 @@ spec:
             seccompProfile: { type: RuntimeDefault }
       volumes:
         - { name: deile-secrets, secret: { secretName: deile-secrets, defaultMode: 288 } }
+        - name: bot-config
+          configMap:
+            name: bot-config
+            defaultMode: 292  # 0o444 — read-only inside pod
+        # ── Persistent home (optional) ───────────────────────────────────────
+        # By default /home/deile is an ephemeral emptyDir. To persist cloned
+        # repos and the working directory across pod restarts:
+        #   1. Apply 36-deile-shell-pvc.yaml to create the PVC.
+        #   2. Comment out the emptyDir entry below.
+        #   3. Uncomment the persistentVolumeClaim entry.
+        #   4. kubectl rollout restart deployment/deile-shell
         - { name: home, emptyDir: { sizeLimit: "256Mi" } }
+        # - name: home
+        #   persistentVolumeClaim:
+        #     claimName: deile-shell-home
         - { name: tmp,  emptyDir: { medium: Memory, sizeLimit: "64Mi" } }

--- a/infra/k8s/manifests/36-deile-shell-pvc.yaml
+++ b/infra/k8s/manifests/36-deile-shell-pvc.yaml
@@ -1,0 +1,33 @@
+# Optional PersistentVolumeClaim for deile-shell's home directory.
+#
+# By default 35-deile-interactive.yaml uses an emptyDir for /home/deile,
+# which means cloned repos and the working directory are lost when the pod
+# restarts. Apply this manifest and follow the instructions in
+# 35-deile-interactive.yaml to switch to persistent storage.
+#
+# Usage:
+#   kubectl apply -f infra/k8s/manifests/36-deile-shell-pvc.yaml
+#   # Then edit 35-deile-interactive.yaml: swap emptyDir for PVC (see comments there).
+#   kubectl rollout restart deployment/deile-shell -n deile
+#
+# To reclaim the disk:
+#   kubectl delete pvc deile-shell-home -n deile
+#
+# Note: Rancher Desktop / k3s uses a local-path provisioner that creates the
+# volume under the node's /var/lib/rancher/k3s/storage/. The data survives
+# pod restarts but NOT cluster wipes (run.sh down; run.sh up).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deile-shell-home
+  namespace: deile
+  labels:
+    app: deile-shell
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName is omitted to use the cluster default (local-path on k3s).
+  # Override explicitly if your cluster has multiple storage classes.

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -328,8 +328,9 @@ if token_file.exists():
 git_bin = home / "bin" / "git"
 
 if git_bin.exists():
-    # Guard present — it enforces the allowlist itself.
+    # Guard present — enforces allowlist and re-injects credential.helper itself.
     git_cmd = str(git_bin)
+    _cred_args = []
 else:
     # Guard absent — perform URL validation using the config file when present.
     # If both guard and config are absent, open policy applies (any repo allowed),
@@ -369,9 +370,10 @@ else:
             sys.exit(1)
 
     git_cmd = "/usr/bin/git"
+    _cred_args = ["-c", "credential.helper=store"]
 
 result = subprocess.run(
-    [git_cmd, "-c", "credential.helper=store", "clone", "--depth", "1", clone_url, work_dir],
+    [git_cmd, *_cred_args, "clone", "--depth", "1", clone_url, work_dir],
     env={**os.environ, "GIT_TERMINAL_PROMPT": "0",
          "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_NOSYSTEM": "1"},
 )

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -302,16 +302,15 @@ work_dir  = os.environ["WORK_DIR"]
 home = Path(os.environ.get("HOME", "/home/deile"))
 token_file = Path("/run/secrets/deile/GITHUB_TOKEN")
 if token_file.exists():
-    import os as _os
     token = token_file.read_text().strip()
     creds = home / ".git-credentials"
-    fd = _os.open(str(creds), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+    fd = os.open(str(creds), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        with _os.fdopen(fd, "w") as fh:
+        with os.fdopen(fd, "w") as fh:
             fh.write("https://oauth2:" + token + "@github.com\n")
     except Exception:
         try:
-            _os.close(fd)
+            os.close(fd)
         except OSError:
             pass
         raise
@@ -327,9 +326,14 @@ if git_bin.exists():
     # Guard present — it enforces the allowlist itself.
     git_cmd = str(git_bin)
 else:
-    # Guard absent — perform URL validation here before falling back to
-    # /usr/bin/git, so the allowlist is always enforced.
-    import yaml
+    # Guard absent — perform URL validation using the config file when present.
+    # If both guard and config are absent, open policy applies (any repo allowed),
+    # matching the documented wrapper.py behaviour for absent config.
+    try:
+        import yaml
+    except ImportError as exc:
+        print(f"clone: PyYAML not available: {exc} — deny all", file=sys.stderr)
+        sys.exit(1)
     config_path = home / "config" / "deilebot.yaml"
     if config_path.exists():
         try:

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -247,10 +247,7 @@ cmd_clone() {
 
   local bearer_token
   bearer_token="$(read_env_var DEILE_BOT_AUTH_TOKEN "$ENV_FILE" || true)"
-  if [ -z "$bearer_token" ]; then
-    bearer_token="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
-    log "WARNING: DEILE_BOT_AUTH_TOKEN absent — minted a fresh token; if the bot is running its auth token will mismatch. Re-run 'up' or add the token to .env."
-  fi
+  [ -n "$bearer_token" ] || fail "DEILE_BOT_AUTH_TOKEN missing in $ENV_FILE — run 'up' first to establish a stable token"
 
   log "wiring GITHUB_TOKEN into deile-secrets (no other secret values echoed)"
   printf "DEILE_BOT_AUTH_TOKEN=%s\nGITHUB_TOKEN=%s\n%s" \

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -256,21 +256,23 @@ cmd_clone() {
     --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
 
   # kubelet syncs projected secret volumes asynchronously (~30-60 s by default).
-  # Poll up to 90 s so the GITHUB_TOKEN file appears under /run/secrets/deile/
-  # before we attempt the clone.
+  # Poll up to 90 s using wall-clock time so kubectl exec latency doesn't
+  # cause early exit.
   log "waiting for kubelet to sync GITHUB_TOKEN into the pod (max 90s)"
-  local elapsed=0
-  while [ "$elapsed" -lt 90 ]; do
+  local START_TS
+  START_TS=$(date +%s)
+  local token_ready=0
+  while [ $(( $(date +%s) - START_TS )) -lt 90 ]; do
     if "$KUBECTL" -n "$NS" exec deploy/deile-shell -- \
         test -f /run/secrets/deile/GITHUB_TOKEN 2>/dev/null; then
       log "GITHUB_TOKEN secret file confirmed in pod"
+      token_ready=1
       break
     fi
     sleep 10
-    elapsed=$((elapsed + 10))
   done
-  if [ "$elapsed" -ge 90 ]; then
-    log "WARNING: GITHUB_TOKEN not yet visible inside pod after 90s — proceeding anyway"
+  if [ "$token_ready" -eq 0 ]; then
+    fail "GITHUB_TOKEN não sincronizado após 90s. Diagnóstico: kubectl -n $NS describe secret deile-secrets && kubectl -n $NS get events"
   fi
 
   local repo_name="${repo##*/}"
@@ -280,38 +282,93 @@ cmd_clone() {
   log "cloning ${clone_url} → ${work_dir} (inside deile-shell)"
   # Run a self-contained Python snippet inside the pod that:
   #   1. Sets up git credentials from the mounted secret file.
-  #   2. Invokes git clone via the ~/bin/git guard (enforces allowlist).
+  #   2. Invokes git clone via the ~/bin/git guard (enforces allowlist), or
+  #      performs its own URL validation if the guard is absent.
   # The token never appears in argv; it is read from the Secret-mounted
   # file and written to ~/.git-credentials inside the pod in-process.
-  "$KUBECTL" -n "$NS" exec deploy/deile-shell -- \
-    python3 -c "
-import os, subprocess, sys
+  # CLONE_URL and WORK_DIR are passed via --env so they are never
+  # interpolated into the Python source (no shell-injection risk).
+  "$KUBECTL" -n "$NS" exec \
+    --env CLONE_URL="${clone_url}" \
+    --env WORK_DIR="${work_dir}" \
+    deploy/deile-shell -- \
+    python3 -c '
+import fnmatch, os, subprocess, sys, urllib.parse
 from pathlib import Path
 
-home = Path(os.environ.get('HOME', '/home/deile'))
-token_file = Path('/run/secrets/deile/GITHUB_TOKEN')
-if token_file.exists():
-    token = token_file.read_text().strip()
-    creds = home / '.git-credentials'
-    creds.write_text('https://oauth2:' + token + '@github.com\n')
-    creds.chmod(0o600)
-    gitconfig = home / '.gitconfig'
-    existing = gitconfig.read_text() if gitconfig.exists() else ''
-    if 'credential.helper' not in existing:
-        with gitconfig.open('a') as fh:
-            fh.write('\n[credential]\n\thelper = store\n')
+clone_url = os.environ["CLONE_URL"]
+work_dir  = os.environ["WORK_DIR"]
 
-(home / 'work').mkdir(parents=True, exist_ok=True)
-git_bin = home / 'bin' / 'git'
-git_cmd = str(git_bin) if git_bin.exists() else '/usr/bin/git'
+home = Path(os.environ.get("HOME", "/home/deile"))
+token_file = Path("/run/secrets/deile/GITHUB_TOKEN")
+if token_file.exists():
+    import os as _os
+    token = token_file.read_text().strip()
+    creds = home / ".git-credentials"
+    fd = _os.open(str(creds), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+    try:
+        with _os.fdopen(fd, "w") as fh:
+            fh.write("https://oauth2:" + token + "@github.com\n")
+    except Exception:
+        try:
+            _os.close(fd)
+        except OSError:
+            pass
+        raise
+    subprocess.run(
+        ["git", "config", "--global", "credential.helper", "store"],
+        check=False,
+    )
+
+(home / "work").mkdir(parents=True, exist_ok=True)
+git_bin = home / "bin" / "git"
+
+if git_bin.exists():
+    # Guard present — it enforces the allowlist itself.
+    git_cmd = str(git_bin)
+else:
+    # Guard absent — perform URL validation here before falling back to
+    # /usr/bin/git, so the allowlist is always enforced.
+    import yaml
+    config_path = home / "config" / "deilebot.yaml"
+    if config_path.exists():
+        try:
+            data = yaml.safe_load(config_path.read_text()) or {}
+            raw = (data.get("git_integration") or {}).get("clonable_repos", [])
+            if isinstance(raw, list) and raw:
+                patterns = [str(p).strip() for p in raw if str(p).strip()]
+            else:
+                patterns = ["*"]
+        except Exception as exc:
+            print(f"clone: could not parse clonable_repos: {exc} — deny all", file=sys.stderr)
+            sys.exit(1)
+    else:
+        patterns = ["*"]
+
+    if patterns != ["*"]:
+        parsed = urllib.parse.urlparse(clone_url)
+        if parsed.hostname == "github.com":
+            repo_path = parsed.path.lstrip("/").removesuffix(".git")
+        else:
+            repo_path = clone_url.removesuffix(".git")
+        if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
+            print(
+                f"clone: {clone_url!r} is not in clonable_repos allowlist. "
+                f"Allowed patterns: {patterns}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    git_cmd = "/usr/bin/git"
+
 result = subprocess.run(
-    [git_cmd, 'clone', '--depth', '1', '${clone_url}', '${work_dir}'],
-    env={**os.environ, 'GIT_TERMINAL_PROMPT': '0'},
+    [git_cmd, "clone", "--depth", "1", clone_url, work_dir],
+    env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
 )
 if result.returncode != 0:
     sys.exit(result.returncode)
-print('clone complete: ${work_dir}')
-"
+print("clone complete: " + work_dir)
+'
   log "done — repo available at ${work_dir} inside deile-shell"
   log "to work: kubectl -n ${NS} exec -it deploy/deile-shell -- python3 /app/wrapper.py deile"
 }

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -272,7 +272,7 @@ cmd_clone() {
     sleep 10
   done
   if [ "$token_ready" -eq 0 ]; then
-    fail "GITHUB_TOKEN não sincronizado após 90s. Diagnóstico: kubectl -n $NS describe secret deile-secrets && kubectl -n $NS get events"
+    fail "GITHUB_TOKEN not synced after 90s. Diagnose: kubectl -n $NS describe secret deile-secrets && kubectl -n $NS get events"
   fi
 
   local repo_name="${repo##*/}"
@@ -306,14 +306,15 @@ if token_file.exists():
     creds = home / ".git-credentials"
     fd = os.open(str(creds), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        with os.fdopen(fd, "w") as fh:
-            fh.write("https://oauth2:" + token + "@github.com\n")
+        fh = os.fdopen(fd, "w")
     except Exception:
         try:
             os.close(fd)
         except OSError:
             pass
         raise
+    with fh:
+        fh.write("https://oauth2:" + token + "@github.com\n")
     subprocess.run(
         ["git", "config", "--global", "credential.helper", "store"],
         check=False,
@@ -329,13 +330,13 @@ else:
     # Guard absent — perform URL validation using the config file when present.
     # If both guard and config are absent, open policy applies (any repo allowed),
     # matching the documented wrapper.py behaviour for absent config.
-    try:
-        import yaml
-    except ImportError as exc:
-        print(f"clone: PyYAML not available: {exc} — deny all", file=sys.stderr)
-        sys.exit(1)
     config_path = home / "config" / "deilebot.yaml"
     if config_path.exists():
+        try:
+            import yaml
+        except ImportError as exc:
+            print(f"clone: PyYAML not available: {exc} — deny all", file=sys.stderr)
+            sys.exit(1)
         try:
             data = yaml.safe_load(config_path.read_text()) or {}
             raw = (data.get("git_integration") or {}).get("clonable_repos", [])

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -113,15 +113,17 @@ cmd_up() {
   # Collect LLM keys that exist in .env. The bot needs at least one
   # for its embedded agent to reply to Discord; deile needs at least
   # one for its own outbound flow.
-  local api_key_args=()
+  local api_key_pairs=""
+  local _api_key_count=0
   for key in ANTHROPIC_API_KEY OPENAI_API_KEY DEEPSEEK_API_KEY GOOGLE_API_KEY; do
     local v
     v="$(read_env_var "$key" "$ENV_FILE" || true)"
     if [ -n "$v" ]; then
-      api_key_args+=( "--from-literal=${key}=${v}" )
+      api_key_pairs+="${key}=${v}"$'\n'
+      _api_key_count=$(( _api_key_count + 1 ))
     fi
   done
-  [ "${#api_key_args[@]}" -gt 0 ] || fail "no LLM API key in $ENV_FILE"
+  [ "$_api_key_count" -gt 0 ] || fail "no LLM API key in $ENV_FILE"
 
   log "wiring Secrets (atomic apply; nothing echoed)"
   # `create … --dry-run=client -o yaml | apply` avoids the delete+create
@@ -131,17 +133,17 @@ cmd_up() {
   # Bot side: Discord token + control-plane Bearer + LLM key (the
   # embedded agent needs a key to reply). The tool whitelist in
   # wrapper.py blocks bash/file/exec from any Discord-driven prompt.
-  "$KUBECTL" -n "$NS" create secret generic bot-secrets \
-    --from-literal=DEILE_BOT_DISCORD_TOKEN="$discord_token" \
-    --from-literal=DEILE_BOT_CONTROL_PLANE_AUTH_TOKEN="$bearer_token" \
-    "${api_key_args[@]}" \
-    --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
+  printf "DEILE_BOT_DISCORD_TOKEN=%s\nDEILE_BOT_CONTROL_PLANE_AUTH_TOKEN=%s\n%s" \
+      "$discord_token" "$bearer_token" "$api_key_pairs" | \
+      "$KUBECTL" -n "$NS" create secret generic bot-secrets \
+        --from-env-file=- \
+        --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
 
   # Deile side: same LLM key + Bearer to talk to bot.
-  "$KUBECTL" -n "$NS" create secret generic deile-secrets \
-    "${api_key_args[@]}" \
-    --from-literal=DEILE_BOT_AUTH_TOKEN="$bearer_token" \
-    --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
+  printf "DEILE_BOT_AUTH_TOKEN=%s\n%s" "$bearer_token" "$api_key_pairs" | \
+      "$KUBECTL" -n "$NS" create secret generic deile-secrets \
+        --from-env-file=- \
+        --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
 
   log "applying bot ConfigMap + Deployment + Service + interactive shell"
   "$KUBECTL" apply -f "$HERE/manifests/15-bot-config.yaml"
@@ -234,26 +236,28 @@ cmd_clone() {
   [ -n "$github_token" ] || fail "GITHUB_TOKEN missing in $ENV_FILE (add a fine-scoped read/clone token)"
 
   # Collect LLM keys that exist in .env (needed to not wipe them from the secret).
-  local api_key_args=()
+  local api_key_pairs=""
+  local _api_key_count=0
   for key in ANTHROPIC_API_KEY OPENAI_API_KEY DEEPSEEK_API_KEY GOOGLE_API_KEY; do
     local v
     v="$(read_env_var "$key" "$ENV_FILE" || true)"
-    [ -n "$v" ] && api_key_args+=("--from-literal=${key}=${v}")
+    [ -n "$v" ] && { api_key_pairs+="${key}=${v}"$'\n'; _api_key_count=$(( _api_key_count + 1 )); }
   done
-  [ "${#api_key_args[@]}" -gt 0 ] || fail "no LLM API key in $ENV_FILE"
+  [ "$_api_key_count" -gt 0 ] || fail "no LLM API key in $ENV_FILE"
 
   local bearer_token
   bearer_token="$(read_env_var DEILE_BOT_AUTH_TOKEN "$ENV_FILE" || true)"
   if [ -z "$bearer_token" ]; then
     bearer_token="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+    log "WARNING: DEILE_BOT_AUTH_TOKEN absent — minted a fresh token; if the bot is running its auth token will mismatch. Re-run 'up' or add the token to .env."
   fi
 
   log "wiring GITHUB_TOKEN into deile-secrets (no other secret values echoed)"
-  "$KUBECTL" -n "$NS" create secret generic deile-secrets \
-    "${api_key_args[@]}" \
-    --from-literal=DEILE_BOT_AUTH_TOKEN="$bearer_token" \
-    --from-literal=GITHUB_TOKEN="$github_token" \
-    --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
+  printf "DEILE_BOT_AUTH_TOKEN=%s\nGITHUB_TOKEN=%s\n%s" \
+      "$bearer_token" "$github_token" "$api_key_pairs" | \
+      "$KUBECTL" -n "$NS" create secret generic deile-secrets \
+        --from-env-file=- \
+        --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
 
   # kubelet syncs projected secret volumes asynchronously (~30-60 s by default).
   # Poll up to 90 s using wall-clock time so kubectl exec latency doesn't
@@ -293,7 +297,7 @@ cmd_clone() {
     --env WORK_DIR="${work_dir}" \
     deploy/deile-shell -- \
     python3 -c '
-import fnmatch, os, subprocess, sys, urllib.parse
+import fnmatch, os, posixpath, subprocess, sys, urllib.parse
 from pathlib import Path
 
 clone_url = os.environ["CLONE_URL"]
@@ -306,7 +310,7 @@ if token_file.exists():
     creds = home / ".git-credentials"
     fd = os.open(str(creds), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        fh = os.fdopen(fd, "w")
+        fh = os.fdopen(fd, "w", encoding="utf-8")
     except Exception:
         try:
             os.close(fd)
@@ -353,7 +357,7 @@ else:
     if patterns != ["*"]:
         parsed = urllib.parse.urlparse(clone_url)
         if parsed.hostname == "github.com":
-            repo_path = parsed.path.lstrip("/").removesuffix(".git")
+            repo_path = posixpath.normpath(parsed.path.lstrip("/").removesuffix(".git"))
         else:
             repo_path = clone_url.removesuffix(".git")
         if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
@@ -367,8 +371,9 @@ else:
     git_cmd = "/usr/bin/git"
 
 result = subprocess.run(
-    [git_cmd, "clone", "--depth", "1", clone_url, work_dir],
-    env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+    [git_cmd, "-c", "credential.helper=store", "clone", "--depth", "1", clone_url, work_dir],
+    env={**os.environ, "GIT_TERMINAL_PROMPT": "0",
+         "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_NOSYSTEM": "1"},
 )
 if result.returncode != 0:
     sys.exit(result.returncode)

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -205,6 +205,117 @@ cmd_logs() {
   fi
 }
 
+cmd_clone() {
+  # Clone a GitHub repo into /home/deile/work/<name> inside deile-shell.
+  #
+  # Requires:
+  #   - GITHUB_TOKEN in .env (fine-scoped read / clone token — no write needed)
+  #   - Namespace and deile-shell deployment already running (run `up` first)
+  #
+  # The token is wired into the deile-secrets Secret, propagated to the pod
+  # by the kubelet volume sync, and picked up by wrapper.py's credential
+  # helper. The ~/bin/git guard then enforces the clonable_repos allowlist
+  # from bot-config before any clone proceeds.
+  local repo="${1:-}"
+  [ -n "$repo" ] || fail "usage: $0 clone <owner/repo>"
+
+  require_file "$ENV_FILE"
+
+  # Verify the namespace is up.
+  "$KUBECTL" get namespace "$NS" >/dev/null 2>&1 \
+    || fail "Namespace $NS not found. Run: $0 up"
+
+  # Verify deile-shell deployment exists.
+  "$KUBECTL" -n "$NS" get deployment deile-shell >/dev/null 2>&1 \
+    || fail "deile-shell not running. Run: $0 up"
+
+  local github_token
+  github_token="$(read_env_var GITHUB_TOKEN "$ENV_FILE" || true)"
+  [ -n "$github_token" ] || fail "GITHUB_TOKEN missing in $ENV_FILE (add a fine-scoped read/clone token)"
+
+  # Collect LLM keys that exist in .env (needed to not wipe them from the secret).
+  local api_key_args=()
+  for key in ANTHROPIC_API_KEY OPENAI_API_KEY DEEPSEEK_API_KEY GOOGLE_API_KEY; do
+    local v
+    v="$(read_env_var "$key" "$ENV_FILE" || true)"
+    [ -n "$v" ] && api_key_args+=("--from-literal=${key}=${v}")
+  done
+  [ "${#api_key_args[@]}" -gt 0 ] || fail "no LLM API key in $ENV_FILE"
+
+  local bearer_token
+  bearer_token="$(read_env_var DEILE_BOT_AUTH_TOKEN "$ENV_FILE" || true)"
+  if [ -z "$bearer_token" ]; then
+    bearer_token="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+  fi
+
+  log "wiring GITHUB_TOKEN into deile-secrets (no other secret values echoed)"
+  "$KUBECTL" -n "$NS" create secret generic deile-secrets \
+    "${api_key_args[@]}" \
+    --from-literal=DEILE_BOT_AUTH_TOKEN="$bearer_token" \
+    --from-literal=GITHUB_TOKEN="$github_token" \
+    --dry-run=client -o yaml | "$KUBECTL" apply -f - >/dev/null
+
+  # kubelet syncs projected secret volumes asynchronously (~30-60 s by default).
+  # Poll up to 90 s so the GITHUB_TOKEN file appears under /run/secrets/deile/
+  # before we attempt the clone.
+  log "waiting for kubelet to sync GITHUB_TOKEN into the pod (max 90s)"
+  local elapsed=0
+  while [ "$elapsed" -lt 90 ]; do
+    if "$KUBECTL" -n "$NS" exec deploy/deile-shell -- \
+        test -f /run/secrets/deile/GITHUB_TOKEN 2>/dev/null; then
+      log "GITHUB_TOKEN secret file confirmed in pod"
+      break
+    fi
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+  if [ "$elapsed" -ge 90 ]; then
+    log "WARNING: GITHUB_TOKEN not yet visible inside pod after 90s — proceeding anyway"
+  fi
+
+  local repo_name="${repo##*/}"
+  local work_dir="/home/deile/work/${repo_name}"
+  local clone_url="https://github.com/${repo}.git"
+
+  log "cloning ${clone_url} → ${work_dir} (inside deile-shell)"
+  # Run a self-contained Python snippet inside the pod that:
+  #   1. Sets up git credentials from the mounted secret file.
+  #   2. Invokes git clone via the ~/bin/git guard (enforces allowlist).
+  # The token never appears in argv; it is read from the Secret-mounted
+  # file and written to ~/.git-credentials inside the pod in-process.
+  "$KUBECTL" -n "$NS" exec deploy/deile-shell -- \
+    python3 -c "
+import os, subprocess, sys
+from pathlib import Path
+
+home = Path(os.environ.get('HOME', '/home/deile'))
+token_file = Path('/run/secrets/deile/GITHUB_TOKEN')
+if token_file.exists():
+    token = token_file.read_text().strip()
+    creds = home / '.git-credentials'
+    creds.write_text('https://oauth2:' + token + '@github.com\n')
+    creds.chmod(0o600)
+    gitconfig = home / '.gitconfig'
+    existing = gitconfig.read_text() if gitconfig.exists() else ''
+    if 'credential.helper' not in existing:
+        with gitconfig.open('a') as fh:
+            fh.write('\n[credential]\n\thelper = store\n')
+
+(home / 'work').mkdir(parents=True, exist_ok=True)
+git_bin = home / 'bin' / 'git'
+git_cmd = str(git_bin) if git_bin.exists() else '/usr/bin/git'
+result = subprocess.run(
+    [git_cmd, 'clone', '--depth', '1', '${clone_url}', '${work_dir}'],
+    env={**os.environ, 'GIT_TERMINAL_PROMPT': '0'},
+)
+if result.returncode != 0:
+    sys.exit(result.returncode)
+print('clone complete: ${work_dir}')
+"
+  log "done — repo available at ${work_dir} inside deile-shell"
+  log "to work: kubectl -n ${NS} exec -it deploy/deile-shell -- python3 /app/wrapper.py deile"
+}
+
 cmd_down() {
   log "removing namespace $NS (this deletes everything in it)"
   "$KUBECTL" delete namespace "$NS" --ignore-not-found
@@ -222,19 +333,22 @@ case "${1:-}" in
   up)      cmd_up ;;
   test)    cmd_test ;;
   logs)    cmd_logs ;;
+  clone)   cmd_clone "${2:-}" ;;
   down)    cmd_down ;;
   all)     cmd_all ;;
   *)
     cat >&2 <<EOF
-usage: $0 {build|up|test|logs|down|all}
+usage: $0 {build|up|test|logs|clone|down|all}
 
-  build  — rebuild the deile-stack:local image into containerd's k8s.io ns
-           (auto-rolls existing deployments so they pick up the new image)
-  up     — namespace, network policies, secrets, bot deployment+svc (idempotent)
-  test   — run the one-shot deile Job; streams logs
-  logs   — show recent bot + Job logs
-  down   — delete the deile namespace (full teardown)
-  all    — build, up, test, logs (the happy path)
+  build        — rebuild the deile-stack:local image into containerd's k8s.io ns
+                 (auto-rolls existing deployments so they pick up the new image)
+  up           — namespace, network policies, secrets, bot deployment+svc (idempotent)
+  test         — run the one-shot deile Job; streams logs
+  logs         — show recent bot + Job logs
+  clone <o/r>  — clone github.com/<owner>/<repo> into /home/deile/work/<repo>
+                 inside deile-shell (requires GITHUB_TOKEN in .env and 'up' first)
+  down         — delete the deile namespace (full teardown)
+  all          — build, up, test, logs (the happy path)
 EOF
     exit 64
     ;;

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -252,7 +252,7 @@ def _setup_git_clone_guard(config_path: str = "") -> None:
         f"""\
 #!/usr/bin/env python3
 \"\"\"git clone allowlist guard — installed by wrapper.py.\"\"\"
-import fnmatch, os, posixpath, re as _re, subprocess, sys, urllib.parse
+import fnmatch, os, posixpath, subprocess, sys, urllib.parse
 
 # Allowlist baked in at wrapper startup — not read from env at runtime.
 _PATTERNS = {allowlist_literal}
@@ -314,13 +314,13 @@ if _subcommand == "clone":
             )
             sys.exit(1)
 
-    # Strip any -c url.*.insteadOf* options from forwarded args — prevents
-    # an agent from redirecting an allowlisted clone URL to another server.
-    _INSTOF_RE = _re.compile(r'url\..+\.insteadof\s*=', _re.IGNORECASE)
+    # Strip ALL -c KEY=VALUE options for clone (deny-by-default): prevents
+    # credential-helper hijacking, hook injection, proxy redirection, etc.
+    # The guard re-injects only the known-safe credential.helper=store.
     _clean = []
     _ci = 0
     while _ci < len(args):
-        if args[_ci] == "-c" and _ci + 1 < len(args) and _INSTOF_RE.match(args[_ci + 1]):
+        if args[_ci] == "-c" and _ci + 1 < len(args):
             _ci += 2
         else:
             _clean.append(args[_ci])

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -257,10 +257,27 @@ import fnmatch, subprocess, sys, urllib.parse
 _PATTERNS = {allowlist_literal}
 
 args = sys.argv[1:]
-if args and args[0] == "clone":
+# Locate the git subcommand: skip global options, handling two-token forms
+# like -c KEY=VAL and -C /dir so `git -C /dir clone <url>` is not bypassed.
+_OPTS_TAKES_ARG = frozenset(["-c", "-C", "--git-dir", "--work-tree",
+                              "--namespace", "--super-prefix", "--exec-path"])
+_subcommand = None
+_sub_idx = 0
+_i = 0
+while _i < len(args):
+    _a = args[_i]
+    if _a in _OPTS_TAKES_ARG:
+        _i += 2
+    elif _a.startswith("-"):
+        _i += 1
+    else:
+        _subcommand = _a
+        _sub_idx = _i
+        break
+if _subcommand == "clone":
     patterns = _PATTERNS if _PATTERNS else []
     if patterns != ["*"]:
-        urls = [a for a in args[1:] if not a.startswith("-")]
+        urls = [a for a in args[_sub_idx + 1:] if not a.startswith("-")]
         if urls:
             url = urls[0].rstrip("/")
             # Use urlparse to extract hostname so userinfo tricks like

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -279,8 +279,7 @@ while _i < len(args):
 _git_env = None  # overridden for clone to neutralize insteadOf entries
 
 if _subcommand == "clone":
-    patterns = _PATTERNS if _PATTERNS else []
-    if patterns != ["*"]:
+    if _PATTERNS != ["*"]:
         urls = [a for a in args[_sub_idx + 1:] if "://" in a or a.startswith("git@")]
         if not urls:
             # No recognizable URL in clone args — deny when allowlist is active.
@@ -306,10 +305,10 @@ if _subcommand == "clone":
                 )
             else:
                 repo_path = url.removesuffix(".git")
-        if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
+        if not any(fnmatch.fnmatch(repo_path, p) for p in _PATTERNS):
             print(
                 f"git-clone-guard: {{url!r}} is not in clonable_repos allowlist. "
-                f"Allowed patterns: {{patterns}}",
+                f"Allowed patterns: {{_PATTERNS}}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -52,6 +52,7 @@ _SENSITIVE_KEYS = (
     "OPENAI_API_KEY",
     "DEEPSEEK_API_KEY",
     "GOOGLE_API_KEY",
+    "GITHUB_TOKEN",
     "DEILE_BOT_AUTH_TOKEN",
     "DEILE_BOT_DISCORD_TOKEN",
     "DEILE_BOT_CONTROL_PLANE_AUTH_TOKEN",
@@ -137,12 +138,17 @@ def _setup_git_credentials() -> None:
     """Wire GITHUB_TOKEN (if loaded) into ~/.git-credentials.
 
     Reads the token from os.environ (already injected by _load_secret_files),
-    writes the credential store file, and configures git's credential helper
+    writes the credential store file atomically (O_WRONLY|O_CREAT|O_TRUNC at
+    mode 0o600 — no TOCTOU window), and configures git's credential helper
     so every subsequent ``git clone/fetch/push`` finds it automatically.
 
     Security: the file is created 0o600 (owner-read only). The token never
     appears in argv or /proc/<pid>/environ — it stays in the file only.
+    After writing, GITHUB_TOKEN is removed from os.environ so subprocesses
+    (bash_tool, python_execute) inherit a clean environment.
     """
+    import subprocess as _subprocess
+
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if not token:
         return
@@ -150,42 +156,73 @@ def _setup_git_credentials() -> None:
     home = Path(os.environ.get("HOME", "/home/deile"))
     creds_file = home / ".git-credentials"
     try:
-        creds_file.write_text(f"https://oauth2:{token}@github.com\n", encoding="utf-8")
-        creds_file.chmod(0o600)
+        # Atomic create-and-write: O_CREAT|O_WRONLY|O_TRUNC with mode 0o600
+        # means the file is never readable by others even between creation
+        # and the explicit chmod call — no TOCTOU window.
+        fd = os.open(str(creds_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(f"https://oauth2:{token}@github.com\n")
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
     except OSError as exc:
         print(f"wrapper: could not write ~/.git-credentials: {exc}", file=sys.stderr)
+        os.environ.pop("GITHUB_TOKEN", None)
         return
 
-    gitconfig = home / ".gitconfig"
+    # Use git config so the update is atomic and idempotent.
     try:
-        existing = gitconfig.read_text(encoding="utf-8") if gitconfig.exists() else ""
-        if "credential.helper" not in existing:
-            with gitconfig.open("a", encoding="utf-8") as fh:
-                fh.write("\n[credential]\n\thelper = store\n")
+        _subprocess.run(
+            ["git", "config", "--global", "credential.helper", "store"],
+            check=False,
+        )
     except OSError as exc:
         print(f"wrapper: could not update ~/.gitconfig: {exc}", file=sys.stderr)
+
+    # Remove GITHUB_TOKEN from the environment so subprocesses (bash_tool,
+    # python_execute) cannot read it via /proc/self/environ or printenv.
+    os.environ.pop("GITHUB_TOKEN", None)
 
     print("wrapper(deile): GITHUB_TOKEN wired into ~/.git-credentials", file=sys.stderr)
 
 
-def _setup_git_clone_guard(config_path: str = "/home/deile/config/deilebot.yaml") -> None:
+def _setup_git_clone_guard(config_path: str = "") -> None:
     """Install ~/bin/git, a guard that enforces the clonable_repos allowlist.
 
     Reads ``git_integration.clonable_repos`` from the mounted deilebot.yaml
-    config. If the list is absent or empty the guard allows all repos (open
-    policy). Prepends ~/bin to PATH so the guard shadows /usr/bin/git.
+    config. If the config file is absent the guard allows all repos (open
+    policy). If the file exists but fails to parse, the guard uses a
+    fail-closed empty allowlist (deny all). Prepends ~/bin to PATH so the
+    guard shadows /usr/bin/git.
 
     The guard is a small Python script so it runs without a shell, avoiding
     quoting / injection issues. It delegates every non-clone sub-command
     directly to /usr/bin/git unchanged.
+
+    The allowlist patterns are baked directly into the guard script as a
+    Python literal — no environment variable is used at runtime, so the
+    list cannot be overwritten by subprocesses or the agent.
     """
+    if not config_path:
+        config_path = str(
+            Path(os.environ.get("HOME", "/home/deile")) / "config/deilebot.yaml"
+        )
+
     home = Path(os.environ.get("HOME", "/home/deile"))
     bin_dir = home / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
-    allowlist: List[str] = ["*"]
     cfg = Path(config_path)
-    if cfg.exists():
+    if not cfg.exists():
+        # Config absent → open policy (allow all)
+        allowlist: List[str] = ["*"]
+    else:
+        # Config present — parse it; any parse error → fail-closed (deny all)
+        allowlist = []
         try:
             import yaml  # PyYAML is a deile dep — always available in the image
 
@@ -193,45 +230,59 @@ def _setup_git_clone_guard(config_path: str = "/home/deile/config/deilebot.yaml"
             raw = (data.get("git_integration") or {}).get("clonable_repos", [])
             if isinstance(raw, list) and raw:
                 allowlist = [str(p).strip() for p in raw if str(p).strip()]
-        except Exception as exc:  # noqa: BLE001 — best-effort
+            else:
+                # Key absent or empty list in a present config → open policy
+                allowlist = ["*"]
+        except Exception as exc:  # noqa: BLE001
             print(
-                f"wrapper: could not parse clonable_repos from {config_path}: {exc}",
+                f"wrapper: could not parse clonable_repos from {config_path}: {exc} "
+                "— fail-closed: no repos allowed",
                 file=sys.stderr,
             )
+            # allowlist stays [] — deny all
 
-    # Encode the allowlist as a pipe-separated string in the env so the guard
-    # script reads it at runtime (no import of yaml inside the guard).
-    os.environ["DEILE_GIT_CLONE_ALLOWLIST"] = "|".join(allowlist)
+    # Bake the allowlist as a Python literal inside the guard script so it
+    # cannot be overwritten via os.environ by subprocesses or the agent.
+    # repr() of a list of strings produces a safe Python literal.
+    allowlist_literal = repr(allowlist)
 
     guard_script = bin_dir / "git"
     guard_script.write_text(
-        """\
+        f"""\
 #!/usr/bin/env python3
 \"\"\"git clone allowlist guard — installed by wrapper.py.\"\"\"
-import fnmatch, os, subprocess, sys
+import fnmatch, subprocess, sys, urllib.parse
+
+# Allowlist baked in at wrapper startup — not read from env at runtime.
+_PATTERNS = {allowlist_literal}
 
 args = sys.argv[1:]
 if args and args[0] == "clone":
-    raw = os.environ.get("DEILE_GIT_CLONE_ALLOWLIST", "*")
-    patterns = [p.strip() for p in raw.split("|") if p.strip()] or ["*"]
+    patterns = _PATTERNS if _PATTERNS else []
     if patterns != ["*"]:
         urls = [a for a in args[1:] if not a.startswith("-")]
         if urls:
             url = urls[0].rstrip("/")
-            # Accept both https://github.com/owner/repo[.git] and owner/repo forms.
-            if "github.com/" in url:
-                repo_path = url.split("github.com/", 1)[-1].removesuffix(".git")
+            # Use urlparse to extract hostname so userinfo tricks like
+            # 'https://evil.com@github.com/...' are rejected correctly.
+            parsed = urllib.parse.urlparse(url)
+            if parsed.hostname == "github.com":
+                repo_path = parsed.path.lstrip("/").removesuffix(".git")
             else:
                 repo_path = url.removesuffix(".git")
             if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
                 print(
-                    f"git-clone-guard: {url!r} is not in clonable_repos allowlist. "
-                    f"Allowed patterns: {patterns}",
+                    f"git-clone-guard: {{url!r}} is not in clonable_repos allowlist. "
+                    f"Allowed patterns: {{patterns}}",
                     file=sys.stderr,
                 )
                 sys.exit(1)
 
-sys.exit(subprocess.run(["/usr/bin/git", *args]).returncode)
+try:
+    sys.exit(subprocess.run(["/usr/bin/git", *args]).returncode)
+except FileNotFoundError:
+    print("git-clone-guard: /usr/bin/git not found", file=sys.stderr)
+    sys.exit(127)
 """,
         encoding="utf-8",
     )

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -161,14 +161,15 @@ def _setup_git_credentials() -> None:
         # and the explicit chmod call — no TOCTOU window.
         fd = os.open(str(creds_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write(f"https://oauth2:{token}@github.com\n")
+            fh = os.fdopen(fd, "w", encoding="utf-8")
         except Exception:
             try:
                 os.close(fd)
             except OSError:
                 pass
             raise
+        with fh:
+            fh.write(f"https://oauth2:{token}@github.com\n")
     except OSError as exc:
         print(f"wrapper: could not write ~/.git-credentials: {exc}", file=sys.stderr)
         os.environ.pop("GITHUB_TOKEN", None)
@@ -277,7 +278,7 @@ while _i < len(args):
 if _subcommand == "clone":
     patterns = _PATTERNS if _PATTERNS else []
     if patterns != ["*"]:
-        urls = [a for a in args[_sub_idx + 1:] if not a.startswith("-")]
+        urls = [a for a in args[_sub_idx + 1:] if "://" in a or a.startswith("git@")]
         if urls:
             url = urls[0].rstrip("/")
             # Use urlparse to extract hostname so userinfo tricks like

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -115,18 +115,137 @@ def _load_secret_files(role_dir: Path) -> List[str]:
 def _harden_runtime_dirs() -> None:
     """Make sure HOME exists and its standard subdirs are writeable.
 
-    Pre-creates ``data/`` and ``logs/`` because the bot's foundation
-    expects them to exist before it opens its sqlite/log files.
+    Pre-creates ``data/``, ``logs/``, ``bin/``, and ``work/`` because
+    the bot's foundation expects them to exist before it opens its
+    sqlite/log files, and the git credential + clone guard helpers
+    need ``bin/`` and ``work/`` to be present.
     """
     home = Path(os.environ.get("HOME", "/home/deile"))
     home.mkdir(parents=True, exist_ok=True)
     (home / ".deile").mkdir(parents=True, exist_ok=True, mode=0o700)
     (home / "data").mkdir(parents=True, exist_ok=True, mode=0o700)
     (home / "logs").mkdir(parents=True, exist_ok=True, mode=0o700)
+    (home / "bin").mkdir(parents=True, exist_ok=True, mode=0o700)
+    (home / "work").mkdir(parents=True, exist_ok=True, mode=0o755)
 
 
 def _has_llm_key(loaded: List[str]) -> bool:
     return any(k.endswith("_API_KEY") for k in loaded)
+
+
+def _setup_git_credentials() -> None:
+    """Wire GITHUB_TOKEN (if loaded) into ~/.git-credentials.
+
+    Reads the token from os.environ (already injected by _load_secret_files),
+    writes the credential store file, and configures git's credential helper
+    so every subsequent ``git clone/fetch/push`` finds it automatically.
+
+    Security: the file is created 0o600 (owner-read only). The token never
+    appears in argv or /proc/<pid>/environ — it stays in the file only.
+    """
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        return
+
+    home = Path(os.environ.get("HOME", "/home/deile"))
+    creds_file = home / ".git-credentials"
+    try:
+        creds_file.write_text(f"https://oauth2:{token}@github.com\n", encoding="utf-8")
+        creds_file.chmod(0o600)
+    except OSError as exc:
+        print(f"wrapper: could not write ~/.git-credentials: {exc}", file=sys.stderr)
+        return
+
+    gitconfig = home / ".gitconfig"
+    try:
+        existing = gitconfig.read_text(encoding="utf-8") if gitconfig.exists() else ""
+        if "credential.helper" not in existing:
+            with gitconfig.open("a", encoding="utf-8") as fh:
+                fh.write("\n[credential]\n\thelper = store\n")
+    except OSError as exc:
+        print(f"wrapper: could not update ~/.gitconfig: {exc}", file=sys.stderr)
+
+    print("wrapper(deile): GITHUB_TOKEN wired into ~/.git-credentials", file=sys.stderr)
+
+
+def _setup_git_clone_guard(config_path: str = "/home/deile/config/deilebot.yaml") -> None:
+    """Install ~/bin/git, a guard that enforces the clonable_repos allowlist.
+
+    Reads ``git_integration.clonable_repos`` from the mounted deilebot.yaml
+    config. If the list is absent or empty the guard allows all repos (open
+    policy). Prepends ~/bin to PATH so the guard shadows /usr/bin/git.
+
+    The guard is a small Python script so it runs without a shell, avoiding
+    quoting / injection issues. It delegates every non-clone sub-command
+    directly to /usr/bin/git unchanged.
+    """
+    home = Path(os.environ.get("HOME", "/home/deile"))
+    bin_dir = home / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    allowlist: List[str] = ["*"]
+    cfg = Path(config_path)
+    if cfg.exists():
+        try:
+            import yaml  # PyYAML is a deile dep — always available in the image
+
+            data = yaml.safe_load(cfg.read_text(encoding="utf-8")) or {}
+            raw = (data.get("git_integration") or {}).get("clonable_repos", [])
+            if isinstance(raw, list) and raw:
+                allowlist = [str(p).strip() for p in raw if str(p).strip()]
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            print(
+                f"wrapper: could not parse clonable_repos from {config_path}: {exc}",
+                file=sys.stderr,
+            )
+
+    # Encode the allowlist as a pipe-separated string in the env so the guard
+    # script reads it at runtime (no import of yaml inside the guard).
+    os.environ["DEILE_GIT_CLONE_ALLOWLIST"] = "|".join(allowlist)
+
+    guard_script = bin_dir / "git"
+    guard_script.write_text(
+        """\
+#!/usr/bin/env python3
+\"\"\"git clone allowlist guard — installed by wrapper.py.\"\"\"
+import fnmatch, os, subprocess, sys
+
+args = sys.argv[1:]
+if args and args[0] == "clone":
+    raw = os.environ.get("DEILE_GIT_CLONE_ALLOWLIST", "*")
+    patterns = [p.strip() for p in raw.split("|") if p.strip()] or ["*"]
+    if patterns != ["*"]:
+        urls = [a for a in args[1:] if not a.startswith("-")]
+        if urls:
+            url = urls[0].rstrip("/")
+            # Accept both https://github.com/owner/repo[.git] and owner/repo forms.
+            if "github.com/" in url:
+                repo_path = url.split("github.com/", 1)[-1].removesuffix(".git")
+            else:
+                repo_path = url.removesuffix(".git")
+            if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
+                print(
+                    f"git-clone-guard: {url!r} is not in clonable_repos allowlist. "
+                    f"Allowed patterns: {patterns}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+sys.exit(subprocess.run(["/usr/bin/git", *args]).returncode)
+""",
+        encoding="utf-8",
+    )
+    guard_script.chmod(0o700)
+
+    # Prepend ~/bin so the guard is found before /usr/bin/git.
+    current_path = os.environ.get("PATH", "/usr/bin:/bin")
+    if str(bin_dir) not in current_path.split(":"):
+        os.environ["PATH"] = f"{bin_dir}:{current_path}"
+
+    print(
+        f"wrapper(deile): git clone guard active — allowlist={allowlist}",
+        file=sys.stderr,
+    )
 
 
 def _install_tool_whitelist(role: str) -> None:
@@ -216,6 +335,8 @@ def _run_deile(passthrough: List[str]) -> int:
         )
         return 78  # EX_CONFIG
 
+    _setup_git_credentials()
+    _setup_git_clone_guard()
     _patch_deile_bootstrap()
 
     # Tool policy is operator-chosen because the deile prompt comes

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -252,7 +252,7 @@ def _setup_git_clone_guard(config_path: str = "") -> None:
         f"""\
 #!/usr/bin/env python3
 \"\"\"git clone allowlist guard — installed by wrapper.py.\"\"\"
-import fnmatch, subprocess, sys, urllib.parse
+import fnmatch, os, posixpath, re as _re, subprocess, sys, urllib.parse
 
 # Allowlist baked in at wrapper startup — not read from env at runtime.
 _PATTERNS = {allowlist_literal}
@@ -275,6 +275,9 @@ while _i < len(args):
         _subcommand = _a
         _sub_idx = _i
         break
+
+_git_env = None  # overridden for clone to neutralize insteadOf entries
+
 if _subcommand == "clone":
     patterns = _PATTERNS if _PATTERNS else []
     if patterns != ["*"]:
@@ -289,8 +292,8 @@ if _subcommand == "clone":
             # SCP-style: git@host:owner/repo.git — urlparse returns hostname=None.
             _host_path = url[len("git@"):]
             _host, _, _path = _host_path.partition(":")
-            if _host == "github.com":
-                repo_path = _path.removesuffix(".git")
+            if _host.lower() == "github.com":
+                repo_path = posixpath.normpath(_path.removesuffix(".git"))
             else:
                 repo_path = url.removesuffix(".git")
         else:
@@ -298,7 +301,9 @@ if _subcommand == "clone":
             # are rejected correctly.
             parsed = urllib.parse.urlparse(url)
             if parsed.hostname == "github.com":
-                repo_path = parsed.path.lstrip("/").removesuffix(".git")
+                repo_path = posixpath.normpath(
+                    parsed.path.lstrip("/").removesuffix(".git")
+                )
             else:
                 repo_path = url.removesuffix(".git")
         if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
@@ -309,8 +314,25 @@ if _subcommand == "clone":
             )
             sys.exit(1)
 
+    # Strip any -c url.*.insteadOf* options from forwarded args — prevents
+    # an agent from redirecting an allowlisted clone URL to another server.
+    _INSTOF_RE = _re.compile(r'url\..+\.insteadof\s*=', _re.IGNORECASE)
+    _clean = []
+    _ci = 0
+    while _ci < len(args):
+        if args[_ci] == "-c" and _ci + 1 < len(args) and _INSTOF_RE.match(args[_ci + 1]):
+            _ci += 2
+        else:
+            _clean.append(args[_ci])
+            _ci += 1
+    # Run clone in a sanitised config environment; re-inject credential.helper
+    # so ~/.git-credentials written by wrapper.py is still honoured.
+    _git_env = {{**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_NOSYSTEM": "1"}}
+    args = ["-c", "credential.helper=store"] + _clean
+
 try:
-    sys.exit(subprocess.run(["/usr/bin/git", *args]).returncode)
+    sys.exit(subprocess.run(["/usr/bin/git", *args], env=_git_env).returncode)
 except FileNotFoundError:
     print("git-clone-guard: /usr/bin/git not found", file=sys.stderr)
     sys.exit(127)

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -279,22 +279,35 @@ if _subcommand == "clone":
     patterns = _PATTERNS if _PATTERNS else []
     if patterns != ["*"]:
         urls = [a for a in args[_sub_idx + 1:] if "://" in a or a.startswith("git@")]
-        if urls:
-            url = urls[0].rstrip("/")
-            # Use urlparse to extract hostname so userinfo tricks like
-            # 'https://evil.com@github.com/...' are rejected correctly.
+        if not urls:
+            # No recognizable URL in clone args — deny when allowlist is active.
+            print("git-clone-guard: no URL recognized in clone arguments — deny all",
+                  file=sys.stderr)
+            sys.exit(1)
+        url = urls[0].rstrip("/")
+        if url.startswith("git@"):
+            # SCP-style: git@host:owner/repo.git — urlparse returns hostname=None.
+            _host_path = url[len("git@"):]
+            _host, _, _path = _host_path.partition(":")
+            if _host == "github.com":
+                repo_path = _path.removesuffix(".git")
+            else:
+                repo_path = url.removesuffix(".git")
+        else:
+            # Use urlparse so userinfo tricks like 'https://evil@github.com/...'
+            # are rejected correctly.
             parsed = urllib.parse.urlparse(url)
             if parsed.hostname == "github.com":
                 repo_path = parsed.path.lstrip("/").removesuffix(".git")
             else:
                 repo_path = url.removesuffix(".git")
-            if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
-                print(
-                    f"git-clone-guard: {{url!r}} is not in clonable_repos allowlist. "
-                    f"Allowed patterns: {{patterns}}",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+        if not any(fnmatch.fnmatch(repo_path, p) for p in patterns):
+            print(
+                f"git-clone-guard: {{url!r}} is not in clonable_repos allowlist. "
+                f"Allowed patterns: {{patterns}}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 try:
     sys.exit(subprocess.run(["/usr/bin/git", *args]).returncode)


### PR DESCRIPTION
## Resumo

- **`git` no container**: adicionado à final stage do Dockerfile — `deile-shell` agora tem `/usr/bin/git` disponível para clonar repos dentro do sandbox.
- **Credential store segura**: `wrapper.py` lê `GITHUB_TOKEN` do arquivo Secret-montado (`/run/secrets/deile/GITHUB_TOKEN`), escreve `~/.git-credentials` (0600) e configura `credential.helper store` — token nunca aparece em `/proc/<pid>/environ` nem em argv.
- **Clone guard**: `wrapper.py` instala `~/bin/git` (script Python) que verifica todo `git clone` contra a allowlist `clonable_repos` do `bot-config` ConfigMap antes de delegar para `/usr/bin/git`.
- **PVC opcional**: `36-deile-shell-pvc.yaml` + instruções em `35-deile-interactive.yaml` para persistir `/home/deile` entre restarts de pod.
- **`run.sh clone <owner/repo>`**: subcomando novo que faz tudo end-to-end — injeta GITHUB_TOKEN no Secret, aguarda kubelet sync, clona dentro do pod.

## Issues

Closes #184

## Decisões-chave (crítica de abordagem)

- **Alt A — `~/bin/git` guard Python** (escolhida): wrapper instala script Python em `~/bin/git` que lê `DEILE_GIT_CLONE_ALLOWLIST` (env var derivado da config) e enforça allowlist via `fnmatch`; delega não-clone sem overhead. Pro: sem modificar `deile/`; enforcement no nível de processo; portável. Contra: exige `~/bin` no PATH (resolvido no wrapper).
- **Alt B — monkey-patch do `BashTool.execute()`** (descartada): violaria separação hexagonal; wrapper de infraestrutura não deveria tocar código de domínio; frágil a refactors do core.

**Modelo de segurança do GITHUB_TOKEN**: Secret montado como arquivo → lido em-processo pelo wrapper → escrito em `~/.git-credentials` (0600) → `/proc/<pid>/environ` congelado na hora do `execve` nunca vê o token → subprocessos herdam env limpo (mesma garantia das chaves LLM).

## Checklist

- [x] pytest 100% verde (2372/2372)
- [x] ruff ok
- [x] isort ok
- [x] cobertura ≥80% (sem novos arquivos em `deile/` — infra-only)
- [x] pilares 03/12 respeitados (mudanças em `infra/`, não em `deile/core/`)
- [x] sem SQL/migration
- [x] GITHUB_TOKEN nunca logado/ecoado/em argv — somente em arquivo 0600
- [x] allowlist por `fnmatch` com glob suportado (`elimarcavalli/*`)
- [x] `bot-config` montado em `deile-shell` para leitura da allowlist
- [x] README §4.2 documenta clonagem, GITHUB_TOKEN, PVC, allowlist
- [x] pilar 14 atualizado com modelo de segurança e fluxo de clonagem

🤖 Pipeline autônomo DEILE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byq7bBF2rfPyyhxsWnqhbm)_