### PR TITLE
feat(math): implement somar(a, b) pure sum function

### DIFF
--- a/deile/common/math_utils.py
+++ b/deile/common/math_utils.py
@@ -1,5 +1,7 @@
 """Pure mathematical utility functions."""
 
+from __future__ import annotations
+
 
 def somar(a: int, b: int) -> int:
     """Retorna a soma de dois números inteiros.

--- a/deile/common/math_utils.py
+++ b/deile/common/math_utils.py
@@ -1,0 +1,24 @@
+"""Pure mathematical utility functions."""
+
+
+def somar(a: int, b: int) -> int:
+    """Retorna a soma de dois números inteiros.
+
+    Função pura — sem efeitos colaterais, determinística.
+
+    Args:
+        a: Primeiro inteiro.
+        b: Segundo inteiro.
+
+    Returns:
+        A soma de a e b como inteiro.
+
+    Examples:
+        >>> somar(2, 3)
+        5
+        >>> somar(-1, -2)
+        -3
+        >>> somar(5, 0)
+        5
+    """
+    return a + b

--- a/deile/tests/common/test_math_utils.py
+++ b/deile/tests/common/test_math_utils.py
@@ -4,7 +4,7 @@ from deile.common.math_utils import somar
 
 
 class TestSomar:
-    """Coverage: positivos, negativos, zero, zero-com-zero."""
+    """Coverage: positivos, negativos, zero, sinais mistos, comutatividade, grandes."""
 
     def test_soma_positivos(self) -> None:
         assert somar(2, 3) == 5
@@ -20,3 +20,12 @@ class TestSomar:
 
     def test_soma_zero_com_zero(self) -> None:
         assert somar(0, 0) == 0
+
+    def test_soma_sinais_mistos(self) -> None:
+        assert somar(-3, 5) == 2
+
+    def test_soma_comutativa(self) -> None:
+        assert somar(2, 3) == somar(3, 2)
+
+    def test_soma_inteiros_grandes(self) -> None:
+        assert somar(10**18, 10**18) == 2 * 10**18

--- a/deile/tests/common/test_math_utils.py
+++ b/deile/tests/common/test_math_utils.py
@@ -1,0 +1,22 @@
+"""Tests for deile.common.math_utils."""
+
+from deile.common.math_utils import somar
+
+
+class TestSomar:
+    """Coverage: positivos, negativos, zero, zero-com-zero."""
+
+    def test_soma_positivos(self) -> None:
+        assert somar(2, 3) == 5
+
+    def test_soma_negativos(self) -> None:
+        assert somar(-1, -2) == -3
+
+    def test_soma_positivo_com_zero(self) -> None:
+        assert somar(5, 0) == 5
+
+    def test_soma_negativo_com_zero(self) -> None:
+        assert somar(-7, 0) == -7
+
+    def test_soma_zero_com_zero(self) -> None:
+        assert somar(0, 0) == 0


### PR DESCRIPTION
Implementa a função pura `somar(a: int, b: int) -> int` no módulo `deile.common.math_utils`, com cobertura completa de testes unitários para:\n\n- ✅ Dois positivos: `somar(2, 3) == 5`\n- ✅ Dois negativos: `somar(-1, -2) == -3`\n- ✅ Positivo com zero: `somar(5, 0) == 5`\n- ✅ Negativo com zero: `somar(-7, 0) == -7`\n- ✅ Zero com zero: `somar(0, 0) == 0`\n\nA função é pura (determinística, sem efeitos colaterais, sem I/O).\n\nCloses #242.\n\nBy [DEILE One](mailto:deile@deile.info)