### PR TITLE
refactor(daily): 2026-05-18 — 3 refatorações arquiteturais (dead code, KISS, SRP)

### DIFF
--- a/deile/core/tool_loop_executor.py
+++ b/deile/core/tool_loop_executor.py
@@ -440,8 +440,7 @@ class ToolLoopExecutor:
                 # cascade_until yields STAGE events while the awaitable runs
                 # and a final ("result", value) tuple when it completes; it
                 # re-raises the underlying exception if the tool fails.
-                tool_result_value: Any = None
-                tool_exc: Optional[BaseException] = None
+                result: Any = None
                 try:
                     async for item in cascade_until(
                         self._tool_registry.execute_tool(tc_name, ctx),
@@ -450,16 +449,9 @@ class ToolLoopExecutor:
                         **tool_kwargs,
                     ):
                         if isinstance(item, tuple) and item and item[0] == "result":
-                            tool_result_value = item[1]
+                            result = item[1]
                         elif isinstance(item, UnifiedStreamEvent):
                             yield item
-                except Exception as _exc:  # pylint: disable=broad-except
-                    tool_exc = _exc
-
-                try:
-                    if tool_exc is not None:
-                        raise tool_exc
-                    result = tool_result_value
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.error(
                         "Tool '%s' raised in ToolLoopExecutor: %s", tc_name, exc, exc_info=True

--- a/deile/core/tool_loop_executor.py
+++ b/deile/core/tool_loop_executor.py
@@ -87,7 +87,7 @@ def _semantic_summary(tool_name: str, result: ToolResult) -> Optional[str]:
     meta = result.metadata or {}
     data = result.data
 
-    if tool_name == "bash_execute" or tool_name == "python_execute":
+    if tool_name in ("bash_execute", "python_execute"):
         # bash_tool.py packs data as dict; execution_tools.py packs string in data + dict in metadata.
         exit_code = None
         exec_time = None

--- a/deile/cron/runner.py
+++ b/deile/cron/runner.py
@@ -36,10 +36,6 @@ logger = logging.getLogger(__name__)
 FireCallback = Callable[[CronEntry], Awaitable[str]]
 
 
-def _default_fire_callback_factory(_entry: CronEntry) -> str:
-    return "(no fire callback wired)"
-
-
 class CronRunner:
     """Polls :class:`CronStore` and fires due entries via callback."""
 

--- a/deile/cron/runner.py
+++ b/deile/cron/runner.py
@@ -5,7 +5,7 @@ When a :class:`CronEntry` becomes due, the runner:
 1. Loads the entry from :class:`CronStore`.
 2. Builds a fresh DEILE turn using ``entry.prompt`` (the user's natural-
    language scheduled instruction).
-3. Calls a host-supplied ``fire_callback(prompt, entry)`` which is expected
+3. Calls a host-supplied ``fire_callback(entry)`` which is expected
    to invoke the agent and return a short summary string.
 4. Persists ``last_fired_at`` / ``next_fire_at`` (recurring) or disables
    (one-shot) and records the summary in ``last_result``.

--- a/deile/tools/dispatch_deile_task.py
+++ b/deile/tools/dispatch_deile_task.py
@@ -79,6 +79,60 @@ def _worker_token() -> str:
     return ""
 
 
+def _build_dispatch_payload(
+    *,
+    brief: str,
+    channel_id: str,
+    persona: str,
+    wait: bool,
+    user_message_id: object,
+    context: ToolContext,
+) -> Dict[str, object]:
+    """Assemble the JSON body POSTed to the worker control plane.
+
+    Attachments are forwarded from ``bot_context`` so the worker can call
+    vision tools without re-downloading from the (expiring) Discord CDN.
+    """
+    payload: Dict[str, object] = {
+        "brief": brief,
+        "channel_id": channel_id,
+        "persona": persona,
+        "wait_for_result": wait,
+    }
+    if user_message_id:
+        payload["user_message_id"] = str(user_message_id)
+    bot_ctx = context.session_data.get("bot_context") or {}
+    atts = bot_ctx.get("attachments")
+    if atts:
+        payload["attachments"] = atts
+    return payload
+
+
+def _summarize_worker_response(data: object) -> str:
+    """Build the compact one-line summary handed back to the bot LLM.
+
+    The user already sees the rich status message edited live by the
+    worker, so this stays terse on purpose — do NOT echo the full output.
+    """
+    if not isinstance(data, dict):
+        return ""
+    if data.get("ok") is True:
+        files = data.get("files") or []
+        elapsed = data.get("elapsed_s") or 0
+        return (
+            f"worker concluiu em {float(elapsed):.1f}s — "
+            f"{len(files)} arquivo(s): " + ", ".join(files[:5])
+        )
+    if data.get("ok") is False:
+        return (
+            f"worker FALHOU: {str(data.get('summary') or data.get('error'))[:300]}"
+        )
+    return (
+        f"worker dispatch aceito (task_id={data.get('task_id')}); "
+        "use wait_for_result=true para acompanhar."
+    )
+
+
 class DispatchDeileTaskTool(Tool):
     """Delegate a code task to a deile-worker Pod and stream UX to Discord."""
 
@@ -226,21 +280,14 @@ class DispatchDeileTaskTool(Tool):
                     error_code="WORKER_AUTH_MISSING",
                 )
 
-            payload = {
-                "brief": brief,
-                "channel_id": channel_id,
-                "persona": persona,
-                "wait_for_result": wait,
-            }
-            if user_message_id:
-                payload["user_message_id"] = str(user_message_id)
-            # Forward attachments from bot_context so the worker can call
-            # vision_describe_image / process file inputs without us
-            # needing to re-download from the (expiring) Discord CDN.
-            bot_ctx = context.session_data.get("bot_context") or {}
-            atts = bot_ctx.get("attachments")
-            if atts:
-                payload["attachments"] = atts
+            payload = _build_dispatch_payload(
+                brief=brief,
+                channel_id=channel_id,
+                persona=persona,
+                wait=wait,
+                user_message_id=user_message_id,
+                context=context,
+            )
 
             try:
                 import httpx
@@ -285,27 +332,7 @@ class DispatchDeileTaskTool(Tool):
                 msg = (err or {}).get("message") or f"HTTP {resp.status_code}"
                 return ToolResult.error_result(msg, error_code=code)
 
-            # Compact summary returned to the LLM. The user already sees the
-            # rich status message edited live by the worker — do NOT echo it.
-            short_summary = ""
-            if isinstance(data, dict):
-                if data.get("ok") is True:
-                    files = data.get("files") or []
-                    elapsed = data.get("elapsed_s") or 0
-                    short_summary = (
-                        f"worker concluiu em {float(elapsed):.1f}s — "
-                        f"{len(files)} arquivo(s): "
-                        + ", ".join(files[:5])
-                    )
-                elif data.get("ok") is False:
-                    short_summary = (
-                        f"worker FALHOU: {str(data.get('summary') or data.get('error'))[:300]}"
-                    )
-                else:
-                    short_summary = (
-                        f"worker dispatch aceito (task_id={data.get('task_id')}); "
-                        "use wait_for_result=true para acompanhar."
-                    )
+            short_summary = _summarize_worker_response(data)
 
             return ToolResult.success_result(
                 data={


### PR DESCRIPTION
## Refatoração Arquitetural Diária — 2026-05-18

**Modo**: PRs exógenas (hoje só houve PRs `simplify/*`, ignoradas; escopo expandido para PRs exógenas de ontem conforme a missão "ontem/hoje")
**PRs exógenas base**: #215 (feat: deilebot revival — worker pool K8s, dispatch, cron NL), #216 (feat(infra): Python orchestrator), #214 (fix(k8s) — sem arquivos `.py` em `deile/`)
**Resumo arquitetural**: O conjunto analisado (9 arquivos-alvo das PRs + 7 de contexto) está em bom estado — vários componentes já refatorados anteriormente (`tool_execution.py` como single-source de serialização, `MessagingTool` como base compartilhada). Os problemas remanescentes eram pontuais: um trecho de dead code provado, um padrão `raise`/re-catch desnecessariamente convoluto e um método de ~150 linhas acumulando responsabilidades. Não há god objects críticos, ciclos de dependência nem ABCs especulativas no escopo.

### Plano executado
| # | Tipo | Valor | Status | Descrição |
|---|---|---|---|---|
| 1 | DEAD_CODE | ALTO | APPLIED | Remove `_default_fire_callback_factory` de `cron/runner.py` — zero callers em `deile/`, assinatura sync incompatível com o tipo `FireCallback` (async) |
| 2 | DRY_CROSS | ALTO | SKIPPED | `_payload_for_model` × `build_tool_result_payload`: serializadores parecidos mas com formatos de payload intencionalmente distintos por consumidor; unificá-los exigiria flags adicionais (YAGNI) e arriscaria drift silencioso do payload visível ao LLM (sem cobertura de teste direta) |
| 3 | SRP | MEDIO | APPLIED | Extrai `_build_dispatch_payload` e `_summarize_worker_response` de `DispatchDeileTaskTool.execute` |
| 4 | KISS | MEDIO | APPLIED | Colapsa o round-trip `raise`/re-catch de `tool_exc` em `ToolLoopExecutor.run` |
| 5 | CLEAN_ARCH | MEDIO | SKIPPED | Mover `DEILE_WORKER_*` de `os.environ` para `Settings`: relocaria um **segredo** (`DEILE_WORKER_BEARER_TOKEN`) para o singleton `Settings` e adicionaria env vars novas justamente quando o projeto deprecia `DEILE_*` env vars — leitura de config de adapter HTTP pela própria tool é aceitável |

### Arquivos modificados
- `deile/cron/runner.py` — remoção de dead code
- `deile/core/tool_loop_executor.py` — simplificação estrutural do tratamento de exceção
- `deile/tools/dispatch_deile_task.py` — extração de 2 helpers puros

### Arquivos criados
nenhum

### Arquivos removidos
nenhum

### Itens revertidos (regressão ou violação de constraint)
nenhum — itens 2 e 5 foram **descartados na análise** (não aplicados), por criarem abstração forçada / risco arquitetural; não houve revert por falha de teste.

### Testes gate local
**Baseline**: 2725 passed, 15 skipped, 0 failed
**Final**: 2725 passed, 15 skipped, 0 failed

### Checklist de segurança
- [x] Testes antes-passando continuam passando (gate local — suite completa idêntica ao baseline)
- [x] Assinaturas públicas inalteradas
- [x] Registry pattern respeitado (pilar 03 §3)
- [x] Arquitetura hexagonal respeitada (pilar 02 + 03 §2)
- [x] Sem nova dependência externa em core/
- [x] Dead code removido com prova de grep (`grep -rn '_default_fire_callback_factory' deile/` → só a definição)
- [x] Sem I/O síncrono em async
- [x] ruff check limpo
- [x] isort limpo

> ⏳ Aguardando revisão e merge pelo pipeline `deile-issue-dev-pr-review-full`.

🤖 Gerado pelo pipeline DEILE refactor-daily (gate local confirmado verde)

---
_Generated by [Claude Code](https://claude.ai/code/session_012JLRKTWZQYT3CUecvQwyCq)_