### PR TITLE
fix(commands): corrigir ESC quebrado e /resume sem dados

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -288,6 +288,25 @@ class _DeileCLI:
     # switch without tight-coupling between the command and the CLI class.
     _SWITCH_SESSION_KEY = "_switch_session"
 
+    def _persist_session(self, user_input: str) -> None:
+        """Write current session history to disk so /resume can find it.
+
+        Only persists after real LLM turns (not slash commands) to avoid
+        storing noise.  Failures are silently ignored — non-fatal.
+        """
+        if user_input.startswith("/"):
+            return
+        session = self.default_session
+        history = getattr(session, "conversation_history", [])
+        if not history:
+            return
+        try:
+            from .commands.builtin._session_store import SessionHistoryStore
+            name = session.context_data.get("conversation_name", "")
+            SessionHistoryStore().save(session.session_id, list(history), name)
+        except Exception:
+            pass
+
     def _check_session_switch(self) -> None:
         """If a command requested a session switch, apply it."""
         new_sid = self.default_session.context_data.pop(self._SWITCH_SESSION_KEY, None)
@@ -429,6 +448,7 @@ class _DeileCLI:
                         await self._stream_with_esc_cancel(event_stream)
                     except KeyboardInterrupt:
                         self.ui.console.print("\n[yellow](turn interrupted)[/yellow]")
+                    self._persist_session(user_input)
                     self._check_session_switch()
                     continue
 
@@ -438,6 +458,7 @@ class _DeileCLI:
                         session_id=self.default_session.session_id,
                     )
 
+                self._persist_session(user_input)
                 self._check_session_switch()
 
                 meta = response.metadata or {}

--- a/deile/commands/builtin/_session_store.py
+++ b/deile/commands/builtin/_session_store.py
@@ -1,0 +1,80 @@
+"""SessionHistoryStore — persists conversation history for /resume."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_SESSIONS_DIR = Path.home() / ".deile" / "sessions"
+
+
+class SessionHistoryStore:
+    """Saves and lists conversation histories for the /resume command.
+
+    Each session is stored as ``~/.deile/sessions/<session_id>/history.json``
+    so that /resume can restore past conversations across process restarts.
+    Writes are atomic (write to .tmp, then rename).
+    """
+
+    def __init__(self, base_dir: Path = _SESSIONS_DIR) -> None:
+        self._base_dir = base_dir
+
+    def save(self, session_id: str, history: List[Dict], name: str = "") -> None:
+        """Persist the current conversation_history to disk (best-effort)."""
+        if not history:
+            return
+        session_dir = self._base_dir / session_id
+        try:
+            session_dir.mkdir(parents=True, exist_ok=True)
+            data = {
+                "session_id": session_id,
+                "conversation_name": name,
+                "last_activity": time.time(),
+                "history": history,
+            }
+            tmp = session_dir / "history.tmp"
+            tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            tmp.replace(session_dir / "history.json")
+        except Exception:
+            pass  # non-fatal
+
+    def list_sessions(self, max_sessions: int = 50) -> List[Dict[str, Any]]:
+        """Return sessions sorted by last_activity descending."""
+        if not self._base_dir.exists():
+            return []
+        sessions: List[Dict[str, Any]] = []
+        for session_dir in self._base_dir.iterdir():
+            if not session_dir.is_dir():
+                continue
+            history_file = session_dir / "history.json"
+            if not history_file.exists():
+                continue
+            try:
+                data = json.loads(history_file.read_text(encoding="utf-8"))
+                user_msgs = [
+                    m for m in data.get("history", [])
+                    if m.get("role") == "user" and not m.get("content", "").startswith("/")
+                ]
+                sessions.append({
+                    "session_id": data["session_id"],
+                    "conversation_name": data.get("conversation_name", ""),
+                    "last_activity": float(data.get("last_activity", 0.0)),
+                    "first_user_input": user_msgs[0]["content"] if user_msgs else "",
+                    "message_count": len(data.get("history", [])),
+                })
+            except Exception:
+                continue
+        sessions.sort(key=lambda s: s["last_activity"], reverse=True)
+        return sessions[:max_sessions]
+
+    def load(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return the stored session data, or None if missing/corrupt."""
+        history_file = self._base_dir / session_id / "history.json"
+        if not history_file.exists():
+            return None
+        try:
+            return json.loads(history_file.read_text(encoding="utf-8"))
+        except Exception:
+            return None

--- a/deile/commands/builtin/resume_command.py
+++ b/deile/commands/builtin/resume_command.py
@@ -12,6 +12,7 @@ from ...core.interfaces.selector import SelectorNotSupported, SelectorOption
 from ...infrastructure.selectors import get_default_selector
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._conv_store import ConversationNameStore
+from ._session_store import SessionHistoryStore
 from ._shared import wrap_command_errors
 
 _SENTINEL = "_switch_session"
@@ -22,16 +23,18 @@ def _fmt_time(ts: float) -> str:
     return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
 
 
-def _truncate(s: str, n: int = _MAX_LABEL) -> str:
-    s = s.replace("\n", " ").strip()
-    return s[:n] + "…" if len(s) > n else s
+def _truncate(s: object, n: int = _MAX_LABEL) -> str:
+    if not s:
+        return ""
+    text = str(s).replace("\n", " ").strip()
+    return text[:n] + "…" if len(text) > n else text
 
 
 class ResumeCommand(DirectCommand):
     """Select a past conversation and continue from where it left off.
 
-    Conversations are loaded from episodic memory (SQLite), so they survive
-    process restarts.  Select with ↑↓ Enter; ESC to cancel.
+    Conversations are loaded from ``~/.deile/sessions/`` (written by the CLI
+    after each LLM turn).  Select with ↑↓ Enter; ESC to cancel.
     """
 
     def __init__(self) -> None:
@@ -40,7 +43,7 @@ class ResumeCommand(DirectCommand):
         super().__init__(
             CommandConfig(
                 name="resume",
-                description="List and reload a past conversation from episodic memory.",
+                description="List and reload a past conversation.",
             )
         )
 
@@ -51,22 +54,17 @@ class ResumeCommand(DirectCommand):
         if agent is None or session is None:
             return CommandResult.error_result("Agent or session not available.")
 
-        memory_manager = getattr(agent, "memory_manager", None)
-        if memory_manager is None:
-            return CommandResult.error_result("MemoryManager não disponível.")
+        name_store = ConversationNameStore()
+        hist_store = SessionHistoryStore()
 
-        episodic = getattr(memory_manager, "episodic_memory", None)
-        if episodic is None:
-            return CommandResult.error_result("EpisodicMemory não disponível.")
-
-        sessions = await episodic.list_sessions(max_sessions=50)
+        sessions = hist_store.list_sessions(max_sessions=50)
         if not sessions:
             return CommandResult(
                 success=True,
                 content=Panel(
                     Text(
-                        "Nenhuma conversa encontrada na memória episódica.\n"
-                        "As conversas ficam disponíveis após a primeira interação.",
+                        "Nenhuma conversa encontrada.\n"
+                        "As conversas ficam disponíveis após a primeira interação com o agente.",
                         style="dim",
                     ),
                     title="Resume",
@@ -74,17 +72,18 @@ class ResumeCommand(DirectCommand):
                 ),
             )
 
-        store = ConversationNameStore()
         selector = get_default_selector()
 
         if not selector.is_supported():
             lines = []
             for row in sessions[:20]:
-                name = store.get(row["session_id"]) or _truncate(
-                    row["first_user_input"], 50
+                name = (
+                    name_store.get(row["session_id"])
+                    or row.get("conversation_name")
+                    or _truncate(row["first_user_input"], 50)
                 )
                 ts = _fmt_time(row["last_activity"])
-                lines.append(f"{ts}  {name}  ({row['episode_count']} msg)")
+                lines.append(f"{ts}  {name}  ({row['message_count']} msg)")
             return CommandResult(
                 success=False,
                 content=Panel(
@@ -101,13 +100,18 @@ class ResumeCommand(DirectCommand):
         options = []
         for row in sessions:
             sid = row["session_id"]
-            name = store.get(sid) or _truncate(row["first_user_input"], 50)
+            name = (
+                name_store.get(sid)
+                or row.get("conversation_name")
+                or _truncate(row["first_user_input"], 50)
+                or sid
+            )
             ts = _fmt_time(row["last_activity"])
             options.append(
                 SelectorOption(
                     label=name,
                     value=sid,
-                    description=f"{ts} · {row['episode_count']} msg · {sid}",
+                    description=f"{ts} · {row['message_count']} msg · {sid}",
                 )
             )
 
@@ -132,15 +136,11 @@ class ResumeCommand(DirectCommand):
             )
 
         target_sid = str(choice.value)
-        episodes = await episodic.get_episodes_for_session(target_sid)
+        stored = hist_store.load(target_sid)
+        if stored is None:
+            return CommandResult.error_result(f"Conversa {target_sid!r} não encontrada em disco.")
 
-        history = []
-        for ep in episodes:
-            if ep["user_input"]:
-                history.append({"role": "user", "content": ep["user_input"], "timestamp": ep["timestamp"], "metadata": {}})
-            if ep["agent_response"]:
-                history.append({"role": "assistant", "content": ep["agent_response"], "timestamp": ep["timestamp"], "metadata": {}})
-
+        history = stored.get("history", [])
         new_sid = f"resume-{int(time.time())}-{target_sid[-8:]}"
         try:
             new_session = agent.create_session(
@@ -150,15 +150,18 @@ class ResumeCommand(DirectCommand):
         except Exception as exc:
             return CommandResult.error_result(f"Não foi possível criar sessão: {exc}")
 
-        new_session.conversation_history = history
+        new_session.conversation_history = [dict(e) for e in history]
 
-        name = store.get(target_sid) or ""
+        name = (
+            name_store.get(target_sid)
+            or stored.get("conversation_name", "")
+        )
         if name:
             new_session.context_data["conversation_name"] = name
 
         session.context_data[_SENTINEL] = new_sid
 
-        label = name or _truncate(episodes[-1]["user_input"]) if episodes else target_sid
+        label = name or _truncate(history[-1].get("content", "")) if history else target_sid
         return CommandResult(
             success=True,
             content=Panel(

--- a/deile/tests/commands/test_conversation_commands.py
+++ b/deile/tests/commands/test_conversation_commands.py
@@ -11,6 +11,7 @@ import pytest
 
 from deile.commands.base import CommandContext
 from deile.commands.builtin._conv_store import ConversationNameStore
+from deile.commands.builtin._session_store import SessionHistoryStore
 from deile.commands.builtin.fork_command import ForkCommand
 from deile.commands.builtin.rename_command import RenameCommand
 from deile.commands.builtin.resume_command import ResumeCommand
@@ -308,47 +309,108 @@ class TestRewindCommand:
 # ---------------------------------------------------------------------------
 
 
+class TestSessionHistoryStore:
+    def test_save_and_list(self, tmp_path):
+        store = SessionHistoryStore(base_dir=tmp_path)
+        history = [
+            {"role": "user", "content": "hello", "timestamp": 1.0, "metadata": {}},
+            {"role": "assistant", "content": "hi!", "timestamp": 1.1, "metadata": {}},
+        ]
+        store.save("s1", history, name="my session")
+        sessions = store.list_sessions()
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "s1"
+        assert sessions[0]["first_user_input"] == "hello"
+        assert sessions[0]["message_count"] == 2
+
+    def test_list_empty(self, tmp_path):
+        store = SessionHistoryStore(base_dir=tmp_path)
+        assert store.list_sessions() == []
+
+    def test_load_returns_none_for_missing(self, tmp_path):
+        store = SessionHistoryStore(base_dir=tmp_path)
+        assert store.load("nonexistent") is None
+
+    def test_load_returns_stored_data(self, tmp_path):
+        store = SessionHistoryStore(base_dir=tmp_path)
+        history = [{"role": "user", "content": "test", "timestamp": 1.0, "metadata": {}}]
+        store.save("s2", history)
+        data = store.load("s2")
+        assert data is not None
+        assert data["session_id"] == "s2"
+        assert len(data["history"]) == 1
+
+    def test_slash_command_messages_excluded_from_first_user_input(self, tmp_path):
+        store = SessionHistoryStore(base_dir=tmp_path)
+        history = [
+            {"role": "user", "content": "/fork", "timestamp": 1.0, "metadata": {}},
+            {"role": "user", "content": "real question", "timestamp": 2.0, "metadata": {}},
+        ]
+        store.save("s3", history)
+        sessions = store.list_sessions()
+        assert sessions[0]["first_user_input"] == "real question"
+
+    def test_corrupted_file_skipped(self, tmp_path):
+        session_dir = tmp_path / "bad-session"
+        session_dir.mkdir()
+        (session_dir / "history.json").write_text("NOT JSON", encoding="utf-8")
+        store = SessionHistoryStore(base_dir=tmp_path)
+        assert store.list_sessions() == []
+
+    def test_sorted_by_last_activity(self, tmp_path):
+        store = SessionHistoryStore(base_dir=tmp_path)
+        store.save("older", [{"role": "user", "content": "x", "timestamp": 1.0, "metadata": {}}])
+        # Overwrite last_activity by re-saving slightly later
+        import time as _time
+        _time.sleep(0.01)
+        store.save("newer", [{"role": "user", "content": "y", "timestamp": 2.0, "metadata": {}}])
+        sessions = store.list_sessions()
+        assert sessions[0]["session_id"] == "newer"
+
+
 class TestResumeCommand:
-    def _make_memory_manager(self, sessions=None, episodes=None):
-        mm = MagicMock()
-        episodic = MagicMock()
-        episodic.list_sessions = AsyncMock(return_value=sessions or [])
-        episodic.get_episodes_for_session = AsyncMock(return_value=episodes or [])
-        mm.episodic_memory = episodic
-        return mm
+    _SESSIONS = [
+        {
+            "session_id": "old-1",
+            "conversation_name": "",
+            "last_activity": 2.0,
+            "first_user_input": "hello",
+            "message_count": 4,
+        }
+    ]
+    _STORED = {
+        "session_id": "old-1",
+        "conversation_name": "",
+        "last_activity": 2.0,
+        "history": [
+            {"role": "user", "content": "hi", "timestamp": 1.0, "metadata": {}},
+            {"role": "assistant", "content": "hello", "timestamp": 1.0, "metadata": {}},
+            {"role": "user", "content": "bye", "timestamp": 2.0, "metadata": {}},
+            {"role": "assistant", "content": "cya", "timestamp": 2.0, "metadata": {}},
+        ],
+    }
 
     @pytest.mark.unit
     async def test_resume_no_sessions(self):
         ctx = _make_context("resume")
-        ctx.agent.memory_manager = self._make_memory_manager(sessions=[])
-        cmd = ResumeCommand()
-        result = await cmd.execute(ctx)
+        with patch.object(SessionHistoryStore, "list_sessions", return_value=[]):
+            cmd = ResumeCommand()
+            result = await cmd.execute(ctx)
         assert result.success
         assert "_switch_session" not in ctx.session.context_data
-
-    @pytest.mark.unit
-    async def test_resume_no_memory_manager(self):
-        ctx = _make_context("resume")
-        ctx.agent.memory_manager = None
-        cmd = ResumeCommand()
-        result = await cmd.execute(ctx)
-        assert not result.success
 
     @pytest.mark.unit
     async def test_resume_cancel(self):
         from deile.commands.builtin import resume_command as res_mod
 
-        sessions = [
-            {"session_id": "old-1", "episode_count": 3, "last_activity": 1.0, "first_user_input": "hello"},
-        ]
         ctx = _make_context("resume")
-        ctx.agent.memory_manager = self._make_memory_manager(sessions=sessions)
 
         mock_selector = MagicMock()
         mock_selector.is_supported.return_value = True
         mock_selector.select = AsyncMock(return_value=None)
 
         with (
+            patch.object(SessionHistoryStore, "list_sessions", return_value=self._SESSIONS),
             patch.object(res_mod, "get_default_selector", return_value=mock_selector),
             patch.object(ConversationNameStore, "get", return_value=None),
         ):
@@ -363,15 +425,7 @@ class TestResumeCommand:
         from deile.commands.builtin import resume_command as res_mod
         from deile.core.interfaces.selector import SelectorOption
 
-        sessions = [
-            {"session_id": "old-1", "episode_count": 2, "last_activity": 2.0, "first_user_input": "hi"},
-        ]
-        episodes = [
-            {"episode_id": "e1", "session_id": "old-1", "user_input": "hi", "agent_response": "hello", "timestamp": 1.0, "context": {}, "metadata": {}},
-            {"episode_id": "e2", "session_id": "old-1", "user_input": "bye", "agent_response": "cya", "timestamp": 2.0, "context": {}, "metadata": {}},
-        ]
         ctx = _make_context("resume")
-        ctx.agent.memory_manager = self._make_memory_manager(sessions=sessions, episodes=episodes)
 
         mock_selector = MagicMock()
         mock_selector.is_supported.return_value = True
@@ -380,6 +434,8 @@ class TestResumeCommand:
         )
 
         with (
+            patch.object(SessionHistoryStore, "list_sessions", return_value=self._SESSIONS),
+            patch.object(SessionHistoryStore, "load", return_value=self._STORED),
             patch.object(res_mod, "get_default_selector", return_value=mock_selector),
             patch.object(ConversationNameStore, "get", return_value=None),
         ):
@@ -392,23 +448,43 @@ class TestResumeCommand:
         assert new_sid.startswith("resume-")
 
         new_sess = ctx.agent.get_session(new_sid)
-        # 2 episodes × 2 messages each = 4 history entries
         assert len(new_sess.conversation_history) == 4
 
     @pytest.mark.unit
     async def test_resume_selector_not_supported(self):
         from deile.commands.builtin import resume_command as res_mod
 
-        sessions = [
-            {"session_id": "old-1", "episode_count": 1, "last_activity": 1.0, "first_user_input": "x"},
-        ]
         ctx = _make_context("resume")
-        ctx.agent.memory_manager = self._make_memory_manager(sessions=sessions)
 
         mock_selector = MagicMock()
         mock_selector.is_supported.return_value = False
 
         with (
+            patch.object(SessionHistoryStore, "list_sessions", return_value=self._SESSIONS),
+            patch.object(res_mod, "get_default_selector", return_value=mock_selector),
+            patch.object(ConversationNameStore, "get", return_value=None),
+        ):
+            cmd = ResumeCommand()
+            result = await cmd.execute(ctx)
+
+        assert not result.success
+
+    @pytest.mark.unit
+    async def test_resume_load_failure(self):
+        from deile.commands.builtin import resume_command as res_mod
+        from deile.core.interfaces.selector import SelectorOption
+
+        ctx = _make_context("resume")
+
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        mock_selector.select = AsyncMock(
+            return_value=SelectorOption(label="hi", value="old-1")
+        )
+
+        with (
+            patch.object(SessionHistoryStore, "list_sessions", return_value=self._SESSIONS),
+            patch.object(SessionHistoryStore, "load", return_value=None),
             patch.object(res_mod, "get_default_selector", return_value=mock_selector),
             patch.object(ConversationNameStore, "get", return_value=None),
         ):

--- a/deile/ui/console_ui.py
+++ b/deile/ui/console_ui.py
@@ -134,7 +134,7 @@ class ConsoleUIManager(UIManager):
                     if _esc['active']:
                         _hide_esc_hint(event)
                         buf.insert_text(_REWIND_SENTINEL)
-                        event.app.validate_and_handle()
+                        event.current_buffer.validate_and_handle()
                         return
                     # First ESC on empty buffer: show rewind hint.
                     _esc['active'] = True


### PR DESCRIPTION
## Problemas corrigidos

### Bug 1 — ESC mostrando `^[^[^[^[^[^[^[^[` no terminal

**Causa raiz**: `event.app.validate_and_handle()` não existe em `Application` do prompt_toolkit. A `AttributeError` era silenciada pelo dispatcher de key bindings, deixando o sentinel `\x00REWIND\x00` preso no buffer. Pressionamentos subsequentes de ESC se comportavam erraticamente e caracteres de escape apareciamvisíveis.

**Fix**: `event.current_buffer.validate_and_handle()` — API correta do prompt_toolkit.

---

### Bug 2 — `/resume` não funciona

**Causa raiz**: `agent.memory_manager` é `None` em produção (nunca é configurado no fluxo de bootstrap real). O comando retornava erro `"MemoryManager não disponível"` imediatamente. Além disso, mesmo que memory_manager existisse, nenhum episódio era gravado na EpisodicMemory durante conversas normais.

**Fix**: Substituir a dependência de `memory_manager`/`EpisodicMemory` por `SessionHistoryStore`:

| Componente | Mudança |
|---|---|
| `_session_store.py` (novo) | `SessionHistoryStore` persiste `conversation_history` em `~/.deile/sessions/<session_id>/history.json` com escrita atômica (write + rename) |
| `cli.py` | `_persist_session()` salva o histórico após cada turno LLM, antes da troca de sessão; slash commands são ignorados |
| `resume_command.py` | Lê `SessionHistoryStore` diretamente, sem dependência de `memory_manager`; `_truncate()` agora é None-safe |

---

## Testes

- 38 testes no arquivo de comandos (7 novos para `TestSessionHistoryStore`, 1 novo `test_resume_load_failure`)
- Suite completa: **2509 passed, 12 skipped**
- `ruff check` ✅ `isort` ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01LU1T6LD4Ax1GqsSGKPAYhb)_