### PR TITLE
fix(k8s): dockerignore, bot-config reconcile, run.sh clone fix

### DIFF
--- a/infra/k8s/manifests/15-bot-config.yaml
+++ b/infra/k8s/manifests/15-bot-config.yaml
@@ -56,14 +56,20 @@ data:
     providers:
       enabled_providers: ["discord"]
 
-    # Allowlist of repos that deile-shell is permitted to clone via git.
-    # Globs follow Python fnmatch rules (e.g. "elimarcavalli/*" matches any
-    # repo under that org). The list is enforced by the ~/bin/git guard
-    # installed by wrapper.py at startup. Omit the section (or leave the
-    # list empty) to allow cloning from any repo (open policy — use with care).
+    # Allowlist of repos que deile-shell pode clonar via git. Globs seguem
+    # as regras de fnmatch do Python. A lista é aplicada pelo guard
+    # ~/bin/git instalado pelo wrapper.py no startup. A entrada única "*" é
+    # a open policy documentada — qualquer repo que a credencial alcance é
+    # permitido (necessário para o bot clonar repositórios públicos
+    # arbitrários pedidos via Discord).
     git_integration:
       clonable_repos:
-        # NOTE: this glob is org-wide and includes private repositories under
-        # the elimarcavalli org. Narrow to specific repos (e.g.
-        # "elimarcavalli/deile") if broader access is undesired.
-        - "elimarcavalli/*"
+        - "*"
+
+    # Login GitHub via Discord (/github_login). O método PAT funciona sem
+    # configuração. O método OAuth (device flow) precisa de um GitHub OAuth
+    # App registrado — cole o Client ID abaixo (o Client ID é público, não
+    # é segredo). Vazio mantém o OAuth desativado; o PAT continua funcionando.
+    github:
+      oauth_client_id: ""
+      oauth_scope: "repo"

--- a/infra/k8s/run.sh
+++ b/infra/k8s/run.sh
@@ -318,18 +318,17 @@ cmd_clone() {
   #      performs its own URL validation if the guard is absent.
   # The token never appears in argv; it is read from the Secret-mounted
   # file and written to ~/.git-credentials inside the pod in-process.
-  # CLONE_URL and WORK_DIR are passed via --env so they are never
-  # interpolated into the Python source (no shell-injection risk).
+  # CLONE_URL and WORK_DIR are passed as positional argv (sys.argv[1:]):
+  # `kubectl exec` has NO --env flag, and argv tokens are never
+  # interpolated into the Python source string (no shell-injection risk).
   "$KUBECTL" -n "$NS" exec \
-    --env CLONE_URL="${clone_url}" \
-    --env WORK_DIR="${work_dir}" \
     deploy/deile-shell -- \
     python3 -c '
 import fnmatch, os, posixpath, subprocess, sys, urllib.parse
 from pathlib import Path
 
-clone_url = os.environ["CLONE_URL"]
-work_dir  = os.environ["WORK_DIR"]
+clone_url = sys.argv[1]
+work_dir  = sys.argv[2]
 
 home = Path(os.environ.get("HOME", "/home/deile"))
 token_file = Path("/run/secrets/deile/GITHUB_TOKEN")
@@ -408,7 +407,7 @@ result = subprocess.run(
 if result.returncode != 0:
     sys.exit(result.returncode)
 print("clone complete: " + work_dir)
-'
+' "${clone_url}" "${work_dir}"
   log "done — repo available at ${work_dir} inside deile-shell"
   log "to work: kubectl -n ${NS} exec -it deploy/deile-shell -- python3 /app/wrapper.py deile"
 }


### PR DESCRIPTION
## Resumo

- **`Dockerfile.dockerignore`**: o glob `**/*secret*` excluía `deile/security/secrets_scanner.py` (código legítimo) do contexto de build — a imagem quebrava em runtime com `ModuleNotFoundError: deile.security.secrets_scanner`. Re-inclui arquivos `.py` via negação (`!**/*secret*.py` etc.).
- **`15-bot-config.yaml`**: reconcilia o manifesto-fonte com o ConfigMap vivo (ID real do owner no lugar do placeholder `REPLACE_ME_DISCORD_USER_ID`, `forced_model`, `agent_invocation_timeout_seconds: 660`, `clonable_repos`) e adiciona a seção `github` do login via Discord.
- **`run.sh`**: `cmd_clone` usava `kubectl exec --env` — flag inexistente no `kubectl exec` (client 1.28). Passa `CLONE_URL`/`WORK_DIR` como argv posicional (`sys.argv[1:]`), mesma propriedade anti-injeção.

## Test plan

- [x] `bash -n run.sh` — sintaxe OK.
- [x] YAML do `15-bot-config.yaml` validado (manifesto externo + `deilebot.yaml` interno).
- [x] Imagem `deile-stack:local` buildada com o `.dockerignore` corrigido — pods `deilebot` e `deile-shell` sobem `1/1 Running`.