### PR TITLE
refactor(daily): 2026-05-16 — 2 refatorações DRY arquiteturais

### DIFF
--- a/deile/commands/builtin/model_command.py
+++ b/deile/commands/builtin/model_command.py
@@ -158,25 +158,9 @@ EXAMPLES:
     async def _select(self, context: CommandContext) -> CommandResult:
         from deile.core.models.catalog import ModelCatalog
 
-        try:
-            ctx_data = getattr(context.session, "context_data", {}) or {}
-        except AttributeError:
-            ctx_data = {}
-        if ctx_data.get("model_override_locked"):
-            locked_model = ctx_data.get("forced_model") or "(unknown)"
-            return CommandResult(
-                success=False,
-                content=Panel(
-                    Text(
-                        "Model selection is locked by bot configuration.\n"
-                        f"Forced model: {locked_model}",
-                        style="yellow",
-                    ),
-                    title="[bold red]Model Override Locked[/bold red]",
-                    border_style="red",
-                ),
-                metadata={"model_override_locked": True, "forced_model": locked_model},
-            )
+        locked = self._locked_result(context)
+        if locked is not None:
+            return locked
 
         selector = self._resolve_selector()
 
@@ -295,27 +279,17 @@ EXAMPLES:
                 ),
             )
 
+        locked = self._locked_result(
+            context,
+            extra_line="Changing it with /model use is not allowed in this session.",
+        )
+        if locked is not None:
+            return locked
+
         try:
             ctx_data = getattr(context.session, "context_data", {}) or {}
         except AttributeError:
             ctx_data = {}
-        if ctx_data.get("model_override_locked"):
-            locked_model = ctx_data.get("forced_model") or "(unknown)"
-            return CommandResult(
-                success=False,
-                content=Panel(
-                    Text(
-                        "Model selection is locked by bot configuration.\n"
-                        f"Forced model: {locked_model}\n"
-                        "Changing it with /model use is not allowed in this session.",
-                        style="yellow",
-                    ),
-                    title="[bold red]Model Override Locked[/bold red]",
-                    border_style="red",
-                ),
-                metadata={"model_override_locked": True, "forced_model": locked_model},
-            )
-
         if target.lower() == "auto":
             if hasattr(context, "session") and context.session is not None:
                 ctx_data.pop("forced_model", None)
@@ -476,6 +450,41 @@ EXAMPLES:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _locked_result(
+        context: CommandContext, extra_line: str = ""
+    ) -> Optional[CommandResult]:
+        """Build the 'Model Override Locked' result when the bot pinned the model.
+
+        Returns ``None`` when the session is free to switch models, or a
+        failing :class:`CommandResult` when ``model_override_locked`` is set in
+        the session context. ``extra_line`` appends a caller-specific trailing
+        sentence (``/model use`` clarifies the override cannot be changed).
+        """
+        try:
+            ctx_data = getattr(context.session, "context_data", {}) or {}
+        except AttributeError:
+            ctx_data = {}
+        if not ctx_data.get("model_override_locked"):
+            return None
+
+        locked_model = ctx_data.get("forced_model") or "(unknown)"
+        message = (
+            "Model selection is locked by bot configuration.\n"
+            f"Forced model: {locked_model}"
+        )
+        if extra_line:
+            message += f"\n{extra_line}"
+        return CommandResult(
+            success=False,
+            content=Panel(
+                Text(message, style="yellow"),
+                title="[bold red]Model Override Locked[/bold red]",
+                border_style="red",
+            ),
+            metadata={"model_override_locked": True, "forced_model": locked_model},
+        )
 
     @staticmethod
     def _get_forced(context: CommandContext) -> Optional[str]:

--- a/deile/core/models/anthropic_provider.py
+++ b/deile/core/models/anthropic_provider.py
@@ -133,6 +133,18 @@ class AnthropicProvider(ModelProvider):
                 result.append({"role": m.role, "content": m.content})
         return result
 
+    @staticmethod
+    def _system_blocks(system: str) -> List[Dict[str, Any]]:
+        """Wrap the system prompt in Anthropic's cached text-block array.
+
+        The ephemeral ``cache_control`` marker lets Anthropic reuse the system
+        prompt across requests. Centralized here so ``generate``,
+        ``chat_with_tools`` and ``generate_stream`` cannot drift apart.
+        """
+        return [
+            {"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}
+        ]
+
     # ------------------------------------------------------------------
     # generate()
     # ------------------------------------------------------------------
@@ -154,9 +166,7 @@ class AnthropicProvider(ModelProvider):
             "messages": anthropic_msgs,
         }
         if system:
-            create_kwargs["system"] = [
-                {"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}
-            ]
+            create_kwargs["system"] = self._system_blocks(system)
 
         try:
             response = await self._client.messages.create(**create_kwargs, **kwargs)
@@ -213,13 +223,7 @@ class AnthropicProvider(ModelProvider):
                 "messages": anthropic_msgs,
             }
             if system:
-                create_kwargs["system"] = [
-                    {
-                        "type": "text",
-                        "text": system,
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ]
+                create_kwargs["system"] = self._system_blocks(system)
             if anthropic_tools:
                 create_kwargs["tools"] = anthropic_tools
 
@@ -339,9 +343,7 @@ class AnthropicProvider(ModelProvider):
             "messages": anthropic_msgs,
         }
         if system:
-            create_kwargs["system"] = [
-                {"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}
-            ]
+            create_kwargs["system"] = self._system_blocks(system)
         if tools:
             create_kwargs["tools"] = [t.to_anthropic_tool() for t in tools]
 


### PR DESCRIPTION
## Refatoração Arquitetural Diária — 2026-05-16

**Modo**: PRs-do-dia
**PRs exógenas base**: #206 (8 architectural refactorings), #207 (5 refatorações), #208 (6 refatorações) — todas tocando `deile/core/models/` e `deile/commands/builtin/model_command.py`. PR #205 (`simplify/*`) ignorada por convenção.

**Resumo arquitetural**: As três PRs de hoje (#206-#208) já eliminaram a duplicação cross-arquivo estrutural — `error_mapping.make_envelope_builder`, `loop_guard.make_loop_break_result`, `tool_execution.resolve_and_execute_tool` e `routing_strategies.py` extraíram os helpers compartilhados, e os três providers principais já os consomem; `deepseek_provider.py` já era um subclass fino sem lógica duplicada. As violações remanescentes eram todas same-file: blocos repetidos de verificação de lock em `model_command.py` e de construção do bloco system Anthropic. Acoplamento Clean Architecture dentro do esperado (providers são adapters em `core/models/`); nenhum dead code provado nem god object partível foi encontrado. Os métodos `chat_with_tools` ainda têm lógica ~70% similar entre providers, mas estão marcados `TODO(streaming-cleanup)` para remoção total — re-extrair um helper agora seria trabalho descartável e alto risco, portanto não recomendado.

### Plano executado
| # | Tipo | Valor | Status | Descrição |
|---|---|---|---|---|
| 1 | DRY | MEDIO | APPLIED | Extrair helper `_locked_result` para o bloco `model_override_locked` duplicado em `_select` e `_use` |
| 2 | DRY | MEDIO | APPLIED | Extrair helper `_system_blocks` para o array de bloco `system`+`cache_control` construído 3x |
| 3 | Async | — | DESCARTADO | Analisador confirmou: `_execute_tool` async está correto (`resolve_and_execute_tool` é coroutine) — não é defeito |

### Arquivos modificados
- `deile/commands/builtin/model_command.py` — novo helper estático `_locked_result`; `_select`/`_use` passam a chamá-lo (−36/+45)
- `deile/core/models/anthropic_provider.py` — novo helper estático `_system_blocks`; `generate`/`chat_with_tools`/`generate_stream` passam a chamá-lo (−13/+15)

### Arquivos criados
nenhum

### Arquivos removidos
nenhum

### Itens revertidos
nenhum

### Testes gate local
**Baseline**: 2699 passed, 13 skipped, 0 failed
**Final**: 2699 passed, 13 skipped, 0 failed

### Checklist de segurança
- [x] Testes antes-passando continuam passando (gate local)
- [x] Assinaturas públicas inalteradas (helpers privados; comportamento idêntico)
- [x] Registry pattern respeitado (pilar 03 §3)
- [x] Arquitetura hexagonal respeitada (pilar 02 + 03 §2)
- [x] Sem nova dependência externa em core/
- [x] Sem dead code (nenhum removido — nada provado morto)
- [x] Sem I/O síncrono em async
- [x] ruff check limpo nos arquivos modificados
- [x] isort limpo nos arquivos modificados

> ⏳ Aguardando revisão e merge pelo pipeline `deile-issue-dev-pr-review-full`.

🤖 Gerado pelo pipeline DEILE refactor-daily (gate local confirmado verde)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaAqxquVfuDG774JBeSMvN)_