### PR TITLE
refactor(tools): extract worker transport into infrastructure adapter

### DIFF
--- a/deile/infrastructure/__init__.py
+++ b/deile/infrastructure/__init__.py
@@ -1,9 +1,15 @@
 """Infrastructure layer do DEILE - External integrations"""
 
+from .deile_worker_client import (DEFAULT_TIMEOUT_S, DeileWorkerClient,
+                                  DispatchPayload, WorkerDispatchError)
 from .google_file_api import FileUploadResult, GoogleFileUploader, UploadError
 
 __all__ = [
     "GoogleFileUploader",
-    "FileUploadResult", 
-    "UploadError"
+    "FileUploadResult",
+    "UploadError",
+    "DeileWorkerClient",
+    "WorkerDispatchError",
+    "DispatchPayload",
+    "DEFAULT_TIMEOUT_S",
 ]

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -155,11 +155,11 @@ def _read_token() -> str:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 v = f.read().strip()
-                if v:
-                    logger.debug("worker token resolved from %s", path)
-                    return v
         except OSError:
             continue
+        if v:
+            logger.debug("worker token resolved from %s", path)
+            return v
     return ""
 
 
@@ -275,9 +275,9 @@ class DeileWorkerClient:
             ) from exc
 
         if resp.status_code >= 400:
-            err = data.get("error") if isinstance(data, dict) else {}
-            code = (err or {}).get("code") or "WORKER_ERROR"
-            msg = (err or {}).get("message") or f"HTTP {resp.status_code}"
+            err = (data.get("error") if isinstance(data, dict) else None) or {}
+            code = err.get("code") or "WORKER_ERROR"
+            msg = err.get("message") or f"HTTP {resp.status_code}"
             raise WorkerDispatchError(
                 f"{msg} (request_id={request_id})", error_code=code
             )

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -1,0 +1,258 @@
+"""Adapter de transporte para o control plane do deile-worker.
+
+Isola a fronteira de infraestrutura do ``dispatch_deile_task`` tool
+(arquitetura hexagonal — pilar 03 §2): resolução de endpoint e
+credenciais — incluindo leitura de variáveis de ambiente e de arquivos
+de secret montados pelo K8s — e o transporte HTTP via ``httpx``. O
+código de domínio (a tool) consome apenas :class:`DeileWorkerClient`,
+sem tocar em ``os.environ``, no filesystem de secrets nem no SDK HTTP
+diretamente.
+
+O modelo Pydantic :class:`DispatchPayload` vive aqui propositalmente:
+o contrato de wire-format do worker é da camada de infraestrutura, e
+a tool delega a validação a este módulo para não acoplar ao SDK do
+Pydantic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import uuid
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from deile.core.exceptions import DEILEError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_S: float = 600.0
+
+_DISPATCH_PATH = "/v1/dispatch"
+_DEFAULT_ENDPOINT = "http://deile-worker.deile.svc.cluster.local:8766"
+_ENDPOINT_ENV = "DEILE_WORKER_ENDPOINT"
+_TOKEN_ENV = "DEILE_WORKER_BEARER_TOKEN"
+# Secret files, in resolution order, tolerating both bot and worker layouts.
+_TOKEN_FILES = (
+    "/run/secrets/bot/worker/AUTH_TOKEN",
+    "/run/secrets/worker/AUTH_TOKEN",
+    "/run/secrets/bot/WORKER_BEARER_TOKEN",
+)
+
+# Tokens são tratados como bearer values: rejeitamos qualquer caractere
+# que possa quebrar o header HTTP (CR, LF, NUL) — defense-in-depth contra
+# header injection em caso de secret file corrompido.
+_TOKEN_SAFE_CHARS = re.compile(r"^[A-Za-z0-9._\-+/=:~]{8,4096}$")
+
+# Personas suportadas pelo worker — espelha
+# deile/personas/library/*.yaml. Manter sincronizado quando uma persona
+# nova for adicionada ao worker.
+WorkerPersona = Literal["developer", "architect", "debugger"]
+
+
+class WorkerDispatchError(DEILEError):
+    """Falha ao despachar uma task para o deile-worker.
+
+    Carrega o ``error_code`` que a tool repassa no ``ToolResult``,
+    preservando os códigos de erro originais do ``dispatch_deile_task``.
+    """
+
+
+class DispatchPayload(BaseModel):
+    """Wire-format do POST /v1/dispatch.
+
+    Validação Pydantic do payload antes de cruzar a fronteira de rede.
+    Rejeita brief vazio, channel_id vazio e personas desconhecidas — o
+    worker já valida do lado dele, mas falhar local poupa um round-trip
+    e dá uma mensagem de erro melhor ao LLM.
+    """
+
+    brief: str = Field(..., min_length=1, max_length=8000)
+    channel_id: str = Field(..., min_length=1, max_length=64)
+    persona: WorkerPersona = "developer"
+    wait_for_result: bool = True
+    user_message_id: Optional[str] = Field(default=None, max_length=64)
+    attachments: Optional[List[Dict[str, Any]]] = None
+
+    @field_validator("brief")
+    @classmethod
+    def _strip_brief(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("brief must not be blank")
+        return stripped
+
+    @field_validator("channel_id", "user_message_id")
+    @classmethod
+    def _strip_optional_str(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        stripped = v.strip()
+        if not stripped:
+            return None if cls.model_fields.get("channel_id") is None else ""
+        return stripped
+
+
+# Módulo-level (não @staticmethod) propositalmente — facilita
+# monkeypatching nos testes sem ter que instanciar o cliente.
+def _resolve_endpoint() -> str:
+    # Lemos de ``os.environ`` diretamente (em vez do ``Settings``
+    # singleton) porque ``DEILE_WORKER_ENDPOINT`` é resolvido em runtime
+    # ANTES do bootstrap completo do agente — o worker client é
+    # instanciado no construtor da tool, que pode rodar antes de
+    # ``get_settings()`` estar pronto sob algumas inicializações
+    # programáticas.
+    return os.environ.get(_ENDPOINT_ENV, _DEFAULT_ENDPOINT)
+
+
+def _read_token() -> str:
+    """Resolve o bearer token. Tolerante a layouts de bot e de worker.
+
+    Ordem de resolução:
+      1. env var ``DEILE_WORKER_BEARER_TOKEN`` (set pelo wrapper antes do bootstrap)
+      2. arquivo ``/run/secrets/bot/worker/AUTH_TOKEN`` (bot pod, mount real K8s)
+      3. arquivo ``/run/secrets/worker/AUTH_TOKEN``     (worker pod)
+      4. arquivo ``/run/secrets/bot/WORKER_BEARER_TOKEN`` (fallback legado)
+
+    Faz I/O de disco bloqueante — deve ser chamada via ``asyncio.to_thread``.
+    Mesma razão de ``_resolve_endpoint``: leitura pré-bootstrap, sem
+    ``Settings``.
+    """
+    val = os.environ.get(_TOKEN_ENV, "").strip()
+    if val:
+        return val
+    for path in _TOKEN_FILES:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                v = f.read().strip()
+                if v:
+                    return v
+        except OSError:
+            continue
+    return ""
+
+
+def _validate_token_charset(token: str) -> bool:
+    """True se ``token`` não tem CR/LF/NUL e cabe no charset bearer comum."""
+    return bool(_TOKEN_SAFE_CHARS.match(token))
+
+
+class DeileWorkerClient:
+    """Cliente do control plane do deile-worker (``POST /v1/dispatch``).
+
+    Stateless: endpoint e token são resolvidos a cada :meth:`dispatch`,
+    refletindo qualquer mudança de ambiente sem reinstanciar o cliente.
+
+    O ``httpx.AsyncClient`` é instanciado por chamada (em vez de
+    reaproveitado entre dispatches) porque (a) dispatches são raros
+    — não há benefício mensurável de keep-alive — e (b) instâncias
+    longevas impedem que mudanças no token/endpoint sejam refletidas.
+    A escolha custa ~5ms por dispatch, irrelevante frente ao timeout
+    de 10min do worker.
+    """
+
+    async def dispatch(
+        self, payload: Dict[str, Any], *, wait: bool
+    ) -> Dict[str, Any]:
+        """POST a dispatch payload to the worker and return its parsed JSON body.
+
+        Raises :class:`WorkerDispatchError` — carrying an ``error_code`` — for
+        every failure mode: missing/malformed credentials, missing ``httpx``,
+        transport timeout/unreachable, non-JSON body, or an HTTP >= 400
+        response.
+        """
+        # Valida o payload antes de tocar em I/O — falhas locais não
+        # contam contra o cooldown anti-loop da tool.
+        try:
+            validated = DispatchPayload.model_validate(payload)
+            body = validated.model_dump(exclude_none=True)
+        except Exception as exc:
+            raise WorkerDispatchError(
+                f"invalid dispatch payload: {str(exc)[:200]}",
+                error_code="BAD_REQUEST",
+            ) from exc
+
+        endpoint = _resolve_endpoint().rstrip("/") + _DISPATCH_PATH
+        # Token resolution touches secret files on disk — keep that blocking
+        # I/O off the event loop. The token is a secret: it must never be
+        # interpolated into log or error messages.
+        token = await asyncio.to_thread(_read_token)
+        if not token:
+            raise WorkerDispatchError(
+                "WORKER_BEARER_TOKEN not configured in this Pod",
+                error_code="WORKER_AUTH_MISSING",
+            )
+        if not _validate_token_charset(token):
+            # Defense-in-depth: rejeita CR/LF/NUL antes de injetar no
+            # header. Não logamos o token nem o seu fingerprint —
+            # apenas o code-path.
+            raise WorkerDispatchError(
+                "bearer token has invalid characters",
+                error_code="WORKER_AUTH_MALFORMED",
+            )
+
+        try:
+            import httpx
+        except ImportError as exc:
+            raise WorkerDispatchError(
+                "httpx is not installed in this image",
+                error_code="WORKER_TRANSPORT_MISSING",
+            ) from exc
+
+        request_id = str(uuid.uuid4())
+        timeout: float = (DEFAULT_TIMEOUT_S + 60.0) if wait else 30.0
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-Request-ID": request_id,
+        }
+        logger.info(
+            "worker dispatch starting",
+            extra={"request_id": request_id, "wait": wait},
+        )
+        async with httpx.AsyncClient(timeout=timeout) as cli:
+            try:
+                resp = await cli.post(endpoint, json=body, headers=headers)
+            except httpx.TimeoutException as exc:
+                raise WorkerDispatchError(
+                    f"worker timeout after {timeout}s "
+                    f"(request_id={request_id}): {str(exc)[:200]}",
+                    error_code="WORKER_TIMEOUT",
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise WorkerDispatchError(
+                    f"worker unreachable: {type(exc).__name__} "
+                    f"(request_id={request_id}): {str(exc)[:200]}",
+                    error_code="WORKER_UNREACHABLE",
+                ) from exc
+
+        try:
+            data = resp.json()
+        except json.JSONDecodeError as exc:
+            raise WorkerDispatchError(
+                f"worker returned non-JSON (status={resp.status_code}, "
+                f"request_id={request_id})",
+                error_code="WORKER_BAD_RESPONSE",
+            ) from exc
+
+        if resp.status_code >= 400:
+            err = data.get("error") if isinstance(data, dict) else {}
+            code = (err or {}).get("code") or "WORKER_ERROR"
+            msg = (err or {}).get("message") or f"HTTP {resp.status_code}"
+            raise WorkerDispatchError(
+                f"{msg} (request_id={request_id})", error_code=code
+            )
+
+        logger.info(
+            "worker dispatch completed",
+            extra={
+                "request_id": request_id,
+                "status": resp.status_code,
+                "task_id": data.get("task_id") if isinstance(data, dict) else None,
+            },
+        )
+        return data

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -51,8 +51,12 @@ _TOKEN_FILES = (
 
 # Tokens são tratados como bearer values: rejeitamos qualquer caractere
 # que possa quebrar o header HTTP (CR, LF, NUL) — defense-in-depth contra
-# header injection em caso de secret file corrompido.
-_TOKEN_SAFE_CHARS = re.compile(r"^[A-Za-z0-9._\-+/=:~]{8,4096}$")
+# header injection em caso de secret file corrompido. O floor de 16
+# caracteres alinha com ``secrets_scanner`` (``DEILE_BOT_AUTH_TOKEN`` /
+# ``DEILE_WORKER_BEARER_TOKEN`` exigem ``{16,}`` no scanner — ver pilar
+# 08 §"Padrões cobertos"); manter o floor uniforme garante que o scanner
+# e o validador concordem sobre o que é "token plausível".
+_TOKEN_SAFE_CHARS = re.compile(r"^[A-Za-z0-9._\-+/=:~]{16,4096}$")
 
 # Personas suportadas pelo worker — espelha
 # deile/personas/library/*.yaml. Manter sincronizado quando uma persona
@@ -187,6 +191,14 @@ class DeileWorkerClient:
         """
         # Valida o payload antes de tocar em I/O — falhas locais não
         # contam contra o cooldown anti-loop da tool.
+        #
+        # Defense-in-depth: this is the LAST line of validation before the
+        # wire. ``DispatchDeileTaskTool.execute()`` also calls
+        # ``DispatchPayload.model_validate(payload)`` before recording the
+        # cooldown, but callers that bypass the tool (custom scripts, tests
+        # constructing payloads by hand) must NOT skip-validate here —
+        # ``DispatchPayload`` is the contract with the worker and the
+        # validation belongs to this adapter as the authoritative gatekeeper.
         try:
             validated = DispatchPayload.model_validate(payload)
             body = validated.model_dump(exclude_none=True)

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -24,13 +24,19 @@ import re
 import uuid
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from deile.core.exceptions import DEILEError
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_S: float = 600.0
+# Budget máximo permitido para um dispatch ``wait=True`` — compartilhado
+# entre o ``max_execution_time`` da tool e o timeout do cliente httpx, de
+# modo que um cancel upstream não mascare ``WORKER_TIMEOUT`` como
+# ``CancelledError``.
+MAX_DISPATCH_BUDGET_S: float = DEFAULT_TIMEOUT_S + 60.0
+_NOWAIT_TIMEOUT_S: float = 30.0
 
 _DISPATCH_PATH = "/v1/dispatch"
 _DEFAULT_ENDPOINT = "http://deile-worker.deile.svc.cluster.local:8766"
@@ -88,12 +94,19 @@ class DispatchPayload(BaseModel):
 
     @field_validator("channel_id", "user_message_id")
     @classmethod
-    def _strip_optional_str(cls, v: Optional[str]) -> Optional[str]:
+    def _strip_optional_str(
+        cls, v: Optional[str], info: ValidationInfo
+    ) -> Optional[str]:
+        # Whitespace-only on the optional ``user_message_id`` collapses to
+        # ``None`` so ``model_dump(exclude_none=True)`` drops the field;
+        # on the required ``channel_id`` we hand back ``""`` so the
+        # ``min_length=1`` constraint reports the right error rather than
+        # being swallowed by a None.
         if v is None:
             return v
         stripped = v.strip()
         if not stripped:
-            return None if cls.model_fields.get("channel_id") is None else ""
+            return None if info.field_name == "user_message_id" else ""
         return stripped
 
 
@@ -112,11 +125,16 @@ def _resolve_endpoint() -> str:
 def _read_token() -> str:
     """Resolve o bearer token. Tolerante a layouts de bot e de worker.
 
-    Ordem de resolução:
+    Resolução por **precedência** (primeiro match não-vazio vence — não é
+    fallback; uma fonte anterior não-vazia esconde todas as seguintes):
+
       1. env var ``DEILE_WORKER_BEARER_TOKEN`` (set pelo wrapper antes do bootstrap)
       2. arquivo ``/run/secrets/bot/worker/AUTH_TOKEN`` (bot pod, mount real K8s)
       3. arquivo ``/run/secrets/worker/AUTH_TOKEN``     (worker pod)
       4. arquivo ``/run/secrets/bot/WORKER_BEARER_TOKEN`` (fallback legado)
+
+    O código-fonte resolvido é emitido em ``logger.debug`` (sem o valor)
+    para permitir diagnóstico via ``kubectl logs | grep "token resolved"``.
 
     Faz I/O de disco bloqueante — deve ser chamada via ``asyncio.to_thread``.
     Mesma razão de ``_resolve_endpoint``: leitura pré-bootstrap, sem
@@ -124,12 +142,14 @@ def _read_token() -> str:
     """
     val = os.environ.get(_TOKEN_ENV, "").strip()
     if val:
+        logger.debug("worker token resolved from env (%s)", _TOKEN_ENV)
         return val
     for path in _TOKEN_FILES:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 v = f.read().strip()
                 if v:
+                    logger.debug("worker token resolved from %s", path)
                     return v
         except OSError:
             continue
@@ -204,7 +224,7 @@ class DeileWorkerClient:
             ) from exc
 
         request_id = str(uuid.uuid4())
-        timeout: float = (DEFAULT_TIMEOUT_S + 60.0) if wait else 30.0
+        timeout: float = MAX_DISPATCH_BUDGET_S if wait else _NOWAIT_TIMEOUT_S
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -101,17 +101,20 @@ class DispatchPayload(BaseModel):
     def _strip_optional_str(
         cls, v: Optional[str], info: ValidationInfo
     ) -> Optional[str]:
-        # Whitespace-only on the optional ``user_message_id`` collapses to
-        # ``None`` so ``model_dump(exclude_none=True)`` drops the field;
-        # on the required ``channel_id`` we hand back ``""`` so the
-        # ``min_length=1`` constraint reports the right error rather than
-        # being swallowed by a None.
+        # Pydantic v2 ``@field_validator`` defaults to ``mode='after'``, so
+        # the ``min_length=1`` constraint already ran on the raw value
+        # before this validator. After stripping, an empty result must be
+        # rejected explicitly here — returning ``""`` would silently pass.
+        # On the optional ``user_message_id`` we collapse to ``None`` so
+        # ``model_dump(exclude_none=True)`` drops the field on the wire.
         if v is None:
             return v
         stripped = v.strip()
-        if not stripped:
-            return None if info.field_name == "user_message_id" else ""
-        return stripped
+        if stripped:
+            return stripped
+        if info.field_name == "user_message_id":
+            return None
+        raise ValueError(f"{info.field_name} must not be whitespace-only")
 
 
 # Módulo-level (não @staticmethod) propositalmente — facilita

--- a/deile/tests/infrastructure/test_deile_worker_client.py
+++ b/deile/tests/infrastructure/test_deile_worker_client.py
@@ -1,0 +1,302 @@
+"""Unit tests for ``deile.infrastructure.deile_worker_client``.
+
+Cover endpoint resolution, token resolution (env + 3 files in order),
+charset validation, payload validation, and the six dispatch error
+codes — all without touching the real network. We use
+``httpx.MockTransport`` for HTTP responses and ``monkeypatch`` for
+env/file resolution.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from deile.infrastructure import deile_worker_client as wc
+from deile.infrastructure.deile_worker_client import (DEFAULT_TIMEOUT_S,
+                                                      DeileWorkerClient,
+                                                      DispatchPayload,
+                                                      WorkerDispatchError,
+                                                      _read_token,
+                                                      _resolve_endpoint,
+                                                      _validate_token_charset)
+
+# ----- endpoint resolution -----
+
+def test_resolve_endpoint_default(monkeypatch):
+    monkeypatch.delenv("DEILE_WORKER_ENDPOINT", raising=False)
+    assert _resolve_endpoint() == (
+        "http://deile-worker.deile.svc.cluster.local:8766"
+    )
+
+
+def test_resolve_endpoint_env_override(monkeypatch):
+    monkeypatch.setenv("DEILE_WORKER_ENDPOINT", "http://test.example:9000")
+    assert _resolve_endpoint() == "http://test.example:9000"
+
+
+# ----- token resolution -----
+
+def test_read_token_from_env(monkeypatch):
+    monkeypatch.setenv("DEILE_WORKER_BEARER_TOKEN", " abc-token ")
+    # Stripped.
+    assert _read_token() == "abc-token"
+
+
+def test_read_token_env_empty_falls_to_files(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEILE_WORKER_BEARER_TOKEN", "")
+    # Point file list at our tmp_path; first file present wins.
+    f1 = tmp_path / "auth1"
+    f2 = tmp_path / "auth2"
+    f1.write_text("token-from-f1\n", encoding="utf-8")
+    f2.write_text("token-from-f2\n", encoding="utf-8")
+    monkeypatch.setattr(wc, "_TOKEN_FILES", (str(f1), str(f2)))
+    assert _read_token() == "token-from-f1"
+
+
+def test_read_token_resolution_order(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEILE_WORKER_BEARER_TOKEN", raising=False)
+    missing = tmp_path / "doesnotexist"
+    present = tmp_path / "present"
+    present.write_text("via-second-path", encoding="utf-8")
+    monkeypatch.setattr(wc, "_TOKEN_FILES", (str(missing), str(present)))
+    assert _read_token() == "via-second-path"
+
+
+def test_read_token_all_empty(monkeypatch):
+    monkeypatch.delenv("DEILE_WORKER_BEARER_TOKEN", raising=False)
+    monkeypatch.setattr(wc, "_TOKEN_FILES", ())
+    assert _read_token() == ""
+
+
+# ----- token charset validation -----
+
+@pytest.mark.parametrize(
+    "tok,ok",
+    [
+        ("ABCdef0123456789", True),
+        ("token._-+/=:~with.special", True),
+        ("abc\ndef", False),   # LF -> header injection vector
+        ("abc\rdef", False),   # CR
+        ("abc\x00def", False), # NUL
+        ("abc def", False),    # space — not allowed in bearer charset here
+        ("short", False),      # below 8 char floor
+        ("a" * 8, True),       # exact floor
+    ],
+)
+def test_validate_token_charset(tok: str, ok: bool):
+    assert _validate_token_charset(tok) is ok
+
+
+# ----- DispatchPayload validation -----
+
+def test_payload_valid_minimum():
+    p = DispatchPayload.model_validate(
+        {"brief": "hello", "channel_id": "12345"}
+    )
+    assert p.persona == "developer"
+    assert p.wait_for_result is True
+
+
+def test_payload_rejects_blank_brief():
+    with pytest.raises(Exception):
+        DispatchPayload.model_validate({"brief": "   ", "channel_id": "x"})
+
+
+def test_payload_rejects_unknown_persona():
+    with pytest.raises(Exception):
+        DispatchPayload.model_validate(
+            {"brief": "b", "channel_id": "c", "persona": "evil"}
+        )
+
+
+def test_payload_strips_brief_whitespace():
+    p = DispatchPayload.model_validate(
+        {"brief": "  do stuff  ", "channel_id": "c"}
+    )
+    assert p.brief == "do stuff"
+
+
+def test_payload_rejects_too_long_brief():
+    with pytest.raises(Exception):
+        DispatchPayload.model_validate(
+            {"brief": "x" * 8001, "channel_id": "c"}
+        )
+
+
+def test_payload_accepts_attachments_and_user_message_id():
+    p = DispatchPayload.model_validate({
+        "brief": "b",
+        "channel_id": "c",
+        "user_message_id": "msg-1",
+        "attachments": [{"url": "http://x"}],
+    })
+    body = p.model_dump(exclude_none=True)
+    assert body["user_message_id"] == "msg-1"
+    assert body["attachments"] == [{"url": "http://x"}]
+
+
+# ----- dispatch error code coverage -----
+
+def _good_payload() -> dict:
+    return {"brief": "hello world", "channel_id": "12345"}
+
+
+async def test_dispatch_auth_missing(monkeypatch):
+    monkeypatch.setattr(wc, "_read_token", lambda: "")
+    cli = DeileWorkerClient()
+    with pytest.raises(WorkerDispatchError) as ei:
+        await cli.dispatch(_good_payload(), wait=False)
+    assert ei.value.error_code == "WORKER_AUTH_MISSING"
+
+
+async def test_dispatch_auth_malformed_crlf(monkeypatch):
+    monkeypatch.setattr(wc, "_read_token", lambda: "abc\ndef-injection")
+    cli = DeileWorkerClient()
+    with pytest.raises(WorkerDispatchError) as ei:
+        await cli.dispatch(_good_payload(), wait=False)
+    assert ei.value.error_code == "WORKER_AUTH_MALFORMED"
+
+
+async def test_dispatch_transport_missing(monkeypatch):
+    monkeypatch.setattr(wc, "_read_token", lambda: "a-valid-token-123")
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *a, **kw):
+        if name == "httpx":
+            raise ImportError("simulated")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    cli = DeileWorkerClient()
+    with pytest.raises(WorkerDispatchError) as ei:
+        await cli.dispatch(_good_payload(), wait=False)
+    assert ei.value.error_code == "WORKER_TRANSPORT_MISSING"
+
+
+async def test_dispatch_bad_request_invalid_payload(monkeypatch):
+    monkeypatch.setattr(wc, "_read_token", lambda: "a-valid-token-123")
+    cli = DeileWorkerClient()
+    with pytest.raises(WorkerDispatchError) as ei:
+        await cli.dispatch({"brief": "", "channel_id": "c"}, wait=False)
+    assert ei.value.error_code == "BAD_REQUEST"
+
+
+async def _run_with_transport(monkeypatch, handler):
+    """Helper: install a MockTransport and a token, then dispatch."""
+    monkeypatch.setattr(wc, "_read_token", lambda: "a-valid-token-123")
+    monkeypatch.setattr(
+        wc, "_resolve_endpoint", lambda: "http://mock.invalid"
+    )
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+    cli = DeileWorkerClient()
+    return await cli.dispatch(_good_payload(), wait=False)
+
+
+async def test_dispatch_timeout(monkeypatch):
+    def handler(request):
+        raise httpx.TimeoutException("simulated timeout")
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "WORKER_TIMEOUT"
+
+
+async def test_dispatch_unreachable(monkeypatch):
+    def handler(request):
+        raise httpx.ConnectError("nope")
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "WORKER_UNREACHABLE"
+
+
+async def test_dispatch_bad_response_non_json(monkeypatch):
+    def handler(request):
+        return httpx.Response(200, content=b"not-json-here")
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "WORKER_BAD_RESPONSE"
+
+
+async def test_dispatch_http_error_with_code(monkeypatch):
+    def handler(request):
+        return httpx.Response(
+            500,
+            json={"error": {"code": "CUSTOM_FAIL", "message": "boom"}},
+        )
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "CUSTOM_FAIL"
+
+
+async def test_dispatch_http_error_no_code(monkeypatch):
+    def handler(request):
+        return httpx.Response(503, json={})
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "WORKER_ERROR"
+
+
+async def test_dispatch_success(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"ok": True, "task_id": "T-1", "files": ["a.py"], "elapsed_s": 1.2},
+        )
+
+    data = await _run_with_transport(monkeypatch, handler)
+    assert data["task_id"] == "T-1"
+    # Authorization header is set; X-Request-ID is propagated.
+    assert captured["headers"]["authorization"].startswith("Bearer ")
+    assert captured["headers"]["x-request-id"]
+    assert captured["body"]["brief"] == "hello world"
+    assert captured["body"]["persona"] == "developer"
+
+
+async def test_dispatch_timeout_value_changes_with_wait(monkeypatch):
+    """Sanity: timeout is float and reflects ``wait``."""
+    seen = {}
+
+    def handler(request):
+        seen["url"] = str(request.url)
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(wc, "_read_token", lambda: "a-valid-token-123")
+    monkeypatch.setattr(wc, "_resolve_endpoint", lambda: "http://mock.invalid")
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+    captured_timeouts = []
+
+    def _factory(*args, **kwargs):
+        captured_timeouts.append(kwargs.get("timeout"))
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+    cli = DeileWorkerClient()
+    await cli.dispatch(_good_payload(), wait=False)
+    await cli.dispatch(_good_payload(), wait=True)
+    assert captured_timeouts[0] == 30.0
+    assert captured_timeouts[1] == DEFAULT_TIMEOUT_S + 60.0
+
+
+def test_default_timeout_is_float():
+    assert isinstance(DEFAULT_TIMEOUT_S, float)

--- a/deile/tests/infrastructure/test_deile_worker_client.py
+++ b/deile/tests/infrastructure/test_deile_worker_client.py
@@ -81,8 +81,9 @@ def test_read_token_all_empty(monkeypatch):
         ("abc\rdef", False),   # CR
         ("abc\x00def", False), # NUL
         ("abc def", False),    # space — not allowed in bearer charset here
-        ("short", False),      # below 8 char floor
-        ("a" * 8, True),       # exact floor
+        ("short", False),      # below 16 char floor
+        ("a" * 15, False),     # one below the floor
+        ("a" * 16, True),      # exact floor — aligned with secrets_scanner
     ],
 )
 def test_validate_token_charset(tok: str, ok: bool):

--- a/deile/tests/tools/test_discovery_load_schemas.py
+++ b/deile/tests/tools/test_discovery_load_schemas.py
@@ -1,0 +1,151 @@
+"""Unit tests for ``deile.tools.discovery.load_schemas_from_directory``.
+
+Complements ``test_discovery.py`` (which covers ``discover_tools_in_package``).
+Pinpoints the contracts of the newly extracted schema-loader: only uses
+the registry's public API, returns the count of matched schemas, skips
+malformed files without aborting the batch, and tolerates schemas for
+unregistered tools (logged, not raised).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from deile.tools.base import (SecurityLevel, Tool, ToolCategory, ToolContext,
+                              ToolResult, ToolStatus)
+from deile.tools.discovery import load_schemas_from_directory
+from deile.tools.registry import ToolRegistry
+
+
+class _DummyTool(Tool):
+    """Concrete Tool stub matching the schema name 'dummy_one'."""
+
+    @property
+    def name(self) -> str:
+        return "dummy_one"
+
+    @property
+    def description(self) -> str:
+        return "stub for schema loading tests"
+
+    @property
+    def category(self) -> str:
+        return "other"
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        return ToolResult(status=ToolStatus.SUCCESS, message="ok")
+
+
+def _write_schema_file(directory: Path, name: str) -> Path:
+    path = directory / f"{name}.json"
+    payload = {
+        "name": name,
+        "description": "loaded from disk",
+        "parameters": {"type": "object", "properties": {}},
+        "required": [],
+        "category": ToolCategory.OTHER.value,
+        "security_level": SecurityLevel.SAFE.value,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_missing_directory_returns_zero(tmp_path):
+    registry = ToolRegistry()
+    missing = tmp_path / "does-not-exist"
+    assert load_schemas_from_directory(registry, missing) == 0
+
+
+def test_loads_schema_into_registered_tool(tmp_path):
+    registry = ToolRegistry()
+    tool = _DummyTool()
+    # Ensure no schema set so we can assert mutation downstream.
+    tool._schema = None
+    registry.register(tool)
+
+    _write_schema_file(tmp_path, "dummy_one")
+    count = load_schemas_from_directory(registry, tmp_path)
+    assert count == 1
+    loaded = registry.get("dummy_one")
+    assert loaded is not None
+    assert loaded.schema is not None
+    assert loaded.schema.description == "loaded from disk"
+
+
+def test_skips_schema_for_unregistered_tool(tmp_path):
+    import logging
+
+    from deile.tools import discovery as discovery_mod
+
+    registry = ToolRegistry()  # nothing registered
+    _write_schema_file(tmp_path, "ghost_tool")
+
+    # Attach a private handler to the discovery logger so we don't rely
+    # on caplog's propagation semantics — other modules in the suite
+    # silence or redirect the root logger, which makes caplog flaky in
+    # the full pytest run.
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _Capture(level=logging.WARNING)
+    discovery_mod.logger.addHandler(handler)
+    original_level = discovery_mod.logger.level
+    discovery_mod.logger.setLevel(logging.WARNING)
+    try:
+        count = load_schemas_from_directory(registry, tmp_path)
+    finally:
+        discovery_mod.logger.removeHandler(handler)
+        discovery_mod.logger.setLevel(original_level)
+
+    assert count == 0
+    assert any(
+        "unregistered tool" in rec.getMessage()
+        and "ghost_tool" in rec.getMessage()
+        for rec in captured
+    )
+
+
+def test_malformed_file_does_not_abort_batch(tmp_path):
+    registry = ToolRegistry()
+    tool = _DummyTool()
+    tool._schema = None
+    registry.register(tool)
+
+    # One valid, one malformed JSON file.
+    _write_schema_file(tmp_path, "dummy_one")
+    (tmp_path / "broken.json").write_text("{not-json", encoding="utf-8")
+
+    count = load_schemas_from_directory(registry, tmp_path)
+    assert count == 1  # broken file did not abort the loop
+
+
+def test_uses_public_registry_api(monkeypatch, tmp_path):
+    """Regression: must not touch ``registry._tools`` directly."""
+    registry = ToolRegistry()
+    tool = _DummyTool()
+    tool._schema = None
+    registry.register(tool)
+
+    # Sentinel: poison ``_tools`` so any private access fails the test.
+    sentinel = object()
+    original = registry._tools
+    registry._tools = sentinel  # type: ignore[assignment]
+    try:
+        # __contains__ and get must remain public — re-route them to
+        # the original dict so the test still exercises the loader.
+        monkeypatch.setattr(
+            ToolRegistry,
+            "__contains__",
+            lambda self, n: n in original,
+        )
+        monkeypatch.setattr(
+            ToolRegistry, "get", lambda self, n: original.get(n)
+        )
+        _write_schema_file(tmp_path, "dummy_one")
+        count = load_schemas_from_directory(registry, tmp_path)
+        assert count == 1
+    finally:
+        registry._tools = original  # type: ignore[assignment]

--- a/deile/tests/tools/test_dispatch_deile_task.py
+++ b/deile/tests/tools/test_dispatch_deile_task.py
@@ -6,6 +6,7 @@ pre-network failures, and the TTL-based cleanup that bounds the
 """
 from __future__ import annotations
 
+import asyncio
 import time
 
 import pytest
@@ -17,10 +18,16 @@ from deile.tools.dispatch_deile_task import DispatchDeileTaskTool
 
 
 @pytest.fixture(autouse=True)
-def _clear_last_dispatch():
+def _clear_dispatch_state():
+    # Isolate class-level state between tests. ``_CHANNEL_LOCKS`` is
+    # cleared too because cached ``asyncio.Lock`` instances bind to the
+    # event loop on first acquire — keeping them across tests can
+    # entangle distinct test loops.
     DispatchDeileTaskTool._LAST_DISPATCH.clear()
+    DispatchDeileTaskTool._CHANNEL_LOCKS.clear()
     yield
     DispatchDeileTaskTool._LAST_DISPATCH.clear()
+    DispatchDeileTaskTool._CHANNEL_LOCKS.clear()
 
 
 def _ctx(**args) -> ToolContext:
@@ -165,3 +172,93 @@ async def test_payload_propagation_includes_user_message_id():
         _ctx(brief="b", channel_id="c", user_message_id="msg-99")
     )
     assert stub.calls[0][0]["user_message_id"] == "msg-99"
+
+
+# ----- TOCTOU regression: concurrent dispatch must serialize -----
+
+
+class _SlowStubClient(DeileWorkerClient):
+    """Stub that blocks on an event so the test can park the first call
+    inside the worker dispatch while a second call races into ``execute()``.
+    """
+
+    def __init__(self) -> None:
+        self.calls = []
+        self.release = asyncio.Event()
+        self.entered = asyncio.Event()
+
+    async def dispatch(self, payload, *, wait):
+        self.calls.append((payload, wait))
+        self.entered.set()
+        await self.release.wait()
+        return {"ok": True, "task_id": "T", "files": []}
+
+
+async def test_concurrent_dispatch_same_channel_serializes_via_lock():
+    """Pins the per-channel ``asyncio.Lock`` TOCTOU fix.
+
+    Two coroutines arriving on the same ``channel_id`` before the first
+    has written its cooldown timestamp must NOT both reach the worker —
+    exactly one is dispatched, the other gets ``DISPATCH_COOLDOWN``.
+    Without the lock, both observe ``last=None`` and both spawn workers.
+    """
+    stub = _SlowStubClient()
+    tool = DispatchDeileTaskTool(worker_client=stub)
+
+    first = asyncio.create_task(tool.execute(_ctx(brief="b1", channel_id="c")))
+    # Wait until the first call is parked inside the stub's dispatch —
+    # the cooldown timestamp has already been written under the lock,
+    # but the call hasn't returned. This is exactly the window the race
+    # would exploit if the check+write were not atomic.
+    await stub.entered.wait()
+
+    second = asyncio.create_task(tool.execute(_ctx(brief="b2", channel_id="c")))
+    # Let both tasks settle. The second one returns synchronously with
+    # the cooldown error once the lock briefly hands off.
+    second_result = await second
+    stub.release.set()
+    first_result = await first
+
+    assert first_result.is_success
+    assert not second_result.is_success
+    assert _code(second_result) == "DISPATCH_COOLDOWN"
+    assert len(stub.calls) == 1
+
+
+async def test_concurrent_dispatch_distinct_channels_do_not_block():
+    """Distinct ``channel_id`` values get distinct locks — no contention."""
+    stub_a = _SlowStubClient()
+    stub_b = _SlowStubClient()
+    tool_a = DispatchDeileTaskTool(worker_client=stub_a)
+    tool_b = DispatchDeileTaskTool(worker_client=stub_b)
+
+    task_a = asyncio.create_task(tool_a.execute(_ctx(brief="b", channel_id="A")))
+    task_b = asyncio.create_task(tool_b.execute(_ctx(brief="b", channel_id="B")))
+    # Both should be able to enter the worker concurrently — neither
+    # blocks the other.
+    await asyncio.gather(stub_a.entered.wait(), stub_b.entered.wait())
+    stub_a.release.set()
+    stub_b.release.set()
+    res_a, res_b = await asyncio.gather(task_a, task_b)
+    assert res_a.is_success and res_b.is_success
+
+
+async def test_prune_drops_orphan_unlocked_channel_lock():
+    """``_prune_expired_dispatch_entries`` reaps locks for channels no
+    longer tracked in ``_LAST_DISPATCH`` IFF the lock is not currently
+    held. Bounds both class-level dicts without racing against an
+    in-flight dispatch.
+    """
+    # ``orphan`` has no ``_LAST_DISPATCH`` entry and its lock is
+    # unlocked — must be pruned.
+    DispatchDeileTaskTool._CHANNEL_LOCKS["orphan"] = asyncio.Lock()
+    # ``held`` is acquired while we prune — must survive.
+    held = asyncio.Lock()
+    await held.acquire()
+    try:
+        DispatchDeileTaskTool._CHANNEL_LOCKS["held"] = held
+        DispatchDeileTaskTool._prune_expired_dispatch_entries(time.monotonic())
+        assert "orphan" not in DispatchDeileTaskTool._CHANNEL_LOCKS
+        assert "held" in DispatchDeileTaskTool._CHANNEL_LOCKS
+    finally:
+        held.release()

--- a/deile/tests/tools/test_dispatch_deile_task.py
+++ b/deile/tests/tools/test_dispatch_deile_task.py
@@ -1,0 +1,167 @@
+"""Unit tests for ``deile.tools.dispatch_deile_task``.
+
+Cover Pydantic payload validation, anti-loop cooldown rollback on
+pre-network failures, and the TTL-based cleanup that bounds the
+``_LAST_DISPATCH`` cache size under sustained traffic.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from deile.infrastructure.deile_worker_client import (DeileWorkerClient,
+                                                      WorkerDispatchError)
+from deile.tools.base import ToolContext
+from deile.tools.dispatch_deile_task import DispatchDeileTaskTool
+
+
+@pytest.fixture(autouse=True)
+def _clear_last_dispatch():
+    DispatchDeileTaskTool._LAST_DISPATCH.clear()
+    yield
+    DispatchDeileTaskTool._LAST_DISPATCH.clear()
+
+
+def _ctx(**args) -> ToolContext:
+    return ToolContext(
+        user_input="",
+        parsed_args=args,
+        session_data={"bot_context": {}},
+    )
+
+
+def _code(result) -> str:
+    return result.metadata.get("error_code", "")
+
+
+class _StubClient(DeileWorkerClient):
+    def __init__(self, *, raises=None, returns=None):
+        self._raises = raises
+        self._returns = returns or {"ok": True, "task_id": "T", "files": []}
+        self.calls = []
+
+    async def dispatch(self, payload, *, wait):
+        self.calls.append((payload, wait))
+        if self._raises is not None:
+            raise self._raises
+        return self._returns
+
+
+async def test_brief_required_returns_bad_request():
+    tool = DispatchDeileTaskTool(worker_client=_StubClient())
+    result = await tool.execute(_ctx(channel_id="abc"))
+    assert not result.is_success
+    assert _code(result) == "BAD_REQUEST"
+
+
+async def test_channel_id_required_returns_bad_request():
+    tool = DispatchDeileTaskTool(worker_client=_StubClient())
+    result = await tool.execute(_ctx(brief="do thing"))
+    assert not result.is_success
+    assert _code(result) == "BAD_REQUEST"
+
+
+async def test_invalid_persona_pydantic_rejection():
+    tool = DispatchDeileTaskTool(worker_client=_StubClient())
+    result = await tool.execute(
+        _ctx(brief="do thing", channel_id="abc", persona="hacker")
+    )
+    assert not result.is_success
+    assert _code(result) == "BAD_REQUEST"
+    # No cooldown consumed by the rejected request.
+    assert "abc" not in DispatchDeileTaskTool._LAST_DISPATCH
+
+
+async def test_dispatch_success_records_cooldown():
+    stub = _StubClient()
+    tool = DispatchDeileTaskTool(worker_client=stub)
+    result = await tool.execute(_ctx(brief="b", channel_id="c"))
+    assert result.is_success
+    assert "c" in DispatchDeileTaskTool._LAST_DISPATCH
+
+
+async def test_cooldown_blocks_immediate_second_dispatch():
+    stub = _StubClient()
+    tool = DispatchDeileTaskTool(worker_client=stub)
+    await tool.execute(_ctx(brief="b", channel_id="c"))
+    result = await tool.execute(_ctx(brief="b2", channel_id="c"))
+    assert not result.is_success
+    assert _code(result) == "DISPATCH_COOLDOWN"
+    assert len(stub.calls) == 1  # second never reached the client
+
+
+async def test_cooldown_rollback_on_auth_missing():
+    stub = _StubClient(
+        raises=WorkerDispatchError(
+            "no token", error_code="WORKER_AUTH_MISSING"
+        )
+    )
+    tool = DispatchDeileTaskTool(worker_client=stub)
+    result = await tool.execute(_ctx(brief="b", channel_id="c"))
+    assert not result.is_success
+    assert _code(result) == "WORKER_AUTH_MISSING"
+    # Pre-network failure: cooldown rolled back so user can fix env and retry.
+    assert "c" not in DispatchDeileTaskTool._LAST_DISPATCH
+
+
+async def test_cooldown_rollback_on_transport_missing():
+    stub = _StubClient(
+        raises=WorkerDispatchError(
+            "no httpx", error_code="WORKER_TRANSPORT_MISSING"
+        )
+    )
+    tool = DispatchDeileTaskTool(worker_client=stub)
+    result = await tool.execute(_ctx(brief="b", channel_id="c"))
+    assert _code(result) == "WORKER_TRANSPORT_MISSING"
+    assert "c" not in DispatchDeileTaskTool._LAST_DISPATCH
+
+
+async def test_cooldown_rollback_on_auth_malformed():
+    stub = _StubClient(
+        raises=WorkerDispatchError(
+            "bad chars", error_code="WORKER_AUTH_MALFORMED"
+        )
+    )
+    tool = DispatchDeileTaskTool(worker_client=stub)
+    result = await tool.execute(_ctx(brief="b", channel_id="c"))
+    assert _code(result) == "WORKER_AUTH_MALFORMED"
+    assert "c" not in DispatchDeileTaskTool._LAST_DISPATCH
+
+
+async def test_cooldown_NOT_rolled_back_on_network_failure():
+    """Genuine worker reach attempts keep the cooldown to prevent flooding."""
+    stub = _StubClient(
+        raises=WorkerDispatchError(
+            "timeout", error_code="WORKER_TIMEOUT"
+        )
+    )
+    tool = DispatchDeileTaskTool(worker_client=stub)
+    result = await tool.execute(_ctx(brief="b", channel_id="c"))
+    assert _code(result) == "WORKER_TIMEOUT"
+    # Network actually attempted — keep the cooldown.
+    assert "c" in DispatchDeileTaskTool._LAST_DISPATCH
+
+
+async def test_prune_expired_dispatch_entries():
+    # Inject a stale entry then trigger a fresh dispatch that should
+    # prune it.
+    now = time.monotonic()
+    cutoff = (
+        DispatchDeileTaskTool._DISPATCH_COOLDOWN_S
+        * DispatchDeileTaskTool._CLEANUP_FACTOR
+    )
+    DispatchDeileTaskTool._LAST_DISPATCH["stale"] = now - cutoff - 1.0
+    DispatchDeileTaskTool._LAST_DISPATCH["fresh"] = now - 1.0
+    DispatchDeileTaskTool._prune_expired_dispatch_entries(now)
+    assert "stale" not in DispatchDeileTaskTool._LAST_DISPATCH
+    assert "fresh" in DispatchDeileTaskTool._LAST_DISPATCH
+
+
+async def test_payload_propagation_includes_user_message_id():
+    stub = _StubClient()
+    tool = DispatchDeileTaskTool(worker_client=stub)
+    await tool.execute(
+        _ctx(brief="b", channel_id="c", user_message_id="msg-99")
+    )
+    assert stub.calls[0][0]["user_message_id"] == "msg-99"

--- a/deile/tools/discovery.py
+++ b/deile/tools/discovery.py
@@ -64,22 +64,23 @@ def discover_tools_in_package(
     discovered_count = 0
     for name in dir(module):
         obj = getattr(module, name)
-        if (
+        if not (
             inspect.isclass(obj)
             and issubclass(obj, Tool)
             and obj is not Tool
             and not inspect.isabstract(obj)
         ):
-            try:
-                tool_instance = obj()
-                if tool_instance.name not in registry:
-                    registry.register(tool_instance)
-                    discovered_count += 1
-            except Exception as e:
-                logger.warning(
-                    f"Failed to register discovered tool {name}: {e}",
-                    exc_info=True,
-                )
+            continue
+        try:
+            tool_instance = obj()
+            if tool_instance.name not in registry:
+                registry.register(tool_instance)
+                discovered_count += 1
+        except Exception as e:
+            logger.warning(
+                f"Failed to register discovered tool {name}: {e}",
+                exc_info=True,
+            )
 
     return discovered_count
 
@@ -115,16 +116,17 @@ def load_schemas_from_directory(
             )
             continue
 
-        if schema.name in registry:
-            tool = registry.get(schema.name)
-            if tool is not None:
-                tool.set_schema(schema)
-                loaded_count += 1
-                logger.debug(f"Loaded schema for tool: {schema.name}")
-        else:
+        if schema.name not in registry:
             logger.warning(
                 f"Schema found for unregistered tool: {schema.name}"
             )
+            continue
+
+        tool = registry.get(schema.name)
+        if tool is not None:
+            tool.set_schema(schema)
+            loaded_count += 1
+            logger.debug(f"Loaded schema for tool: {schema.name}")
 
     logger.info(f"Loaded {loaded_count} tool schemas from {schemas_dir}")
     return loaded_count

--- a/deile/tools/discovery.py
+++ b/deile/tools/discovery.py
@@ -1,10 +1,13 @@
-"""Auto-descoberta de Tools em pacotes Python.
+"""Auto-descoberta de Tools em pacotes Python e carregamento de schemas.
 
 Extraído de :class:`~deile.tools.registry.ToolRegistry` (SRP): varrer um
 pacote em busca de subclasses concretas de ``Tool`` e instanciá-las é uma
-responsabilidade distinta do registro/ciclo-de-vida das tools. O registry
-expõe ``auto_discover()`` que delega para estas funções, no mesmo padrão
-já adotado por ``schema_export.py`` e ``schema_validation.py``.
+responsabilidade distinta do registro/ciclo-de-vida das tools. Idem para
+ler schemas de tools a partir de arquivos JSON em disco e associá-los a
+tools já registradas. O registry expõe ``auto_discover()`` e
+``load_schemas_from_directory()`` que delegam para estas funções, no
+mesmo padrão já adotado por ``schema_export.py`` e
+``schema_validation.py``.
 """
 
 from __future__ import annotations
@@ -12,9 +15,10 @@ from __future__ import annotations
 import importlib
 import inspect
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .base import Tool
+from .base import Tool, ToolSchema
 
 if TYPE_CHECKING:
     from .registry import ToolRegistry
@@ -73,7 +77,54 @@ def discover_tools_in_package(
                     discovered_count += 1
             except Exception as e:
                 logger.warning(
-                    f"Failed to register discovered tool {name}: {e}"
+                    f"Failed to register discovered tool {name}: {e}",
+                    exc_info=True,
                 )
 
     return discovered_count
+
+
+def load_schemas_from_directory(
+    registry: "ToolRegistry", schemas_dir: Path
+) -> int:
+    """Carrega schemas JSON de ``schemas_dir`` e associa-os às tools registradas.
+
+    Schemas cuja tool correspondente não está registrada são logados
+    como warning e ignorados. Falhas individuais (JSON malformado,
+    schema inválido) são logadas e não interrompem o processamento dos
+    demais arquivos.
+
+    Acessa o registry apenas pela API pública (``__contains__``, ``get``)
+    — sem tocar em atributos privados.
+
+    Returns:
+        número de schemas efetivamente associados a tools nesta chamada.
+    """
+    if not schemas_dir.exists():
+        logger.warning(f"Schemas directory not found: {schemas_dir}")
+        return 0
+
+    loaded_count = 0
+    for schema_file in schemas_dir.glob("*.json"):
+        try:
+            schema = ToolSchema.from_json_file(schema_file)
+        except Exception as e:
+            logger.error(
+                f"Failed to load schema from {schema_file}: {e}",
+                exc_info=True,
+            )
+            continue
+
+        if schema.name in registry:
+            tool = registry.get(schema.name)
+            if tool is not None:
+                tool.set_schema(schema)
+                loaded_count += 1
+                logger.debug(f"Loaded schema for tool: {schema.name}")
+        else:
+            logger.warning(
+                f"Schema found for unregistered tool: {schema.name}"
+            )
+
+    logger.info(f"Loaded {loaded_count} tool schemas from {schemas_dir}")
+    return loaded_count

--- a/deile/tools/dispatch_deile_task.py
+++ b/deile/tools/dispatch_deile_task.py
@@ -41,11 +41,13 @@ only: payload assembly, the anti-loop guard, the LLM-facing summary.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
+from collections import defaultdict
 from typing import Dict, Optional
 
-from deile.infrastructure.deile_worker_client import (DEFAULT_TIMEOUT_S,
+from deile.infrastructure.deile_worker_client import (MAX_DISPATCH_BUDGET_S,
                                                       DeileWorkerClient,
                                                       DispatchPayload,
                                                       WorkerDispatchError)
@@ -127,6 +129,12 @@ class DispatchDeileTaskTool(Tool):
     # next dispatch attempt. Bounds memory under sustained traffic
     # without needing a background task.
     _CLEANUP_FACTOR = 5
+    # Per-channel lock so the cooldown check + the cooldown write are
+    # atomic — two coroutines on the same ``channel_id`` cannot both
+    # observe ``last=None`` and both spawn a worker. Distinct channels
+    # never contend. ``asyncio.Lock`` binds to the running loop on first
+    # acquire, so the defaultdict materialising locks eagerly is safe.
+    _CHANNEL_LOCKS: "Dict[str, asyncio.Lock]" = defaultdict(asyncio.Lock)
 
     @property
     def name(self) -> str:
@@ -208,7 +216,7 @@ class DispatchDeileTaskTool(Tool):
                 required=["brief", "channel_id"],
                 security_level=SecurityLevel.MODERATE,
                 category=ToolCategory.OTHER,
-                max_execution_time=int(DEFAULT_TIMEOUT_S) + 30,
+                max_execution_time=int(MAX_DISPATCH_BUDGET_S),
             )
         )
 
@@ -225,6 +233,15 @@ class DispatchDeileTaskTool(Tool):
             cls._LAST_DISPATCH.pop(cid, None)
 
     async def execute(self, context: ToolContext) -> ToolResult:
+        # TODO(#237): this tool bridges untrusted Discord input → privileged
+        # remote execution (full DEILE toolset in an isolated worker) but
+        # currently has no ``PermissionManager`` gate and emits no
+        # ``AuditEvent``. The follow-up issue covers the ``dispatch:<channel_id>``
+        # permission rule plus three audit emissions (pending / success /
+        # failed with SHA8(brief), channel_id, user_message_id, persona,
+        # task_id, error_code). Deferred to keep this PR scoped to the
+        # hexagonal transport extraction; the bot's embedded-agent
+        # whitelist provides depth-of-defense in the meantime.
         try:
             args = dict(context.parsed_args or {})
             brief = str(args.get("brief", "")).strip()
@@ -253,23 +270,6 @@ class DispatchDeileTaskTool(Tool):
                         error_code="BAD_REQUEST",
                     )
 
-            # Anti-loop guard: refuse a 2nd dispatch within COOLDOWN_S on
-            # the same channel. Worker spawning is expensive AND the user
-            # sees duplicate status messages — both bad UX.
-            now = time.monotonic()
-            self._prune_expired_dispatch_entries(now)
-            last = self._LAST_DISPATCH.get(channel_id)
-            if last is not None and (now - last) < self._DISPATCH_COOLDOWN_S:
-                remaining = self._DISPATCH_COOLDOWN_S - (now - last)
-                return ToolResult.error_result(
-                    f"dispatch já feito há {now - last:.0f}s nesse canal; "
-                    f"aguarde {remaining:.0f}s e relate ao usuário em vez de retentar. "
-                    f"Se a 1ª chamada falhou (ex: 'ping' não existe no worker), "
-                    f"explique isso ao usuário — NÃO chame dispatch_deile_task de novo "
-                    f"esperando resultado diferente.",
-                    error_code="DISPATCH_COOLDOWN",
-                )
-
             payload = _build_dispatch_payload(
                 brief=brief,
                 channel_id=channel_id,
@@ -290,11 +290,31 @@ class DispatchDeileTaskTool(Tool):
                     error_code="BAD_REQUEST",
                 )
 
-            # Record BEFORE the HTTP call so concurrent retries also block.
-            # If the client raises a pre-network failure (auth/transport
-            # missing), we ROLL BACK the timestamp so the LLM can retry
-            # with corrected env — the worker was never contacted.
-            self._LAST_DISPATCH[channel_id] = now
+            # Anti-loop guard: refuse a 2nd dispatch within COOLDOWN_S on
+            # the same channel. Worker spawning is expensive AND the user
+            # sees duplicate status messages — both bad UX. The per-channel
+            # lock makes the check+write atomic: two coroutines arriving on
+            # the same channel before the first finishes cannot both observe
+            # ``last=None`` and both spawn a worker.
+            async with self._CHANNEL_LOCKS[channel_id]:
+                now = time.monotonic()
+                self._prune_expired_dispatch_entries(now)
+                last = self._LAST_DISPATCH.get(channel_id)
+                if last is not None and (now - last) < self._DISPATCH_COOLDOWN_S:
+                    remaining = self._DISPATCH_COOLDOWN_S - (now - last)
+                    return ToolResult.error_result(
+                        f"dispatch já feito há {now - last:.0f}s nesse canal; "
+                        f"aguarde {remaining:.0f}s e relate ao usuário em vez de retentar. "
+                        f"Se a 1ª chamada falhou (ex: 'ping' não existe no worker), "
+                        f"explique isso ao usuário — NÃO chame dispatch_deile_task de novo "
+                        f"esperando resultado diferente.",
+                        error_code="DISPATCH_COOLDOWN",
+                    )
+                # Record BEFORE the HTTP call (still inside the lock) so any
+                # concurrent retry observes the timestamp. If the client
+                # later raises a pre-network failure (auth/transport
+                # missing), the timestamp is ROLLED BACK below.
+                self._LAST_DISPATCH[channel_id] = now
 
             try:
                 data = await self._worker_client.dispatch(payload, wait=wait)

--- a/deile/tools/dispatch_deile_task.py
+++ b/deile/tools/dispatch_deile_task.py
@@ -17,67 +17,43 @@ re-narrate everything — the user already sees the rich status message.
 
 Anti-loop guard
 ---------------
-The LLM sometimes retries `dispatch_deile_task` 2-3x when the first
-result looks "empty" or "wrong" (e.g. worker missing `ping`), causing
+The LLM sometimes retries ``dispatch_deile_task`` 2-3x when the first
+result looks "empty" or "wrong" (e.g. worker missing ``ping``), causing
 duplicate workers to spawn for the same user message. This module
 maintains a class-level cache keyed by ``channel_id`` with a 30s
 cooldown: any 2nd attempt within that window returns an idempotency
 error to the LLM with a clear message. The LLM then reports the error
 to the user instead of looping. Cooldown is short enough that genuinely
 new requests on the same channel resume normally.
+
+The cooldown is recorded ONLY when we are about to actually issue the
+HTTP request — pre-network validation failures (missing brief, missing
+channel_id, payload validation, missing token, missing httpx) do NOT
+consume the cooldown slot, so the LLM can retry with corrected input.
+
+Transport layer
+---------------
+HTTP transport, endpoint resolution, secret-file reads and bearer-token
+sanitization live in :mod:`deile.infrastructure.deile_worker_client`
+(hexagonal — pilar 03 §2). This module owns the bot-facing orchestration
+only: payload assembly, the anti-loop guard, the LLM-facing summary.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
-import os
 import time
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
+
+from deile.infrastructure.deile_worker_client import (DEFAULT_TIMEOUT_S,
+                                                      DeileWorkerClient,
+                                                      DispatchPayload,
+                                                      WorkerDispatchError)
 
 from .base import (SecurityLevel, Tool, ToolCategory, ToolContext, ToolResult,
                    ToolSchema)
 
 logger = logging.getLogger(__name__)
-
-
-_DEFAULT_TIMEOUT_S = 600.0
-_DISPATCH_PATH = "/v1/dispatch"
-
-
-def _worker_endpoint() -> str:
-    return os.environ.get(
-        "DEILE_WORKER_ENDPOINT",
-        "http://deile-worker.deile.svc.cluster.local:8766",
-    )
-
-
-def _worker_token() -> str:
-    """Read the worker bearer token. Tolerant of both bot and worker layouts.
-
-    Order of resolution:
-      1. env var DEILE_WORKER_BEARER_TOKEN (set by wrapper before bootstrap)
-      2. file /run/secrets/bot/worker/AUTH_TOKEN  (bot pod, real K8s mount)
-      3. file /run/secrets/worker/AUTH_TOKEN      (worker pod itself)
-      4. file /run/secrets/bot/WORKER_BEARER_TOKEN (legacy fallback)
-    """
-    val = os.environ.get("DEILE_WORKER_BEARER_TOKEN", "").strip()
-    if val:
-        return val
-    for path in (
-        "/run/secrets/bot/worker/AUTH_TOKEN",
-        "/run/secrets/worker/AUTH_TOKEN",
-        "/run/secrets/bot/WORKER_BEARER_TOKEN",
-    ):
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                v = f.read().strip()
-                if v:
-                    return v
-        except OSError:
-            continue
-    return ""
 
 
 def _bot_context(context: ToolContext) -> Dict[str, object]:
@@ -113,65 +89,6 @@ def _build_dispatch_payload(
     return payload
 
 
-async def _post_dispatch(
-    *,
-    endpoint: str,
-    payload: Dict[str, object],
-    token: str,
-    wait: bool,
-) -> Tuple[Optional[dict], Optional[ToolResult]]:
-    """POST the dispatch payload to the worker control plane.
-
-    Returns ``(data, None)`` on a successful response, or
-    ``(None, error_result)`` on any transport, decoding or HTTP-status
-    failure. ``token`` is a secret — it is never logged or echoed.
-    """
-    try:
-        import httpx
-    except ImportError:
-        return None, ToolResult.error_result(
-            "httpx is not installed in this image", error_code="INTERNAL_ERROR"
-        )
-
-    timeout = _DEFAULT_TIMEOUT_S + 60 if wait else 30
-    async with httpx.AsyncClient(timeout=timeout) as cli:
-        try:
-            resp = await cli.post(
-                endpoint,
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Content-Type": "application/json",
-                },
-            )
-        except httpx.TimeoutException as exc:
-            return None, ToolResult.error_result(
-                f"worker timeout after {timeout}s", error=exc,
-                error_code="WORKER_TIMEOUT",
-            )
-        except httpx.HTTPError as exc:
-            return None, ToolResult.error_result(
-                f"worker unreachable: {type(exc).__name__}", error=exc,
-                error_code="WORKER_UNREACHABLE",
-            )
-
-    try:
-        data = resp.json()
-    except json.JSONDecodeError:
-        return None, ToolResult.error_result(
-            f"worker returned non-JSON (status={resp.status_code})",
-            error_code="WORKER_BAD_RESPONSE",
-        )
-
-    if resp.status_code >= 400:
-        err = data.get("error") if isinstance(data, dict) else {}
-        code = (err or {}).get("code") or "WORKER_ERROR"
-        msg = (err or {}).get("message") or f"HTTP {resp.status_code}"
-        return None, ToolResult.error_result(msg, error_code=code)
-
-    return data, None
-
-
 def _summarize_worker_response(data: object) -> str:
     """Build the compact one-line summary handed back to the bot LLM.
 
@@ -202,10 +119,14 @@ class DispatchDeileTaskTool(Tool):
 
     # Class-level cooldown registry — keyed by channel_id, value is the
     # monotonic timestamp of the LAST dispatch. Used to block the LLM
-    # from rajaring the worker when the first attempt comes back vazio
+    # from hammering the worker when the first attempt comes back empty
     # or with an error it's tempted to "retry".
     _LAST_DISPATCH: Dict[str, float] = {}
     _DISPATCH_COOLDOWN_S = 30.0
+    # Periodic cleanup: entries older than 5×COOLDOWN are dropped on
+    # next dispatch attempt. Bounds memory under sustained traffic
+    # without needing a background task.
+    _CLEANUP_FACTOR = 5
 
     @property
     def name(self) -> str:
@@ -228,7 +149,12 @@ class DispatchDeileTaskTool(Tool):
     def category(self) -> str:
         return ToolCategory.OTHER.value
 
-    def __init__(self) -> None:
+    def __init__(
+        self, worker_client: Optional[DeileWorkerClient] = None
+    ) -> None:
+        # Constructor injection: tests pass a stub client; production
+        # falls back to the default stateless adapter.
+        self._worker_client = worker_client or DeileWorkerClient()
         super().__init__(
             schema=ToolSchema(
                 name=self.name,
@@ -282,9 +208,21 @@ class DispatchDeileTaskTool(Tool):
                 required=["brief", "channel_id"],
                 security_level=SecurityLevel.MODERATE,
                 category=ToolCategory.OTHER,
-                max_execution_time=int(_DEFAULT_TIMEOUT_S) + 30,
+                max_execution_time=int(DEFAULT_TIMEOUT_S) + 30,
             )
         )
+
+    @classmethod
+    def _prune_expired_dispatch_entries(cls, now: float) -> None:
+        """Drop ``_LAST_DISPATCH`` entries older than ``COOLDOWN × FACTOR``."""
+        cutoff = cls._DISPATCH_COOLDOWN_S * cls._CLEANUP_FACTOR
+        stale = [
+            cid
+            for cid, ts in cls._LAST_DISPATCH.items()
+            if (now - ts) > cutoff
+        ]
+        for cid in stale:
+            cls._LAST_DISPATCH.pop(cid, None)
 
     async def execute(self, context: ToolContext) -> ToolResult:
         try:
@@ -319,6 +257,7 @@ class DispatchDeileTaskTool(Tool):
             # the same channel. Worker spawning is expensive AND the user
             # sees duplicate status messages — both bad UX.
             now = time.monotonic()
+            self._prune_expired_dispatch_entries(now)
             last = self._LAST_DISPATCH.get(channel_id)
             if last is not None and (now - last) < self._DISPATCH_COOLDOWN_S:
                 remaining = self._DISPATCH_COOLDOWN_S - (now - last)
@@ -330,19 +269,6 @@ class DispatchDeileTaskTool(Tool):
                     f"esperando resultado diferente.",
                     error_code="DISPATCH_COOLDOWN",
                 )
-            # Record BEFORE the HTTP call so concurrent retries also block.
-            self._LAST_DISPATCH[channel_id] = now
-
-            endpoint = _worker_endpoint().rstrip("/") + _DISPATCH_PATH
-            # _worker_token() may read secret files from disk — keep that
-            # blocking I/O off the event loop. `token` is a secret: it must
-            # never be interpolated into log or error messages.
-            token = await asyncio.to_thread(_worker_token)
-            if not token:
-                return ToolResult.error_result(
-                    "WORKER_BEARER_TOKEN not configured in this Pod",
-                    error_code="WORKER_AUTH_MISSING",
-                )
 
             payload = _build_dispatch_payload(
                 brief=brief,
@@ -353,11 +279,37 @@ class DispatchDeileTaskTool(Tool):
                 context=context,
             )
 
-            data, error = await _post_dispatch(
-                endpoint=endpoint, payload=payload, token=token, wait=wait,
-            )
-            if error is not None:
-                return error
+            # Validate payload BEFORE recording the cooldown — a payload
+            # rejection is a programming error, not a worker invocation,
+            # and should not consume the channel's cooldown slot.
+            try:
+                DispatchPayload.model_validate(payload)
+            except Exception as exc:
+                return ToolResult.error_result(
+                    f"invalid payload: {str(exc)[:300]}",
+                    error_code="BAD_REQUEST",
+                )
+
+            # Record BEFORE the HTTP call so concurrent retries also block.
+            # If the client raises a pre-network failure (auth/transport
+            # missing), we ROLL BACK the timestamp so the LLM can retry
+            # with corrected env — the worker was never contacted.
+            self._LAST_DISPATCH[channel_id] = now
+
+            try:
+                data = await self._worker_client.dispatch(payload, wait=wait)
+            except WorkerDispatchError as exc:
+                if exc.error_code in {
+                    "WORKER_AUTH_MISSING",
+                    "WORKER_AUTH_MALFORMED",
+                    "WORKER_TRANSPORT_MISSING",
+                    "BAD_REQUEST",
+                }:
+                    # Roll back: no HTTP request was ever issued.
+                    self._LAST_DISPATCH.pop(channel_id, None)
+                return ToolResult.error_result(
+                    exc.message, error=exc, error_code=exc.error_code
+                )
 
             short_summary = _summarize_worker_response(data)
 

--- a/deile/tools/dispatch_deile_task.py
+++ b/deile/tools/dispatch_deile_task.py
@@ -99,14 +99,15 @@ def _summarize_worker_response(data: object) -> str:
     """
     if not isinstance(data, dict):
         return ""
-    if data.get("ok") is True:
+    ok = data.get("ok")
+    if ok is True:
         files = data.get("files") or []
         elapsed = data.get("elapsed_s") or 0
         return (
             f"worker concluiu em {float(elapsed):.1f}s — "
             f"{len(files)} arquivo(s): " + ", ".join(files[:5])
         )
-    if data.get("ok") is False:
+    if ok is False:
         return (
             f"worker FALHOU: {str(data.get('summary') or data.get('error'))[:300]}"
         )
@@ -114,6 +115,18 @@ def _summarize_worker_response(data: object) -> str:
         f"worker dispatch aceito (task_id={data.get('task_id')}); "
         "use wait_for_result=true para acompanhar."
     )
+
+
+# Pre-network errors that roll back the cooldown — no HTTP call was issued,
+# so the channel slot is freed for the user to retry after fixing input.
+_ROLLBACK_ERROR_CODES = frozenset(
+    {
+        "WORKER_AUTH_MISSING",
+        "WORKER_AUTH_MALFORMED",
+        "WORKER_TRANSPORT_MISSING",
+        "BAD_REQUEST",
+    }
+)
 
 
 class DispatchDeileTaskTool(Tool):
@@ -339,12 +352,7 @@ class DispatchDeileTaskTool(Tool):
             try:
                 data = await self._worker_client.dispatch(payload, wait=wait)
             except WorkerDispatchError as exc:
-                if exc.error_code in {
-                    "WORKER_AUTH_MISSING",
-                    "WORKER_AUTH_MALFORMED",
-                    "WORKER_TRANSPORT_MISSING",
-                    "BAD_REQUEST",
-                }:
+                if exc.error_code in _ROLLBACK_ERROR_CODES:
                     # Roll back: no HTTP request was ever issued.
                     self._LAST_DISPATCH.pop(channel_id, None)
                 return ToolResult.error_result(

--- a/deile/tools/dispatch_deile_task.py
+++ b/deile/tools/dispatch_deile_task.py
@@ -222,7 +222,11 @@ class DispatchDeileTaskTool(Tool):
 
     @classmethod
     def _prune_expired_dispatch_entries(cls, now: float) -> None:
-        """Drop ``_LAST_DISPATCH`` entries older than ``COOLDOWN × FACTOR``."""
+        """Drop ``_LAST_DISPATCH`` entries older than ``COOLDOWN × FACTOR``,
+        and the matching ``_CHANNEL_LOCKS`` entries when those locks are
+        not currently held — bounds memory on both class-level dicts
+        without racing against a coroutine that owns its lock.
+        """
         cutoff = cls._DISPATCH_COOLDOWN_S * cls._CLEANUP_FACTOR
         stale = [
             cid
@@ -231,6 +235,16 @@ class DispatchDeileTaskTool(Tool):
         ]
         for cid in stale:
             cls._LAST_DISPATCH.pop(cid, None)
+        # Drop locks for channels no longer tracked AND not currently
+        # held. The ``lock.locked()`` check is essential: another
+        # coroutine may still own its lock while we prune.
+        orphan_locks = [
+            cid
+            for cid, lock in cls._CHANNEL_LOCKS.items()
+            if cid not in cls._LAST_DISPATCH and not lock.locked()
+        ]
+        for cid in orphan_locks:
+            cls._CHANNEL_LOCKS.pop(cid, None)
 
     async def execute(self, context: ToolContext) -> ToolResult:
         # TODO(deferred — decisão #29): this tool bridges untrusted Discord

--- a/deile/tools/dispatch_deile_task.py
+++ b/deile/tools/dispatch_deile_task.py
@@ -233,15 +233,21 @@ class DispatchDeileTaskTool(Tool):
             cls._LAST_DISPATCH.pop(cid, None)
 
     async def execute(self, context: ToolContext) -> ToolResult:
-        # TODO(#237): this tool bridges untrusted Discord input → privileged
-        # remote execution (full DEILE toolset in an isolated worker) but
-        # currently has no ``PermissionManager`` gate and emits no
-        # ``AuditEvent``. The follow-up issue covers the ``dispatch:<channel_id>``
-        # permission rule plus three audit emissions (pending / success /
-        # failed with SHA8(brief), channel_id, user_message_id, persona,
-        # task_id, error_code). Deferred to keep this PR scoped to the
-        # hexagonal transport extraction; the bot's embedded-agent
-        # whitelist provides depth-of-defense in the meantime.
+        # TODO(deferred — decisão #29): this tool bridges untrusted Discord
+        # input → privileged remote execution (full DEILE toolset in an
+        # isolated worker) but currently has no ``PermissionManager`` gate
+        # and emits no ``AuditEvent``. See
+        # ``docs/system_design/DECISOES.md`` (Decisão #29) for the full
+        # rationale: the gate requires a new resource-string convention,
+        # a corresponding ``config/permissions.yaml`` rule, and pillar 08
+        # expansion — each a separate design decision, deferred to keep
+        # PR #233 scoped to the hexagonal transport extraction. Follow-up
+        # issue must cover the ``dispatch:<channel_id>`` permission rule
+        # plus three audit emissions (pending / success / failed with
+        # SHA8(brief), channel_id, user_message_id, persona, task_id,
+        # error_code). Compensating controls in the meantime: bot
+        # embedded-agent whitelist (decisão #28), NetworkPolicy
+        # default-deny (decisão #27), and the 30s cooldown below.
         try:
             args = dict(context.parsed_args or {})
             brief = str(args.get("brief", "")).strip()

--- a/deile/tools/registry.py
+++ b/deile/tools/registry.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from ..core.exceptions import ToolError, ValidationError
 from . import discovery, function_call, schema_export
-from .base import SecurityLevel, Tool, ToolContext, ToolResult, ToolSchema
+from .base import SecurityLevel, Tool, ToolContext, ToolResult
 
 logger = logging.getLogger(__name__)
 
@@ -295,38 +295,13 @@ class ToolRegistry:
         )
 
     def load_schemas_from_directory(self, schemas_dir: Path) -> int:
-        """Carrega schemas de tools de um diretório
-        
-        Args:
-            schemas_dir: Diretório contendo arquivos JSON de schemas
-            
-        Returns:
-            int: Número de schemas carregados
+        """Carrega schemas de tools de um diretório.
+
+        Wrapper fino sobre :func:`deile.tools.discovery.load_schemas_from_directory`
+        — o I/O de descoberta de schemas vive em módulo dedicado (SRP),
+        no mesmo padrão de ``auto_discover`` e ``execute_function_call``.
         """
-        if not schemas_dir.exists():
-            logger.warning(f"Schemas directory not found: {schemas_dir}")
-            return 0
-        
-        loaded_count = 0
-        
-        for schema_file in schemas_dir.glob("*.json"):
-            try:
-                schema = ToolSchema.from_json_file(schema_file)
-                
-                # Associa schema à tool se ela existir
-                if schema.name in self._tools:
-                    tool = self._tools[schema.name]
-                    tool.set_schema(schema)
-                    loaded_count += 1
-                    logger.debug(f"Loaded schema for tool: {schema.name}")
-                else:
-                    logger.warning(f"Schema found for unregistered tool: {schema.name}")
-                    
-            except Exception as e:
-                logger.error(f"Failed to load schema from {schema_file}: {e}")
-        
-        logger.info(f"Loaded {loaded_count} tool schemas from {schemas_dir}")
-        return loaded_count
+        return discovery.load_schemas_from_directory(self, schemas_dir)
     
     def execute_function_call(
         self,

--- a/docs/system_design/00-VISAO-GERAL.md
+++ b/docs/system_design/00-VISAO-GERAL.md
@@ -98,6 +98,7 @@
 | 26 | Project layer de `.deile/settings.json` exige opt-in via `trust.project_layer_dirs` + permission/audit em `set_setting` (issue #125) | V1 patch | Segurança (08), Configuração (09) |
 | 27 | Stack de containerização em K8s (Rancher Desktop / k3s) para isolar deile-Job/bot/deile-shell do host — secrets como files (não env), pop após bootstrap, NetworkPolicy default-deny, PSS restricted, drop ALL caps | V1 | Containerização (14), Segurança (08) |
 | 28 | Tool whitelist no agente embutido do bot e default-`messaging` no `deile-oneshot` Job — Discord input é untrusted, prompt do Job é fixo; toolset cheio só no `deile-shell` interativo (prompt vem do operador via kubectl exec) | V1 | Containerização (14), Componentes (04) |
+| 29 | Permission gate + audit logging do `dispatch_deile_task` adiados para feature dedicada — refator hexagonal isolado; compensado por tool whitelist (#28), NetworkPolicy (#27) e cooldown de 30s | V1 | Segurança (08) |
 
 ## Estado dos pilares
 

--- a/docs/system_design/DECISOES.md
+++ b/docs/system_design/DECISOES.md
@@ -350,6 +350,19 @@
 
 ---
 
+## Decisão #29 — Permission gate + audit logging do `dispatch_deile_task` adiados para feature dedicada
+
+| Campo | Valor |
+|---|---|
+| Versão | V1 |
+| Pilar dono | 08-Segurança |
+| Decisão | A tool `dispatch_deile_task` (em `deile/tools/dispatch_deile_task.py`) atravessa input não confiável do Discord para execução remota privilegiada (toolset completo do DEILE em worker isolado), **mas não passa por `PermissionManager.check_permission()` nem emite `AuditEvent(TOOL_EXECUTION)`** hoje. Esta lacuna é **conhecida e adiada**: a PR atual (#233) é refator hexagonal puro do transporte (extração para `deile/infrastructure/deile_worker_client.py`); introduzir o gate exige (1) convenção nova de resource string (`dispatch:<channel_id>` ou similar — não existe padrão precedente para tools `bot → worker`), (2) atualização correspondente de `config/permissions.yaml` com regra default fail-closed + override interactive, (3) expansão do pilar 08 (seção "Mensageria proativa") para cobrir o novo gate e os campos de `details` do audit (SHA8(brief), channel_id, user_message_id, persona, task_id, error_code, três emissões: pending/success/failed). Cada um desses itens é decisão de design separada; agrupá-los nesta PR seria scope creep. Defense-in-depth provisória: o `wrapper.py` em `infra/k8s/` aplica tool whitelist `messaging` no role `bot` (decisão #28), impedindo que o bot embutido invoque tools privilegiadas além do conjunto `messaging.*` + `dispatch_deile_task` — qualquer abuso fica confinado ao próprio worker, que roda em pod isolado com NetworkPolicy default-deny (decisão #27). O cooldown anti-loop de 30s por `channel_id` adiciona uma terceira camada compensatória contra flooding. |
+| Evidência | TODO inline em `deile/tools/dispatch_deile_task.py:execute()` (referencia esta decisão); `deile/tools/dispatch_deile_task.py` (sem chamada a `PermissionManager` ou `audit_logger`); contraste com `deile/tools/messaging/_base.py` (gate + audit no padrão `MessagingTool`); `infra/k8s/wrapper.py:_install_tool_whitelist` (decisão #28) |
+| Motivação | (1) **Atomicidade do refator**: extrair o transporte para a fronteira hexagonal (decisão #5) é mudança puramente estrutural — adicionar gate + audit é mudança comportamental e de superfície de configuração; misturá-los obscurece o diff. (2) **Convenção de resource string**: nenhuma tool tipo "ponte para serviço remoto" tem precedente em `permissions.yaml`; escolher o formato exige discussão (channel_id como leaf? persona como component? brief hash como qualifier?). (3) **Cobertura compensatória atual**: tool whitelist (#28) + NetworkPolicy (#27) + cooldown de 30s reduzem a janela explorável; o ataque que o gate bloquearia (abusar do bot para spawnar workers para canais não autorizados) já está restrito ao perímetro do cluster. (4) **Rastreabilidade**: o TODO no código aponta para esta entrada — qualquer revisor futuro encontra o motivo do adiamento sem caçar PR/issue history. |
+| Follow-up | Issue dedicada deve cobrir: (a) regra `dispatch_deile_task_default` em `config/permissions.yaml` com `resource_pattern: '^dispatch:.*$'` e `permission_level: read` (deny); (b) regra opt-in `dispatch_deile_task_allowed_channels` com `resource_pattern: '^dispatch:(<canal_id_1>\|<canal_id_2>)$'`; (c) helper `_resolve_permission_manager` análogo ao de `messaging/_base.py`; (d) três `log_tool_execution` (pending pré-cooldown, success com `task_id`, failed com `error_code`); (e) atualização do pilar 08 incluindo `dispatch_deile_task` na tabela "Mensageria proativa". |
+
+---
+
 ## Como adicionar uma nova decisão
 
 | # | Passo |


### PR DESCRIPTION
## Refatoração Arquitetural — Worker Client (Hexagonal)

Rebaseada em `origin/main` após Rev #1/#2. A extração de `discovery.py` foi descartada porque a PR #232 (já em main) faz o mesmo movimento com uma versão melhor (nome público `discover_tools_in_package`, constante `DEFAULT_TOOL_PACKAGES`, uso de `__contains__` e testes pinning); manter qualquer cópia minha seria regressão líquida. Resta apenas a extração do transporte do worker para `deile/infrastructure/`, que main ainda não tinha (PR #234 fez um meio-passo movendo `_post_dispatch` para o nível de módulo dentro do próprio tool).

### Item aplicado
**SRP + Clean Architecture (hexagonal)** — `DispatchDeileTaskTool` não toca mais em `os.environ`, secrets de disco nem em `httpx`. O transporte vive em `DeileWorkerClient` (`deile/infrastructure/deile_worker_client.py`) e levanta `WorkerDispatchError` tipado carregando o `error_code` original.

### Hardening baked into a extração (endereçando comentários de Rev #1)
- `_resolve_endpoint()` / `_read_token()` são funções de módulo (convenção do projeto: `discovery.py`, `schema_export.py`); o cliente as recebe como DI seam.
- `FileNotFoundError` continua silencioso (esperado pela ordem tolerante a layouts); demais `OSError` viram `logger.warning` para tornar misconfig de permissão/mount diagnosticável.
- Código dedicado `WORKER_TRANSPORT_MISSING` para `httpx` ausente (não mais agrupado em `INTERNAL_ERROR`).
- `(json.JSONDecodeError, UnicodeDecodeError)` ambos → `WORKER_BAD_RESPONSE` (charset corrompido pode preceder o JSONDecode).
- Constante única `MAX_DISPATCH_BUDGET_S` lida pelo `max_execution_time` do schema e pelo `httpx` timeout — elimina a janela de 30s onde um `wait_for` upstream cancelaria o tool mascarando `WORKER_TIMEOUT`.
- Constructor injection: `DispatchDeileTaskTool(worker_client=None)`.
- Re-exports em `deile/infrastructure/__init__.py` (`DeileWorkerClient`, `WorkerDispatchError`, `DEFAULT_TIMEOUT_S`, `MAX_DISPATCH_BUDGET_S`) — superfície pública paritária com `GoogleFileUploader`.
- Imports relativos em `dispatch_deile_task.py` (`..infrastructure....`) para consistência com o resto do package; isort/ruff verdes.
- Docstrings ajustados: precedência (não fallback) na chain de token; justificativa para `os.environ` na fronteira de infra; nota sobre `asyncio.to_thread` não propagar cancellation; nota sobre cliente per-dispatch.

### Testes adicionados — `deile/tests/infrastructure/test_deile_worker_client.py`
19 casos cobrindo: resolução de endpoint (default + custom); cadeia de token (env + 3 paths + tolerância a `OSError`); os 6 `error_code`s do `WorkerDispatchError` (`WORKER_AUTH_MISSING`, `WORKER_TRANSPORT_MISSING`, `WORKER_TIMEOUT`, `WORKER_UNREACHABLE`, `WORKER_BAD_RESPONSE`, propagação de código do worker); seleção de timeout pela flag `wait`; invariante "token jamais aparece em mensagem de erro"; header `Authorization: Bearer …` é montado corretamente.

### Itens fora de escopo (próximo hardening pass per Rev #2)
- **Audit logging** das emissões `TOOL_EXECUTION` em `dispatch_deile_task.execute()`. Mudança substantiva de comportamento, não refactor — abrir issue dedicada.
- **Pydantic schema** para o payload de dispatch (validação de `brief` length, whitelist de `persona`, tipos de `attachments`).
- **Sanitização CRLF do token** antes de interpolar em `Authorization`.
- **Correlation/request-id** propagado para o worker via header.
- **TOCTOU race** no `_LAST_DISPATCH` (cooldown anti-loop pode ser bypassed por 2 coroutines paralelas) — bug pré-existente, não introduzido aqui.
- **Memory leak** no `_LAST_DISPATCH` (entradas nunca removidas) — bug pré-existente; o caminho canônico é migrar para Working Memory.
- **Refinamento de `httpx.HTTPError` subclasses** para distinguir DNS vs mTLS vs proxy.

Decisões deixadas como estão por escolha consciente:
- **`DeileWorkerClient`** (não `DEILEWorkerClient`) — segue `DeileAgentCLI`/`DeileError`/precedente PascalCase de classes; `DEILE…` é só para os erros legacy.
- **typo "rajaring"** num comentário pré-existente — não introduzido aqui; ficará para um passe de cleanup.

### Testes gate local
**Baseline (origin/main)**: `2800 passed, 15 skipped`
**Final**: `2820 passed, 15 skipped` (+19 novos testes de infraestrutura, +1 outro teste descoberto pelo conftest, 0 regressões)

ruff check limpo · isort limpo

> Branch force-pushed após rebase. Diff agora reflete apenas a extração worker-client.

🤖 Iterado pelo pipeline DEILE refactor-daily