### PR TITLE
[FEATURE] função is_impar(n) em deile/common

### DIFF
--- a/deile/common/__init__.py
+++ b/deile/common/__init__.py
@@ -1,1 +1,5 @@
 """deile.common — shared types between deile core and deilebot."""
+
+from deile.common.numbers import is_impar
+
+__all__ = ["is_impar"]

--- a/deile/common/numbers.py
+++ b/deile/common/numbers.py
@@ -1,0 +1,12 @@
+"""Numeric helpers — pure integer predicates."""
+
+from __future__ import annotations
+
+
+def is_impar(n: int) -> bool:
+    """Return True if *n* is odd (ímpar in Portuguese).
+
+    Works for any integer: positive, negative, or zero.
+    Zero is even, so ``is_impar(0) → False``.
+    """
+    return n % 2 != 0

--- a/deile/tests/common/test_numbers.py
+++ b/deile/tests/common/test_numbers.py
@@ -1,0 +1,31 @@
+"""Tests for deile.common.numbers — is_impar()."""
+
+import pytest
+
+from deile.common.numbers import is_impar
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        # Ímpares
+        (1, True),
+        (3, True),
+        (5, True),
+        (7, True),
+        (99, True),
+        (-1, True),
+        (-3, True),
+        (-99, True),
+        # Pares
+        (2, False),
+        (4, False),
+        (100, False),
+        (-2, False),
+        (-100, False),
+        # Zero
+        (0, False),
+    ],
+)
+def test_is_impar(n: int, expected: bool) -> None:
+    assert is_impar(n) == expected


### PR DESCRIPTION
Implementa função pura `is_impar(n)` em `deile/common/numbers.py` que retorna `True` se o inteiro `n` for ímpar.

**Casos cobertos pelos testes:**
- Números ímpares (positivos e negativos)
- Números pares (positivos e negativos)
- Zero (retorna `False`)
- Negativos

**Arquivos alterados:**
- `deile/common/numbers.py` — nova função `is_impar`
- `deile/common/__init__.py` — exporta `is_impar`
- `deile/tests/common/test_numbers.py` — 14 testes parametrizados

Closes #249.

By [DEILE One](mailto:deile@deile.info)