### PR TITLE
feat(commands): /fork /rename /rewind /resume + ESC cancel streaming

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -23,6 +23,9 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+import threading
+import time
+import uuid
 import venv as _venv  # noqa: N812 — local alias for testability (patched as deile.cli._venv)
 from pathlib import Path
 from typing import List, Optional
@@ -249,8 +252,9 @@ class _DeileCLI:
                 if self.settings.pipeline_autostart:
                     await _autostart_pipeline(self.agent)
 
+                _cli_session_id = f"cli-{int(time.time())}-{uuid.uuid4().hex[:8]}"
                 self.default_session = self.agent.create_session(
-                    session_id="default_cli_session",
+                    session_id=_cli_session_id,
                     working_directory=self.settings.working_directory,
                 )
 
@@ -277,6 +281,111 @@ class _DeileCLI:
                 files.append(str(rel).replace("\\", "/"))
         return sorted(files)[:500]
 
+    # Sentinel returned by get_user_input() when the user presses ESC ESC on
+    # an empty prompt — signals the main loop to trigger /rewind.
+    _REWIND_SENTINEL = "\x00REWIND\x00"
+    # Context-data key written by /fork, /rewind, /resume to request a session
+    # switch without tight-coupling between the command and the CLI class.
+    _SWITCH_SESSION_KEY = "_switch_session"
+
+    def _check_session_switch(self) -> None:
+        """If a command requested a session switch, apply it."""
+        new_sid = self.default_session.context_data.pop(self._SWITCH_SESSION_KEY, None)
+        if not new_sid:
+            return
+        new_session = self.agent.get_session(new_sid)
+        if new_session is not None:
+            self.default_session = new_session
+            name = new_session.context_data.get("conversation_name", "")
+            label = f'"{name}"' if name else new_sid
+            self.ui.console.print(f"\n[dim cyan]› Sessão alternada para {label}[/dim cyan]")
+        else:
+            self.ui.console.print(f"[yellow]Sessão {new_sid!r} não encontrada — mantendo atual.[/yellow]")
+
+    async def _stream_with_esc_cancel(self, event_stream):
+        """Run display_streaming_turn, cancelling on ESC keypress.
+
+        Uses a daemon thread to watch for a plain ESC byte (0x1b without a
+        following escape-sequence) while stdin is briefly set to cbreak mode.
+        Falls back to the plain streaming call when stdin is not a TTY or when
+        the platform is Windows (no termios).
+        """
+        try:
+            import select as _select
+            import termios
+            import tty
+        except ImportError:
+            return await self.ui.display_streaming_turn(event_stream)
+
+        if not sys.stdin.isatty():
+            return await self.ui.display_streaming_turn(event_stream)
+
+        esc_event: asyncio.Event = asyncio.Event()
+        loop = asyncio.get_event_loop()
+
+        try:
+            saved = termios.tcgetattr(sys.stdin.fileno())
+        except Exception:
+            return await self.ui.display_streaming_turn(event_stream)
+
+        def _watch() -> None:
+            try:
+                tty.setcbreak(sys.stdin.fileno())
+                while not esc_event.is_set():
+                    r, _, _ = _select.select([sys.stdin], [], [], 0.1)
+                    if not r:
+                        continue
+                    ch = sys.stdin.read(1)
+                    if ch != "\x1b":
+                        continue
+                    # Distinguish plain ESC from multi-byte escape sequences
+                    # (arrow keys etc.) by checking for more bytes within 50ms.
+                    r2, _, _ = _select.select([sys.stdin], [], [], 0.05)
+                    if not r2:
+                        loop.call_soon_threadsafe(esc_event.set)
+                        break
+                    # Escape sequence — consume and ignore remaining bytes.
+                    while _select.select([sys.stdin], [], [], 0.01)[0]:
+                        sys.stdin.read(1)
+            except Exception:
+                pass
+            finally:
+                try:
+                    termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, saved)
+                except Exception:
+                    pass
+
+        watcher = threading.Thread(target=_watch, daemon=True)
+        watcher.start()
+
+        stream_task = asyncio.ensure_future(self.ui.display_streaming_turn(event_stream))
+        esc_task = asyncio.ensure_future(esc_event.wait())
+        try:
+            done, pending = await asyncio.wait(
+                [stream_task, esc_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for t in pending:
+                t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+            if esc_event.is_set() and stream_task not in done:
+                self.ui.console.print("\n[yellow](ESC — request cancelada)[/yellow]")
+                return None
+
+            if stream_task in done and not stream_task.cancelled():
+                return stream_task.result()
+        finally:
+            esc_event.set()
+            try:
+                termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, saved)
+            except Exception:
+                pass
+        return None
+
     async def run_interactive(self) -> None:
         from rich.panel import Panel
         from rich.text import Text
@@ -293,7 +402,10 @@ class _DeileCLI:
                 user_input = await asyncio.to_thread(self.ui.get_user_input, "\n > ")
                 user_input = user_input.strip()
 
-                if not user_input:
+                # ESC ESC on empty prompt → trigger /rewind
+                if user_input == self._REWIND_SENTINEL:
+                    user_input = "/rewind"
+                elif not user_input:
                     sys.stdout.write("\033[A\033[2K\r")
                     sys.stdout.flush()
                     continue
@@ -312,9 +424,10 @@ class _DeileCLI:
                         session_id=self.default_session.session_id,
                     )
                     try:
-                        await self.ui.display_streaming_turn(event_stream)
+                        await self._stream_with_esc_cancel(event_stream)
                     except KeyboardInterrupt:
                         self.ui.console.print("\n[yellow](turn interrupted)[/yellow]")
+                    self._check_session_switch()
                     continue
 
                 with self.ui.show_loading("Processando sua solicitação..."):
@@ -322,6 +435,8 @@ class _DeileCLI:
                         user_input=user_input,
                         session_id=self.default_session.session_id,
                     )
+
+                self._check_session_switch()
 
                 meta = response.metadata or {}
                 if meta.get("budget_exceeded"):

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -321,7 +321,7 @@ class _DeileCLI:
             return await self.ui.display_streaming_turn(event_stream)
 
         esc_event: asyncio.Event = asyncio.Event()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         try:
             saved = termios.tcgetattr(sys.stdin.fileno())
@@ -369,7 +369,9 @@ class _DeileCLI:
                 t.cancel()
                 try:
                     await t
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError:
+                    pass  # expected — we requested this cancellation
+                except Exception:
                     pass
 
             if esc_event.is_set() and stream_task not in done:

--- a/deile/commands/builtin/_conv_store.py
+++ b/deile/commands/builtin/_conv_store.py
@@ -1,0 +1,55 @@
+"""ConversationNameStore — lightweight JSON persistence for conversation names.
+
+Stored at ``~/.deile/conversation_names.json``.  Resilient to missing file
+and concurrent writes (last-write-wins; no lock needed for this use-case).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_STORE_PATH = Path.home() / ".deile" / "conversation_names.json"
+
+
+class ConversationNameStore:
+    """Maps session_id → human-readable conversation name."""
+
+    def __init__(self, path: Path = _STORE_PATH) -> None:
+        self._path = path
+
+    def _load(self) -> dict:
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {}
+        except Exception:
+            logger.debug("conversation_names.json unreadable — starting fresh")
+            return {}
+
+    def _save(self, data: dict) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        except Exception as exc:
+            logger.warning("Could not persist conversation name: %s", exc)
+
+    def get(self, session_id: str) -> Optional[str]:
+        return self._load().get(session_id)
+
+    def set(self, session_id: str, name: str) -> None:
+        data = self._load()
+        data[session_id] = name
+        self._save(data)
+
+    def delete(self, session_id: str) -> None:
+        data = self._load()
+        data.pop(session_id, None)
+        self._save(data)
+
+    def all(self) -> dict:
+        return self._load()

--- a/deile/commands/builtin/fork_command.py
+++ b/deile/commands/builtin/fork_command.py
@@ -1,0 +1,78 @@
+"""ForkCommand — /fork: branch the current conversation into a new session."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from rich.panel import Panel
+from rich.text import Text
+
+from ..base import CommandContext, CommandResult, DirectCommand
+from ._conv_store import ConversationNameStore
+from ._shared import split_args, wrap_command_errors
+
+_SENTINEL = "_switch_session"
+
+
+class ForkCommand(DirectCommand):
+    """Fork the current conversation into a new independent session.
+
+    The fork starts with a copy of the current conversation history so the
+    dialogue can continue in parallel without affecting the original thread.
+    Optionally assign a name to the fork with ``/fork <name>``.
+    """
+
+    def __init__(self) -> None:
+        from ...config.manager import CommandConfig
+
+        super().__init__(
+            CommandConfig(
+                name="fork",
+                description="Fork the current conversation into a new named session.",
+            )
+        )
+
+    @wrap_command_errors("fork")
+    async def execute(self, context: CommandContext) -> CommandResult:
+        agent = context.agent
+        session = context.session
+        if agent is None or session is None:
+            return CommandResult.error_result("Agent or session not available.")
+
+        parts = split_args(context)
+        name: str = " ".join(parts).strip() if parts else ""
+
+        history = list(getattr(session, "conversation_history", []))
+        new_sid = f"fork-{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+        try:
+            new_session = agent.create_session(
+                session_id=new_sid,
+                working_directory=session.working_directory,
+            )
+        except Exception as exc:
+            return CommandResult.error_result(f"Could not create forked session: {exc}")
+
+        new_session.conversation_history = [dict(e) for e in history]
+
+        if name:
+            store = ConversationNameStore()
+            store.set(new_sid, name)
+            new_session.context_data["conversation_name"] = name
+
+        session.context_data[_SENTINEL] = new_sid
+
+        label = f'"{name}"' if name else new_sid
+        return CommandResult(
+            success=True,
+            content=Panel(
+                Text.from_markup(
+                    f"Conversa forked para [bold cyan]{label}[/bold cyan].\n"
+                    f"[dim]ID: {new_sid}[/dim]\n"
+                    f"[dim]{len(history)} mensagem(ns) copiada(s)[/dim]"
+                ),
+                title="[bold green]Fork criado[/bold green]",
+                border_style="green",
+            ),
+        )

--- a/deile/commands/builtin/rename_command.py
+++ b/deile/commands/builtin/rename_command.py
@@ -1,0 +1,57 @@
+"""RenameCommand — /rename: give a human-readable name to the current conversation."""
+
+from __future__ import annotations
+
+from rich.panel import Panel
+from rich.text import Text
+
+from ..base import CommandContext, CommandResult, DirectCommand
+from ._conv_store import ConversationNameStore
+from ._shared import split_args, wrap_command_errors
+
+
+class RenameCommand(DirectCommand):
+    """Rename the current conversation session.
+
+    The name is persisted in ``~/.deile/conversation_names.json`` and shown
+    by ``/resume`` when listing past conversations.
+    """
+
+    def __init__(self) -> None:
+        from ...config.manager import CommandConfig
+
+        super().__init__(
+            CommandConfig(
+                name="rename",
+                description="Name the current conversation for easier resumption.",
+            )
+        )
+
+    @wrap_command_errors("rename")
+    async def execute(self, context: CommandContext) -> CommandResult:
+        session = context.session
+        if session is None:
+            return CommandResult.error_result("No active session.")
+
+        parts = split_args(context)
+        name = " ".join(parts).strip() if parts else ""
+        if not name:
+            return CommandResult.error_result(
+                "Uso: /rename <nome>\nEx: /rename minha-conversa-de-debug"
+            )
+
+        store = ConversationNameStore()
+        store.set(session.session_id, name)
+        session.context_data["conversation_name"] = name
+
+        return CommandResult(
+            success=True,
+            content=Panel(
+                Text.from_markup(
+                    f"Conversa renomeada para [bold cyan]{name}[/bold cyan].\n"
+                    f"[dim]ID: {session.session_id}[/dim]"
+                ),
+                title="[bold green]Conversa renomeada[/bold green]",
+                border_style="green",
+            ),
+        )

--- a/deile/commands/builtin/resume_command.py
+++ b/deile/commands/builtin/resume_command.py
@@ -1,0 +1,172 @@
+"""ResumeCommand — /resume: list past conversations and reload one."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+
+from rich.panel import Panel
+from rich.text import Text
+
+from ...core.interfaces.selector import SelectorNotSupported, SelectorOption
+from ...infrastructure.selectors import get_default_selector
+from ..base import CommandContext, CommandResult, DirectCommand
+from ._conv_store import ConversationNameStore
+from ._shared import wrap_command_errors
+
+_SENTINEL = "_switch_session"
+_MAX_LABEL = 72
+
+
+def _fmt_time(ts: float) -> str:
+    return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+
+
+def _truncate(s: str, n: int = _MAX_LABEL) -> str:
+    s = s.replace("\n", " ").strip()
+    return s[:n] + "…" if len(s) > n else s
+
+
+class ResumeCommand(DirectCommand):
+    """Select a past conversation and continue from where it left off.
+
+    Conversations are loaded from episodic memory (SQLite), so they survive
+    process restarts.  Select with ↑↓ Enter; ESC to cancel.
+    """
+
+    def __init__(self) -> None:
+        from ...config.manager import CommandConfig
+
+        super().__init__(
+            CommandConfig(
+                name="resume",
+                description="List and reload a past conversation from episodic memory.",
+            )
+        )
+
+    @wrap_command_errors("resume")
+    async def execute(self, context: CommandContext) -> CommandResult:
+        agent = context.agent
+        session = context.session
+        if agent is None or session is None:
+            return CommandResult.error_result("Agent or session not available.")
+
+        memory_manager = getattr(agent, "memory_manager", None)
+        if memory_manager is None:
+            return CommandResult.error_result("MemoryManager não disponível.")
+
+        episodic = getattr(memory_manager, "episodic_memory", None)
+        if episodic is None:
+            return CommandResult.error_result("EpisodicMemory não disponível.")
+
+        sessions = await episodic.list_sessions(max_sessions=50)
+        if not sessions:
+            return CommandResult(
+                success=True,
+                content=Panel(
+                    Text(
+                        "Nenhuma conversa encontrada na memória episódica.\n"
+                        "As conversas ficam disponíveis após a primeira interação.",
+                        style="dim",
+                    ),
+                    title="Resume",
+                    border_style="yellow",
+                ),
+            )
+
+        store = ConversationNameStore()
+        selector = get_default_selector()
+
+        if not selector.is_supported():
+            lines = []
+            for row in sessions[:20]:
+                name = store.get(row["session_id"]) or _truncate(
+                    row["first_user_input"], 50
+                )
+                ts = _fmt_time(row["last_activity"])
+                lines.append(f"{ts}  {name}  ({row['episode_count']} msg)")
+            return CommandResult(
+                success=False,
+                content=Panel(
+                    Text(
+                        "Seletor interativo não disponível (sem TTY).\n\n"
+                        + "\n".join(lines),
+                        style="yellow",
+                    ),
+                    title="Resume — sem TTY",
+                    border_style="yellow",
+                ),
+            )
+
+        options = []
+        for row in sessions:
+            sid = row["session_id"]
+            name = store.get(sid) or _truncate(row["first_user_input"], 50)
+            ts = _fmt_time(row["last_activity"])
+            options.append(
+                SelectorOption(
+                    label=name,
+                    value=sid,
+                    description=f"{ts} · {row['episode_count']} msg · {sid}",
+                )
+            )
+
+        try:
+            choice = await selector.select(
+                options,
+                prompt="Resume — selecione uma conversa (↑↓ Enter ESC):",
+                default_index=0,
+            )
+        except SelectorNotSupported:
+            return CommandResult.error_result("Seletor não suportado neste ambiente.")
+
+        if choice is None:
+            return CommandResult(
+                success=True,
+                content=Panel(
+                    Text("Resume cancelado.", style="dim"),
+                    title="Resume",
+                    border_style="yellow",
+                ),
+                metadata={"cancelled": True},
+            )
+
+        target_sid = str(choice.value)
+        episodes = await episodic.get_episodes_for_session(target_sid)
+
+        history = []
+        for ep in episodes:
+            if ep["user_input"]:
+                history.append({"role": "user", "content": ep["user_input"], "timestamp": ep["timestamp"], "metadata": {}})
+            if ep["agent_response"]:
+                history.append({"role": "assistant", "content": ep["agent_response"], "timestamp": ep["timestamp"], "metadata": {}})
+
+        new_sid = f"resume-{int(time.time())}-{target_sid[-8:]}"
+        try:
+            new_session = agent.create_session(
+                session_id=new_sid,
+                working_directory=session.working_directory,
+            )
+        except Exception as exc:
+            return CommandResult.error_result(f"Não foi possível criar sessão: {exc}")
+
+        new_session.conversation_history = history
+
+        name = store.get(target_sid) or ""
+        if name:
+            new_session.context_data["conversation_name"] = name
+
+        session.context_data[_SENTINEL] = new_sid
+
+        label = name or _truncate(episodes[-1]["user_input"]) if episodes else target_sid
+        return CommandResult(
+            success=True,
+            content=Panel(
+                Text.from_markup(
+                    f"Conversa [bold cyan]{label}[/bold cyan] carregada.\n"
+                    f"[dim]{len(history)} mensagem(ns) · ID: {new_sid}[/dim]"
+                ),
+                title="[bold green]Resume — conversa carregada[/bold green]",
+                border_style="green",
+            ),
+        )

--- a/deile/commands/builtin/rewind_command.py
+++ b/deile/commands/builtin/rewind_command.py
@@ -1,0 +1,146 @@
+"""RewindCommand — /rewind: go back to an earlier point in the conversation."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from rich.panel import Panel
+from rich.text import Text
+
+from ...core.interfaces.selector import SelectorNotSupported, SelectorOption
+from ...infrastructure.selectors import get_default_selector
+from ..base import CommandContext, CommandResult, DirectCommand
+from ._shared import wrap_command_errors
+
+_SENTINEL = "_switch_session"
+_MAX_LABEL = 80
+
+
+def _truncate(s: str, n: int = _MAX_LABEL) -> str:
+    s = s.replace("\n", " ").strip()
+    return s[:n] + "…" if len(s) > n else s
+
+
+class RewindCommand(DirectCommand):
+    """Go back to an earlier point in the conversation.
+
+    Shows the current conversation history as a navigable list.  Selecting a
+    message creates a **fork** of the conversation up to and including that
+    point, then switches to it — the original thread is not modified.
+
+    ESC cancels with no effect.
+    """
+
+    def __init__(self) -> None:
+        from ...config.manager import CommandConfig
+
+        super().__init__(
+            CommandConfig(
+                name="rewind",
+                description="Navigate history and fork at a chosen point.",
+                aliases=["rw"],
+            )
+        )
+
+    @wrap_command_errors("rewind")
+    async def execute(self, context: CommandContext) -> CommandResult:
+        agent = context.agent
+        session = context.session
+        if agent is None or session is None:
+            return CommandResult.error_result("Agent or session not available.")
+
+        history = list(getattr(session, "conversation_history", []))
+        user_entries = [
+            (i, e) for i, e in enumerate(history) if e.get("role") == "user"
+        ]
+
+        if not user_entries:
+            return CommandResult(
+                success=True,
+                content=Panel(
+                    Text("Nenhuma mensagem no histórico desta conversa.", style="dim"),
+                    title="Rewind",
+                    border_style="yellow",
+                ),
+            )
+
+        selector = get_default_selector()
+        if not selector.is_supported():
+            lines = "\n".join(
+                f"{idx + 1}. {_truncate(e['content'])}"
+                for idx, (_, e) in enumerate(user_entries)
+            )
+            return CommandResult(
+                success=False,
+                content=Panel(
+                    Text(
+                        f"Seletor interativo não disponível (sem TTY).\n\n{lines}",
+                        style="yellow",
+                    ),
+                    title="Rewind — sem TTY",
+                    border_style="yellow",
+                ),
+            )
+
+        options = [
+            SelectorOption(
+                label=f"#{idx + 1}  {_truncate(e['content'])}",
+                value=hist_idx,
+                description="",
+            )
+            for idx, (hist_idx, e) in enumerate(user_entries)
+        ]
+
+        try:
+            choice = await selector.select(
+                options,
+                prompt="Rewind — selecione o ponto de retorno (↑↓ Enter ESC):",
+                default_index=len(options) - 1,
+            )
+        except SelectorNotSupported:
+            return CommandResult.error_result("Seletor não suportado neste ambiente.")
+
+        if choice is None:
+            return CommandResult(
+                success=True,
+                content=Panel(
+                    Text("Rewind cancelado.", style="dim"),
+                    title="Rewind",
+                    border_style="yellow",
+                ),
+                metadata={"cancelled": True},
+            )
+
+        cut = int(choice.value) + 1
+        trimmed = history[:cut]
+
+        new_sid = f"rewind-{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        try:
+            new_session = agent.create_session(
+                session_id=new_sid,
+                working_directory=session.working_directory,
+            )
+        except Exception as exc:
+            return CommandResult.error_result(f"Não foi possível criar sessão: {exc}")
+
+        new_session.conversation_history = [dict(e) for e in trimmed]
+
+        orig_name = session.context_data.get("conversation_name", "")
+        if orig_name:
+            new_session.context_data["conversation_name"] = f"{orig_name} (rewind)"
+
+        session.context_data[_SENTINEL] = new_sid
+
+        label = _truncate(trimmed[-1]["content"]) if trimmed else "—"
+        return CommandResult(
+            success=True,
+            content=Panel(
+                Text.from_markup(
+                    f"Fork criado a partir de: [bold cyan]{label}[/bold cyan]\n"
+                    f"[dim]{len(trimmed)} mensagem(ns) preservada(s) · ID: {new_sid}[/dim]"
+                ),
+                title="[bold green]Rewind — fork criado[/bold green]",
+                border_style="green",
+            ),
+        )

--- a/deile/memory/episodic_memory.py
+++ b/deile/memory/episodic_memory.py
@@ -51,11 +51,15 @@ class EpisodicMemory:
                     agent_response TEXT,
                     timestamp REAL,
                     context TEXT,
-                    metadata TEXT,
-                    INDEX(session_id),
-                    INDEX(timestamp)
+                    metadata TEXT
                 )
             """)
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_episodes_session_id ON episodes (session_id)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_episodes_timestamp ON episodes (timestamp)"
+            )
             await db.commit()
 
         self._is_initialized = True
@@ -125,6 +129,58 @@ class EpisodicMemory:
                 })
 
         return results
+
+    async def get_episodes_for_session(self, session_id: str) -> List[Dict[str, Any]]:
+        """Return all episodes for a session ordered by timestamp ASC."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT * FROM episodes WHERE session_id = ? ORDER BY timestamp ASC",
+                (session_id,),
+            )
+            rows = await cursor.fetchall()
+        return [
+            {
+                "episode_id": row[0],
+                "session_id": row[1],
+                "user_input": row[2],
+                "agent_response": row[3],
+                "timestamp": row[4],
+                "context": json.loads(row[5]),
+                "metadata": json.loads(row[6]),
+            }
+            for row in rows
+        ]
+
+    async def list_sessions(self, max_sessions: int = 30) -> List[Dict[str, Any]]:
+        """Return recent sessions ordered by last activity DESC.
+
+        Each entry: session_id, episode_count, last_activity, first_user_input.
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                """
+                SELECT
+                    session_id,
+                    COUNT(*) AS episode_count,
+                    MAX(timestamp) AS last_activity,
+                    MIN(user_input) AS first_user_input
+                FROM episodes
+                GROUP BY session_id
+                ORDER BY last_activity DESC
+                LIMIT ?
+                """,
+                (max_sessions,),
+            )
+            rows = await cursor.fetchall()
+        return [
+            {
+                "session_id": row[0],
+                "episode_count": row[1],
+                "last_activity": row[2],
+                "first_user_input": row[3],
+            }
+            for row in rows
+        ]
 
     async def get_stats(self) -> Dict[str, Any]:
         """Retorna estatísticas"""

--- a/deile/memory/episodic_memory.py
+++ b/deile/memory/episodic_memory.py
@@ -145,8 +145,8 @@ class EpisodicMemory:
                 "user_input": row[2],
                 "agent_response": row[3],
                 "timestamp": row[4],
-                "context": json.loads(row[5]),
-                "metadata": json.loads(row[6]),
+                "context": json.loads(row[5]) if row[5] is not None else {},
+                "metadata": json.loads(row[6]) if row[6] is not None else {},
             }
             for row in rows
         ]
@@ -163,8 +163,10 @@ class EpisodicMemory:
                     session_id,
                     COUNT(*) AS episode_count,
                     MAX(timestamp) AS last_activity,
-                    MIN(user_input) AS first_user_input
-                FROM episodes
+                    (SELECT user_input FROM episodes e2
+                     WHERE e2.session_id = e.session_id
+                     ORDER BY e2.timestamp ASC LIMIT 1) AS first_user_input
+                FROM episodes e
                 GROUP BY session_id
                 ORDER BY last_activity DESC
                 LIMIT ?

--- a/deile/tests/commands/test_conversation_commands.py
+++ b/deile/tests/commands/test_conversation_commands.py
@@ -1,0 +1,473 @@
+"""Tests for /fork, /rename, /rewind, /resume conversation commands."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.commands.base import CommandContext
+from deile.commands.builtin._conv_store import ConversationNameStore
+from deile.commands.builtin.fork_command import ForkCommand
+from deile.commands.builtin.rename_command import RenameCommand
+from deile.commands.builtin.resume_command import ResumeCommand
+from deile.commands.builtin.rewind_command import RewindCommand
+from deile.memory.episodic_memory import EpisodicMemory
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HISTORY = [
+    {"role": "user", "content": "olá mundo", "timestamp": 1.0, "metadata": {}},
+    {"role": "assistant", "content": "Olá!", "timestamp": 1.1, "metadata": {}},
+    {"role": "user", "content": "como vai?", "timestamp": 2.0, "metadata": {}},
+    {"role": "assistant", "content": "Bem!", "timestamp": 2.1, "metadata": {}},
+]
+
+
+def _make_session(
+    session_id: str = "test-sid",
+    history: Optional[List[Dict[str, Any]]] = None,
+) -> MagicMock:
+    s = MagicMock()
+    s.session_id = session_id
+    s.conversation_history = list(history if history is not None else _HISTORY)
+    s.context_data = {}
+    s.working_directory = Path("/tmp")
+    return s
+
+
+def _make_agent(existing_sessions: Optional[Dict] = None) -> MagicMock:
+    agent = MagicMock()
+    _sessions: Dict[str, Any] = dict(existing_sessions or {})
+
+    def _create_session(session_id, **kwargs):
+        sess = MagicMock()
+        sess.session_id = session_id
+        sess.conversation_history = []
+        sess.context_data = {}
+        sess.working_directory = kwargs.get("working_directory", Path("/tmp"))
+        _sessions[session_id] = sess
+        return sess
+
+    def _get_session(session_id):
+        return _sessions.get(session_id)
+
+    agent.create_session.side_effect = _create_session
+    agent.get_session.side_effect = _get_session
+    return agent
+
+
+def _make_context(
+    command: str,
+    args: str = "",
+    session_id: str = "test-sid",
+    history: Optional[List] = None,
+    agent: Optional[Any] = None,
+    session: Optional[Any] = None,
+) -> CommandContext:
+    sess = session or _make_session(session_id=session_id, history=history)
+    ag = agent or _make_agent()
+    ctx = CommandContext(user_input=f"/{command} {args}".strip(), args=args)
+    ctx.agent = ag
+    ctx.session = sess
+    return ctx
+
+
+def _render(obj) -> str:
+    from rich.console import Console
+    buf = StringIO()
+    Console(file=buf, highlight=False, markup=False, width=200).print(obj)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# ConversationNameStore
+# ---------------------------------------------------------------------------
+
+
+class TestConversationNameStore:
+    def test_get_missing(self, tmp_path):
+        store = ConversationNameStore(path=tmp_path / "names.json")
+        assert store.get("unknown") is None
+
+    def test_set_and_get(self, tmp_path):
+        store = ConversationNameStore(path=tmp_path / "names.json")
+        store.set("sid1", "minha conversa")
+        assert store.get("sid1") == "minha conversa"
+
+    def test_overwrite(self, tmp_path):
+        store = ConversationNameStore(path=tmp_path / "names.json")
+        store.set("sid1", "alpha")
+        store.set("sid1", "beta")
+        assert store.get("sid1") == "beta"
+
+    def test_all(self, tmp_path):
+        store = ConversationNameStore(path=tmp_path / "names.json")
+        store.set("a", "A")
+        store.set("b", "B")
+        assert store.all() == {"a": "A", "b": "B"}
+
+    def test_delete(self, tmp_path):
+        store = ConversationNameStore(path=tmp_path / "names.json")
+        store.set("x", "X")
+        store.delete("x")
+        assert store.get("x") is None
+
+    def test_delete_missing_is_noop(self, tmp_path):
+        store = ConversationNameStore(path=tmp_path / "names.json")
+        store.delete("nonexistent")  # should not raise
+
+    def test_corrupted_file_returns_empty(self, tmp_path):
+        p = tmp_path / "names.json"
+        p.write_text("NOT JSON", encoding="utf-8")
+        store = ConversationNameStore(path=p)
+        assert store.get("x") is None
+
+
+# ---------------------------------------------------------------------------
+# ForkCommand
+# ---------------------------------------------------------------------------
+
+
+class TestForkCommand:
+    @pytest.mark.unit
+    async def test_fork_creates_new_session(self, tmp_path):
+        ctx = _make_context("fork")
+        with patch.object(ConversationNameStore, "set"):
+            cmd = ForkCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        ctx.agent.create_session.assert_called_once()
+        new_sid = ctx.session.context_data.get("_switch_session")
+        assert new_sid is not None
+        assert new_sid.startswith("fork-")
+
+    @pytest.mark.unit
+    async def test_fork_copies_history(self, tmp_path):
+        ctx = _make_context("fork", history=_HISTORY)
+        with patch.object(ConversationNameStore, "set"):
+            cmd = ForkCommand()
+            await cmd.execute(ctx)
+
+        new_sid = ctx.session.context_data["_switch_session"]
+        new_sess = ctx.agent.get_session(new_sid)
+        assert len(new_sess.conversation_history) == len(_HISTORY)
+
+    @pytest.mark.unit
+    async def test_fork_with_name(self, tmp_path):
+        ctx = _make_context("fork", args="minha feature")
+        with patch.object(ConversationNameStore, "set") as mock_set:
+            cmd = ForkCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        mock_set.assert_called_once()
+        _, call_name = mock_set.call_args[0]
+        assert call_name == "minha feature"
+
+    @pytest.mark.unit
+    async def test_fork_no_agent_returns_error(self):
+        ctx = _make_context("fork")
+        ctx.agent = None
+        cmd = ForkCommand()
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+    @pytest.mark.unit
+    async def test_fork_no_session_returns_error(self):
+        ctx = _make_context("fork")
+        ctx.session = None
+        cmd = ForkCommand()
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# RenameCommand
+# ---------------------------------------------------------------------------
+
+
+class TestRenameCommand:
+    @pytest.mark.unit
+    async def test_rename_sets_name(self, tmp_path):
+        ctx = _make_context("rename", args="meu debug")
+        with patch.object(ConversationNameStore, "set") as mock_set:
+            cmd = RenameCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        mock_set.assert_called_once_with(ctx.session.session_id, "meu debug")
+
+    @pytest.mark.unit
+    async def test_rename_updates_context_data(self, tmp_path):
+        ctx = _make_context("rename", args="novo nome")
+        with patch.object(ConversationNameStore, "set"):
+            cmd = RenameCommand()
+            await cmd.execute(ctx)
+
+        assert ctx.session.context_data.get("conversation_name") == "novo nome"
+
+    @pytest.mark.unit
+    async def test_rename_no_name_returns_error(self):
+        ctx = _make_context("rename", args="")
+        cmd = RenameCommand()
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+    @pytest.mark.unit
+    async def test_rename_no_session_returns_error(self):
+        ctx = _make_context("rename", args="test")
+        ctx.session = None
+        cmd = RenameCommand()
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# RewindCommand
+# ---------------------------------------------------------------------------
+
+
+class TestRewindCommand:
+    @pytest.mark.unit
+    async def test_rewind_empty_history(self):
+        ctx = _make_context("rewind", history=[])
+        cmd = RewindCommand()
+        result = await cmd.execute(ctx)
+        assert result.success
+        # No session switch when history is empty
+        assert "_switch_session" not in ctx.session.context_data
+
+    @pytest.mark.unit
+    async def test_rewind_selector_not_supported(self):
+        from deile.commands.builtin import rewind_command as rw_mod
+
+        ctx = _make_context("rewind", history=_HISTORY)
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = False
+
+        with patch.object(rw_mod, "get_default_selector", return_value=mock_selector):
+            cmd = RewindCommand()
+            result = await cmd.execute(ctx)
+
+        assert not result.success
+
+    @pytest.mark.unit
+    async def test_rewind_cancel_returns_no_switch(self):
+        from deile.commands.builtin import rewind_command as rw_mod
+
+        ctx = _make_context("rewind", history=_HISTORY)
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        mock_selector.select = AsyncMock(return_value=None)
+
+        with patch.object(rw_mod, "get_default_selector", return_value=mock_selector):
+            cmd = RewindCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        assert result.metadata.get("cancelled")
+        assert "_switch_session" not in ctx.session.context_data
+
+    @pytest.mark.unit
+    async def test_rewind_choice_creates_fork(self):
+        from deile.commands.builtin import rewind_command as rw_mod
+        from deile.core.interfaces.selector import SelectorOption
+
+        ctx = _make_context("rewind", history=_HISTORY)
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        # Select the first user message (index 0 in history)
+        mock_selector.select = AsyncMock(
+            return_value=SelectorOption(label="#1 olá mundo", value=0)
+        )
+
+        with patch.object(rw_mod, "get_default_selector", return_value=mock_selector):
+            cmd = RewindCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        new_sid = ctx.session.context_data.get("_switch_session")
+        assert new_sid is not None
+        assert new_sid.startswith("rewind-")
+
+        # Fork should contain only up to the first user message (index 0 + 1 = 1 entry)
+        new_sess = ctx.agent.get_session(new_sid)
+        assert len(new_sess.conversation_history) == 1
+        assert new_sess.conversation_history[0]["content"] == "olá mundo"
+
+
+# ---------------------------------------------------------------------------
+# ResumeCommand
+# ---------------------------------------------------------------------------
+
+
+class TestResumeCommand:
+    def _make_memory_manager(self, sessions=None, episodes=None):
+        mm = MagicMock()
+        episodic = MagicMock()
+        episodic.list_sessions = AsyncMock(return_value=sessions or [])
+        episodic.get_episodes_for_session = AsyncMock(return_value=episodes or [])
+        mm.episodic_memory = episodic
+        return mm
+
+    @pytest.mark.unit
+    async def test_resume_no_sessions(self):
+        ctx = _make_context("resume")
+        ctx.agent.memory_manager = self._make_memory_manager(sessions=[])
+        cmd = ResumeCommand()
+        result = await cmd.execute(ctx)
+        assert result.success
+        assert "_switch_session" not in ctx.session.context_data
+
+    @pytest.mark.unit
+    async def test_resume_no_memory_manager(self):
+        ctx = _make_context("resume")
+        ctx.agent.memory_manager = None
+        cmd = ResumeCommand()
+        result = await cmd.execute(ctx)
+        assert not result.success
+
+    @pytest.mark.unit
+    async def test_resume_cancel(self):
+        from deile.commands.builtin import resume_command as res_mod
+
+        sessions = [
+            {"session_id": "old-1", "episode_count": 3, "last_activity": 1.0, "first_user_input": "hello"},
+        ]
+        ctx = _make_context("resume")
+        ctx.agent.memory_manager = self._make_memory_manager(sessions=sessions)
+
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        mock_selector.select = AsyncMock(return_value=None)
+
+        with (
+            patch.object(res_mod, "get_default_selector", return_value=mock_selector),
+            patch.object(ConversationNameStore, "get", return_value=None),
+        ):
+            cmd = ResumeCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        assert result.metadata.get("cancelled")
+
+    @pytest.mark.unit
+    async def test_resume_loads_history(self):
+        from deile.commands.builtin import resume_command as res_mod
+        from deile.core.interfaces.selector import SelectorOption
+
+        sessions = [
+            {"session_id": "old-1", "episode_count": 2, "last_activity": 2.0, "first_user_input": "hi"},
+        ]
+        episodes = [
+            {"episode_id": "e1", "session_id": "old-1", "user_input": "hi", "agent_response": "hello", "timestamp": 1.0, "context": {}, "metadata": {}},
+            {"episode_id": "e2", "session_id": "old-1", "user_input": "bye", "agent_response": "cya", "timestamp": 2.0, "context": {}, "metadata": {}},
+        ]
+        ctx = _make_context("resume")
+        ctx.agent.memory_manager = self._make_memory_manager(sessions=sessions, episodes=episodes)
+
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        mock_selector.select = AsyncMock(
+            return_value=SelectorOption(label="hi", value="old-1")
+        )
+
+        with (
+            patch.object(res_mod, "get_default_selector", return_value=mock_selector),
+            patch.object(ConversationNameStore, "get", return_value=None),
+        ):
+            cmd = ResumeCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        new_sid = ctx.session.context_data.get("_switch_session")
+        assert new_sid is not None
+        assert new_sid.startswith("resume-")
+
+        new_sess = ctx.agent.get_session(new_sid)
+        # 2 episodes × 2 messages each = 4 history entries
+        assert len(new_sess.conversation_history) == 4
+
+    @pytest.mark.unit
+    async def test_resume_selector_not_supported(self):
+        from deile.commands.builtin import resume_command as res_mod
+
+        sessions = [
+            {"session_id": "old-1", "episode_count": 1, "last_activity": 1.0, "first_user_input": "x"},
+        ]
+        ctx = _make_context("resume")
+        ctx.agent.memory_manager = self._make_memory_manager(sessions=sessions)
+
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = False
+
+        with (
+            patch.object(res_mod, "get_default_selector", return_value=mock_selector),
+            patch.object(ConversationNameStore, "get", return_value=None),
+        ):
+            cmd = ResumeCommand()
+            result = await cmd.execute(ctx)
+
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# EpisodicMemory — new methods
+# ---------------------------------------------------------------------------
+
+
+class TestEpisodicMemoryNewMethods:
+    @pytest.fixture
+    async def mem(self, tmp_path):
+        em = EpisodicMemory(storage_dir=tmp_path / "episodic")
+        await em.initialize()
+        return em
+
+    @pytest.mark.unit
+    async def test_list_sessions_empty(self, mem):
+        sessions = await mem.list_sessions()
+        assert sessions == []
+
+    @pytest.mark.unit
+    async def test_list_sessions_returns_rows(self, mem):
+        await mem.store_episode("hello", "world", session_id="s1")
+        await mem.store_episode("bye", "cya", session_id="s2")
+        sessions = await mem.list_sessions()
+        assert len(sessions) == 2
+        sids = {r["session_id"] for r in sessions}
+        assert "s1" in sids and "s2" in sids
+
+    @pytest.mark.unit
+    async def test_list_sessions_ordered_by_recency(self, mem):
+        await mem.store_episode("old", "resp", session_id="early")
+        await mem.store_episode("new", "resp", session_id="recent")
+        sessions = await mem.list_sessions()
+        assert sessions[0]["session_id"] == "recent"
+
+    @pytest.mark.unit
+    async def test_get_episodes_for_session(self, mem):
+        await mem.store_episode("q1", "a1", session_id="sx")
+        await mem.store_episode("q2", "a2", session_id="sx")
+        eps = await mem.get_episodes_for_session("sx")
+        assert len(eps) == 2
+        assert eps[0]["user_input"] == "q1"
+        assert eps[1]["user_input"] == "q2"
+
+    @pytest.mark.unit
+    async def test_get_episodes_for_unknown_session(self, mem):
+        eps = await mem.get_episodes_for_session("nonexistent")
+        assert eps == []
+
+    @pytest.mark.unit
+    async def test_list_sessions_respects_max(self, mem):
+        for i in range(10):
+            await mem.store_episode(f"q{i}", f"a{i}", session_id=f"s{i}")
+        sessions = await mem.list_sessions(max_sessions=5)
+        assert len(sessions) == 5

--- a/deile/ui/console_ui.py
+++ b/deile/ui/console_ui.py
@@ -102,6 +102,9 @@ class ConsoleUIManager(UIManager):
             from prompt_toolkit.layout.controls import FormattedTextControl
             from prompt_toolkit.output import ColorDepth
 
+            # Sentinel returned to the CLI loop to signal "open /rewind".
+            _REWIND_SENTINEL = "\x00REWIND\x00"
+
             kb = KeyBindings()
             _esc = {'active': False, 'task': None}
 
@@ -123,12 +126,33 @@ class ConsoleUIManager(UIManager):
 
             @kb.add("escape")
             def _on_esc(event):
-                if not event.current_buffer.text:
-                    _hide_esc_hint(event)
+                buf = event.current_buffer
+                if not buf.text:
+                    # ESC on empty buffer: if hint was already active (i.e. this
+                    # is the *second* ESC on an empty prompt), emit the rewind
+                    # sentinel so the CLI loop opens /rewind.
+                    if _esc['active']:
+                        _hide_esc_hint(event)
+                        buf.insert_text(_REWIND_SENTINEL)
+                        event.app.validate_and_handle()
+                        return
+                    # First ESC on empty buffer: show rewind hint.
+                    _esc['active'] = True
+                    event.app.invalidate()
+
+                    async def _auto_hide_empty():
+                        await asyncio.sleep(1.5)
+                        _esc['active'] = False
+                        _esc['task'] = None
+                        event.app.invalidate()
+
+                    if _esc['task']:
+                        _esc['task'].cancel()
+                    _esc['task'] = event.app.create_background_task(_auto_hide_empty())
                     return
 
                 if _esc['active']:
-                    event.current_buffer.reset()
+                    buf.reset()
                     _hide_esc_hint(event)
                     return
 
@@ -191,12 +215,23 @@ class ConsoleUIManager(UIManager):
             # separator would persist in scrollback after submission because
             # prompt_toolkit reserves the row for ConditionalContainer even when the
             # filter collapses to false on is_done.
+            def _esc_hint_text():
+                # Prompt_toolkit captures `session` at closure time, so we
+                # inspect the current buffer through the live app.
+                try:
+                    buf_text = get_app().current_buffer.text
+                except Exception:
+                    buf_text = ""
+                if buf_text:
+                    msg = " Esc novamente para limpar"
+                else:
+                    msg = " Esc novamente para /rewind"
+                return FormattedText([("fg:ansibrightblack", msg)])
+
             hint_win = ConditionalContainer(
                 content=Window(
                     height=1,
-                    content=FormattedTextControl(
-                        lambda: FormattedText([('fg:ansibrightblack', ' Esc novamente para limpar')])
-                    ),
+                    content=FormattedTextControl(_esc_hint_text),
                     dont_extend_height=True,
                 ),
                 filter=Condition(lambda: _esc['active']),


### PR DESCRIPTION
## Summary

Closes #199

Implements all four conversation-management commands and the ESC streaming-cancel feature requested in the intent issue.

### What changed

| Component | Change |
|---|---|
| `deile/commands/builtin/fork_command.py` | New `/fork [name]` — copies conversation history to a new session and signals a session switch |
| `deile/commands/builtin/rename_command.py` | New `/rename <name>` — persists a human-readable label for the current session |
| `deile/commands/builtin/rewind_command.py` | New `/rewind` (alias `rw`) — interactive picker over user messages; forks at the selected point |
| `deile/commands/builtin/resume_command.py` | New `/resume` — lists sessions from episodic memory, restores selected history into a new session |
| `deile/commands/builtin/_conv_store.py` | New `ConversationNameStore` — JSON file at `~/.deile/conversation_names.json` |
| `deile/memory/episodic_memory.py` | **Bug fix**: invalid `INDEX()` syntax inside `CREATE TABLE`; two new methods: `get_episodes_for_session()` and `list_sessions()` |
| `deile/cli.py` | Unique session IDs (`cli-<ts>-<uuid8>`), `_stream_with_esc_cancel()` (daemon thread cbreak ESC detection), `_check_session_switch()` (pops sentinel from `context_data`) |
| `deile/ui/console_ui.py` | Double-ESC on empty prompt inserts `\x00REWIND\x00` sentinel → main loop triggers `/rewind`; hint updates to reflect empty-buffer context |
| `deile/tests/commands/test_conversation_commands.py` | 31 new unit tests across 6 classes |

### Architecture notes

- Commands signal a session switch via `session.context_data["_switch_session"] = new_sid`; the CLI pops this sentinel after each turn — no tight coupling between commands and the CLI class.
- ESC detection uses `termios`/`tty` cbreak mode in a daemon thread with `asyncio.wait(FIRST_COMPLETED)`, with graceful fallback on Windows/non-TTY.
- All new commands use `@wrap_command_errors`, `InteractiveSelector` (existing port/adapter), and `SelectorNotSupported` fallback path.

## Test plan

- [x] `python3 -m pytest deile/tests/ -q --no-cov` → 2502 passed, 12 skipped
- [x] `ruff check deile/` → all checks passed
- [x] `isort --check-only deile/` → no issues
- [x] All 31 new tests cover: ConversationNameStore CRUD, /fork happy path + error paths, /rename happy path + error paths, /rewind (empty, no TTY, cancel, selection), /resume (no sessions, no memory manager, cancel, loads history, no TTY), EpisodicMemory new methods

---
_Generated by [Claude Code](https://claude.ai/code/session_01LU1T6LD4Ax1GqsSGKPAYhb)_