### PR TITLE
feat(pipeline): autonomous DEILE-to-DEILE loop with atomic claim and configurable tool budget

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Solicitação de Funcionalidade
 about: Proponha uma nova capacidade ou melhoria voltada ao usuário no DEILE
 title: '[FEATURE] '
-labels: 'enhancement'
+labels: 'feature'
 assignees: ''
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,44 @@ Entry point: `python3 deile.py` (CLI shell in `DeileAgentCLI`; all logic lives i
 | Imports | `isort --check-only deile/` |
 | Complexity | `radon cc deile/ -a` |
 
+## Kubernetes / cluster operations (deile-pipeline · deile-worker · deilebot · deile-shell)
+
+The cluster runs on **Rancher Desktop (k3s/containerd)**, namespace **`deile`**, single image **`deile-stack:local`** (`imagePullPolicy: Never`). All four pods share that image; `/app` is **baked at build time** (not mounted), so **code changes only go live after a rebuild + pod restart**. `kubectl` lives at `~/.rd/bin/kubectl` (may not be on `PATH`).
+
+Everything is driven by the orchestrator **`infra/k8s/deploy.py`** (run from repo root). It prints a plan before any mutating action; `--yes` skips the prompt, `--dry-run` shows the plan only.
+
+| Goal | Command |
+|---|---|
+| Interactive menu / list all verbs | `python3 infra/k8s/deploy.py` / `... help` |
+| **Rebuild image + restart pods** (deploy code changes) | `python3 infra/k8s/deploy.py k8s build --restart --yes` |
+| Provision / update the whole stack (idempotent) | `python3 infra/k8s/deploy.py k8s up` |
+| Rollout restart (no rebuild) | `python3 infra/k8s/deploy.py k8s restart` |
+| Pause / resume (scale 0 / 1; keeps data + Secrets) | `... k8s stop` / `... k8s start` |
+| Status (pods, deployments, services) | `python3 infra/k8s/deploy.py k8s status` |
+| Logs (bot + worker) | `python3 infra/k8s/deploy.py k8s logs [bot\|worker]` |
+| One-shot Job (fixed prompt) | `python3 infra/k8s/deploy.py k8s test` |
+| Clone a repo into `deile-shell` (allowlisted) | `python3 infra/k8s/deploy.py k8s clone <owner/repo>` |
+| **Teardown** (DELETES namespace + all data) | `python3 infra/k8s/deploy.py k8s down` |
+
+Direct `kubectl` (when you need a specific pod), `K=~/.rd/bin/kubectl`:
+
+```bash
+$K -n deile get pods,deployments,services
+$K -n deile logs deploy/deile-pipeline --tail=80          # or deploy/deile-worker, deploy/deilebot
+$K -n deile rollout status deployment/deile-pipeline --timeout=180s
+$K -n deile exec -it deploy/deile-shell -- python3 /app/wrapper.py deile   # interactive REPL in-cluster
+```
+
+Roles & control-plane ports: **deilebot** `:8765` (Discord I/O), **deile-worker** `:8766` (runs DEILE in-process for dispatch), **deile-pipeline** (the GitHub monitor — no Service, only "calls out"), **deile-shell** (`kubectl exec` only). Only `deile-pipeline` runs the autonomous monitor; the others never autostart it.
+
+**Pipeline label state machine** (issues): `~workflow:nova` → `~workflow:em_revisao` → `~workflow:revisada` → `~workflow:em_implementacao` → `~workflow:em_pr`. PRs: `~review:pendente` → `~review:em_andamento` → `~review:concluida`. Locks: `~batch:<sha8>` (claim), `~by:<id>` (owner). A failed/no-PR implementation **parks** in `~workflow:em_implementacao` (out of every stage's queue, no auto-retry) — **to requeue, move it back to `~workflow:revisada`**.
+
+> **Label edits must use the REST issues endpoint, NOT `gh issue/pr edit --add-label`** — the latter runs a GraphQL `login` query that demands the `read:org` scope (which the pipeline token lacks). The pipeline already does this in `github_client.py`; for manual ops:
+> ```bash
+> gh api -X POST   "repos/elimarcavalli/deile/issues/<N>/labels" -f 'labels[]=~workflow:revisada'
+> gh api -X DELETE "repos/elimarcavalli/deile/issues/<N>/labels/%7Eworkflow%3Arevisada"   # ~=%7E :=%3A
+> ```
+
 ## Gotchas (not in the system design)
 
 - **At least one provider API key is required at startup** — the agent exits if none are set. Configure any of: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, or `GOOGLE_API_KEY` in `.env` (loaded via `python-dotenv`). The `bootstrap_providers()` function in `deile/core/models/bootstrap.py` handles conditional registration.

--- a/config/pipeline_schedule_default.yaml
+++ b/config/pipeline_schedule_default.yaml
@@ -3,24 +3,24 @@ recurring:
   action: classify
   cron: '*/2 * * * *'
   enabled: true
-  last_run_at: null
+  last_run_at: '2026-05-21T22:22:12Z'
   replay_all: false
 - id: review_loop
   action: review
   cron: '*/3 * * * *'
   enabled: true
-  last_run_at: null
+  last_run_at: '2026-05-21T22:22:12Z'
   replay_all: false
 - id: implement_loop
   action: implement
   cron: '*/5 * * * *'
   enabled: true
-  last_run_at: null
+  last_run_at: '2026-05-21T22:22:11Z'
   replay_all: false
 - id: pr_review_loop
   action: pr_review
   cron: '*/4 * * * *'
   enabled: true
-  last_run_at: null
+  last_run_at: '2026-05-21T22:22:11Z'
   replay_all: false
 oneshot: []

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -618,28 +618,15 @@ async def _autostart_pipeline(agent) -> None:  # type: ignore[type-arg]
     import logging as _logging
     _log = _logging.getLogger(__name__)
     try:
-        from deile.config.settings import get_settings
-        from deile.orchestration.pipeline.constants import \
-            PIPELINE_DEFAULT_REPO
-        from deile.orchestration.pipeline.monitor import (PipelineConfig,
-                                                          PipelineMonitor)
+        from deile.orchestration.pipeline.monitor import (
+            PipelineMonitor, build_default_pipeline_config)
         from deile.orchestration.pipeline.review_callback import \
             make_review_callback
-        s = get_settings()
-        repo = s.pipeline_repo or PIPELINE_DEFAULT_REPO
-        base_path = s.pipeline_base_path
-        if base_path is None:
-            from pathlib import Path
-            base_path = Path.cwd()
-        cfg = PipelineConfig(
-            repo=repo,
-            base_repo_path=base_path.resolve(),
-            notify_user_id=s.pipeline_notify_user_id,
-        )
+        cfg = build_default_pipeline_config()
         monitor = PipelineMonitor(cfg, review_callback=make_review_callback(agent))
         agent.pipeline_monitor = monitor  # type: ignore[attr-defined]
         await monitor.start()
-        _log.info("pipeline autostarted (repo=%s)", repo)
+        _log.info("pipeline autostarted (repo=%s, dispatch=%s)", cfg.repo, cfg.dispatch_mode)
     except Exception as exc:  # noqa: BLE001 — autostart is best-effort; never abort CLI
         _log.warning("pipeline autostart failed: %s", exc)
 

--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -98,6 +98,20 @@ class PipelineCommand(DirectCommand):
         agent = context.agent
         monitor: Optional[PipelineMonitor] = getattr(agent, "pipeline_monitor", None)
 
+        # ``status`` must be HONEST about the process boundary: never fabricate a
+        # throwaway monitor just to report it as "parado". That is what misled
+        # the operator — running /pipeline status inside the deile-worker (which
+        # has no monitor) said "stopped" while the real autonomous pipeline (the
+        # separate ``deile-pipeline`` deployment) was running fine.
+        if sub == "status" and monitor is None:
+            return CommandResult(success=True, content=(
+                "📊 Nenhum monitor de pipeline rodando NESTE processo.\n"
+                "O pipeline autônomo roda como a deployment separada "
+                "`deile-pipeline` — verifique com `kubectl -n deile get deploy "
+                "deile-pipeline` e `kubectl -n deile logs deploy/deile-pipeline`.\n"
+                "(Para iniciar um monitor local: /pipeline start.)"
+            ))
+
         if monitor is None:
             from deile.orchestration.pipeline.post_merge_callback import \
                 make_post_merge_callback

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -35,6 +35,7 @@ _DEILE_DEPRECATED_ENV_VARS: Dict[str, str] = {
     "DEILE_PIPELINE_POLL_INTERVAL": "pipeline.poll_interval",
     "DEILE_PIPELINE_CLAUDE_TIMEOUT": "pipeline.claude_timeout",
     "DEILE_PIPELINE_AUTOSTART": "pipeline.autostart",
+    "DEILE_PIPELINE_DISPATCH_MODE": "pipeline.dispatch_mode",
     "DEILE_CRON_DB_PATH": "cron.db_path",
     "DEILE_CRON_POLL_INTERVAL": "cron.poll_interval",
     "DEILE_DEBUG": "debug.enabled",
@@ -273,10 +274,22 @@ class Settings:
     pipeline_poll_interval: int = 60
     pipeline_claude_timeout: int = 1800
     pipeline_autostart: bool = False  # gap #3: set True via DEILE_PIPELINE_AUTOSTART
+    # Implementation/review strategy: "deile_worker" (DEILE-to-DEILE via the
+    # worker Pod, the product default — Claude is optional) or "claude"
+    # (claude -p one-shot in a local worktree). Set via DEILE_PIPELINE_DISPATCH_MODE.
+    pipeline_dispatch_mode: str = "deile_worker"
 
     # Cron
     cron_db_path: Optional[Path] = None
     cron_poll_interval: int = 30
+
+    # Agent tool-loop
+    # Max function-calling rounds per turn before the loop is force-stopped. A
+    # real implementation (read files + edit + test + commit + push + open PR)
+    # easily exceeds a low cap, so the agent would stop before finishing.
+    # Override via DEILE_MAX_TOOL_ITERATIONS or settings.json
+    # `agent.max_tool_iterations`.
+    max_tool_iterations: int = 100
 
     # Perfil e skills (lidos via SettingsManager, mantidos aqui para conveniência)
     profile_name: str = "autonomous_agent"
@@ -615,8 +628,10 @@ _JSON_FIELD_MAP: Dict[str, str] = {
     "pipeline.claude_timeout": "pipeline_claude_timeout",
     "pipeline.notify_user_id": "pipeline_notify_user_id",
     "pipeline.autostart": "pipeline_autostart",
+    "pipeline.dispatch_mode": "pipeline_dispatch_mode",
     "cron.db_path": "cron_db_path",
     "cron.poll_interval": "cron_poll_interval",
+    "agent.max_tool_iterations": "max_tool_iterations",
     # Trust boundary (issue #125) — see ``_OVERRIDE_HANDLERS`` for the
     # strict converters; this map covers the layered-loading path.
     "trust.project_layer_dirs": "trust_project_layer_dirs",
@@ -809,6 +824,11 @@ def _apply_env_overrides(settings: "Settings") -> None:
     if raw:
         settings.pipeline_autostart = raw.lower().strip() in ("1", "true", "yes", "on")
 
+    raw = env("DEILE_PIPELINE_DISPATCH_MODE")
+    if raw:
+        _warn("DEILE_PIPELINE_DISPATCH_MODE", "pipeline.dispatch_mode")
+        settings.pipeline_dispatch_mode = raw.strip().lower()
+
     # cron
     raw = env("DEILE_CRON_DB_PATH")
     if raw:
@@ -820,6 +840,14 @@ def _apply_env_overrides(settings: "Settings") -> None:
         _warn("DEILE_CRON_POLL_INTERVAL", "cron.poll_interval")
         try:
             settings.cron_poll_interval = int(raw)
+        except ValueError:
+            pass
+
+    # Agent tool-loop cap — current knob (not deprecated), so no migration warning.
+    raw = env("DEILE_MAX_TOOL_ITERATIONS")
+    if raw:
+        try:
+            settings.max_tool_iterations = max(1, int(raw))
         except ValueError:
             pass
 

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -725,6 +725,12 @@ def _set_typed(settings: "Settings", attr: str, value: Any) -> None:
                 return
         elif isinstance(current, int) and not isinstance(value, bool):
             value = int(value)
+            # Symmetry with the DEILE_MAX_TOOL_ITERATIONS env path
+            # (``max(1, int(raw))``): a non-positive cap would disable tool use,
+            # so clamp the settings.json path too instead of relying on a
+            # downstream consumer to neutralise it.
+            if attr == "max_tool_iterations":
+                value = max(1, value)
         elif isinstance(current, Path) or (current is None and attr in (
             "pipeline_base_path", "cron_db_path", "deile_md_user_path"
         )):

--- a/deile/core/models/base.py
+++ b/deile/core/models/base.py
@@ -16,7 +16,14 @@ from deile.core.models.tier import ModelTier
 logger = logging.getLogger(__name__)
 
 # Defaults shared by tool-loop-capable providers (anthropic, openai, gemini).
-DEFAULT_MAX_TOOL_ITERATIONS = 25
+# 100 (raised from 25): a real implementation turn — read several files, edit,
+# run tests, fix, commit, push, open the PR — routinely needs well over 25
+# tool-call rounds, so a low cap silently truncated the agent before it could
+# finish (e.g. before opening the PR). Configurable per-deployment via
+# DEILE_MAX_TOOL_ITERATIONS / settings.json `agent.max_tool_iterations`, which
+# ToolLoopExecutor (the streaming path) reads; this constant is the fallback
+# and the cap for the legacy provider tool-loops.
+DEFAULT_MAX_TOOL_ITERATIONS = 100
 DEFAULT_MAX_OUTPUT_TOKENS = 16384
 
 if TYPE_CHECKING:

--- a/deile/core/tool_loop_executor.py
+++ b/deile/core/tool_loop_executor.py
@@ -48,6 +48,11 @@ def _resolve_max_iterations() -> int:
         value = int(getattr(get_settings(), "max_tool_iterations", MAX_TOOL_ITERATIONS))
         return value if value > 0 else MAX_TOOL_ITERATIONS
     except Exception:  # noqa: BLE001 — config errors must not disable tool use
+        logger.debug(
+            "max_tool_iterations config unavailable; using default %d",
+            MAX_TOOL_ITERATIONS,
+            exc_info=True,
+        )
         return MAX_TOOL_ITERATIONS
 
 

--- a/deile/core/tool_loop_executor.py
+++ b/deile/core/tool_loop_executor.py
@@ -35,6 +35,22 @@ logger = logging.getLogger(__name__)
 MAX_TOOL_ITERATIONS = DEFAULT_MAX_TOOL_ITERATIONS
 
 
+def _resolve_max_iterations() -> int:
+    """Configured tool-loop cap (settings/env), falling back to the constant.
+
+    Resolved at executor construction so ``DEILE_MAX_TOOL_ITERATIONS`` /
+    settings.json ``agent.max_tool_iterations`` take effect without a code
+    change. Config must never break the loop — any failure falls back to the
+    module constant.
+    """
+    try:
+        from deile.config.settings import get_settings
+        value = int(getattr(get_settings(), "max_tool_iterations", MAX_TOOL_ITERATIONS))
+        return value if value > 0 else MAX_TOOL_ITERATIONS
+    except Exception:  # noqa: BLE001 — config errors must not disable tool use
+        return MAX_TOOL_ITERATIONS
+
+
 class ToolLoopExecutor:
     """Run a multi-iteration tool-use loop against any provider.
 
@@ -52,12 +68,16 @@ class ToolLoopExecutor:
     def __init__(
         self,
         tool_registry: Optional[ToolRegistry] = None,
-        max_iterations: int = MAX_TOOL_ITERATIONS,
+        max_iterations: Optional[int] = None,
         event_publisher: Optional[Any] = None,
         loop_guard: Optional[ToolLoopGuard] = None,
     ) -> None:
         self._tool_registry = tool_registry or get_tool_registry()
-        self._max_iterations = max_iterations
+        # None → resolve from settings (DEILE_MAX_TOOL_ITERATIONS /
+        # agent.max_tool_iterations); an explicit value (e.g. from tests) wins.
+        self._max_iterations = (
+            max_iterations if max_iterations is not None else _resolve_max_iterations()
+        )
         self._event_publisher = event_publisher  # callable: (kind, name, **kw) -> awaitable
         # Each ``run()`` invocation builds its own guard (one per turn). The
         # constructor accepts an explicit guard only so tests can inject a

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -20,6 +20,7 @@ import shutil
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Iterable, List, Optional, Sequence, Tuple
+from urllib.parse import quote
 
 from deile.core.exceptions import DEILEError
 from deile.orchestration.pipeline._time_utils import format_iso_utc
@@ -238,21 +239,35 @@ class GitHubClient:
         labels_list = list(labels)
         if not labels_list:
             return
-        await self._run_checked(
-            kind, "edit", str(number),
-            "--repo", self.repo,
-            "--add-label", ",".join(labels_list),
-        )
+        # Use the REST issues endpoint (PRs ARE issues in REST) instead of
+        # ``gh {kind} edit --add-label``. For PRs, ``gh pr edit`` runs a
+        # GraphQL query that resolves the author ``login`` and demands the
+        # ``read:org`` token scope, which the pipeline token does not carry —
+        # so labeling a PR fails. The REST call needs only ``repo`` scope and
+        # behaves identically for issues and PRs.
+        args = ["api", "-X", "POST", f"repos/{self.repo}/issues/{number}/labels"]
+        for lb in labels_list:
+            args += ["-f", f"labels[]={lb}"]
+        await self._run_checked(*args)
 
     async def remove_labels(self, kind: str, number: int, labels: Iterable[str]) -> None:
         labels_list = list(labels)
         if not labels_list:
             return
-        await self._run_checked(
-            kind, "edit", str(number),
-            "--repo", self.repo,
-            "--remove-label", ",".join(labels_list),
-        )
+        # REST DELETE per label (see add_labels for why we avoid gh pr edit).
+        # The label name lives in the URL path, so it must be percent-encoded
+        # (``~`` and ``:`` in workflow/batch labels are reserved). A 404 means
+        # the label was not present — treat that as an idempotent no-op so a
+        # transition whose ``from_label`` is already absent doesn't error.
+        for lb in labels_list:
+            path = f"repos/{self.repo}/issues/{number}/labels/{quote(lb, safe='')}"
+            rc, out, err = await self._run("api", "-X", "DELETE", path)
+            if rc != 0:
+                low = err.lower()
+                if "404" in err or "not found" in low or "does not exist" in low:
+                    logger.debug("remove_labels: %r absent on #%d (ignored)", lb, number)
+                    continue
+                raise GhCommandError(("api", "-X", "DELETE", path), rc, out, err)
 
     async def transition_issue(
         self, number: int, *, from_label: Optional[str], to_label: str,

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -1,0 +1,295 @@
+"""Pluggable implementation/review strategy for the autonomous pipeline.
+
+The pipeline used to be hardwired to ``claude -p`` (Claude Code one-shot) for
+the *implement* and *review* stages. This module introduces a strategy so the
+heavy work can instead be dispatched to **another DEILE** — the long-running
+``deile-worker`` Pod — over HTTP. Claude becomes one configurable option among
+two, not a hard dependency.
+
+Two strategies:
+
+- :class:`ClaudeImplementer` — legacy path. Creates a local git worktree and
+  runs ``claude -p`` inside it. Behaviour is preserved verbatim from the
+  original inline code in :mod:`stages`.
+- :class:`WorkerImplementer` — DEILE-to-DEILE path. POSTs a brief to the
+  ``deile-worker`` control plane (:mod:`deile.infrastructure.deile_worker_client`).
+  The worker clones the repo, branches, implements/reviews, runs tests and
+  opens/merges the PR inside its own isolated workspace — so no local worktree
+  is created on the pipeline side.
+
+The monitor holds a single ``implementer`` (selected by
+``PipelineConfig.dispatch_mode``); the stage handlers in :mod:`stages` delegate
+the "do the work" step to it and keep the GitHub label orchestration to
+themselves.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from deile.orchestration.pipeline.claude_dispatcher import (
+    render_implement_prompt, render_mention_prompt, render_review_prompt)
+from deile.orchestration.pipeline.constants import ISSUE_BODY_MAX_CHARS
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from deile.orchestration.pipeline.github_client import (CommentRef,
+                                                            IssueRef, PrRef)
+    from deile.orchestration.pipeline.monitor import PipelineMonitor
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WorkOutcome:
+    """Result of one implement/review/mention unit of work.
+
+    ``text`` is the agent's stdout (Claude) or final summary (worker); the
+    stage handler scans it for a PR URL / the word ``merged``. ``error``
+    carries a short diagnostic when ``ok`` is False (surfaced to Discord).
+    """
+
+    ok: bool
+    text: str
+    error: str = ""
+
+
+class PipelineImplementer(ABC):
+    """Strategy that performs the implement / review / mention work."""
+
+    name: str = "base"
+
+    @abstractmethod
+    async def implement(self, monitor: "PipelineMonitor", issue: "IssueRef") -> WorkOutcome:
+        ...
+
+    @abstractmethod
+    async def review(self, monitor: "PipelineMonitor", pr: "PrRef") -> WorkOutcome:
+        ...
+
+    @abstractmethod
+    async def mention(self, monitor: "PipelineMonitor", ref: "CommentRef") -> WorkOutcome:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Claude Code one-shot (legacy strategy)
+# ---------------------------------------------------------------------------
+
+
+class ClaudeImplementer(PipelineImplementer):
+    """Run ``claude -p`` inside a local git worktree (legacy default).
+
+    Uses ``monitor.worktrees`` + ``monitor.claude`` exactly as the original
+    inline stage code did, so injecting a mocked ``claude``/``worktrees`` keeps
+    behaving identically.
+    """
+
+    name = "claude"
+
+    async def implement(self, monitor: "PipelineMonitor", issue: "IssueRef") -> WorkOutcome:
+        branch = monitor.branch_for_issue(issue.number)
+        # Re-use an existing worktree when present; force_recreate would delete
+        # and re-clone on every attempt (expensive) — reserve for /pipeline reset.
+        try:
+            worktree = await monitor.worktrees.create_branch_worktree(
+                branch, force_recreate=False
+            )
+        except Exception as exc:  # noqa: BLE001 — surface as a failed outcome
+            logger.exception("worktree setup for #%s failed", issue.number)
+            return WorkOutcome(ok=False, text="", error=f"worktree: {type(exc).__name__}: {exc}")
+        prompt = render_implement_prompt(
+            monitor.config.repo, issue.number, issue.title, issue.body
+        )
+        result = await monitor.claude.run(prompt, cwd=worktree.path)
+        return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
+
+    async def review(self, monitor: "PipelineMonitor", pr: "PrRef") -> WorkOutcome:
+        worktree_branch = pr.head_ref or f"pr/{pr.number}"
+        try:
+            wt = await monitor.worktrees.create_branch_worktree(worktree_branch)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("PR worktree #%s failed", pr.number)
+            return WorkOutcome(ok=False, text="", error=f"worktree: {type(exc).__name__}: {exc}")
+        prompt = render_review_prompt(monitor.config.repo, pr.number, pr.title)
+        result = await monitor.claude.run(prompt, cwd=wt.path)
+        return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
+
+    async def mention(self, monitor: "PipelineMonitor", ref: "CommentRef") -> WorkOutcome:
+        prompt = render_mention_prompt(
+            monitor.config.repo, ref.html_url, ref.body, ref.author
+        )
+        result = await monitor.claude.run(prompt, cwd=monitor.config.base_repo_path)
+        return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
+
+
+# ---------------------------------------------------------------------------
+# DEILE-to-DEILE via the deile-worker (HTTP)
+# ---------------------------------------------------------------------------
+
+# Briefs are deliberately explicit and imperative: the worker DEILE owns the
+# full clone → branch → implement → test → PR lifecycle inside its sandbox.
+# The worker envelope already pins its CWD and forbids escaping it, so the
+# briefs work strictly under ``./repo`` relative to that workspace.
+
+_WORKER_IMPLEMENT_BRIEF = """\
+Implemente a issue #{number} do repositório {repo} e abra uma Pull Request — execute de verdade, não simule nem invente.
+
+Passo a passo:
+1. Trabalhe na subpasta ./repo do seu diretório atual. Se ./repo não existir, rode: gh repo clone {repo} repo
+   Se já existir, entre nela e rode: git fetch origin && git checkout {main} && git reset --hard origin/{main}
+2. Dentro de ./repo, crie e dê checkout no branch {branch} a partir de {main}.
+3. Implemente a feature descrita na issue abaixo. Crie/edite os arquivos necessários e ADICIONE testes cobrindo todos os casos.
+4. Rode os testes e garanta 100% de aprovação. As dependências (incl. pytest) JÁ estão instaladas no ambiente — NÃO rode `pip install` (o filesystem é read-only). Para rodar só os testes novos sem esbarrar no gate global de cobertura: python3 -m pytest <arquivos_de_teste_novos> -p no:cov -q
+5. Faça commit atômico e `git push -u origin {branch}`.
+6. ABRA A PR (passo OBRIGATÓRIO — sem PR a tarefa NÃO está concluída):
+   gh pr create --repo {repo} --base {main} --head {branch} --title "<título coerente>" --body "<resumo>. Closes #{number}."
+7. CONFIRME que a PR existe antes de responder:
+   gh pr view {branch} --repo {repo} --json url -q .url
+   (se não retornar URL, a PR NÃO foi criada — volte ao passo 6 e crie de fato.)
+8. NÃO faça force-push. NÃO altere nada fora de ./repo.
+9. Na ÚLTIMA LINHA da resposta final, escreva SOMENTE a URL da PR confirmada no passo 7 (ex.: https://github.com/{repo}/pull/NN). Nada depois dela.
+
+DEFINITION OF DONE: existe uma PR aberta cuja URL você confirmou via gh. Se push/gh/testes falharem, reporte o erro REAL — NUNCA invente uma URL nem diga "concluído" sem a PR existir.
+
+=== Issue #{number}: {title} ===
+{body}
+"""
+
+_WORKER_REVIEW_BRIEF = """\
+Revise, corrija e mergeie a Pull Request #{number} do repositório {repo} — execute de verdade.
+
+1. Garanta um clone atualizado de {repo} em ./repo (gh repo clone {repo} repo se não existir; senão git fetch origin).
+2. Dentro de ./repo rode: gh pr checkout {number}
+3. Rode os testes. As dependências (incl. pytest) JÁ estão no ambiente — NÃO rode `pip install` (filesystem read-only). Para os testes do PR sem o gate global de cobertura: python3 -m pytest <arquivos> -p no:cov -q. Corrija o que falhar com commits normais (SEM force-push) e dê push.
+4. Quando 100% dos testes passarem, MERGEIE. NÃO tente `gh pr review --approve` (você é o autor da PR; o GitHub recusa auto-aprovação, e não há branch protection exigindo review). Mergeie via REST (evita o escopo read:org que o `gh pr merge` às vezes exige):
+   gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge
+   Se a REST falhar, tente: gh pr merge {number} --repo {repo} --merge
+5. Confirme o merge: gh pr view {number} --repo {repo} --json state,merged -q .merged  (deve ser true).
+6. Na ÚLTIMA LINHA escreva a URL da PR seguida da palavra MERGED, ex.: https://github.com/{repo}/pull/{number} MERGED
+   Se NÃO conseguir mergear, escreva a URL e o motivo real — NUNCA escreva MERGED sem ter mergeado de fato.
+"""
+
+_WORKER_MENTION_BRIEF = """\
+Você foi mencionado por @{author} em {context_url} (repositório {repo}).
+
+Mensagem recebida:
+{body}
+
+Responda de forma concreta ao que foi pedido e poste a resposta como comentário usando o gh
+(gh issue comment <n> --repo {repo}  ou  gh pr comment <n> --repo {repo}) apontando para {context_url}.
+"""
+
+
+def _render_worker_implement_brief(
+    repo: str, main: str, branch: str, number: int, title: str, body: str
+) -> str:
+    return _WORKER_IMPLEMENT_BRIEF.format(
+        repo=repo,
+        main=main,
+        branch=branch,
+        number=number,
+        title=title,
+        body=(body or "").strip()[:ISSUE_BODY_MAX_CHARS] or "(sem corpo — implemente a partir do título)",
+    )
+
+
+def _render_worker_review_brief(repo: str, main: str, number: int, title: str) -> str:
+    return _WORKER_REVIEW_BRIEF.format(repo=repo, main=main, number=number, title=title)
+
+
+def _render_worker_mention_brief(repo: str, context_url: str, body: str, author: str) -> str:
+    return _WORKER_MENTION_BRIEF.format(
+        repo=repo, context_url=context_url, body=(body or "").strip()[:2000], author=author
+    )
+
+
+class WorkerImplementer(PipelineImplementer):
+    """Dispatch implement/review/mention work to the ``deile-worker`` Pod.
+
+    The worker is another DEILE running the full toolset behind an HTTP
+    control plane. It clones the repo, branches, implements/reviews, runs
+    tests and opens/merges the PR in its own isolated, per-channel workspace.
+    The pipeline-side ``channel_id`` is synthetic (``pipeline-issue-<N>`` /
+    ``pipeline-pr-<N>``) so each work item gets a stable, reusable sandbox.
+    """
+
+    name = "deile_worker"
+
+    def __init__(self, client: Optional[object] = None) -> None:
+        if client is None:
+            from deile.infrastructure.deile_worker_client import \
+                DeileWorkerClient
+            client = DeileWorkerClient()
+        self._client = client
+
+    async def _dispatch(self, brief: str, *, channel_id: str) -> WorkOutcome:
+        from deile.infrastructure.deile_worker_client import (
+            WorkerDispatchError, build_dispatch_payload)
+
+        payload = build_dispatch_payload(
+            brief=brief, channel_id=channel_id, persona="developer", wait=True
+        )
+        try:
+            data = await self._client.dispatch(payload, wait=True)
+        except WorkerDispatchError as exc:
+            return WorkOutcome(ok=False, text="", error=f"{exc.error_code}: {exc}"[:500])
+        except Exception as exc:  # noqa: BLE001 — never crash the tick
+            logger.exception("worker dispatch raised")
+            return WorkOutcome(ok=False, text="", error=f"{type(exc).__name__}: {exc}"[:500])
+        ok = bool(data.get("ok")) if isinstance(data, dict) else False
+        text = str(data.get("summary") or "") if isinstance(data, dict) else ""
+        if ok:
+            return WorkOutcome(ok=True, text=text, error="")
+        err = ""
+        if isinstance(data, dict):
+            err = str(data.get("error") or data.get("summary") or "worker reported failure")
+        return WorkOutcome(ok=False, text=text, error=err[:500])
+
+    async def implement(self, monitor: "PipelineMonitor", issue: "IssueRef") -> WorkOutcome:
+        branch = monitor.branch_for_issue(issue.number)
+        brief = _render_worker_implement_brief(
+            monitor.config.repo, monitor.config.main_branch, branch,
+            issue.number, issue.title, issue.body,
+        )
+        return await self._dispatch(brief, channel_id=f"pipeline-issue-{issue.number}")
+
+    async def review(self, monitor: "PipelineMonitor", pr: "PrRef") -> WorkOutcome:
+        brief = _render_worker_review_brief(
+            monitor.config.repo, monitor.config.main_branch, pr.number, pr.title
+        )
+        return await self._dispatch(brief, channel_id=f"pipeline-pr-{pr.number}")
+
+    async def mention(self, monitor: "PipelineMonitor", ref: "CommentRef") -> WorkOutcome:
+        brief = _render_worker_mention_brief(
+            monitor.config.repo, ref.html_url, ref.body, ref.author
+        )
+        return await self._dispatch(brief, channel_id="pipeline-mentions")
+
+
+# ---------------------------------------------------------------------------
+# factory
+# ---------------------------------------------------------------------------
+
+_WORKER_ALIASES = frozenset({"deile_worker", "worker", "deile", "deile-worker"})
+_CLAUDE_ALIASES = frozenset({"claude", "claude_code", "claude-code"})
+
+
+def build_implementer(
+    dispatch_mode: str, *, worker_client: Optional[object] = None
+) -> PipelineImplementer:
+    """Return the implementer strategy selected by ``dispatch_mode``.
+
+    ``deile_worker`` (and aliases) → :class:`WorkerImplementer`;
+    ``claude`` (and aliases) → :class:`ClaudeImplementer`. An unknown value
+    falls back to Claude with a warning, since that is the original behaviour.
+    """
+    mode = (dispatch_mode or "claude").strip().lower()
+    if mode in _WORKER_ALIASES:
+        return WorkerImplementer(client=worker_client)
+    if mode in _CLAUDE_ALIASES:
+        return ClaudeImplementer()
+    logger.warning("unknown pipeline dispatch_mode %r; falling back to 'claude'", dispatch_mode)
+    return ClaudeImplementer()

--- a/deile/orchestration/pipeline/labels.py
+++ b/deile/orchestration/pipeline/labels.py
@@ -15,13 +15,19 @@ from __future__ import annotations
 # Issue workflow ----------------------------------------------------------
 # Only the states actually transitioned by the pipeline live here.
 # Stage 0 sets ``WORKFLOW_NEW``, Stage 1 transitions to ``WORKFLOW_REVIEWING``
-# and then ``WORKFLOW_REVIEWED``, Stage 2 to ``WORKFLOW_PR``. There is
-# currently no handler that transitions through ``em_implementacao`` or
-# closes to ``concluida`` (the PR is the final state for the issue's
-# perspective), so those labels are intentionally absent.
+# and then ``WORKFLOW_REVIEWED``. Stage 2 *claims* the issue by transitioning
+# ``WORKFLOW_REVIEWED`` → ``WORKFLOW_IMPLEMENTING`` BEFORE doing any work — this
+# is the lock that stops the same issue from being picked up twice (the
+# candidate query only returns ``WORKFLOW_REVIEWED`` issues, so a claimed one
+# drops out of the set) — then moves it to ``WORKFLOW_PR`` on success. An
+# implementation that fails or opens no PR stays parked in
+# ``WORKFLOW_IMPLEMENTING`` (out of every stage's candidate set) until a human
+# moves it back to ``WORKFLOW_REVIEWED``. There is no ``concluida`` close state
+# — the PR is the final state from the issue's perspective — so it is absent.
 WORKFLOW_NEW = "~workflow:nova"
 WORKFLOW_REVIEWING = "~workflow:em_revisao"
 WORKFLOW_REVIEWED = "~workflow:revisada"
+WORKFLOW_IMPLEMENTING = "~workflow:em_implementacao"
 WORKFLOW_PR = "~workflow:em_pr"
 
 # PR workflow -------------------------------------------------------------
@@ -36,6 +42,7 @@ WORKFLOW_LABELS = (
     WORKFLOW_NEW,
     WORKFLOW_REVIEWING,
     WORKFLOW_REVIEWED,
+    WORKFLOW_IMPLEMENTING,
     WORKFLOW_PR,
 )
 
@@ -45,6 +52,7 @@ LABEL_COLORS = {
     WORKFLOW_NEW: "0e8a16",
     WORKFLOW_REVIEWING: "fbca04",
     WORKFLOW_REVIEWED: "5319e7",
+    WORKFLOW_IMPLEMENTING: "fbca04",
     WORKFLOW_PR: "0052cc",
     REVIEW_PENDING: "0e8a16",
     REVIEW_IN_PROGRESS: "fbca04",
@@ -55,6 +63,7 @@ LABEL_DESCRIPTIONS = {
     WORKFLOW_NEW: "Pipeline: issue nova, ainda não revisada",
     WORKFLOW_REVIEWING: "Pipeline: DEILE revisando (lock)",
     WORKFLOW_REVIEWED: "Pipeline: revisada, pronta para implementação",
+    WORKFLOW_IMPLEMENTING: "Pipeline: DEILE implementando (lock)",
     WORKFLOW_PR: "Pipeline: PR aberta",
     REVIEW_PENDING: "Pipeline: PR aguardando revisão",
     REVIEW_IN_PROGRESS: "Pipeline: PR em revisão (lock)",

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -34,6 +34,8 @@ from deile.orchestration.pipeline.constants import (
     PIPELINE_POLL_INTERVAL_SECONDS, PIPELINE_STOP_TIMEOUT_SECONDS)
 from deile.orchestration.pipeline.github_client import GitHubClient, IssueRef
 from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.orchestration.pipeline.implementer import (PipelineImplementer,
+                                                      build_implementer)
 from deile.orchestration.pipeline.lockfile import LockHeldError
 from deile.orchestration.pipeline.lockfile import acquire as acquire_lock
 from deile.orchestration.pipeline.lockfile import release as release_lock
@@ -70,8 +72,18 @@ class PipelineConfig:
     enable_pr_review: bool = True
     enable_classify: bool = True
     enable_follow_ups: bool = True
+    # Labels que disparam a auto-classificação. Convenção do projeto: o label
+    # CANÔNICO é IDÊNTICO ao prefixo entre colchetes do título da issue
+    # (``[FEATURE]`` → ``feature``, ``[BUG]`` → ``bug``, ``[INTENT]`` →
+    # ``intent``, ``[REFACTOR]`` → ``refactor``), espelhando o ``labels:`` dos
+    # templates em ``.github/ISSUE_TEMPLATE/``. ``security`` é aceito sem
+    # template dedicado. ``enhancement`` entra como alias tolerado: é o label
+    # padrão do GitHub para features e o que o template antigo aplicava — sem
+    # ele, uma issue de feature criada com o label convencional ficava
+    # invisível ao pipeline (foi exatamente o que travou a demo: a #247 nasceu
+    # com ``enhancement`` e só andou quando virou ``intent``).
     classifiable_labels: frozenset = frozenset(
-        {"intent", "bug", "refactor", "feature_request", "security"}
+        {"intent", "bug", "refactor", "feature", "enhancement", "security"}
     )
     classify_skip_labels: frozenset = frozenset({"infra"})
     enable_pr_triage: bool = True
@@ -86,6 +98,15 @@ class PipelineConfig:
     bootstrap_replay_window_hours: Optional[int] = 1
     # When True, cleanup_merged_branches() runs once on startup.
     enable_worktree_cleanup: bool = True
+    # Which strategy implements/reviews the work (see ``implementer.py``):
+    #   "claude"       → run ``claude -p`` in a local git worktree (legacy);
+    #   "deile_worker" → dispatch to the deile-worker Pod over HTTP (DEILE-to-DEILE).
+    # The dataclass default stays "claude" so hand-built configs (unit tests
+    # that inject a mocked ``claude``) keep the legacy behaviour. The *product*
+    # default is "deile_worker", resolved from settings in
+    # ``build_default_pipeline_config`` — every real entry point (CLI autostart,
+    # /pipeline tool/command, the deile-pipeline deployment) uses the worker.
+    dispatch_mode: str = "claude"
 
 
 def build_default_pipeline_config(*, use_pid_lock: bool = True) -> PipelineConfig:
@@ -101,11 +122,18 @@ def build_default_pipeline_config(*, use_pid_lock: bool = True) -> PipelineConfi
     from deile.orchestration.pipeline.constants import resolve_pipeline_repo
     from deile.tools._pipeline_paths import resolve_base_path
 
+    settings = get_settings()
+    dispatch_mode = (settings.pipeline_dispatch_mode or "deile_worker").strip().lower()
     return PipelineConfig(
         repo=resolve_pipeline_repo(),
         base_repo_path=resolve_base_path(),
-        notify_user_id=get_settings().pipeline_notify_user_id,
+        notify_user_id=settings.pipeline_notify_user_id,
         use_pid_lock=use_pid_lock,
+        dispatch_mode=dispatch_mode,
+        # The deile_worker path implements/reviews inside the worker Pod; the
+        # pipeline process has no local clone, so the on-startup worktree
+        # cleanup would only emit warnings. Keep it for the claude path.
+        enable_worktree_cleanup=dispatch_mode in ("claude", "claude_code", "claude-code"),
     )
 
 
@@ -145,16 +173,34 @@ class PipelineMonitor:
         post_merge_callback: Optional[Callable[[int, str, str], Awaitable[None]]] = None,
         identity: Optional[MonitorIdentity] = None,
         schedule_store: Optional[ScheduleStore] = None,
+        implementer: Optional[PipelineImplementer] = None,
     ) -> None:
         self.config = config
         self.identity = identity or MonitorIdentity.from_env()
         self.github = github or GitHubClient(config.repo)
-        self.worktrees = worktrees or WorktreeManager(
-            config.base_repo_path,
-            main_branch=config.main_branch,
-            subdir=self.identity.worktree_subdir(),
-        )
+        # WorktreeManager validates that base_repo_path is a git repo at
+        # construction. The deile_worker strategy never creates local
+        # worktrees (the worker Pod owns its own clone) and runs where
+        # base_repo_path is typically NOT a git repo — so only build the
+        # manager for the claude strategy (or when one is injected).
+        if worktrees is not None:
+            self.worktrees = worktrees
+        elif (config.dispatch_mode or "claude").strip().lower() in (
+            "claude", "claude_code", "claude-code"
+        ):
+            self.worktrees = WorktreeManager(
+                config.base_repo_path,
+                main_branch=config.main_branch,
+                subdir=self.identity.worktree_subdir(),
+            )
+        else:
+            self.worktrees = None
         self.claude = claude or ClaudeDispatcher()
+        # Strategy that does the implement/review/mention work. When not
+        # injected it is selected from ``config.dispatch_mode``: "claude"
+        # uses ``self.claude`` + ``self.worktrees``; "deile_worker" dispatches
+        # to the worker Pod over HTTP. Stage handlers delegate to it.
+        self.implementer = implementer or build_implementer(config.dispatch_mode)
         self.notifier = notifier or DiscordNotifier(config.notify_user_id)
         self._review_cb = review_callback
         self._stats = _Stats()
@@ -259,7 +305,7 @@ class PipelineMonitor:
     async def _catch_up_pending(self) -> None:
         """On startup, drain any schedule entries whose time already passed."""
         # Opportunistic cleanup: remove on-disk worktrees for already-merged PRs.
-        if self.config.enable_worktree_cleanup:
+        if self.config.enable_worktree_cleanup and self.worktrees is not None:
             try:
                 merged_prs = await self.github.list_recently_merged_prs(limit=100)
                 merged_branches = [pr.head_ref for pr in merged_prs if pr.head_ref]

--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -18,7 +18,9 @@ import logging
 from typing import Awaitable, Callable, Optional
 
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
-from deile.orchestration.pipeline.labels import WORKFLOW_NEW
+from deile.orchestration.pipeline.labels import (WORKFLOW_IMPLEMENTING,
+                                                 WORKFLOW_NEW,
+                                                 WORKFLOW_REVIEWED)
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +116,22 @@ class DiscordNotifier:
             await self._send(
                 f"⚠️ **Implementação finalizada sem PR** para issue #{number}"
             )
+
+    async def implementation_parked(self, number: int, reason: str) -> None:
+        """Fired when an implementation attempt failed or opened no PR.
+
+        The issue is left parked in ``~workflow:em_implementacao`` (out of every
+        stage's candidate set) with NO automatic retry — so this DM is sent at
+        most once per attempt, never on a loop. The message is actionable: to
+        retry, the operator moves the label back to ``~workflow:revisada``.
+        """
+        await self._send(
+            f"⏸️ **Implementação pausada** — issue #{number}: "
+            f"{reason[:PIPELINE_MSG_TRUNCATE_CHARS]}\n"
+            f"A issue ficou em `{WORKFLOW_IMPLEMENTING}` (fora da fila, sem "
+            f"re-tentativa automática). Para tentar de novo, mova o label de "
+            f"volta para `{WORKFLOW_REVIEWED}`."
+        )
 
     async def pr_picked_up(self, number: int, title: str, url: str) -> None:
         await self._send(

--- a/deile/orchestration/pipeline/runner.py
+++ b/deile/orchestration/pipeline/runner.py
@@ -1,0 +1,85 @@
+"""Headless entrypoint that runs the :class:`PipelineMonitor` until killed.
+
+Used by the ``deile-pipeline`` deployment (via the ``pipeline`` role of
+``infra/k8s/wrapper.py``) to run the autonomous issue → PR → merge loop as a
+long-lived process with **no TTY, CLI or ``rich`` dependency** — it imports
+only the monitor + config, never ``deile.cli``.
+
+When ``dispatch_mode == "deile_worker"`` (the product default) the monitor
+needs no local LLM provider: it orchestrates via the ``gh`` CLI and dispatches
+the heavy implement/review work to the ``deile-worker`` Pod over HTTP. That is
+why this runner does **not** call ``bootstrap_providers`` or construct a
+``DeileAgent`` — keeping the pipeline Pod lean.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+
+logger = logging.getLogger("deile.pipeline.runner")
+
+
+def _build_notifier(user_id: str):
+    """DiscordNotifier whose DM sender routes through the bot control plane.
+
+    The default :func:`send_discord_dm` path spins up a ``discord.Client`` and
+    needs ``DEILE_BOT_DISCORD_TOKEN`` — which the pipeline Pod does not carry.
+    The Pod *does* have ``DEILE_BOT_ENDPOINT`` + ``DEILE_BOT_AUTH_TOKEN``, so we
+    send DMs through the bot's control plane (the same facade the worker uses
+    for status messages). When ``user_id`` is empty the notifier is disabled
+    and the dm_fn is never invoked.
+    """
+    from deile.orchestration.pipeline.notifier import DiscordNotifier
+
+    async def _dm(uid: str, text: str):
+        from deile.integrations.bot import get_bot_client
+        return await get_bot_client().dm_send(user_id=uid, text=text)
+
+    return DiscordNotifier(user_id or None, dm_fn=_dm)
+
+
+async def run_pipeline_forever() -> int:
+    """Build the monitor from settings, start it, and block until SIGTERM/SIGINT."""
+    from deile.orchestration.pipeline.monitor import (
+        PipelineMonitor, build_default_pipeline_config)
+
+    cfg = build_default_pipeline_config()
+    # review_callback stays None on purpose: the optional issue-body summary
+    # would require a local LLM agent. The pipeline still flows
+    # nova → revisada → implement without it; the worker does the real work.
+    monitor = PipelineMonitor(cfg, notifier=_build_notifier(cfg.notify_user_id or ""))
+    logger.info(
+        "starting pipeline monitor (repo=%s, dispatch=%s, poll=%ss, identity=%s)",
+        cfg.repo, cfg.dispatch_mode, cfg.poll_interval_seconds,
+        monitor.identity.monitor_id,
+    )
+    await monitor.start()
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except (NotImplementedError, RuntimeError):  # pragma: no cover — non-unix
+            pass
+    try:
+        await stop.wait()
+    finally:
+        logger.info("stopping pipeline monitor")
+        await monitor.stop()
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(
+        level="INFO",
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    return asyncio.run(run_pipeline_forever())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+    sys.exit(main())

--- a/deile/orchestration/pipeline/runner.py
+++ b/deile/orchestration/pipeline/runner.py
@@ -10,6 +10,13 @@ needs no local LLM provider: it orchestrates via the ``gh`` CLI and dispatches
 the heavy implement/review work to the ``deile-worker`` Pod over HTTP. That is
 why this runner does **not** call ``bootstrap_providers`` or construct a
 ``DeileAgent`` — keeping the pipeline Pod lean.
+
+Throughput tradeoff: ``tick()`` runs sequentially in a single loop, and in
+``deile_worker`` mode implement/review delegate to a blocking (``wait=True``)
+worker dispatch. A single long implementation therefore stalls the whole tick
+— PR review, mention handling, every other issue — until it returns. This is
+intentional for now (one worker does one thing at a time); interleaving long
+work as a background task is tracked separately (see issue #254).
 """
 
 from __future__ import annotations

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -355,13 +355,18 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
     )
     if target is None:
         return
-    # Atomic claim BEFORE any notification or work: move the issue out of
-    # ~workflow:revisada and into ~workflow:em_implementacao. This is the lock
-    # that stops the SAME issue from being picked up twice — the candidate
-    # query (list_issues_with_label) only returns ~workflow:revisada issues, so
-    # once claimed the issue drops out of the set for every later tick (and any
-    # second monitor). Without this claim, an issue that never produces a PR
-    # (e.g. a vague/meta issue the worker cannot implement) was re-selected and
+    # Best-effort claim (sequential-tick lock) BEFORE any notification or work:
+    # move the issue out of ~workflow:revisada and into ~workflow:em_implementacao.
+    # The candidate query (list_issues_with_label) only returns
+    # ~workflow:revisada issues, so once claimed the issue drops out of the set
+    # for every LATER tick — which is what stops the SAME issue from being
+    # re-picked across sequential ticks. NOTE: transition_issue is remove-then-add
+    # over two REST calls (not a single atomic op), so two genuinely concurrent
+    # monitors could still both observe ~workflow:revisada and double-claim;
+    # multi-monitor safety relies on the PID lock + single-replica Recreate +
+    # hash sharding of the shipped deile-pipeline deployment, not on this label
+    # flip. Without this claim, an issue that never produces a PR (e.g. a
+    # vague/meta issue the worker cannot implement) was re-selected and
     # re-dispatched on every tick, flooding the operator with duplicate
     # "Implementação iniciada" DMs.
     try:

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -22,16 +22,15 @@ import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
 
-from deile.orchestration.pipeline.claude_dispatcher import (
-    render_implement_prompt, render_mention_prompt, render_review_prompt)
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
 from deile.orchestration.pipeline.follow_up_detector import detect_follow_ups
 from deile.orchestration.pipeline.github_client import (CommentRef,
                                                         GhCommandError)
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
-                                                 REVIEW_PENDING, WORKFLOW_NEW,
-                                                 WORKFLOW_PR,
+                                                 REVIEW_PENDING,
+                                                 WORKFLOW_IMPLEMENTING,
+                                                 WORKFLOW_NEW, WORKFLOW_PR,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING)
 
@@ -146,6 +145,16 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
             logger.error("auto-classify label #%s failed: %s", issue.number, exc)
             await monitor.notifier.error(f"auto-classify #{issue.number}", f"{type(exc).__name__}: {exc}")
             continue
+        # Release the classify claim so Stage 1 (review) can pick the issue up
+        # via its own claim — review_one_new_issue only considers issues with
+        # ``batch_id is None``. Mirrors classify_new_prs; without this the
+        # auto-classify → review handoff deadlocks (the issue stays ~nova
+        # forever, batch-locked). Best-effort: the ~workflow:nova label is
+        # already applied, so a clear failure must not abort the loop.
+        try:
+            await monitor.github.clear_batch_label("issue", issue.number)
+        except Exception as exc:  # noqa: BLE001 — label applied; clear is best-effort
+            logger.warning("auto-classify: could not clear batch on #%s: %s", issue.number, exc)
         monitor._stats.issues_classified += 1
         logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
         await monitor.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
@@ -229,19 +238,15 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
     for ref in all_comments:
         if handle not in ref.body.lower():
             continue
-        prompt = render_mention_prompt(
-            monitor.config.repo, ref.html_url, ref.body, ref.author
-        )
         try:
-            result = await monitor.claude.run(prompt, cwd=monitor.config.base_repo_path)
-            if not result.ok:
-                logger.warning(
-                    "mention dispatch failed (rc=%d) for %s",
-                    result.returncode, ref.html_url,
-                )
-                continue
+            outcome = await monitor.implementer.mention(monitor, ref)
         except Exception as exc:  # noqa: BLE001
             logger.warning("mention dispatch error for %s: %s", ref.html_url, exc)
+            continue
+        if not outcome.ok:
+            logger.warning(
+                "mention dispatch failed for %s: %s", ref.html_url, outcome.error
+            )
             continue
         monitor._stats.mentions_processed += 1
         logger.info("mention processed: %s by @%s", ref.html_url, ref.author)
@@ -337,6 +342,12 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
         (
             i for i in issues
             if WORKFLOW_PR not in i.labels
+            # Defense-in-depth: never re-pick an issue already claimed for
+            # implementation. The list query is scoped to WORKFLOW_REVIEWED so a
+            # cleanly-claimed issue already drops out, but this guards the edge
+            # case of an issue transiently carrying both labels (partial
+            # transition, operator mislabel) — the bug class behind #253.
+            and WORKFLOW_IMPLEMENTING not in i.labels
             and monitor._this_monitor_owns(i)
             and (i.batch_id is not None or ownership_label in i.labels)
         ),
@@ -344,37 +355,67 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
     )
     if target is None:
         return
-    branch = monitor.branch_for_issue(target.number)
-    await monitor.notifier.implementation_started(target.number, target.title, branch)
-    # Re-use an existing worktree when present; force_recreate=True would delete and
-    # re-clone on every attempt which is expensive — reserve for explicit /pipeline reset.
-    try:
-        worktree = await monitor.worktrees.create_branch_worktree(
-            branch, force_recreate=False
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception("worktree setup for #%s failed", target.number)
-        await monitor.notifier.error(
-            f"worktree #{target.number}", f"{type(exc).__name__}: {exc}"
-        )
-        monitor._stats.errors += 1
-        return
-    prompt = render_implement_prompt(monitor.config.repo, target.number, target.title, target.body)
-    result = await monitor.claude.run(prompt, cwd=worktree.path)
-    pr_url = _extract_pr_url(result.stdout)
-    if not result.ok:
-        # ClaudeDispatcher already logs auth-specific warnings when prefer_subscription_auth=True.
-        monitor._stats.errors += 1
-        monitor._stats.claude_errors += 1
-        err_detail = result.stderr.strip()[:PIPELINE_MSG_TRUNCATE_CHARS] or "non-zero exit"
-        logger.error(
-            "implement #%d: claude returned rc=%d: %s", target.number, result.returncode, err_detail
-        )
-        await monitor.notifier.error(f"implement #{target.number}", err_detail)
-        return
+    # Atomic claim BEFORE any notification or work: move the issue out of
+    # ~workflow:revisada and into ~workflow:em_implementacao. This is the lock
+    # that stops the SAME issue from being picked up twice — the candidate
+    # query (list_issues_with_label) only returns ~workflow:revisada issues, so
+    # once claimed the issue drops out of the set for every later tick (and any
+    # second monitor). Without this claim, an issue that never produces a PR
+    # (e.g. a vague/meta issue the worker cannot implement) was re-selected and
+    # re-dispatched on every tick, flooding the operator with duplicate
+    # "Implementação iniciada" DMs.
     try:
         await monitor.github.transition_issue(
-            target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_PR
+            target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_IMPLEMENTING
+        )
+    except GhCommandError as exc:
+        await _record_gh_error(
+            monitor, f"could not claim issue #{target.number} for implementation", exc,
+            notifier_label=f"implement claim #{target.number}",
+        )
+        return
+    branch = monitor.branch_for_issue(target.number)
+    await monitor.notifier.implementation_started(target.number, target.title, branch)
+    # Delegate the actual implementation to the configured strategy
+    # (claude -p in a worktree, or a dispatch to the deile-worker). The
+    # strategy returns a uniform outcome; label orchestration stays here.
+    outcome = await monitor.implementer.implement(monitor, target)
+    pr_url = _extract_pr_url(outcome.text)
+    # A real failure (worker errored / unreachable): the issue is now parked in
+    # ~workflow:em_implementacao (NOT reverted to revisada), so it will not be
+    # re-picked. Ping the operator once; requeue is a deliberate human action
+    # (move the label back to ~workflow:revisada). Auto-retry-forever was what
+    # produced the duplicate-DM storm.
+    if not outcome.ok:
+        monitor._stats.errors += 1
+        monitor._stats.claude_errors += 1
+        err_detail = (outcome.error or "implementation failed")[:PIPELINE_MSG_TRUNCATE_CHARS]
+        logger.error(
+            "implement #%d failed: %s — parked in %s",
+            target.number, err_detail, WORKFLOW_IMPLEMENTING,
+        )
+        await monitor.notifier.implementation_parked(target.number, err_detail)
+        return
+    # ok=True but no PR URL: the agent finished its turn without actually
+    # opening a PR (common for vague/meta issues). Same treatment as a failure
+    # — park in ~workflow:em_implementacao and notify once, never silently
+    # retry (the silent retry kept the issue in revisada and re-fired the
+    # "Implementação iniciada" DM every tick).
+    if not pr_url:
+        monitor._stats.errors += 1
+        monitor._stats.claude_errors += 1
+        logger.warning(
+            "implement #%d: agent finished but produced no PR URL — parked in %s",
+            target.number, WORKFLOW_IMPLEMENTING,
+        )
+        await monitor.notifier.implementation_parked(
+            target.number, "o agente finalizou sem abrir PR"
+        )
+        return
+    # Success: a real PR exists. Move ~workflow:em_implementacao → ~workflow:em_pr.
+    try:
+        await monitor.github.transition_issue(
+            target.number, from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_PR
         )
     except GhCommandError as exc:
         await _record_gh_error(
@@ -426,27 +467,17 @@ async def review_one_open_pr(monitor: "PipelineMonitor") -> None:
     except GhCommandError:
         # ~review:pendente may not be set; that's ok.
         await monitor.github.add_labels("pr", target.number, [REVIEW_IN_PROGRESS])
-    # The PR was opened on a branch — for the worktree, we just need a
-    # checkout of that branch. Use the same naming convention if the branch
-    # follows it; otherwise fall back to ``main`` and let Claude `gh pr
-    # checkout`.
-    worktree_branch = target.head_ref or f"pr/{target.number}"
-    try:
-        wt = await monitor.worktrees.create_branch_worktree(worktree_branch)
-    except Exception as exc:  # noqa: BLE001
-        await monitor.notifier.error(
-            f"PR worktree #{target.number}", f"{type(exc).__name__}: {exc}"
-        )
-        monitor._stats.errors += 1
-        return
-    prompt = render_review_prompt(monitor.config.repo, target.number, target.title)
-    result = await monitor.claude.run(prompt, cwd=wt.path)
-    merged = result.ok and "merged" in result.stdout.lower()
-    if not result.ok:
+    # Delegate the review/merge work to the configured strategy. The Claude
+    # strategy checks out the branch in a worktree; the worker strategy clones
+    # and runs ``gh pr checkout`` inside its own sandbox.
+    outcome = await monitor.implementer.review(monitor, target)
+    merged = outcome.ok and "merged" in outcome.text.lower()
+    if not outcome.ok:
         monitor._stats.errors += 1
         monitor._stats.claude_errors += 1
         logger.error(
-            "pr_review #%d: claude returned rc=%d", target.number, result.returncode
+            "pr_review #%d failed: %s", target.number,
+            (outcome.error or "review failed")[:PIPELINE_MSG_TRUNCATE_CHARS],
         )
     try:
         await monitor.github.transition_pr(

--- a/deile/tests/core/test_tool_loop_executor.py
+++ b/deile/tests/core/test_tool_loop_executor.py
@@ -278,6 +278,24 @@ async def test_max_iterations_caps_loop(monkeypatch):
     assert sum(1 for e in events if e.type == StreamEventType.TOOL_RESULT) == 3
 
 
+def test_max_iterations_defaults_to_configured_setting(monkeypatch):
+    # No explicit cap → resolved from settings (DEILE_MAX_TOOL_ITERATIONS /
+    # agent.max_tool_iterations). Raised from 25 to 100 so a real implementation
+    # turn (read files + edit + test + commit + push + open PR) isn't truncated.
+    from deile.config.settings import get_settings
+    from deile.core.tool_loop_executor import _resolve_max_iterations
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "max_tool_iterations", 137, raising=False)
+    assert _resolve_max_iterations() == 137
+    assert ToolLoopExecutor(tool_registry=FakeRegistry())._max_iterations == 137
+    # An explicit value always wins over the configured setting.
+    assert (
+        ToolLoopExecutor(tool_registry=FakeRegistry(), max_iterations=5)._max_iterations
+        == 5
+    )
+
+
 @pytest.mark.asyncio
 async def test_iteration_field_is_set_on_events():
     provider = FakeProvider(

--- a/deile/tests/infra/test_infra_tooling.py
+++ b/deile/tests/infra/test_infra_tooling.py
@@ -52,38 +52,63 @@ def test_set_color_toggles_state():
 
 # ===== deploy.py — parse_args ================================================
 
-def test_parse_args_empty_is_help():
-    assert deploy.parse_args([])["command"] == "help"
+def test_parse_args_empty_has_no_positionals():
+    # Sem argumentos → o dispatch abre o menu; parse_args não decide "command".
+    assert deploy.parse_args([])["positionals"] == []
 
 
-def test_parse_args_simple_command():
-    args = deploy.parse_args(["up"])
-    assert args["command"] == "up"
-    assert args["extra"] == []
+def test_parse_args_namespaced_command():
+    args = deploy.parse_args(["k8s", "up"])
+    assert args["positionals"] == ["k8s", "up"]
 
 
-def test_parse_args_positional_extra():
-    args = deploy.parse_args(["clone", "elimarcavalli/deile"])
-    assert args["command"] == "clone"
-    assert args["extra"] == ["elimarcavalli/deile"]
+def test_parse_args_clone_keeps_all_positionals():
+    args = deploy.parse_args(["k8s", "clone", "elimarcavalli/deile"])
+    assert args["positionals"] == ["k8s", "clone", "elimarcavalli/deile"]
 
 
-def test_parse_args_target_flag():
+def test_parse_args_target_flag_for_legacy_compat():
     args = deploy.parse_args(["status", "--target", "local"])
-    assert args["command"] == "status"
+    assert args["positionals"] == ["status"]
     assert args["target"] == "local"
 
 
 def test_parse_args_boolean_flags():
-    args = deploy.parse_args(["reset", "--yes", "--rebuild"])
-    assert args["command"] == "reset"
+    args = deploy.parse_args(["k8s", "build", "--yes", "--restart"])
+    assert args["positionals"] == ["k8s", "build"]
     assert args["yes"] is True
-    assert args["rebuild"] is True
+    assert args["restart"] is True
 
 
-def test_parse_args_help_flag():
-    assert deploy.parse_args(["--help"])["command"] == "help"
-    assert deploy.parse_args(["--no-color", "logs"])["no_color"] is True
+def test_parse_args_dry_run_flag():
+    args = deploy.parse_args(["--dry-run", "k8s", "up"])
+    assert args["dry_run"] is True
+    assert args["positionals"] == ["k8s", "up"]
+
+
+def test_parse_args_help_and_no_color_flags():
+    assert deploy.parse_args(["--help"])["positionals"] == ["help"]
+    assert deploy.parse_args(["--no-color", "local", "logs"])["no_color"] is True
+
+
+def test_command_tables_cover_expected_actions():
+    assert {"up", "down", "start", "stop", "restart", "status",
+            "logs", "build", "test", "clone"} <= set(deploy._K8S)
+    assert {"start", "stop", "restart", "status", "logs"} <= set(deploy._LOCAL)
+
+
+def test_announce_plan_dry_run_short_circuits():
+    # dry-run → False (chamador não executa); normal → True (segue).
+    assert deploy.announce_plan({"dry_run": True}, "t", "alvo", ["passo"]) is False
+    assert deploy.announce_plan({"dry_run": False}, "t", "alvo", ["passo"]) is True
+
+
+def test_legacy_command_classification():
+    # As tabelas de compat distinguem container-only de lifecycle; reset saiu.
+    assert "up" in deploy._OLD_CONTAINER
+    assert "start" in deploy._OLD_LIFECYCLE
+    assert "reset" not in deploy._OLD_CONTAINER
+    assert "reset" not in deploy._OLD_LIFECYCLE
 
 
 # ===== deploy.py — .env e deploy-state =======================================
@@ -192,65 +217,6 @@ def test_channel_workdir_sanitization():
     assert worker_server._channel_workdir(None) == "default"
     # Hífen e underscore são preservados.
     assert worker_server._channel_workdir("abc-DEF_12") == "abc-DEF_12"
-
-
-# ===== deploy.py — resolve_target (precedência) ==============================
-
-def test_resolve_target_explicit_wins(monkeypatch):
-    # --target explícito vence tudo, sem tocar deploy.json nem detectar nada.
-    monkeypatch.setattr(deploy, "read_deploy_target", lambda: "local")
-    monkeypatch.setattr(deploy, "namespace_exists", lambda: True)
-    assert deploy.resolve_target("container") == "container"
-    assert deploy.resolve_target("local") == "local"
-
-
-def test_resolve_target_ignores_invalid_request(monkeypatch):
-    # Valor inválido em --target é descartado; cai no deploy.json.
-    monkeypatch.setattr(deploy, "read_deploy_target", lambda: "container")
-    monkeypatch.setattr(deploy, "namespace_exists", lambda: False)
-    assert deploy.resolve_target("garbage") == "container"
-
-
-def test_resolve_target_saved_state(monkeypatch):
-    # Sem --target, o deploy.json vence a auto-detecção.
-    monkeypatch.setattr(deploy, "read_deploy_target", lambda: "local")
-    monkeypatch.setattr(deploy, "namespace_exists", lambda: True)
-    assert deploy.resolve_target(None) == "local"
-
-
-def test_resolve_target_autodetect_container(monkeypatch):
-    # Sem --target e sem deploy.json: namespace presente → container.
-    monkeypatch.setattr(deploy, "read_deploy_target", lambda: None)
-    monkeypatch.setattr(deploy, "namespace_exists", lambda: True)
-    assert deploy.resolve_target(None) == "container"
-
-
-def _fake_local_service(running: bool, detail: str):
-    """Devolve um stub de LocalService cujo status() é fixo."""
-    class _FakeSvc:
-        def __init__(self, *_a, **_kw):
-            pass
-
-        def status(self):
-            return running, detail
-
-    return _FakeSvc
-
-
-def test_resolve_target_autodetect_local(monkeypatch):
-    # Sem namespace, mas serviço local rodando → local.
-    monkeypatch.setattr(deploy, "read_deploy_target", lambda: None)
-    monkeypatch.setattr(deploy, "namespace_exists", lambda: False)
-    monkeypatch.setattr(deploy, "LocalService", _fake_local_service(True, "rodando"))
-    assert deploy.resolve_target(None) == "local"
-
-
-def test_resolve_target_undetermined(monkeypatch):
-    # Nada configurado e nada rodando → None.
-    monkeypatch.setattr(deploy, "read_deploy_target", lambda: None)
-    monkeypatch.setattr(deploy, "namespace_exists", lambda: False)
-    monkeypatch.setattr(deploy, "LocalService", _fake_local_service(False, "parado"))
-    assert deploy.resolve_target(None) is None
 
 
 # ===== deploy.py — _image_build_cmd (seleção de runtime) =====================

--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -60,7 +60,7 @@ def _make_monitor(*, unclassified: list | None = None) -> tuple[PipelineMonitor,
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
-        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "implementation_finished", "implementation_parked", "pr_picked_up", "pr_reviewed",
         "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
     ):
         setattr(notifier, attr, AsyncMock())
@@ -334,7 +334,7 @@ class TestIssueAutoClassifiedNotification:
 # ---------------------------------------------------------------------------
 
 class TestClassifiableLabelCoverage:
-    @pytest.mark.parametrize("label", ["intent", "bug", "refactor", "feature_request"])
+    @pytest.mark.parametrize("label", ["intent", "bug", "refactor", "feature", "security"])
     async def test_classifies_each_classifiable_label(self, label):
         issue = _issue(99, (label,), body="some body")
         monitor, github, _ = _make_monitor(unclassified=[issue])
@@ -398,7 +398,7 @@ class TestSchedulerClassifyAction:
         notifier = MagicMock()
         for attr in (
             "issue_picked_up", "issue_reviewed", "implementation_started",
-            "implementation_finished", "pr_picked_up", "pr_reviewed",
+            "implementation_finished", "implementation_parked", "pr_picked_up", "pr_reviewed",
             "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
         ):
             setattr(notifier, attr, AsyncMock())

--- a/deile/tests/orchestration/pipeline/test_gap_regressions.py
+++ b/deile/tests/orchestration/pipeline/test_gap_regressions.py
@@ -113,7 +113,7 @@ def _make_monitor(
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
-        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "implementation_finished", "implementation_parked", "pr_picked_up", "pr_reviewed",
         "issue_auto_classified", "follow_ups_processed", "error",
     ):
         setattr(notifier, attr, AsyncMock())

--- a/deile/tests/orchestration/pipeline/test_gaps_132.py
+++ b/deile/tests/orchestration/pipeline/test_gaps_132.py
@@ -697,19 +697,21 @@ class TestGetPrMethods:
         client = GitHubClient("owner/repo")
         issue = IssueRef(number=1, title="t", url="u",
                          labels=("~batch:abc12345", WORKFLOW_NEW))
+        # remove_labels now issues a REST DELETE via _run (not _run_checked).
         with patch.object(client, "get_issue", new=AsyncMock(return_value=issue)), \
-             patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+             patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))) as run:
             await client.clear_batch_label("issue", 1)
-        # Should have called remove_labels with the batch label.
+        # Should have called remove_labels (DELETE) with the batch label.
         assert run.called
+        assert any("DELETE" in c.args for c in run.call_args_list)
 
     async def test_clear_batch_label_noop_when_no_batch(self):
         client = GitHubClient("owner/repo")
         issue = IssueRef(number=1, title="t", url="u", labels=(WORKFLOW_NEW,))
         with patch.object(client, "get_issue", new=AsyncMock(return_value=issue)), \
-             patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+             patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))) as run:
             await client.clear_batch_label("issue", 1)
-        # No labels to remove, so run_checked should NOT be called.
+        # No batch labels to remove, so no DELETE should be issued.
         assert not run.called
 
     async def test_clear_batch_label_invalid_kind_raises(self):

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -93,16 +93,17 @@ class TestGetIssue:
 class TestTransitions:
     async def test_transition_issue_swaps_labels(self):
         client = GitHubClient("owner/name")
-        with patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run:
+        # Labels now go through the REST issues/labels endpoint: remove is a
+        # DELETE via _run (404-tolerant), add is a POST via _run_checked.
+        with patch.object(client, "_run", new=AsyncMock(return_value=(0, "", ""))) as run, \
+             patch.object(client, "_run_checked", new=AsyncMock(return_value="")) as run_checked:
             await client.transition_issue(7, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING)
-        # Two calls: remove + add
-        assert run.call_count == 2
         remove_call = run.call_args_list[0].args
-        add_call = run.call_args_list[1].args
-        assert "--remove-label" in remove_call
-        assert WORKFLOW_NEW in remove_call
-        assert "--add-label" in add_call
-        assert WORKFLOW_REVIEWING in add_call
+        assert "DELETE" in remove_call
+        assert any(isinstance(a, str) and "/labels/" in a for a in remove_call)
+        add_call = run_checked.call_args.args
+        assert "POST" in add_call
+        assert any(a == f"labels[]={WORKFLOW_REVIEWING}" for a in add_call)
 
     async def test_transition_skips_remove_when_from_label_none(self):
         client = GitHubClient("owner/name")
@@ -231,8 +232,14 @@ class TestEnsureLabelOnClaim:
             (i for i, c in enumerate(calls) if c[0] == "_run" and "label" in c and "create" in c),
             None,
         )
+        # add_labels now POSTs to the REST issues/labels endpoint (avoids the
+        # read:org scope that ``gh pr edit`` demands), so match the api call.
         add_idx = next(
-            (i for i, c in enumerate(calls) if c[0] == "_run_checked" and "edit" in c),
+            (
+                i for i, c in enumerate(calls)
+                if c[0] == "_run_checked" and "api" in c
+                and any(isinstance(x, str) and x.endswith("/labels") for x in c)
+            ),
             None,
         )
         assert ensure_idx is not None, f"_ensure_label not called; calls={calls}"

--- a/deile/tests/orchestration/pipeline/test_implementer.py
+++ b/deile/tests/orchestration/pipeline/test_implementer.py
@@ -1,0 +1,181 @@
+"""Unit tests for the pluggable pipeline implementer strategy.
+
+Covers the factory selection, the Claude strategy (delegates to the injected
+``monitor.claude`` + ``monitor.worktrees``) and the deile-worker strategy
+(builds the brief, picks the synthetic channel, parses the worker response).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.implementer import (ClaudeImplementer,
+                                                      WorkerImplementer,
+                                                      WorkOutcome,
+                                                      build_implementer)
+
+
+def _make_monitor(*, claude_stdout="", claude_rc=0, worktree_raises=False):
+    monitor = MagicMock()
+    monitor.config = SimpleNamespace(
+        repo="owner/name", main_branch="main", base_repo_path=Path("/tmp/fake")
+    )
+    monitor.branch_for_issue = lambda n: f"auto/issue-{n}"
+    if worktree_raises:
+        monitor.worktrees.create_branch_worktree = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+    else:
+        monitor.worktrees.create_branch_worktree = AsyncMock(
+            return_value=SimpleNamespace(path=Path("/tmp/fake/.worktrees/x"))
+        )
+    monitor.claude.run = AsyncMock(
+        return_value=ClaudeRunResult(
+            returncode=claude_rc, stdout=claude_stdout, stderr="err" if claude_rc else "",
+            duration_seconds=0.1, cmd=("claude", "-p", "x"),
+        )
+    )
+    return monitor
+
+
+def _issue(number=242, title="t", body="b"):
+    return SimpleNamespace(number=number, title=title, body=body)
+
+
+def _pr(number=7, title="t", head_ref="auto/issue-242"):
+    return SimpleNamespace(number=number, title=title, head_ref=head_ref)
+
+
+def _comment():
+    return SimpleNamespace(
+        html_url="https://github.com/owner/name/issues/1#c1",
+        body="@deile-one olá", author="someone",
+    )
+
+
+# ----- factory ------------------------------------------------------------
+
+class TestFactory:
+    @pytest.mark.parametrize("mode", ["claude", "claude_code", "claude-code"])
+    def test_claude_aliases(self, mode):
+        assert isinstance(build_implementer(mode), ClaudeImplementer)
+
+    @pytest.mark.parametrize("mode", ["deile_worker", "worker", "deile", "deile-worker"])
+    def test_worker_aliases(self, mode):
+        impl = build_implementer(mode, worker_client=MagicMock())
+        assert isinstance(impl, WorkerImplementer)
+
+    def test_unknown_mode_falls_back_to_claude(self):
+        assert isinstance(build_implementer("nonsense"), ClaudeImplementer)
+
+    def test_empty_mode_falls_back_to_claude(self):
+        assert isinstance(build_implementer(""), ClaudeImplementer)
+
+
+# ----- ClaudeImplementer --------------------------------------------------
+
+class TestClaudeImplementer:
+    async def test_implement_uses_worktree_and_claude(self):
+        monitor = _make_monitor(claude_stdout="https://github.com/owner/name/pull/9")
+        out = await ClaudeImplementer().implement(monitor, _issue())
+        assert out.ok is True
+        assert "pull/9" in out.text
+        monitor.worktrees.create_branch_worktree.assert_awaited_once()
+        monitor.claude.run.assert_awaited_once()
+
+    async def test_implement_worktree_failure_returns_not_ok(self):
+        monitor = _make_monitor(worktree_raises=True)
+        out = await ClaudeImplementer().implement(monitor, _issue())
+        assert out.ok is False
+        assert "worktree" in out.error
+        monitor.claude.run.assert_not_awaited()
+
+    async def test_implement_claude_nonzero_returns_not_ok(self):
+        monitor = _make_monitor(claude_rc=2)
+        out = await ClaudeImplementer().implement(monitor, _issue())
+        assert out.ok is False
+
+    async def test_review_uses_worktree_and_claude(self):
+        monitor = _make_monitor(claude_stdout="merged https://github.com/owner/name/pull/9")
+        out = await ClaudeImplementer().review(monitor, _pr())
+        assert out.ok is True
+        assert "merged" in out.text.lower()
+
+    async def test_mention_runs_in_base_repo_path(self):
+        monitor = _make_monitor(claude_stdout="done")
+        out = await ClaudeImplementer().mention(monitor, _comment())
+        assert out.ok is True
+        _, kwargs = monitor.claude.run.call_args
+        assert kwargs["cwd"] == monitor.config.base_repo_path
+
+
+# ----- WorkerImplementer --------------------------------------------------
+
+class _FakeClient:
+    """Captures the dispatch payload and returns a canned response."""
+
+    def __init__(self, response):
+        self._response = response
+        self.last_payload = None
+        self.last_wait = None
+
+    async def dispatch(self, payload, *, wait):
+        self.last_payload = payload
+        self.last_wait = wait
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+class TestWorkerImplementer:
+    async def test_implement_dispatches_brief_and_parses_ok(self):
+        client = _FakeClient({"ok": True, "summary": "Feito.\nhttps://github.com/owner/name/pull/12"})
+        impl = WorkerImplementer(client=client)
+        out = await impl.implement(_make_monitor(), _issue(number=242, title="soma", body="impl"))
+        assert out.ok is True
+        assert "pull/12" in out.text
+        assert client.last_payload["channel_id"] == "pipeline-issue-242"
+        assert client.last_wait is True
+        # The brief must name the repo, the issue number and the branch.
+        brief = client.last_payload["brief"]
+        assert "owner/name" in brief
+        assert "#242" in brief
+        assert "auto/issue-242" in brief
+
+    async def test_implement_worker_failure_returns_not_ok(self):
+        client = _FakeClient({"ok": False, "summary": "erro: deu ruim", "error": "boom"})
+        out = await WorkerImplementer(client=client).implement(_make_monitor(), _issue())
+        assert out.ok is False
+        assert out.error
+
+    async def test_dispatch_error_is_caught(self):
+        from deile.infrastructure.deile_worker_client import \
+            WorkerDispatchError
+        client = _FakeClient(WorkerDispatchError("nope", error_code="WORKER_TIMEOUT"))
+        out = await WorkerImplementer(client=client).implement(_make_monitor(), _issue())
+        assert out.ok is False
+        assert "WORKER_TIMEOUT" in out.error
+
+    async def test_review_uses_pr_channel_and_merged_marker(self):
+        client = _FakeClient({"ok": True, "summary": "https://github.com/owner/name/pull/7 MERGED"})
+        out = await WorkerImplementer(client=client).review(_make_monitor(), _pr(number=7))
+        assert out.ok is True
+        assert "merged" in out.text.lower()
+        assert client.last_payload["channel_id"] == "pipeline-pr-7"
+
+    async def test_mention_dispatches_to_mentions_channel(self):
+        client = _FakeClient({"ok": True, "summary": "respondido"})
+        out = await WorkerImplementer(client=client).mention(_make_monitor(), _comment())
+        assert out.ok is True
+        assert client.last_payload["channel_id"] == "pipeline-mentions"
+
+
+class TestWorkOutcome:
+    def test_defaults(self):
+        o = WorkOutcome(ok=True, text="x")
+        assert o.error == ""

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -52,7 +52,7 @@ def _make_monitor(
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
-        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "implementation_finished", "implementation_parked", "pr_picked_up", "pr_reviewed",
         "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
     ):
         setattr(notifier, attr, AsyncMock())

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -10,7 +10,9 @@ from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
 from deile.orchestration.pipeline.github_client import IssueRef, PrRef
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
-                                                 REVIEW_PENDING, WORKFLOW_NEW,
+                                                 REVIEW_PENDING,
+                                                 WORKFLOW_IMPLEMENTING,
+                                                 WORKFLOW_NEW, WORKFLOW_PR,
                                                  WORKFLOW_REVIEWED)
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor,
@@ -73,8 +75,8 @@ def _make_monitor(
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
-        "implementation_finished", "pr_picked_up", "pr_reviewed",
-        "issue_auto_classified", "follow_ups_processed", "error",
+        "implementation_finished", "implementation_parked", "pr_picked_up",
+        "pr_reviewed", "issue_auto_classified", "follow_ups_processed", "error",
         "pr_auto_classified", "mention_processed",
     ):
         setattr(notifier, attr, AsyncMock())
@@ -156,6 +158,32 @@ class TestStage2Implement:
         assert args[1] == "https://github.com/owner/name/pull/3"
         assert monitor.stats.issues_implemented == 1
 
+    async def test_claims_before_notifying_and_completes_to_em_pr(self):
+        # The claim (revisada → em_implementacao) MUST happen before the
+        # "started" notification, and a successful PR moves em_implementacao →
+        # em_pr. These two transitions are the lock + the completion marker.
+        rev = IssueRef(
+            number=2, title="impl me", url="u",
+            labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
+        )
+        monitor, notifier = _make_monitor(
+            issues_reviewed=[rev],
+            claude_stdout="Done. https://github.com/owner/name/pull/3",
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        calls = monitor.github.transition_issue.call_args_list
+        # First transition is the atomic claim out of the candidate queue.
+        assert calls[0].kwargs == {
+            "from_label": WORKFLOW_REVIEWED, "to_label": WORKFLOW_IMPLEMENTING
+        }
+        # Last transition marks the PR as opened.
+        assert calls[-1].kwargs == {
+            "from_label": WORKFLOW_IMPLEMENTING, "to_label": WORKFLOW_PR
+        }
+        notifier.implementation_started.assert_called_once()
+
     async def test_skips_reviewed_without_batch(self):
         rev = IssueRef(
             number=2, title="t", url="u",
@@ -167,7 +195,46 @@ class TestStage2Implement:
         await monitor.tick()
         notifier.implementation_started.assert_not_called()
 
-    async def test_claude_failure_emits_error(self):
+    async def test_already_claimed_issue_is_not_picked_again(self):
+        # Regression for the duplicate-DM storm (#253): an issue already in
+        # ~workflow:em_implementacao must NOT be re-selected even if it still
+        # carries revisada-era labels. Without the claim guard the same issue
+        # was re-dispatched every tick.
+        claimed = IssueRef(
+            number=2, title="t", url="u",
+            labels=(WORKFLOW_REVIEWED, WORKFLOW_IMPLEMENTING, "~batch:abc12345"),
+        )
+        monitor, notifier = _make_monitor(issues_reviewed=[claimed])
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        notifier.implementation_started.assert_not_called()
+        monitor.github.transition_issue.assert_not_called()
+
+    async def test_no_pr_url_parks_without_retry(self):
+        # ok=True but the agent opened no PR: park in em_implementacao + notify
+        # once. Crucially it does NOT advance to em_pr and does NOT count as an
+        # implemented issue — and is not re-tried (the issue left revisada).
+        rev = IssueRef(
+            number=2, title="vague meta issue", url="u",
+            labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
+        )
+        monitor, notifier = _make_monitor(
+            issues_reviewed=[rev],
+            claude_stdout="I thought about it but opened no PR.",
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor.tick()
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_parked.assert_called_once()
+        notifier.implementation_finished.assert_not_called()
+        assert monitor.stats.issues_implemented == 0
+        # Only the claim transition fired — never the em_pr completion.
+        for call in monitor.github.transition_issue.call_args_list:
+            assert call.kwargs.get("to_label") != WORKFLOW_PR
+
+    async def test_claude_failure_parks_issue(self):
         rev = IssueRef(
             number=2, title="t", url="u",
             labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
@@ -179,7 +246,8 @@ class TestStage2Implement:
         monitor.config.enable_review = False
         monitor.config.enable_pr_review = False
         await monitor.tick()
-        notifier.error.assert_called_once()
+        # A real failure parks the issue (one ping) instead of completing it.
+        notifier.implementation_parked.assert_called_once()
         notifier.implementation_finished.assert_not_called()
 
 

--- a/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
+++ b/deile/tests/orchestration/pipeline/test_monitor_with_schedule.py
@@ -94,6 +94,7 @@ def _make_monitor_sched(
         "issue_reviewed",
         "implementation_started",
         "implementation_finished",
+        "implementation_parked",
         "pr_picked_up",
         "pr_reviewed",
         "issue_auto_classified",

--- a/deile/tests/orchestration/pipeline/test_notifier.py
+++ b/deile/tests/orchestration/pipeline/test_notifier.py
@@ -72,6 +72,21 @@ class TestNotifierEvents:
         assert "sem PR" in sent[0]
         assert "https://github.com/x/y/pull/1" in sent[1]
 
+    async def test_implementation_parked_is_actionable(self):
+        sent = []
+
+        async def fake_dm(uid, text):
+            sent.append(text)
+
+        n = DiscordNotifier(user_id="42", dm_fn=fake_dm)
+        await n.implementation_parked(7, "o agente finalizou sem abrir PR")
+        assert len(sent) == 1
+        # Mentions the issue, why it parked, where it parked, and how to retry.
+        assert "#7" in sent[0]
+        assert "sem abrir PR" in sent[0]
+        assert "~workflow:em_implementacao" in sent[0]
+        assert "~workflow:revisada" in sent[0]
+
     async def test_dm_failure_swallowed(self):
         async def failing_dm(uid, text):
             raise RuntimeError("network")

--- a/deile/tests/orchestration/pipeline/test_pipeline_integration.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_integration.py
@@ -16,8 +16,9 @@ from deile.orchestration.pipeline.github_client import IssueRef, PrRef
 from deile.orchestration.pipeline.identity import MonitorIdentity
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
-                                                 REVIEW_PENDING, WORKFLOW_NEW,
-                                                 WORKFLOW_PR,
+                                                 REVIEW_PENDING,
+                                                 WORKFLOW_IMPLEMENTING,
+                                                 WORKFLOW_NEW, WORKFLOW_PR,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING)
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
@@ -94,6 +95,7 @@ def _make_monitor_full(
         "issue_reviewed",
         "implementation_started",
         "implementation_finished",
+        "implementation_parked",
         "pr_picked_up",
         "pr_reviewed",
         "issue_auto_classified",
@@ -185,10 +187,11 @@ class TestStageIntegration:
         assert args[1] == _PR_URL
         assert monitor2.stats.issues_implemented == 1
 
-        # Transition: revisada → em_pr
-        github2.transition_issue.assert_called_once_with(
-            10, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_PR
-        )
+        # Transitions: revisada → em_implementacao (atomic claim) → em_pr (PR opened)
+        assert github2.transition_issue.call_args_list == [
+            call(10, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_IMPLEMENTING),
+            call(10, from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_PR),
+        ]
 
         # -- Tick 3: stage 3 only -----------------------------------------
         monitor3, github3, notifier3 = _make_monitor_full(

--- a/deile/tests/orchestration/pipeline/test_pipeline_tool.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_tool.py
@@ -139,18 +139,20 @@ class TestPipelineToolMonitorReuse:
         # The same instance was reused — no new monitor was attached to the agent.
         assert agent.pipeline_monitor is existing
 
-    async def test_creates_monitor_when_agent_has_none(self, repo_git_tmp):
-        # The fresh-monitor path goes through WorktreeManager which validates
-        # that base_repo_path is a real git repo. repo_git_tmp provides one
-        # inside the git repo root (safe root) with DEILE_PIPELINE_BASE_PATH set.
+    async def test_status_does_not_fabricate_monitor_when_none(self):
+        # Honest status: with no monitor in THIS process, the tool must NOT
+        # build a throwaway monitor (doing so misreported "parado" and misled
+        # the operator during a live demo). It returns running=False and points
+        # at the separate deile-pipeline deployment.
         tool = PipelineTool()
         agent = MagicMock(spec=["pipeline_monitor"])
         agent.pipeline_monitor = None
         ctx = _make_context("status", agent=agent)
         result = await tool.execute(ctx)
         assert result.status == ToolStatus.SUCCESS
-        # The tool tried to attach a fresh monitor to the agent.
-        assert agent.pipeline_monitor is not None
+        assert result.data["running"] is False
+        assert agent.pipeline_monitor is None  # not fabricated
+        assert "deile-pipeline" in result.message
 
     async def test_works_without_agent(self, repo_git_tmp):
         tool = PipelineTool()

--- a/deile/tests/orchestration/pipeline/test_post_merge_callback.py
+++ b/deile/tests/orchestration/pipeline/test_post_merge_callback.py
@@ -115,7 +115,7 @@ def _make_monitor_with_cb(
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
-        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "implementation_finished", "implementation_parked", "pr_picked_up", "pr_reviewed",
         "issue_auto_classified", "follow_ups_processed", "error",
         "pr_auto_classified", "mention_processed",
     ):

--- a/deile/tests/orchestration/pipeline/test_pr_triage.py
+++ b/deile/tests/orchestration/pipeline/test_pr_triage.py
@@ -47,7 +47,7 @@ def _make_monitor(*, unclassified_prs: list | None = None) -> tuple[PipelineMoni
     notifier = MagicMock()
     for attr in (
         "issue_picked_up", "issue_reviewed", "implementation_started",
-        "implementation_finished", "pr_picked_up", "pr_reviewed",
+        "implementation_finished", "implementation_parked", "pr_picked_up", "pr_reviewed",
         "issue_auto_classified", "error", "pr_auto_classified", "mention_processed",
     ):
         setattr(notifier, attr, AsyncMock())

--- a/deile/tools/pipeline_tool.py
+++ b/deile/tools/pipeline_tool.py
@@ -79,13 +79,18 @@ class PipelineTool(Tool):
         if action == "status":
             monitor = self._existing_monitor(agent)
             if monitor is None or not self._is_running(monitor):
+                attached = monitor is not None
+                state = (
+                    "Há um monitor anexado a ESTE processo, mas ele está parado"
+                    if attached
+                    else "Nenhum monitor de pipeline anexado a ESTE processo"
+                )
                 return ToolResult.success_result(
-                    data={"running": False, "monitor_in_process": monitor is not None},
+                    data={"running": False, "monitor_in_process": attached},
                     message=(
-                        "Nenhum monitor de pipeline rodando NESTE processo. O "
-                        "pipeline autônomo roda como a deployment separada "
-                        "`deile-pipeline` — verifique com `kubectl -n deile get "
-                        "deploy deile-pipeline` e `kubectl -n deile logs "
+                        f"{state}. O pipeline autônomo roda como a deployment "
+                        "separada `deile-pipeline` — verifique com `kubectl -n "
+                        "deile get deploy deile-pipeline` e `kubectl -n deile logs "
                         "deploy/deile-pipeline`. (Para um monitor local: /pipeline start.)"
                     ),
                 )

--- a/deile/tools/pipeline_tool.py
+++ b/deile/tools/pipeline_tool.py
@@ -69,6 +69,31 @@ class PipelineTool(Tool):
             )
 
         agent = context.session_data.get("agent") or context.extra.get("agent")
+
+        # ``status`` must be HONEST about the process boundary. Building a
+        # throwaway monitor here (as start/stop/tick/reset need) would report a
+        # never-started monitor as "parado" — which is exactly what misled the
+        # operator: in the deile-worker (which never runs a monitor) /pipeline
+        # status said "stopped" while the real autonomous pipeline — the
+        # separate ``deile-pipeline`` deployment — was running fine.
+        if action == "status":
+            monitor = self._existing_monitor(agent)
+            if monitor is None or not self._is_running(monitor):
+                return ToolResult.success_result(
+                    data={"running": False, "monitor_in_process": monitor is not None},
+                    message=(
+                        "Nenhum monitor de pipeline rodando NESTE processo. O "
+                        "pipeline autônomo roda como a deployment separada "
+                        "`deile-pipeline` — verifique com `kubectl -n deile get "
+                        "deploy deile-pipeline` e `kubectl -n deile logs "
+                        "deploy/deile-pipeline`. (Para um monitor local: /pipeline start.)"
+                    ),
+                )
+            return ToolResult.success_result(
+                data={"running": True, **self._stats_dict(monitor)},
+                message=f"pipeline rodando neste processo | repo={monitor.config.repo}",
+            )
+
         monitor = self._get_or_create_monitor(agent)
 
         try:
@@ -117,14 +142,9 @@ class PipelineTool(Tool):
                 if not ok:
                     return ToolResult.error_result(message=msg, error_code="RESET_FAILED")
                 return ToolResult.success_result(data={"issue": issue_number}, message=msg)
-            # status (default)
-            running = self._is_running(monitor)
-            return ToolResult.success_result(
-                data={"running": running, **self._stats_dict(monitor)},
-                message=(
-                    f"pipeline {'rodando' if running else 'parado'} | "
-                    f"repo={monitor.config.repo}"
-                ),
+            # ``status`` is handled before _get_or_create_monitor (above).
+            return ToolResult.error_result(
+                message=f"unhandled action {action!r}", error_code="INVALID_ACTION"
             )
         except Exception as exc:  # noqa: BLE001 — surface any failure to the LLM
             return ToolResult.error_result(
@@ -136,6 +156,19 @@ class PipelineTool(Tool):
     # ------------------------------------------------------------------
     # helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _existing_monitor(agent: Optional[Any]) -> Optional[PipelineMonitor]:
+        """Return a monitor already attached to THIS process's agent, or None.
+
+        Unlike :meth:`_get_or_create_monitor`, this never fabricates a monitor,
+        so ``status`` cannot misreport a freshly-built, never-started monitor as
+        "parado". In the deile-worker (which never runs a monitor) it returns
+        None and status tells the truth.
+        """
+        if agent is not None:
+            return getattr(agent, "pipeline_monitor", None)
+        return None
 
     @staticmethod
     def _get_or_create_monitor(agent: Optional[Any]) -> PipelineMonitor:

--- a/docs/system_design/14-CONTAINERIZACAO.md
+++ b/docs/system_design/14-CONTAINERIZACAO.md
@@ -76,10 +76,10 @@ com o prompt **fixado no manifest** (ou parametrizado em build time).
 Kubernetes Events.
 
 ```bash
-python3 infra/k8s/deploy.py build   # uma vez, ou após mudar código
-python3 infra/k8s/deploy.py up      # namespace + NetworkPolicies + Secrets + bot
-python3 infra/k8s/deploy.py test    # cria o Job → executa o prompt → sai
-python3 infra/k8s/deploy.py down    # remove tudo (kubectl delete ns deile)
+python3 infra/k8s/deploy.py k8s build   # uma vez, ou após mudar código
+python3 infra/k8s/deploy.py k8s up      # namespace + NetworkPolicies + Secrets + bot
+python3 infra/k8s/deploy.py k8s test    # cria o Job → executa o prompt → sai
+python3 infra/k8s/deploy.py k8s down    # remove tudo (kubectl delete ns deile)
 ```
 
 Tool whitelist do Job: **só `messaging.*`** (decisão #28 — veja
@@ -147,11 +147,11 @@ vem do operador via `kubectl exec`, então não há risco de prompt-injection.
 | Allowlist | `wrapper.py` instala `~/bin/git` (guard Python) que lê `DEILE_GIT_CLONE_ALLOWLIST` (derivado de `git_integration.clonable_repos` em `bot-config` ConfigMap) e rejeita `git clone` para URLs fora da lista. O fluxo de clone é **fail-closed**: se o guard `~/bin/git` não estiver instalado, o clone é RECUSADO em vez de cair para `/usr/bin/git` — assim a allowlist é sempre garantida |
 | Isolamento de rede | NetworkPolicy já permite egress `0.0.0.0/0:443 except RFC1918` — github.com é alcançável; Mac/LAN não |
 
-### Fluxo completo (`deploy.py clone <owner/repo>`)
+### Fluxo completo (`deploy.py k8s clone <owner/repo>`)
 
 ```
 operador
-  → deploy.py clone elimarcavalli/deile
+  → deploy.py k8s clone elimarcavalli/deile
       → wira GITHUB_TOKEN em deile-secrets (kubectl apply --dry-run)
       → aguarda kubelet sincronizar arquivo no pod (max 90s)
       → kubectl exec deploy/deile-shell -- python3 -c "..."

--- a/infra/k8s/Dockerfile
+++ b/infra/k8s/Dockerfile
@@ -57,6 +57,19 @@ RUN python -m venv /venv \
     && /venv/bin/pip install . \
     && find /venv -type d -name __pycache__ -exec rm -rf {} +
 
+# Test toolchain — baked in so the deile-worker can run a cloned repo's
+# pytest suite at runtime WITHOUT `pip install` (the Pod rootfs is
+# read-only). Versions pinned to match the repo's dev-requirements.txt so
+# the worker's runs mirror CI. Kept to the pytest runner stack (no
+# black/isort/radon/safety/bandit) to limit image growth.
+RUN /venv/bin/pip install \
+        pytest==8.4.2 \
+        pytest-asyncio==1.2.0 \
+        pytest-mock==3.15.1 \
+        pytest-cov==6.3.0 \
+        pytest-xdist==3.8.0 \
+    && find /venv -type d -name __pycache__ -exec rm -rf {} +
+
 # Bug: neither pyproject declares `package-data`, so non-Python files
 # (.sql migrations, .md persona prompts, .yaml configs) get dropped on
 # wheel build. Without these the bot cannot init its sqlite schema and

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -8,10 +8,11 @@
 
 > **Orquestrador:** o `run.sh` virou um shim — o orquestrador agora é o
 > `infra/k8s/deploy.py` (Python, colorido, com `help`). `bash run.sh X`
-> equivale a `python3 deploy.py X`. Comandos novos: `start`, `stop`,
-> `restart`, `status`, `reset`, `doctor` — veja `python3 deploy.py help`.
-> Para preparar uma máquina do zero (k3s/colima/dependências), use
-> `python3 infra/setup_environment.py`.
+> equivale a `python3 deploy.py X`. O alvo é explícito no verbo:
+> `deploy.py k8s <ação>` (stack no Kubernetes) ou `deploy.py local <ação>`
+> (bot como serviço no host); rodar `deploy.py` sem argumentos abre um
+> menu. Veja `python3 deploy.py help`. Para preparar uma máquina do zero
+> (k3s/colima/dependências), use `python3 infra/setup_environment.py`.
 
 ---
 
@@ -86,9 +87,9 @@ DEILE_BOT_DISCORD_TOKEN=MTQ5...  # do passo 1.2
 ## 2. Build e deploy — caminho feliz
 
 ```bash
-python3 infra/k8s/deploy.py build   # ~5–10 min na 1ª vez; cache nas próximas
-python3 infra/k8s/deploy.py up      # namespace + NPs + Secrets + bot + worker
-python3 infra/k8s/deploy.py test    # cria o Job de prova → DM no Discord
+python3 infra/k8s/deploy.py k8s build   # ~5–10 min na 1ª vez; cache nas próximas
+python3 infra/k8s/deploy.py k8s up      # namespace + NPs + Secrets + bot + worker
+python3 infra/k8s/deploy.py k8s test    # cria o Job de prova → DM no Discord
 ```
 
 Sucesso = DM aparece no Discord (no canal direto entre você e o bot)

--- a/infra/k8s/deploy.py
+++ b/infra/k8s/deploy.py
@@ -1,21 +1,27 @@
 #!/usr/bin/env python3
 """Orquestrador do ciclo de vida do deilebot / DEILE.
 
-Substitui o antigo `run.sh`. Sobe, para, reinicia e inspeciona o bot —
-tanto no modo **container** (Kubernetes) quanto no modo **local** (o bot
-como serviço de segundo plano numa máquina sem k8s).
+Substitui o antigo `run.sh`. Dois alvos, **sempre explícitos no verbo**
+— nunca há adivinhação de qual será atingido:
 
-    python3 infra/k8s/deploy.py help          # lista todos os comandos
-    python3 infra/k8s/deploy.py doctor        # diagnostica os pré-requisitos
-    python3 infra/k8s/deploy.py up            # sobe a stack no Kubernetes
-    python3 infra/k8s/deploy.py stop          # fecha o bot
-    python3 infra/k8s/deploy.py reset         # reset completo
+    python3 infra/k8s/deploy.py                 # menu interativo (detecta o estado)
+    python3 infra/k8s/deploy.py k8s   <ação>    # stack no Kubernetes
+    python3 infra/k8s/deploy.py local <ação>    # bot como serviço no host (sem k8s)
+    python3 infra/k8s/deploy.py doctor          # checa os pré-requisitos
+    python3 infra/k8s/deploy.py help            # lista tudo
 
-O alvo (local/container) vem de `.deile/deploy.json` (gravado pelo
-`deilebot setup`); use `--target local|container` para forçar.
+Cada comando que ALTERA algo imprime um **plano** antes de executar; use
+`--dry-run` para só ver o plano sem rodar nada. Comandos de inspeção
+(`status`, `logs`) não têm plano — eles são a própria inspeção.
 
-Antes de qualquer operação de container, os pré-requisitos são checados;
-se faltar Kubernetes, o `setup_environment.py` é oferecido.
+`k8s` cobre a stack inteira (namespace, Secrets, Deployments, Job, shell).
+`local` roda só o bot como serviço de segundo plano (systemd/launchd/pidfile).
+Antes de qualquer operação de container os pré-requisitos são checados; se
+faltar Kubernetes, o `setup_environment.py` é oferecido.
+
+Compat: comandos antigos (`up`, `build`, `start`, ...) ainda funcionam, mas
+avisam a forma nova. `reset` foi removido (use `k8s down`+`k8s up` ou
+`local restart`).
 """
 
 from __future__ import annotations
@@ -46,7 +52,7 @@ SETUP_ENV = _INFRA / "setup_environment.py"
 NS = "deile"
 IMAGE = "deile-stack:local"
 LLM_KEYS = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DEEPSEEK_API_KEY", "GOOGLE_API_KEY")
-K8S_DEPLOYMENTS = ("deilebot", "deile-worker", "deile-shell")
+K8S_DEPLOYMENTS = ("deilebot", "deile-worker", "deile-shell", "deile-pipeline")
 
 
 # ===== helpers ===============================================================
@@ -102,7 +108,7 @@ def read_env() -> Dict[str, str]:
 
 
 def read_deploy_target() -> Optional[str]:
-    """Lê o alvo gravado pelo wizard em `.deile/deploy.json`."""
+    """Lê o alvo gravado pelo wizard em `.deile/deploy.json` (só informativo)."""
     try:
         data = json.loads(DEPLOY_STATE.read_text(encoding="utf-8"))
         target = data.get("target")
@@ -142,20 +148,24 @@ def namespace_exists() -> bool:
     ) == 0
 
 
-def resolve_target(requested: Optional[str]) -> Optional[str]:
-    """--target > .deile/deploy.json > auto-detecção."""
-    if requested in ("local", "container"):
-        return requested
-    saved = read_deploy_target()
-    if saved:
-        return saved
-    if namespace_exists():
-        return "container"
-    svc = LocalService(ROOT)
-    running, _ = svc.status()
-    if running:
-        return "local"
-    return None
+# ===== plano (prévia do que vai acontecer) ===================================
+
+def announce_plan(args: dict, title: str, target_desc: str, steps: List[str]) -> bool:
+    """Imprime o plano de uma ação que ALTERA estado, antes de executar.
+
+    Devolve ``True`` se a execução deve seguir, ``False`` quando ``--dry-run``
+    está ligado (o chamador deve então retornar 0 sem fazer nada). Comandos de
+    inspeção (status/logs) não chamam isto — eles são a própria inspeção.
+    """
+    ui.section(f"Plano: {title}")
+    ui.info(f"alvo: {target_desc}")
+    for i, msg in enumerate(steps, 1):
+        ui.step(i, len(steps), msg)
+    ui.plain()
+    if args.get("dry_run"):
+        ui.warn("--dry-run: nada foi executado.")
+        return False
+    return True
 
 
 # ===== pré-requisitos ========================================================
@@ -181,7 +191,7 @@ def ensure_container_prereqs(yes: bool) -> bool:
     return True
 
 
-# ===== comandos de container =================================================
+# ===== k8s: build ============================================================
 
 def _image_build_cmd() -> Optional[List[str]]:
     """Monta o comando de build conforme o runtime de container disponível."""
@@ -201,8 +211,28 @@ def _image_build_cmd() -> Optional[List[str]]:
     return None
 
 
-def cmd_build(args: dict) -> int:
-    ui.section("Build da imagem")
+def _rollout_restart_all() -> None:
+    """Reinicia os deployments existentes para pegarem a nova imagem."""
+    kubectl = _kubectl()
+    if kubectl is None:
+        return
+    for dep in K8S_DEPLOYMENTS:
+        if _run([kubectl, "-n", NS, "get", "deployment", dep],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
+            ui.info(f"reiniciando deployment/{dep} para pegar a nova imagem")
+            _run([kubectl, "-n", NS, "rollout", "restart", f"deployment/{dep}"],
+                 stdout=subprocess.DEVNULL)
+
+
+def k8s_build(args: dict) -> int:
+    restart = bool(args.get("restart"))
+    steps = [f"build da imagem {IMAGE} (nerdctl/colima/docker)"]
+    if restart:
+        steps.append("rollout restart dos deployments existentes")
+    else:
+        steps.append("NÃO reinicia os pods (use --restart, ou `k8s restart`)")
+    if not announce_plan(args, "k8s build", f"imagem {IMAGE}", steps):
+        return 0
     if not ensure_container_prereqs(args["yes"]):
         return 1
     build_cmd = _image_build_cmd()
@@ -216,16 +246,15 @@ def cmd_build(args: dict) -> int:
         return 1
     ui.ok("imagem construída.")
     # imagePullPolicy: Never → um rebuild só vale após reiniciar os pods.
-    kubectl = _kubectl()
-    for dep in K8S_DEPLOYMENTS:
-        if kubectl and _run([kubectl, "-n", NS, "get", "deployment", dep],
-                            stdout=subprocess.DEVNULL,
-                            stderr=subprocess.DEVNULL) == 0:
-            ui.info(f"reiniciando deployment/{dep} para pegar a nova imagem")
-            _run([kubectl, "-n", NS, "rollout", "restart", f"deployment/{dep}"],
-                 stdout=subprocess.DEVNULL)
+    if restart:
+        _rollout_restart_all()
+    else:
+        ui.info("imagem pronta; rode `k8s restart` (ou `k8s build --restart`) "
+                "para os pods pegarem a nova imagem.")
     return 0
 
+
+# ===== k8s: up / down ========================================================
 
 def _apply_secret(kubectl: str, name: str, kv: Dict[str, str]) -> bool:
     """Cria/atualiza um Secret a partir de pares chave=valor.
@@ -261,8 +290,17 @@ def _apply_secret(kubectl: str, name: str, kv: Dict[str, str]) -> bool:
             pass
 
 
-def cmd_up(args: dict) -> int:
-    ui.section("Subir a stack (Kubernetes)")
+def k8s_up(args: dict) -> int:
+    if not announce_plan(
+        args, "k8s up", f"Kubernetes (namespace `{NS}`)",
+        [
+            "aplica namespace + network policies",
+            "cria/atualiza os Secrets (bot, deile, worker) — nada é impresso",
+            "aplica ConfigMap, PVCs, Deployments e Services",
+            "aguarda os pods ficarem prontos (até 180s cada)",
+        ],
+    ):
+        return 0
     if not ensure_container_prereqs(args["yes"]):
         return 1
     kubectl = _kubectl()
@@ -307,7 +345,8 @@ def cmd_up(args: dict) -> int:
     ui.info("aplicando ConfigMap, PVCs, Deployments e Services")
     for manifest in ("15-bot-config.yaml", "19-bot-data-pvc.yaml",
                      "20-bot-deployment.yaml", "35-deile-interactive.yaml",
-                     "41-worker-pvc.yaml", "45-deile-worker-deployment.yaml"):
+                     "41-worker-pvc.yaml", "45-deile-worker-deployment.yaml",
+                     "46-deile-pipeline-deployment.yaml"):
         _run([kubectl, "apply", "-f", str(MANIFESTS / manifest)])
 
     for dep in K8S_DEPLOYMENTS:
@@ -325,14 +364,18 @@ def cmd_up(args: dict) -> int:
     return 0
 
 
-def cmd_down(args: dict) -> int:
-    ui.section("Teardown completo (Kubernetes)")
+def k8s_down(args: dict) -> int:
     kubectl = _kubectl()
     if kubectl is None:
         ui.err("kubectl não encontrado.")
         return 1
-    ui.warn(f"isto APAGA o namespace `{NS}` inteiro: pods, Secrets, PVCs e os "
-            "dados persistidos (histórico, cron, sessões).")
+    if not announce_plan(
+        args, "k8s down", f"Kubernetes (namespace `{NS}`)",
+        [f"DELETA o namespace `{NS}` inteiro: pods, Secrets, PVCs e "
+         "TODOS os dados (histórico, cron, sessões)"],
+    ):
+        return 0
+    ui.warn("isto é destrutivo e NÃO tem volta.")
     if not args["yes"] and not ui.confirm("Confirmar o teardown?", default=False):
         ui.info("Cancelado.")
         return 1
@@ -342,12 +385,103 @@ def cmd_down(args: dict) -> int:
     return rc
 
 
-def cmd_test(args: dict) -> int:
-    ui.section("Job one-shot do DEILE")
+# ===== k8s: ciclo de vida (scale / rollout) ==================================
+
+def k8s_start(args: dict) -> int:
+    kubectl = _kubectl()
+    if kubectl is None or not namespace_exists():
+        ui.err(f"namespace `{NS}` ausente — rode `deploy.py k8s up` primeiro.")
+        return 1
+    if not announce_plan(
+        args, "k8s start", f"Kubernetes (namespace `{NS}`)",
+        ["religa os deployments (scale → 1): " + ", ".join(K8S_DEPLOYMENTS)],
+    ):
+        return 0
+    for dep in K8S_DEPLOYMENTS:
+        _run([kubectl, "-n", NS, "scale", f"deployment/{dep}", "--replicas=1"],
+             stdout=subprocess.DEVNULL)
+    ui.ok("deployments religados (scale → 1).")
+    return 0
+
+
+def k8s_stop(args: dict) -> int:
+    kubectl = _kubectl()
+    if kubectl is None or not namespace_exists():
+        ui.warn("nada para parar (namespace ausente).")
+        return 0
+    if not announce_plan(
+        args, "k8s stop", f"Kubernetes (namespace `{NS}`)",
+        ["escala os deployments para 0 (os dados e os Secrets ficam intactos)"],
+    ):
+        return 0
+    for dep in K8S_DEPLOYMENTS:
+        _run([kubectl, "-n", NS, "scale", f"deployment/{dep}", "--replicas=0"],
+             stdout=subprocess.DEVNULL)
+    ui.ok("bot parado (scale → 0).")
+    return 0
+
+
+def k8s_restart(args: dict) -> int:
+    kubectl = _kubectl()
+    if kubectl is None or not namespace_exists():
+        ui.err(f"namespace `{NS}` ausente — rode `deploy.py k8s up`.")
+        return 1
+    if not announce_plan(
+        args, "k8s restart", f"Kubernetes (namespace `{NS}`)",
+        ["rollout restart dos deployments: " + ", ".join(K8S_DEPLOYMENTS)],
+    ):
+        return 0
+    for dep in K8S_DEPLOYMENTS:
+        _run([kubectl, "-n", NS, "rollout", "restart", f"deployment/{dep}"],
+             stdout=subprocess.DEVNULL)
+    ui.ok("rollout restart disparado.")
+    return 0
+
+
+def k8s_status(args: dict) -> int:
+    ui.section("Status — Kubernetes")
+    kubectl = _kubectl()
+    if kubectl is None:
+        ui.err("kubectl não encontrado.")
+        return 1
+    if not namespace_exists():
+        ui.warn(f"namespace `{NS}` ausente — a stack não está no ar.")
+        ui.info("Rode `deploy.py k8s up` para subir.")
+        return 0
+    _run([kubectl, "-n", NS, "get", "pods,deployments,services"])
+    return 0
+
+
+def k8s_logs(args: dict) -> int:
+    ui.section("Logs — Kubernetes")
+    kubectl = _kubectl()
+    if kubectl is None or not namespace_exists():
+        ui.err(f"namespace `{NS}` ausente.")
+        return 1
+    alias = {"bot": "deilebot", "worker": "deile-worker", "shell": "deile-shell"}
+    which_pod = args["extra"][0] if args["extra"] else "all"
+    deps = ["deilebot", "deile-worker"] if which_pod == "all" \
+        else [alias.get(which_pod, which_pod)]
+    for dep in deps:
+        ui.info(f"logs de {dep} (tail 80):")
+        _run([kubectl, "-n", NS, "logs", f"deploy/{dep}", "--tail=80"])
+    return 0
+
+
+# ===== k8s: test (Job one-shot) ==============================================
+
+def k8s_test(args: dict) -> int:
     kubectl = _kubectl()
     if kubectl is None or not cluster_reachable():
         ui.err("cluster Kubernetes inacessível.")
         return 1
+    if not announce_plan(
+        args, "k8s test", f"Kubernetes (namespace `{NS}`)",
+        ["remove um Job deile-oneshot anterior (se houver)",
+         "aplica o manifest 30-deile-job.yaml (prompt fixo)",
+         "streama os logs do pod do Job"],
+    ):
+        return 0
     _run([kubectl, "-n", NS, "delete", "job", "deile-oneshot", "--ignore-not-found"],
          stdout=subprocess.DEVNULL)
     _run([kubectl, "apply", "-f", str(MANIFESTS / "30-deile-job.yaml")])
@@ -369,6 +503,8 @@ def cmd_test(args: dict) -> int:
     _run([kubectl, "-n", NS, "logs", "--pod-running-timeout=120s", "-f", pod])
     return 0
 
+
+# ===== k8s: clone ============================================================
 
 _CLONE_SNIPPET = r'''
 import os, subprocess, sys
@@ -409,16 +545,25 @@ sys.exit(result.returncode)
 '''
 
 
-def cmd_clone(args: dict) -> int:
-    ui.section("Clonar repositório no deile-shell")
+def k8s_clone(args: dict) -> int:
     if not args["extra"]:
-        ui.err("uso: deploy.py clone <owner/repo>")
+        ui.err("uso: deploy.py k8s clone <owner/repo>")
         return 1
     repo = args["extra"][0]
     kubectl = _kubectl()
     if kubectl is None or not namespace_exists():
-        ui.err("namespace não encontrado — rode `up` primeiro.")
+        ui.err("namespace não encontrado — rode `deploy.py k8s up` primeiro.")
         return 1
+    name = repo.rstrip("/").split("/")[-1]
+    clone_url = f"https://github.com/{repo}.git"
+    work_dir = f"/home/deile/work/{name}"
+    if not announce_plan(
+        args, "k8s clone", "Kubernetes (deile-shell)",
+        ["injeta o GITHUB_TOKEN no Secret deile-secrets",
+         "aguarda o kubelet sincronizar o token no pod (até 90s)",
+         f"clona {clone_url} → {work_dir} (via guard ~/bin/git, fail-closed)"],
+    ):
+        return 0
     env = read_env()
     github_token = env.get("GITHUB_TOKEN", "").strip()
     if not github_token:
@@ -427,7 +572,7 @@ def cmd_clone(args: dict) -> int:
     llm = {k: env[k] for k in LLM_KEYS if env.get(k, "").strip()}
     bearer = env.get("DEILE_BOT_AUTH_TOKEN", "").strip()
     if not bearer:
-        ui.err("DEILE_BOT_AUTH_TOKEN ausente — rode `up` primeiro.")
+        ui.err("DEILE_BOT_AUTH_TOKEN ausente — rode `deploy.py k8s up` primeiro.")
         return 1
 
     ui.info("injetando o GITHUB_TOKEN no Secret deile-secrets")
@@ -450,9 +595,6 @@ def cmd_clone(args: dict) -> int:
         ui.err("o token não sincronizou no pod em 90s.")
         return 1
 
-    name = repo.rstrip("/").split("/")[-1]
-    clone_url = f"https://github.com/{repo}.git"
-    work_dir = f"/home/deile/work/{name}"
     ui.info(f"clonando {clone_url} → {work_dir}")
     rc = _run([kubectl, "-n", NS, "exec", "deploy/deile-shell", "--",
                "python3", "-c", _CLONE_SNIPPET, clone_url, work_dir])
@@ -461,196 +603,220 @@ def cmd_clone(args: dict) -> int:
     return rc
 
 
-# ===== ciclo de vida (sensível ao modo) ======================================
+# ===== local: bot como serviço no host =======================================
 
-def cmd_start(args: dict) -> int:
-    target = resolve_target(args["target"])
-    ui.section("Iniciar")
-    if target == "local":
-        return 0 if LocalService(ROOT).start() else 1
-    if target == "container":
-        kubectl = _kubectl()
-        if kubectl and namespace_exists():
-            ui.info("religando os deployments (scale → 1)")
-            for dep in K8S_DEPLOYMENTS:
-                _run([kubectl, "-n", NS, "scale", f"deployment/{dep}",
-                      "--replicas=1"], stdout=subprocess.DEVNULL)
-            ui.ok("deployments religados.")
-            return 0
-        return cmd_up(args)
-    ui.err("alvo indefinido — rode `deilebot setup` ou use --target local|container.")
-    return 1
-
-
-def cmd_stop(args: dict) -> int:
-    target = resolve_target(args["target"])
-    ui.section("Parar (fechar o bot)")
-    if target == "local":
-        return 0 if LocalService(ROOT).stop() else 1
-    if target == "container":
-        kubectl = _kubectl()
-        if kubectl is None or not namespace_exists():
-            ui.warn("nada para parar (namespace ausente).")
-            return 0
-        ui.info("escalando os deployments para 0 (dados e Secrets ficam)")
-        for dep in K8S_DEPLOYMENTS:
-            _run([kubectl, "-n", NS, "scale", f"deployment/{dep}",
-                  "--replicas=0"], stdout=subprocess.DEVNULL)
-        ui.ok("bot parado.")
+def local_start(args: dict) -> int:
+    svc = LocalService(ROOT)
+    if not announce_plan(
+        args, "local start", f"host (serviço {svc.backend})",
+        [f"instala/atualiza a unidade de serviço ({svc.backend})",
+         "inicia o bot: python3 -m deilebot run --provider discord"],
+    ):
         return 0
-    ui.err("alvo indefinido — use --target local|container.")
-    return 1
+    return 0 if svc.start() else 1
 
 
-def cmd_restart(args: dict) -> int:
-    target = resolve_target(args["target"])
-    ui.section("Reiniciar")
-    if target == "local":
-        return 0 if LocalService(ROOT).restart() else 1
-    if target == "container":
-        kubectl = _kubectl()
-        if kubectl is None or not namespace_exists():
-            ui.err("namespace ausente — rode `up`.")
-            return 1
-        for dep in K8S_DEPLOYMENTS:
-            _run([kubectl, "-n", NS, "rollout", "restart", f"deployment/{dep}"],
-                 stdout=subprocess.DEVNULL)
-        ui.ok("rollout restart disparado.")
+def local_stop(args: dict) -> int:
+    svc = LocalService(ROOT)
+    if not announce_plan(
+        args, "local stop", f"host (serviço {svc.backend})",
+        ["para o bot e desabilita a unidade de serviço"],
+    ):
         return 0
-    ui.err("alvo indefinido — use --target local|container.")
-    return 1
+    return 0 if svc.stop() else 1
 
 
-def cmd_status(args: dict) -> int:
-    target = resolve_target(args["target"])
-    ui.section("Status")
-    if target == "local":
-        running, detail = LocalService(ROOT).status()
-        (ui.ok if running else ui.warn)(detail)
+def local_restart(args: dict) -> int:
+    svc = LocalService(ROOT)
+    if not announce_plan(
+        args, "local restart", f"host (serviço {svc.backend})",
+        ["para o bot (se rodando)", "sobe o bot de novo"],
+    ):
         return 0
-    if target == "container":
-        kubectl = _kubectl()
-        if kubectl is None:
-            ui.err("kubectl não encontrado.")
-            return 1
-        if not namespace_exists():
-            ui.warn("namespace ausente — a stack não está no ar.")
-            return 0
-        _run([kubectl, "-n", NS, "get", "pods,deployments,services"])
-        return 0
-    ui.warn("nenhum alvo detectado — nada parece estar configurado ainda.")
-    ui.info("Rode `deilebot setup` para configurar.")
+    return 0 if svc.restart() else 1
+
+
+def local_status(args: dict) -> int:
+    ui.section("Status — local (host)")
+    running, detail = LocalService(ROOT).status()
+    (ui.ok if running else ui.warn)(detail)
     return 0
 
 
-def cmd_logs(args: dict) -> int:
-    target = resolve_target(args["target"])
-    ui.section("Logs")
-    if target == "local":
-        if args["extra"]:
-            ui.warn(f"filtro `{args['extra'][0]}` ignorado — no modo local "
-                    "só existe o bot.")
-        LocalService(ROOT).logs()
-        return 0
-    if target == "container":
-        kubectl = _kubectl()
-        if kubectl is None or not namespace_exists():
-            ui.err("namespace ausente.")
-            return 1
-        alias = {"bot": "deilebot", "worker": "deile-worker",
-                 "shell": "deile-shell"}
-        which_pod = args["extra"][0] if args["extra"] else "all"
-        if which_pod == "all":
-            deps = ["deilebot", "deile-worker"]
-        else:
-            deps = [alias.get(which_pod, which_pod)]
-        for dep in deps:
-            ui.info(f"logs de {dep} (tail 80):")
-            _run([kubectl, "-n", NS, "logs", f"deploy/{dep}", "--tail=80"])
-        return 0
-    ui.err("alvo indefinido — use --target local|container.")
-    return 1
+def local_logs(args: dict) -> int:
+    ui.section("Logs — local (host)")
+    if args["extra"]:
+        ui.warn(f"filtro `{args['extra'][0]}` ignorado — no modo local só existe o bot.")
+    LocalService(ROOT).logs()
+    return 0
 
 
-def cmd_reset(args: dict) -> int:
-    target = resolve_target(args["target"])
-    ui.section("Reset completo")
-    if target == "local":
-        svc = LocalService(ROOT)
-        svc.stop()
-        return 0 if svc.start() else 1
-    if target == "container":
-        ui.warn("o reset apaga e recria a stack no Kubernetes.")
-        if not args["yes"] and not ui.confirm("Confirmar o reset?", default=False):
-            ui.info("Cancelado.")
-            return 1
-        if args["rebuild"]:
-            if cmd_build(args) != 0:
-                return 1
-        cmd_down({**args, "yes": True})
-        return cmd_up(args)
-    ui.err("alvo indefinido — use --target local|container.")
-    return 1
-
-
-# ===== doctor / help =========================================================
+# ===== doctor / help / menu ==================================================
 
 def cmd_doctor(args: dict) -> int:
     ui.section("Diagnóstico do ambiente")
     if not SETUP_ENV.is_file():
         ui.err(f"instalador de ambiente não encontrado em {SETUP_ENV}")
         return 1
-    target = resolve_target(args["target"]) or "local"
-    return _run([sys.executable, str(SETUP_ENV), "--check", "--mode", target])
+    # `doctor` (ou `k8s doctor`) checa container; `local doctor` checa o host.
+    mode = "local" if args.get("namespace") == "local" else "container"
+    ui.info(f"checando pré-requisitos do modo: {mode}")
+    return _run([sys.executable, str(SETUP_ENV), "--check", "--mode", mode])
+
+
+def _k8s_state_label() -> str:
+    """Rótulo curto do estado do k8s para o menu/diagnóstico."""
+    if _kubectl() is None:
+        return "kubectl não encontrado"
+    if not cluster_reachable():
+        return "cluster inacessível"
+    if not namespace_exists():
+        return "namespace ausente (não provisionado)"
+    pods = _capture([_kubectl(), "-n", NS, "get", "pods", "--no-headers"]) or ""
+    n = len([ln for ln in pods.splitlines() if ln.strip()])
+    return f"no ar ({n} pod(s))" if n else "provisionado, 0 pods (parado)"
+
+
+_K8S = {
+    "up": k8s_up, "down": k8s_down, "start": k8s_start, "stop": k8s_stop,
+    "restart": k8s_restart, "status": k8s_status, "logs": k8s_logs,
+    "build": k8s_build, "test": k8s_test, "clone": k8s_clone,
+    "doctor": cmd_doctor,
+}
+_LOCAL = {
+    "start": local_start, "stop": local_stop, "restart": local_restart,
+    "status": local_status, "logs": local_logs, "doctor": cmd_doctor,
+}
+
+# (ação, descrição) — usado no help E no menu interativo. `clone` fica fora do
+# menu por exigir um argumento <owner/repo>.
+_K8S_ACTIONS = [
+    ("status", "ver pods, deployments e services"),
+    ("up", "provisionar / atualizar a stack (idempotente)"),
+    ("build", "rebuildar a imagem (--restart religa os pods)"),
+    ("restart", "rollout restart dos deployments"),
+    ("start", "religar (scale → 1)"),
+    ("stop", "pausar (scale → 0; mantém dados e Secrets)"),
+    ("logs", "logs recentes (bot + worker)"),
+    ("test", "rodar o Job one-shot deile-oneshot"),
+    ("clone", "clone <owner/repo> — clona um repo no deile-shell"),
+    ("down", "APAGAR o namespace e TODOS os dados"),
+]
+_LOCAL_ACTIONS = [
+    ("status", "ver se o bot está rodando"),
+    ("start", "subir o bot como serviço (systemd/launchd/pidfile)"),
+    ("restart", "reiniciar o bot"),
+    ("stop", "parar o bot"),
+    ("logs", "logs recentes do bot"),
+]
 
 
 def cmd_help(_args: dict) -> int:
     ui.header("deploy.py — orquestrador do deilebot / DEILE")
-    ui.section("Ciclo de vida (modo local ou container)")
+    ui.section("Uso")
     ui.command_table([
-        ("start", "Sobe / religa o bot."),
-        ("stop", "Fecha o bot (mantém dados e configuração)."),
-        ("restart", "Reinicia o bot."),
-        ("status", "Mostra o estado atual."),
-        ("logs", "Mostra os logs recentes."),
-        ("reset", "Reset completo (--rebuild rebuilda a imagem)."),
+        ("deploy.py", "menu interativo (detecta o estado de cada alvo)"),
+        ("deploy.py k8s <ação>", "opera a stack no Kubernetes"),
+        ("deploy.py local <ação>", "opera o bot como serviço no host (sem k8s)"),
+        ("deploy.py doctor", "checa os pré-requisitos da máquina"),
+        ("deploy.py --dry-run k8s <ação>", "mostra o plano e sai, sem executar"),
     ])
-    ui.section("Modo container (Kubernetes)")
+    ui.section("k8s — stack no Kubernetes")
+    ui.command_table(_K8S_ACTIONS)
+    ui.section("local — bot como serviço no host (sem k8s)")
+    ui.command_table(_LOCAL_ACTIONS)
+    ui.section("Flags")
     ui.command_table([
-        ("build", "Builda a imagem deile-stack:local."),
-        ("up", "Sobe a stack do zero (namespace, Secrets, deployments)."),
-        ("down", "Teardown completo — apaga o namespace e os dados."),
-        ("test", "Roda o Job one-shot do DEILE."),
-        ("clone", "clone <owner/repo> — clona um repo no deile-shell."),
+        ("--dry-run", "mostra o plano e sai (só nos comandos que alteram algo)"),
+        ("--restart", "no `k8s build`, religa os deployments após o build"),
+        ("--yes / -y", "não pergunta nada (não-interativo)"),
+        ("--no-color", "desliga as cores"),
     ])
-    ui.section("Ambiente e ajuda")
-    ui.command_table([
-        ("doctor", "Diagnostica os pré-requisitos da máquina."),
-        ("help", "Mostra esta ajuda."),
-    ])
-    ui.section("Opções globais")
-    ui.command_table([
-        ("--target local|container", "Força o alvo (senão usa .deile/deploy.json)."),
-        ("--yes", "Não pergunta nada (não-interativo)."),
-        ("--rebuild", "No reset, rebuilda a imagem antes."),
-        ("--no-color", "Desliga as cores."),
-    ])
+    saved = read_deploy_target()
+    if saved:
+        ui.section("Setup")
+        nice = "k8s" if saved == "container" else "local"
+        ui.info(f"seu `deilebot setup` configurou o alvo: {nice}")
     ui.plain()
     return 0
 
 
-_COMMANDS = {
-    "help": cmd_help, "doctor": cmd_doctor,
-    "build": cmd_build, "up": cmd_up, "down": cmd_down,
-    "test": cmd_test, "clone": cmd_clone,
-    "start": cmd_start, "stop": cmd_stop, "restart": cmd_restart,
-    "status": cmd_status, "logs": cmd_logs, "reset": cmd_reset,
-}
+def _run_action(namespace: str, action: str, args: dict) -> int:
+    table = _K8S if namespace == "k8s" else _LOCAL
+    handler = table.get(action)
+    if handler is None:
+        ui.err(f"ação desconhecida para `{namespace}`: {action}")
+        ui.info(f"Ações de `{namespace}`: " + ", ".join(
+            a for a, _ in (_K8S_ACTIONS if namespace == "k8s" else _LOCAL_ACTIONS)))
+        return 64
+    args["namespace"] = namespace
+    return handler(args)
 
+
+def cmd_menu(args: dict, preset_ns: Optional[str] = None) -> int:
+    """Menu interativo: detecta o estado, pergunta o alvo e a ação."""
+    if not sys.stdin.isatty():
+        ui.warn("sem terminal interativo — mostrando a ajuda.")
+        return cmd_help(args)
+    ui.header("deploy.py — deilebot / DEILE")
+    k8s_label = _k8s_state_label()
+    _, local_detail = LocalService(ROOT).status()
+    ui.section("Estado atual")
+    ui.info(f"k8s:   {k8s_label}")
+    ui.info(f"local: {local_detail}")
+
+    namespace = preset_ns
+    if namespace is None:
+        namespace = ui.choose("Qual alvo?", [
+            ("k8s", k8s_label),
+            ("local", local_detail),
+        ])
+    actions = _K8S_ACTIONS if namespace == "k8s" else _LOCAL_ACTIONS
+    # `clone` precisa de argumento — fora do menu.
+    menu_actions = [(a, d) for a, d in actions if a != "clone"]
+    ui.section(f"Ações — {namespace}")
+    action = ui.choose("Qual ação?", menu_actions)
+    return _run_action(namespace, action, args)
+
+
+# ===== compat com a CLI antiga ===============================================
+
+_OLD_CONTAINER = {"up", "down", "build", "test", "clone"}   # eram sempre k8s
+_OLD_LIFECYCLE = {"start", "stop", "restart", "status", "logs"}  # exigiam alvo
+
+
+def _handle_legacy(args: dict, positionals: List[str]) -> int:
+    cmd = positionals[0]
+    args["extra"] = positionals[1:]
+    if cmd in _OLD_CONTAINER:
+        ui.warn(f"`deploy.py {cmd}` agora é `deploy.py k8s {cmd}` — rodando isso.")
+        return _run_action("k8s", cmd, args)
+    if cmd == "reset":
+        ui.err("`reset` foi removido (era ambíguo). Use:")
+        ui.info("  k8s:   `deploy.py k8s down` e depois `deploy.py k8s up`")
+        ui.info("  local: `deploy.py local restart`")
+        return 64
+    if cmd in _OLD_LIFECYCLE:
+        ns = {"local": "local", "container": "k8s"}.get(args.get("target") or "")
+        if ns:
+            ui.warn(f"`deploy.py {cmd} --target {args['target']}` agora é "
+                    f"`deploy.py {ns} {cmd}` — rodando isso.")
+            return _run_action(ns, cmd, args)
+        ui.err(f"`{cmd}` agora exige o alvo no verbo:")
+        ui.info(f"  `deploy.py k8s {cmd}`   (stack no Kubernetes)")
+        ui.info(f"  `deploy.py local {cmd}` (bot como serviço no host)")
+        return 64
+    ui.err(f"comando desconhecido: {cmd}")
+    ui.info("Rode `deploy.py help` para ver os comandos.")
+    return 64
+
+
+# ===== parsing / main ========================================================
 
 def parse_args(argv: List[str]) -> dict:
-    args = {"command": None, "target": None, "yes": False,
-            "no_color": False, "rebuild": False, "extra": []}
+    args = {"target": None, "yes": False, "no_color": False,
+            "dry_run": False, "restart": False, "extra": [],
+            "namespace": None, "positionals": []}
     positionals: List[str] = []
     i = 0
     while i < len(argv):
@@ -663,16 +829,18 @@ def parse_args(argv: List[str]) -> dict:
             args["yes"] = True
         elif a == "--no-color":
             args["no_color"] = True
-        elif a == "--rebuild":
-            args["rebuild"] = True
+        elif a == "--dry-run":
+            args["dry_run"] = True
+        elif a == "--restart":
+            args["restart"] = True
+        elif a == "--no-restart":
+            args["restart"] = False
         elif a in ("-h", "--help"):
-            args["command"] = "help"
+            positionals.append("help")
         else:
             positionals.append(a)
         i += 1
-    if args["command"] is None:
-        args["command"] = positionals[0] if positionals else "help"
-    args["extra"] = positionals[1:]
+    args["positionals"] = positionals
     return args
 
 
@@ -680,13 +848,22 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parse_args(list(argv if argv is not None else sys.argv[1:]))
     if args["no_color"]:
         ui.set_color(False)
-    handler = _COMMANDS.get(args["command"])
-    if handler is None:
-        ui.err(f"comando desconhecido: {args['command']}")
-        ui.info("Rode `deploy.py help` para ver os comandos.")
-        return 64
+    pos = args["positionals"]
     try:
-        return handler(args)
+        if not pos:
+            return cmd_menu(args)
+        head = pos[0]
+        if head == "help":
+            return cmd_help(args)
+        if head == "doctor":
+            return cmd_doctor(args)
+        if head in ("k8s", "local"):
+            if len(pos) < 2:
+                # `deploy.py k8s` sem ação → menu já filtrado nesse alvo.
+                return cmd_menu(args, preset_ns=head)
+            args["extra"] = pos[2:]
+            return _run_action(head, pos[1], args)
+        return _handle_legacy(args, pos)
     except KeyboardInterrupt:
         ui.plain()
         ui.warn("interrompido.")

--- a/infra/k8s/manifests/36-deile-shell-pvc.yaml
+++ b/infra/k8s/manifests/36-deile-shell-pvc.yaml
@@ -15,7 +15,7 @@
 #
 # Note: Rancher Desktop / k3s uses a local-path provisioner that creates the
 # volume under the node's /var/lib/rancher/k3s/storage/. The data survives
-# pod restarts but NOT cluster wipes (deploy.py down; deploy.py up).
+# pod restarts but NOT cluster wipes (deploy.py k8s down; deploy.py k8s up).
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/infra/k8s/manifests/40-network-policy.yaml
+++ b/infra/k8s/manifests/40-network-policy.yaml
@@ -136,7 +136,10 @@ spec:
         - protocol: TCP
           port: 443
 ---
-# ---- 4. deile-worker ingress (only from bot) on :8766 ---------------
+# ---- 4. deile-worker ingress on :8766 — from bot AND pipeline -------
+# The deilebot Pod dispatches user-driven work; the deile-pipeline Pod
+# dispatches autonomous implement/review work. Both reach the worker on
+# 8766. The two podSelectors are OR'd within a single `from` list.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -153,6 +156,9 @@ spec:
         - podSelector:
             matchLabels:
               app: deilebot
+        - podSelector:
+            matchLabels:
+              app: deile-pipeline
       ports:
         - protocol: TCP
           port: 8766
@@ -167,6 +173,30 @@ spec:
   podSelector:
     matchLabels:
       app: deilebot
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: deile-worker
+      ports:
+        - protocol: TCP
+          port: 8766
+---
+# ---- 6. deile-pipeline egress to deile-worker:8766 ------------------
+# The autonomous loop dispatches implement/review briefs to the worker.
+# (443 for the gh CLI and 8765 for the bot notifier are already covered
+# by the role=deile egress policies above.)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pipeline-egress-to-worker
+  namespace: deile
+spec:
+  podSelector:
+    matchLabels:
+      app: deile-pipeline
   policyTypes:
     - Egress
   egress:

--- a/infra/k8s/manifests/42-worker-bearer-secret.yaml
+++ b/infra/k8s/manifests/42-worker-bearer-secret.yaml
@@ -1,6 +1,6 @@
 # worker-bearer Secret — a 32-byte random token shared between bot and
 # worker. The bot uses it to authenticate against the worker's :8766
-# control plane. Created by `infra/k8s/deploy.py up`; this
+# control plane. Created by `infra/k8s/deploy.py k8s up`; this
 # manifest is the placeholder applied if the operator did not
 # pre-generate.
 #

--- a/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
+++ b/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
@@ -1,0 +1,87 @@
+# deile-pipeline — long-running pod that drives the autonomous
+# issue → review → implement → PR → review → merge loop (PipelineMonitor).
+#
+# It ORCHESTRATES only: it lists/labels issues + PRs via the `gh` CLI and
+# dispatches the heavy implement/review work to the deile-worker Pod over
+# HTTP (DEILE_PIPELINE_DISPATCH_MODE=deile_worker — "DEILE-to-DEILE"). It runs
+# NO LLM in-process, so it needs GITHUB_TOKEN (gh) and the worker bearer (to
+# dispatch), but no provider bootstrap and no embedded agent.
+#
+# Jail posture mirrors deile-worker: readOnlyRootFilesystem, drop ALL caps,
+# uid 10001, PSS restricted, secrets as files. NetworkPolicy: egress to the
+# worker:8766 (rule 6), to the bot:8765 (notifier, via role=deile) and 443
+# (gh → github, via role=deile). No ingress is opened — nothing calls it.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deile-pipeline
+  namespace: deile
+  labels:
+    app: deile-pipeline
+    role: deile        # inherits deile-egress-to-bot (8765) + deile-egress-https-llm (443)
+spec:
+  replicas: 1
+  strategy: { type: Recreate }   # single monitor: never run two at once (PID lock + label races)
+  selector:
+    matchLabels:
+      app: deile-pipeline
+      role: deile
+  template:
+    metadata:
+      labels:
+        app: deile-pipeline
+        role: deile
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pipeline
+          image: deile-stack:local
+          imagePullPolicy: Never
+          workingDir: /home/deile
+          args: ["python3", "/app/wrapper.py", "pipeline"]
+          env:
+            - { name: HOME,                          value: /home/deile }
+            - { name: PYTHONUNBUFFERED,              value: "1" }
+            - { name: PYTHONDONTWRITEBYTECODE,       value: "1" }
+            # Dispatch implement/review work to the worker (DEILE-to-DEILE).
+            - { name: DEILE_PIPELINE_DISPATCH_MODE,  value: "deile_worker" }
+            - { name: DEILE_WORKER_ENDPOINT,         value: "http://deile-worker.deile.svc.cluster.local:8766" }
+            - { name: DEILE_PIPELINE_REPO,           value: "elimarcavalli/deile" }
+            - { name: DEILE_PIPELINE_POLL_INTERVAL,  value: "60" }
+            # Notifier posts pipeline progress to Discord via the bot control
+            # plane. notify_user_id (DEILE_PIPELINE_NOTIFY_USER_ID) is left
+            # unset by default — set it to a Discord user id to receive DMs.
+            - { name: DEILE_BOT_ENDPOINT,            value: "http://deilebot.deile.svc.cluster.local:8765" }
+            - { name: DEILE_BOT_APPROVAL_AUTO,       value: "1" }
+          volumeMounts:
+            # GITHUB_TOKEN (gh) + DEILE_BOT_AUTH_TOKEN (notifier) + LLM keys
+            # (unused here, harmless) — same Secret as worker/shell.
+            - { name: deile-secrets,  mountPath: /run/secrets/deile,  readOnly: true }
+            # Worker bearer — needed to authenticate dispatches to the worker.
+            - { name: worker-bearer,  mountPath: /run/secrets/worker, readOnly: true }
+            - { name: home,           mountPath: /home/deile }
+            - { name: tmp,            mountPath: /tmp }
+          resources:
+            requests: { cpu: "50m", memory: "128Mi" }
+            limits:   { cpu: "500m", memory: "512Mi" }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities: { drop: ["ALL"] }
+            seccompProfile: { type: RuntimeDefault }
+      volumes:
+        - { name: deile-secrets, secret: { secretName: deile-secrets,  defaultMode: 288 } }
+        - { name: worker-bearer, secret: { secretName: worker-bearer,  defaultMode: 288 } }
+        - { name: home,          emptyDir: { sizeLimit: "256Mi" } }
+        - { name: tmp,           emptyDir: { medium: Memory, sizeLimit: "64Mi" } }

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -732,9 +732,58 @@ def _install_worker_negative_whitelist() -> None:
         agent_mod.DeileAgent.initialize = _harden
 
 
+def _run_pipeline(passthrough: List[str]) -> int:
+    """deile-pipeline mode: run the autonomous issue → PR → merge loop.
+
+    The pipeline Pod only ORCHESTRATES: it lists/labels issues+PRs via the
+    ``gh`` CLI and dispatches the heavy implement/review work to the
+    deile-worker Pod over HTTP (``DEILE_PIPELINE_DISPATCH_MODE=deile_worker``).
+    It therefore needs GITHUB_TOKEN (for gh) and the worker bearer (to
+    dispatch), but no LLM provider of its own — the worker carries the model.
+
+    Differences from ``_run_worker``:
+      - No provider bootstrap, no embedded agent, no tool whitelist (there is
+        no agent to constrain — the loop never runs an LLM in-process).
+      - No clone guard (the pipeline Pod never clones; the worker does).
+    """
+    _harden_runtime_dirs()
+    loaded = _load_secret_files(Path("/run/secrets/deile"))
+    # GITHUB_TOKEN is the only hard requirement: the loop cannot list/label
+    # issues or PRs without it. LLM keys are optional (work goes to the worker).
+    if "GITHUB_TOKEN" not in loaded and not os.environ.get("GITHUB_TOKEN"):
+        print(
+            "wrapper(pipeline): no GITHUB_TOKEN under /run/secrets/deile — "
+            "the pipeline cannot drive GitHub.",
+            file=sys.stderr,
+        )
+        return 78
+
+    _setup_gh_auth()
+    _setup_git_credentials()
+
+    # Worker bearer — needed to dispatch implement/review work to the worker.
+    bearer = Path("/run/secrets/worker/AUTH_TOKEN")
+    if bearer.is_file():
+        try:
+            os.environ["DEILE_WORKER_BEARER_TOKEN"] = bearer.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            print(f"wrapper(pipeline): cannot read worker bearer: {exc}", file=sys.stderr)
+            return 78
+    else:
+        print(
+            "wrapper(pipeline): worker bearer not mounted at "
+            "/run/secrets/worker/AUTH_TOKEN — dispatch_mode=deile_worker will fail.",
+            file=sys.stderr,
+        )
+
+    sys.path.insert(0, str(Path("/app")))
+    from deile.orchestration.pipeline.runner import main as pipeline_main
+    return pipeline_main()
+
+
 def main(argv: List[str]) -> int:
     if len(argv) < 2:
-        print("usage: wrapper.py {deile|bot|worker} <args ...>", file=sys.stderr)
+        print("usage: wrapper.py {deile|bot|worker|pipeline} <args ...>", file=sys.stderr)
         return 64  # EX_USAGE
     role, rest = argv[1], argv[2:]
     if role == "deile":
@@ -743,7 +792,13 @@ def main(argv: List[str]) -> int:
         return _run_bot(rest)
     if role == "worker":
         return _run_worker(rest)
-    print(f"wrapper: unknown role {role!r} (expected 'deile' | 'bot' | 'worker')", file=sys.stderr)
+    if role == "pipeline":
+        return _run_pipeline(rest)
+    print(
+        f"wrapper: unknown role {role!r} "
+        "(expected 'deile' | 'bot' | 'worker' | 'pipeline')",
+        file=sys.stderr,
+    )
     return 64
 
 


### PR DESCRIPTION
## Resumo

Este PR consolida um esforço coeso: o **loop autônomo DEILE-para-DEILE** (issue → revisão → implementação → PR → revisão → merge) executável de forma headless, mais as correções que o tornam confiável em produção.

## O que muda e por quê

- **Estratégia plugável de implementação/revisão** (`deile/orchestration/pipeline/implementer.py`): o pipeline deixa de estar amarrado ao `claude -p`. Há duas estratégias — `ClaudeImplementer` (one-shot em worktree local, comportamento legado preservado) e `WorkerImplementer` (delega o trabalho pesado a outro DEILE, o Pod `deile-worker`, por HTTP). A escolha vem de `pipeline.dispatch_mode` (padrão `deile_worker`).
- **Entrypoint headless** (`runner.py`): roda o `PipelineMonitor` como processo de longa duração, sem TTY/CLI/`rich` e sem provider LLM local, mantendo o Pod `deile-pipeline` enxuto.
- **Correção da tempestade de DMs duplicadas**: a etapa de implementação agora **reivindica a issue de forma atômica** (`~workflow:revisada` → `~workflow:em_implementacao`) ANTES de notificar ou trabalhar. Uma issue que nunca produz PR (vaga/meta) deixa de ser reselecionada a cada tick. Falha ou ausência de PR **estaciona** a issue em `~workflow:em_implementacao` (fora da fila, sem re-tentativa) com um único aviso `implementation_parked` no Discord. Para reprocessar, o Humano move o label de volta para `~workflow:revisada`.
- **Teto de iterações de tool-call 25 → 100, configurável**: uma implementação real (ler arquivos, editar, testar, commitar, push, abrir PR) excede com folga 25 rodadas, e o agente parava antes de concluir. Agora ajustável via `DEILE_MAX_TOOL_ITERATIONS` ou `agent.max_tool_iterations` no `settings.json`, lido pelo `ToolLoopExecutor`.
- **`/pipeline status` honesto**: não fabrica mais um monitor descartável só para reportá-lo como "parado" (o que enganava ao rodar dentro do worker). Reporta a fronteira de processo e aponta para a deployment `deile-pipeline`.
- **Operações de label via REST**: substitui `gh issue/pr edit --add-label` (que exige o escopo `read:org`, ausente no token do pipeline) pelo endpoint REST de issues; remoção idempotente (404 = no-op).
- **Documentação e infra**: nova seção de operações de cluster Kubernetes no `CLAUDE.md`; deployment `deile-pipeline` (`infra/k8s/manifests/46-deile-pipeline-deployment.yaml`); atualização da NetworkPolicy (egress/ingress pipeline ↔ worker); toolchain de pytest fixado no `Dockerfile` para o worker rodar a suíte de um repo clonado sem `pip install` (rootfs read-only); reestruturação do `deploy.py` em verbos explícitos `k8s`/`local`.

## Plano de teste

- [x] `python3 -m pytest deile/tests/ -q` — 2935 passam, 17 skipped, 1 falha conhecida e NÃO relacionada (`test_format_iso_utc_promotes_naive_to_utc`, vermelha só em máquina UTC-3; verde no CI/UTC).
- [x] `ruff check deile/` limpo nos arquivos alterados.
- [x] `isort --check-only` limpo nos arquivos alterados (`monitor.py` e `test_implementer.py` reordenados neste PR).
- [x] Novos testes unitários da estratégia plugável em `deile/tests/orchestration/pipeline/test_implementer.py` (factory, Claude, worker, parking).
- [ ] Validação de cluster: subir `deile-pipeline` e confirmar o handoff `revisada → em_implementacao → em_pr` e o aviso `implementation_parked` único.