### PR TITLE
refactor(daily): 2026-05-18 — 5 refatorações arquiteturais

### DIFF
--- a/deile/cron/parsing.py
+++ b/deile/cron/parsing.py
@@ -43,6 +43,23 @@ class ScheduleParseError(ValueError):
     """Falha ao interpretar a string de agendamento."""
 
 
+def parse_iso_datetime(text: str, naive_tz: timezone = BRT) -> Optional[datetime]:
+    """Interpreta uma string ISO-8601 e retorna um ``datetime`` em UTC.
+
+    Aceita o sufixo ``Z``. Datetimes naive (sem offset) são interpretados
+    em ``naive_tz`` antes da conversão para UTC. Retorna ``None`` quando a
+    string não casa com ISO-8601.
+    """
+    iso_attempt = text.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(iso_attempt)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=naive_tz)
+    return dt.astimezone(timezone.utc)
+
+
 def parse_natural_schedule(text: str) -> Tuple[Optional[str], Optional[datetime]]:
     """Interpreta uma string de agendamento e retorna ``(cron_expr, run_at_utc)``.
 
@@ -61,16 +78,10 @@ def parse_natural_schedule(text: str) -> Tuple[Optional[str], Optional[datetime]
     if _CRON_RE.match(stripped):
         return stripped, None
 
-    # 2. ISO 8601 (com ou sem timezone). Aceita 'Z' como sufixo.
-    iso_attempt = stripped.replace("Z", "+00:00")
-    try:
-        dt = datetime.fromisoformat(iso_attempt)
-    except ValueError:
-        dt = None
+    # 2. ISO 8601 (com ou sem timezone). Naive assume BRT.
+    dt = parse_iso_datetime(stripped, naive_tz=BRT)
     if dt is not None:
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=BRT)
-        return None, dt.astimezone(timezone.utc)
+        return None, dt
 
     # 3. BR humano: DD/MM[/YYYY] HH[:MM|hMM]
     m = _BR_DATE_RE.match(stripped)

--- a/deile/cron/parsing.py
+++ b/deile/cron/parsing.py
@@ -50,9 +50,11 @@ def parse_iso_datetime(text: str, naive_tz: timezone = BRT) -> Optional[datetime
     em ``naive_tz`` antes da conversão para UTC. Retorna ``None`` quando a
     string não casa com ISO-8601.
     """
-    iso_attempt = text.strip().replace("Z", "+00:00")
+    stripped = text.strip()
+    if stripped.endswith("Z"):
+        stripped = stripped[:-1] + "+00:00"
     try:
-        dt = datetime.fromisoformat(iso_attempt)
+        dt = datetime.fromisoformat(stripped)
     except ValueError:
         return None
     if dt.tzinfo is None:

--- a/deile/tools/cron_create_tool.py
+++ b/deile/tools/cron_create_tool.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from deile.cron.parsing import ScheduleParseError, parse_natural_schedule
+from deile.cron.parsing import (ScheduleParseError, parse_iso_datetime,
+                                parse_natural_schedule)
 from deile.cron.store import (CronEntry, CronStore, CronStoreError, make_id,
                               resolve_db_path)
 from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
@@ -152,15 +153,12 @@ class CronCreateTool(Tool):
                     message=str(exc), error=exc, error_code="INVALID_WHEN",
                 )
         elif run_at_str:
-            try:
-                run_at = datetime.fromisoformat(str(run_at_str).rstrip("Z"))
-            except ValueError as exc:
+            run_at = parse_iso_datetime(str(run_at_str), naive_tz=timezone.utc)
+            if run_at is None:
                 return ToolResult.error_result(
                     message=f"invalid run_at: {run_at_str!r}",
-                    error=exc, error_code="INVALID_DATETIME",
+                    error_code="INVALID_DATETIME",
                 )
-            if run_at.tzinfo is None:
-                run_at = run_at.replace(tzinfo=timezone.utc)
 
         try:
             entry = CronEntry(

--- a/deile/tools/messaging/__init__.py
+++ b/deile/tools/messaging/__init__.py
@@ -25,16 +25,23 @@ from .discord_send_message import DiscordSendMessageTool
 from .discord_start_thread import DiscordStartThreadTool
 from .whatsapp_send_template import WhatsAppSendTemplateTool
 
+# Single source of truth for the messaging tool classes. The tuple
+# order is the registration order used by register_messaging_tools().
+MESSAGING_TOOL_CLASSES = (
+    DiscordSendMessageTool,
+    DiscordSendDMTool,
+    DiscordEditMessageTool,
+    DiscordReactTool,
+    DiscordStartThreadTool,
+    DiscordPinMessageTool,
+    DiscordMentionRoleTool,
+    DiscordGetUserProfileTool,
+    WhatsAppSendTemplateTool,
+)
+
 __all__ = [
     "MessagingTool",
-    "DiscordSendMessageTool",
-    "DiscordSendDMTool",
-    "DiscordEditMessageTool",
-    "DiscordReactTool",
-    "DiscordStartThreadTool",
-    "DiscordPinMessageTool",
-    "DiscordMentionRoleTool",
-    "DiscordGetUserProfileTool",
-    "WhatsAppSendTemplateTool",
+    "MESSAGING_TOOL_CLASSES",
     "register_messaging_tools",
+    *(cls.__name__ for cls in MESSAGING_TOOL_CLASSES),
 ]

--- a/deile/tools/messaging/auto_discover.py
+++ b/deile/tools/messaging/auto_discover.py
@@ -26,19 +26,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_TOOL_CLASSES = (
-    "DiscordSendMessageTool",
-    "DiscordSendDMTool",
-    "DiscordEditMessageTool",
-    "DiscordReactTool",
-    "DiscordStartThreadTool",
-    "DiscordPinMessageTool",
-    "DiscordMentionRoleTool",
-    "DiscordGetUserProfileTool",
-    "WhatsAppSendTemplateTool",
-)
-
-
 def register_messaging_tools(registry: "ToolRegistry") -> int:
     """Register messaging tools on the given registry. Returns count.
 
@@ -57,27 +44,14 @@ def register_messaging_tools(registry: "ToolRegistry") -> int:
         logger.debug("messaging tools skipped: bot integration not configured")
         return 0
 
-    # Lazy imports — keep them inside the conditional so absence of
-    # deilebot never breaks the deile import chain.
-    from . import (DiscordEditMessageTool, DiscordGetUserProfileTool,
-                   DiscordMentionRoleTool, DiscordPinMessageTool,
-                   DiscordReactTool, DiscordSendDMTool, DiscordSendMessageTool,
-                   DiscordStartThreadTool, WhatsAppSendTemplateTool)
-
-    candidates = [
-        DiscordSendMessageTool(),
-        DiscordSendDMTool(),
-        DiscordEditMessageTool(),
-        DiscordReactTool(),
-        DiscordStartThreadTool(),
-        DiscordPinMessageTool(),
-        DiscordMentionRoleTool(),
-        DiscordGetUserProfileTool(),
-        WhatsAppSendTemplateTool(),
-    ]
+    # Lazy import — kept inside the conditional so absence of deilebot
+    # never breaks the deile import chain. MESSAGING_TOOL_CLASSES is the
+    # single source of truth for the messaging tool roster.
+    from . import MESSAGING_TOOL_CLASSES
 
     registered = 0
-    for tool in candidates:
+    for tool_cls in MESSAGING_TOOL_CLASSES:
+        tool = tool_cls()
         if tool.name in registry:
             continue  # idempotent — register_messaging_tools is safe to call twice
         try:

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -22,6 +22,22 @@ def _run_coro_sync(coro):
     a running loop (e.g. ``PlanManager._run_tool_with_params``), the
     coroutine is run in a worker thread so it never reenters the live
     loop — ``loop.run_until_complete`` would raise ``RuntimeError`` there.
+
+    Two constraints apply when the worker-thread path is taken, and
+    callers must account for both:
+
+    1. Cancellation/timeout does NOT cross into the worker thread. An
+       ``asyncio.CancelledError`` or timeout raised against the caller
+       (e.g. an ``asyncio.wait_for`` wrapping a ``PlanManager`` step)
+       cannot interrupt the blocking ``.result()`` call — the worker
+       runs the coroutine to completion regardless. Step-level
+       timeout/cancellation therefore does not propagate into the tool.
+    2. The coroutine runs on a fresh event loop in a different thread.
+       Any tool invoked through this sync bridge must NOT hold or
+       capture resources bound to the caller's event loop (e.g.
+       ``asyncio.Lock``, connection pools, async clients/sessions);
+       such resources will misbehave or raise
+       ``RuntimeError: ... attached to a different loop``.
     """
     try:
         asyncio.get_running_loop()

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -5,6 +5,7 @@ import importlib
 import inspect
 import logging
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
@@ -12,6 +13,22 @@ from ..core.exceptions import ToolError, ValidationError
 from .base import SecurityLevel, Tool, ToolContext, ToolResult, ToolSchema
 
 logger = logging.getLogger(__name__)
+
+
+def _run_coro_sync(coro):
+    """Run a coroutine to completion from synchronous code.
+
+    Uses ``asyncio.run`` when no loop is active. When invoked from inside
+    a running loop (e.g. ``PlanManager._run_tool_with_params``), the
+    coroutine is run in a worker thread so it never reenters the live
+    loop — ``loop.run_until_complete`` would raise ``RuntimeError`` there.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
 
 
 class ToolRegistry:
@@ -484,11 +501,10 @@ class ToolRegistry:
             # Se é SyncTool, executa diretamente
             if hasattr(tool, 'execute_sync'):
                 return tool.execute_sync(context)
-            else:
-                # Executa async tool de forma síncrona
-                loop = asyncio.get_event_loop()
-                return loop.run_until_complete(tool.execute(context))
-                
+            # Executa async tool de forma síncrona — seguro tanto fora
+            # quanto dentro de um event loop ativo.
+            return _run_coro_sync(tool.execute(context))
+
         except Exception as e:
             logger.error(f"Error executing function call '{function_name}': {e}")
             return ToolResult.error_result(

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -320,33 +320,40 @@ class ToolRegistry:
         
         return discovered_count
     
+    def _iter_authorized_tools(
+        self,
+        authorized_only: bool,
+        security_level: Optional[SecurityLevel],
+    ):
+        """Yield tools passing the authorization and security-level filters.
+
+        Shared by the per-provider schema exporters so the filtering
+        logic is defined in exactly one place.
+        """
+        for tool_name, tool in self._tools.items():
+            if authorized_only and tool_name not in self._enabled_tools:
+                continue
+            if security_level and tool.schema:
+                if not self._is_security_level_allowed(tool.schema.security_level, security_level):
+                    continue
+            yield tool
+
     def get_gemini_functions(self, authorized_only: bool = True, security_level: Optional[SecurityLevel] = None) -> List:
         """Retorna tools no formato FunctionDeclaration para novo Google GenAI SDK
-        
+
         Args:
             authorized_only: Se deve retornar apenas tools autorizadas
             security_level: Nível máximo de segurança das tools
-            
+
         Returns:
             List[FunctionDeclaration]: Lista de function declarations para novo SDK
         """
         functions = []
-        
-        for tool_name, tool in self._tools.items():
-            # Verifica se tool está habilitada
-            if authorized_only and tool_name not in self._enabled_tools:
-                continue
-            
-            # Verifica nível de segurança
-            if security_level and tool.schema:
-                if not self._is_security_level_allowed(tool.schema.security_level, security_level):
-                    continue
-            
-            # Obtém definição da função
+        for tool in self._iter_authorized_tools(authorized_only, security_level):
             function_def = tool.get_function_definition()
             if function_def:
                 functions.append(function_def)
-        
+
         logger.debug(f"Generated {len(functions)} function definitions for Gemini API")
         return functions
 
@@ -360,16 +367,11 @@ class ToolRegistry:
         Returns:
             List of dicts compatible with anthropic.types.ToolParam
         """
-        result = []
-        for tool_name, tool in self._tools.items():
-            if authorized_only and tool_name not in self._enabled_tools:
-                continue
-            if security_level and tool.schema:
-                if not self._is_security_level_allowed(tool.schema.security_level, security_level):
-                    continue
-            if tool.schema:
-                result.append(tool.schema.to_anthropic_tool())
-        return result
+        return [
+            tool.schema.to_anthropic_tool()
+            for tool in self._iter_authorized_tools(authorized_only, security_level)
+            if tool.schema
+        ]
 
     def get_openai_functions(
         self,
@@ -381,16 +383,11 @@ class ToolRegistry:
         Returns:
             List of dicts compatible with openai.types.chat.ChatCompletionToolParam
         """
-        result = []
-        for tool_name, tool in self._tools.items():
-            if authorized_only and tool_name not in self._enabled_tools:
-                continue
-            if security_level and tool.schema:
-                if not self._is_security_level_allowed(tool.schema.security_level, security_level):
-                    continue
-            if tool.schema:
-                result.append(tool.schema.to_openai_function())
-        return result
+        return [
+            tool.schema.to_openai_function()
+            for tool in self._iter_authorized_tools(authorized_only, security_level)
+            if tool.schema
+        ]
 
     def load_schemas_from_directory(self, schemas_dir: Path) -> int:
         """Carrega schemas de tools de um diretório


### PR DESCRIPTION
## Refatoração Arquitetural Diária — 2026-05-18

**Modo**: PRs exógenas mergeadas (janela: ontem 2026-05-17 BRT — nenhuma PR hoje)
**PRs exógenas base**:
- #216 — feat(infra): Python orchestrator and environment installer
- #215 — feat: deilebot revival — worker pool K8s, dispatch, cron NL
- #214 — fix(k8s): dockerignore, bot-config reconcile, run.sh clone fix

**Resumo arquitetural**: As 3 PRs paralelas (orquestração de infra, revival do deilebot worker-pool, dispatch de tasks) introduziram duplicação concentrada nas tools de messaging e no `ToolRegistry`. O problema mais claro foi a lista das classes de messaging duplicada — incluindo a tupla `_TOOL_CLASSES` em `auto_discover.py` que era dead code comprovado. Em `registry.py` os três exportadores de schema por provider repetiam o mesmo loop+filtro, havia um parser ISO divergente em `cron_create_tool.py` e um uso async deprecado em `execute_function_call`.

### Plano executado
| # | Tipo | Valor | Status | Descrição |
|---|---|---|---|---|
| 1 | DEAD_CODE | ALTO | APPLIED | Remoção da tupla `_TOOL_CLASSES` (dead code, zero referências) em `auto_discover.py` |
| 2 | DRY_CROSS | ALTO | APPLIED | Lista de classes de messaging unificada numa única fonte `MESSAGING_TOOL_CLASSES` |
| 3 | DRY_CROSS | MEDIO | APPLIED | Dedup dos 3 exportadores de schema por provider via `_iter_authorized_tools` |
| 4 | DRY_CROSS | MEDIO | APPLIED | Parsing ISO-8601 consolidado em `parse_iso_datetime` (BRT vs UTC parametrizado) |
| 6 | ASYNC | MEDIO | APPLIED | `execute_function_call` — `get_event_loop`/`run_until_complete` deprecado → `_run_coro_sync` |
| 5 | GOD_OBJECT | MEDIO | SKIPPED | Extração da camada de schema-export do `ToolRegistry` — risco HIGH (move símbolos públicos cross-módulo, quebraria `gemini_provider.py`, `plan_manager.py` e ~dezenas de testes); o próprio analisador recomendou restringir ao item 3, que foi aplicado |

### Arquivos modificados
- `deile/tools/messaging/__init__.py` — nova tupla `MESSAGING_TOOL_CLASSES` (single source of truth)
- `deile/tools/messaging/auto_discover.py` — dead code removido; `candidates` derivado da fonte única
- `deile/tools/registry.py` — helper `_iter_authorized_tools` + helper `_run_coro_sync`
- `deile/cron/parsing.py` — novo helper `parse_iso_datetime`
- `deile/tools/cron_create_tool.py` — ramo `run_at` legacy usa o helper compartilhado

### Arquivos criados
nenhum

### Arquivos removidos
nenhum

### Itens revertidos (regressão ou violação de constraint)
nenhum revertido por regressão. Item 5 não foi aplicado por decisão de escopo (risco HIGH desproporcional ao valor — registry de 637 linhas não é egrégio e os métodos de export são coesos com a responsabilidade do registry).

### Testes gate local
**Baseline**: 2718 passed, 15 skipped
**Final**: 2718 passed, 15 skipped

### Checklist de segurança
- [x] Testes antes-passando continuam passando (gate local — 2718/2718)
- [x] Assinaturas públicas inalteradas (nenhum símbolo movido cross-módulo)
- [x] Registry pattern respeitado (pilar 03 §3)
- [x] Arquitetura hexagonal respeitada (pilar 02 + 03 §2)
- [x] Sem nova dependência externa em core/
- [x] Dead code removido com prova de grep (`_TOOL_CLASSES`)
- [x] Sem I/O síncrono em async — item 6 corrige justamente o oposto
- [x] ruff check limpo
- [x] isort limpo

> ⏳ Aguardando revisão e merge pelo pipeline `deile-issue-dev-pr-review-full`.

🤖 Gerado pelo pipeline DEILE refactor-daily (gate local confirmado verde)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEthHu8YL9bux1ZJpB9A2p)_