### PR TITLE
feat(pipeline): unified mention/assignment monitoring (issue #253)

### DIFF
--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -125,6 +125,61 @@ class CommentRef:
     kind: str  # "issue" | "pr_review"
 
 
+@dataclass(frozen=True)
+class MentionTrigger:
+    """A detected mention/assignment trigger from any GitHub source.
+
+    Carries the full context so the stage handler can decide which action to
+    take (implement, review, respond) without re-fetching from the API.
+    """
+
+    trigger_type: str
+    # "assignee" — DEILE was assigned to an issue/PR
+    # "reviewer"  — DEILE was requested as reviewer on a PR
+    # "comment"   — @deile-one appeared in a comment
+    # "body"      — @deile-one appeared in the body of an issue/PR
+
+    issue: Optional["IssueRef"] = None
+    pr: Optional["PrRef"] = None
+    comment: Optional["CommentRef"] = None
+
+    @property
+    def target_number(self) -> int:
+        """Return the issue or PR number this trigger targets."""
+        if self.issue is not None:
+            return self.issue.number
+        if self.pr is not None:
+            return self.pr.number
+        if self.comment is not None:
+            # Extract number from the comment's html_url or issue_url
+            import re
+            m = re.search(r"/(\d+)(?:#|$)", self.comment.html_url)
+            if m:
+                return int(m.group(1))
+        return 0
+
+    @property
+    def target_kind(self) -> str:
+        """Return 'issue' or 'pr' depending on what this trigger targets."""
+        if self.pr is not None:
+            return "pr"
+        if self.issue is not None:
+            return "issue"
+        if self.comment is not None:
+            return "pr" if self.comment.kind == "pr_review" else "issue"
+        return "unknown"
+
+    @property
+    def dedup_key(self) -> str:
+        """Return a stable deduplication key for this trigger.
+
+        Groups triggers by the target object (issue or PR), not by the trigger
+        type — so if DEILE is both assigned AND mentioned on the same issue, they
+        share a dedup key and are handled together in a single dispatch.
+        """
+        return f"{self.target_kind}:{self.target_number}"
+
+
 def compute_batch_id_for_number(kind: str, number: int) -> str:
     """SHA-8 of ``<kind>:<number>`` — collision-free unique batch lock id.
 
@@ -440,6 +495,130 @@ class GitHubClient:
             return 0
         m = re.search(r"/issues/(\d+)", out)
         return int(m.group(1)) if m else 0
+
+    # -- mention/assignment queries (issue #253) -------------------------
+
+    async def list_issues_assigned_to(self, login: str, *, limit: int = 100) -> List["IssueRef"]:
+        """Return open issues assigned to *login*."""
+        try:
+            out = await self._run_checked(
+                "issue", "list",
+                "--repo", self.repo,
+                "--state", "open",
+                "--assignee", login,
+                "--limit", str(limit),
+                "--json", "number,title,url,labels,body,state",
+            )
+        except GhCommandError as exc:
+            logger.warning("list_issues_assigned_to failed: %s", exc)
+            return []
+        data = json.loads(out or "[]")
+        return [IssueRef.from_gh_json(item) for item in data]
+
+    async def list_prs_assigned_to(self, login: str, *, limit: int = 100) -> List["PrRef"]:
+        """Return open, non-draft PRs assigned to *login*."""
+        try:
+            out = await self._run_checked(
+                "pr", "list",
+                "--repo", self.repo,
+                "--state", "open",
+                "--assignee", login,
+                "--limit", str(limit),
+                "--json", "number,title,url,labels,headRefName,baseRefName,state,isDraft",
+            )
+        except GhCommandError as exc:
+            logger.warning("list_prs_assigned_to failed: %s", exc)
+            return []
+        data = json.loads(out or "[]")
+        return [PrRef.from_gh_json(item) for item in data]
+
+    async def list_prs_with_review_requests(self, login: str) -> List["PrRef"]:
+        """Return open PRs where *login* is a requested reviewer.
+
+        Uses the REST API because ``gh pr list`` has no reviewer filter.
+        """
+        try:
+            out = await self._run_checked(
+                "api", f"repos/{self.repo}/pulls",
+                "--field", "state=open",
+                "--field", "per_page=100",
+                "--jq", (
+                    f'.[] | select(.requested_reviewers != null) | '
+                    f'select(any(.requested_reviewers[]; .login == "{login}")) | '
+                    f'{{number, title, url, labels, headRefName: .head.ref, '
+                    f'baseRefName: .base.ref, state, isDraft: .draft}}'
+                ),
+            )
+        except GhCommandError as exc:
+            logger.warning("list_prs_with_review_requests failed: %s", exc)
+            return []
+        data = json.loads(out or "[]")
+        # gh api --jq may return a single object when there is exactly 1 match.
+        if isinstance(data, dict):
+            data = [data]
+        result: List[PrRef] = []
+        for item in data:
+            try:
+                # Normalize labels to the [{name: ...}] format expected by PrRef.
+                labels_raw = item.get("labels", [])
+                if labels_raw and isinstance(labels_raw[0], str):
+                    labels_normalized = [{"name": lb} for lb in labels_raw]
+                else:
+                    labels_normalized = labels_raw
+                result.append(PrRef(
+                    number=int(item["number"]),
+                    title=str(item.get("title", "")),
+                    url=str(item.get("url", "")),
+                    labels=_labels_from_gh({"labels": labels_normalized}),
+                    head_ref=str(item.get("headRefName") or ""),
+                    base_ref=str(item.get("baseRefName") or "main"),
+                    state=str(item.get("state", "open")),
+                    is_draft=bool(item.get("isDraft", False)),
+                ))
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning("skipping malformed review-request PR: %s", exc)
+        return result
+
+    async def search_items_mentioning(
+        self, query: str, *, limit: int = 50
+    ) -> tuple:
+        """Return (issues, prs) where the body contains *query*.
+
+        Uses ``gh search issues`` which covers both issues and PRs.
+        """
+        issues: List[IssueRef] = []
+        prs: List[PrRef] = []
+        try:
+            out = await self._run_checked(
+                "search", "issues", query,
+                "--repo", self.repo,
+                "--state", "open",
+                "--limit", str(limit),
+                "--json", "number,title,url,labels,body,state",
+            )
+        except GhCommandError as exc:
+            logger.warning("search_items_mentioning failed: %s", exc)
+            return issues, prs
+        data = json.loads(out or "[]")
+        for item in data:
+            try:
+                url = str(item.get("url", ""))
+                if "/pull/" in url or "/pulls/" in url:
+                    prs.append(PrRef(
+                        number=int(item["number"]),
+                        title=str(item.get("title", "")),
+                        url=url,
+                        labels=_labels_from_gh(item),
+                        head_ref="",
+                        base_ref="main",
+                        state=str(item.get("state", "open")),
+                        is_draft=False,
+                    ))
+                else:
+                    issues.append(IssueRef.from_gh_json(item))
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning("skipping malformed search result: %s", exc)
+        return issues, prs
 
     async def list_unclassified_issues(self, *, limit: int = 100) -> List[IssueRef]:
         """Return open issues that have no pipeline labels (no ``~workflow:*``, ``~batch:*``, ``~review:*``).

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -31,12 +31,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 from deile.orchestration.pipeline.claude_dispatcher import (
-    render_implement_prompt, render_mention_prompt, render_review_prompt)
+    render_implement_prompt, render_review_prompt)
 from deile.orchestration.pipeline.constants import ISSUE_BODY_MAX_CHARS
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from deile.orchestration.pipeline.github_client import (CommentRef,
-                                                            IssueRef, PrRef)
+                                                            IssueRef,
+                                                            MentionTrigger,
+                                                            PrRef)
     from deile.orchestration.pipeline.monitor import PipelineMonitor
 
 logger = logging.getLogger(__name__)
@@ -95,7 +97,14 @@ class PipelineImplementer(ABC):
         ...
 
     @abstractmethod
-    async def mention(self, monitor: "PipelineMonitor", ref: "CommentRef") -> WorkOutcome:
+    async def mention(
+        self,
+        monitor: "PipelineMonitor",
+        ref: "MentionTrigger",
+        *,
+        trigger_types: list[str] | None = None,
+        all_triggers: list["MentionTrigger"] | None = None,
+    ) -> WorkOutcome:
         ...
 
 
@@ -149,9 +158,17 @@ class ClaudeImplementer(PipelineImplementer):
         result = await monitor.claude.run(prompt, cwd=wt.path)
         return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
 
-    async def mention(self, monitor: "PipelineMonitor", ref: "CommentRef") -> WorkOutcome:
-        prompt = render_mention_prompt(
-            monitor.config.repo, ref.html_url, ref.body, ref.author
+    async def mention(
+        self,
+        monitor: "PipelineMonitor",
+        ref: "MentionTrigger",
+        *,
+        trigger_types: list[str] | None = None,
+        all_triggers: list["MentionTrigger"] | None = None,
+    ) -> WorkOutcome:
+        # Build context-aware prompt from all trigger types
+        prompt = _render_claude_mention_prompt(
+            monitor.config.repo, ref, trigger_types or [], all_triggers or []
         )
         result = await monitor.claude.run(prompt, cwd=monitor.config.base_repo_path)
         return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
@@ -254,14 +271,119 @@ RETOMADA da revisão/merge da Pull Request #{number} do repositório {repo} — 
 """
 
 _WORKER_MENTION_BRIEF = """\
-Você foi mencionado por @{author} em {context_url} (repositório {repo}).
+Você foi acionado por {trigger_summary} no repositório {repo}.
 
-Mensagem recebida:
-{body}
+Contexto completo dos gatilhos detectados:
+{trigger_details}
 
-Responda de forma concreta ao que foi pedido e poste a resposta como comentário usando o gh
-(gh issue comment <n> --repo {repo}  ou  gh pr comment <n> --repo {repo}) apontando para {context_url}.
+Ação esperada:
+{expected_action}
+
+IMPORTANTE:
+- Se for um ASSIGNEE em uma issue SEM PR aberta, implemente a issue completa (use o fluxo normal de implementação: branch + commit + teste + PR).
+- Se for um ASSIGNEE em uma issue que JÁ TEM PR aberta, verifique se a PR cobre tudo da issue. Se não cobrir, faça checkout do branch da PR e continue a implementação.
+- Se for REQUESTED REVIEWER, faça review completa (arquitetura, DRY, KISS, SOLID, clean code) + teste + corrija o que precisar + commit + push + comente as evidências + merge.
+- Se for MENTION em comentário, responda diretamente ao que foi pedido. Se o comentário está numa PR, trabalhe no branch da PR.
+- Poste SEMPRE a resposta ou evidências como comentário no GitHub.
+- Na ÚLTIMA LINHA, escreva a URL relevante (PR, issue, etc).
 """
+
+# Context-aware worker mention brief builder (issue #253)
+def _render_worker_mention_brief(
+    repo: str,
+    ref: "MentionTrigger",
+    trigger_types: list[str],
+    all_triggers: list["MentionTrigger"],
+) -> str:
+    """Build a context-rich mention brief from all trigger types."""
+    # Summarize trigger types
+    type_labels = {
+        "assignee": "assignee (atribuído a você)",
+        "reviewer": "reviewer (solicitado como revisor)",
+        "comment": "menção em comentário (@deile-one)",
+        "body": "menção no corpo (@deile-one)",
+    }
+    trigger_summary = " + ".join(type_labels.get(t, t) for t in trigger_types)
+
+    # Detailed trigger info
+    details_parts: list[str] = []
+    for t in all_triggers:
+        if t.trigger_type == "comment" and t.comment is not None:
+            details_parts.append(
+                f"- **Comentário** de @{t.comment.author} em {t.comment.html_url}:\n"
+                f"  ```\n  {t.comment.body[:500]}\n  ```"
+            )
+        elif t.trigger_type == "assignee" and t.issue is not None:
+            details_parts.append(
+                f"- **Assignado** na issue #{t.issue.number}: [{t.issue.title}]({t.issue.url})"
+            )
+        elif t.trigger_type == "assignee" and t.pr is not None:
+            details_parts.append(
+                f"- **Assignado** na PR #{t.pr.number}: [{t.pr.title}]({t.pr.url})"
+            )
+        elif t.trigger_type == "reviewer" and t.pr is not None:
+            details_parts.append(
+                f"- **Solicitado como reviewer** na PR #{t.pr.number}: [{t.pr.title}]({t.pr.url})"
+            )
+        elif t.trigger_type == "body":
+            if t.issue is not None:
+                details_parts.append(
+                    f"- **Menção no corpo** da issue #{t.issue.number}: [{t.issue.title}]({t.issue.url})"
+                )
+            elif t.pr is not None:
+                details_parts.append(
+                    f"- **Menção no corpo** da PR #{t.pr.number}: [{t.pr.title}]({t.pr.url})"
+                )
+    trigger_details = "\n".join(details_parts)
+
+    # Determine expected action
+    target_kind = ref.target_kind
+    has_assignee = "assignee" in trigger_types
+    has_reviewer = "reviewer" in trigger_types
+    has_comment = "comment" in trigger_types
+    has_body = "body" in trigger_types
+
+    if has_reviewer and target_kind == "pr":
+        expected_action = (
+            f"**REVIEW REQUEST**: Você foi solicitado como revisor da PR #{ref.target_number}. "
+            f"Faça uma revisão completa (arquitetura, DRY, KISS, SOLID, clean code), "
+            f"rode os testes, corrija problemas, faça commit + push, poste evidências como "
+            f"comentário na PR e faça o merge."
+        )
+    elif has_assignee and target_kind == "issue":
+        expected_action = (
+            f"**ASSIGNED**: Você foi atribuído à issue #{ref.target_number}. "
+            f"Implemente a feature completa, crie testes, abra uma PR. "
+            f"Se já existir uma PR para esta issue, verifique se cobre tudo e "
+            f"continue a implementação no branch existente."
+        )
+    elif has_assignee and target_kind == "pr":
+        expected_action = (
+            f"**ASSIGNED TO PR**: Você foi atribuído à PR #{ref.target_number}. "
+            f"Revise, corrija, teste, faça commit + push e mergeie se estiver pronto."
+        )
+    elif has_comment or has_body:
+        if target_kind == "pr":
+            expected_action = (
+                f"**MENTION ON PR**: Você foi mencionado na PR #{ref.target_number}. "
+                f"Atenda ao que foi pedido no comentário/corpo, trabalhe no branch da PR, "
+                f"teste, faça commit + push e poste a resposta como comentário na PR."
+            )
+        else:
+            expected_action = (
+                f"**MENTION ON ISSUE**: Você foi mencionado na issue #{ref.target_number}. "
+                f"Atenda ao que foi pedido no comentário/corpo. "
+                f"Se a issue já tem PR aberta, trabalhe no branch da PR."
+            )
+    else:
+        expected_action = "Atenda ao contexto acima da forma mais apropriada."
+
+    return _WORKER_MENTION_BRIEF.format(
+        repo=repo,
+        trigger_summary=trigger_summary,
+        trigger_details=trigger_details,
+        expected_action=expected_action,
+    )
 
 
 def _render_worker_implement_brief(
@@ -315,10 +437,7 @@ def _render_worker_review_resume_brief(
     )
 
 
-def _render_worker_mention_brief(repo: str, context_url: str, body: str, author: str) -> str:
-    return _WORKER_MENTION_BRIEF.format(
-        repo=repo, context_url=context_url, body=(body or "").strip()[:2000], author=author
-    )
+# (removed duplicate _render_worker_mention_brief — the context-aware version above is authoritative)
 
 
 def _build_resume_block(
@@ -467,11 +586,115 @@ class WorkerImplementer(PipelineImplementer):
             brief, channel_id=f"pipeline-pr-{pr.number}", resume_block=resume_block
         )
 
-    async def mention(self, monitor: "PipelineMonitor", ref: "CommentRef") -> WorkOutcome:
+    async def mention(
+        self,
+        monitor: "PipelineMonitor",
+        ref: "MentionTrigger",
+        *,
+        trigger_types: list[str] | None = None,
+        all_triggers: list["MentionTrigger"] | None = None,
+    ) -> WorkOutcome:
         brief = _render_worker_mention_brief(
-            monitor.config.repo, ref.html_url, ref.body, ref.author
+            monitor.config.repo, ref,
+            trigger_types or [],
+            all_triggers or [],
         )
-        return await self._dispatch(brief, channel_id="pipeline-mentions")
+        channel_id = f"pipeline-mention-{ref.target_kind}-{ref.target_number}"
+        return await self._dispatch(brief, channel_id=channel_id)
+
+
+# ---------------------------------------------------------------------------
+# Claude mention prompt builder (issue #253)
+# ---------------------------------------------------------------------------
+
+def _render_claude_mention_prompt(
+    repo: str,
+    ref: "MentionTrigger",
+    trigger_types: list[str],
+    all_triggers: list["MentionTrigger"],
+) -> str:
+    """Build a context-rich mention prompt for the Claude path."""
+    type_labels = {
+        "assignee": "assignee (atribuído a você)",
+        "reviewer": "reviewer (solicitado como revisor)",
+        "comment": "menção em comentário (@deile-one)",
+        "body": "menção no corpo (@deile-one)",
+    }
+    trigger_summary = " + ".join(type_labels.get(t, t) for t in trigger_types)
+
+    details_parts: list[str] = []
+    for t in all_triggers:
+        if t.trigger_type == "comment" and t.comment is not None:
+            details_parts.append(
+                f"- Comentário de @{t.comment.author} em {t.comment.html_url}:\n"
+                f"  {t.comment.body[:500]}"
+            )
+        elif t.trigger_type == "assignee" and t.issue is not None:
+            details_parts.append(
+                f"- Assignado na issue #{t.issue.number}: {t.issue.title} ({t.issue.url})"
+            )
+        elif t.trigger_type == "assignee" and t.pr is not None:
+            details_parts.append(
+                f"- Assignado na PR #{t.pr.number}: {t.pr.title} ({t.pr.url})"
+            )
+        elif t.trigger_type == "reviewer" and t.pr is not None:
+            details_parts.append(
+                f"- Solicitado como reviewer na PR #{t.pr.number}: {t.pr.title} ({t.pr.url})"
+            )
+        elif t.trigger_type == "body":
+            if t.issue is not None:
+                details_parts.append(
+                    f"- Menção no corpo da issue #{t.issue.number}: {t.issue.title} ({t.issue.url})"
+                )
+            elif t.pr is not None:
+                details_parts.append(
+                    f"- Menção no corpo da PR #{t.pr.number}: {t.pr.title} ({t.pr.url})"
+                )
+    trigger_details = "\n".join(details_parts)
+
+    target_kind = ref.target_kind
+    has_assignee = "assignee" in trigger_types
+    has_reviewer = "reviewer" in trigger_types
+    has_comment = "comment" in trigger_types
+    has_body = "body" in trigger_types
+
+    if has_reviewer and target_kind == "pr":
+        action = (
+            f"REVIEW REQUEST: Revise a PR #{ref.target_number} completamente "
+            f"(arquitetura, DRY, KISS, SOLID, clean code), rode testes, corrija, "
+            f"commit + push, comente evidências e faça merge."
+        )
+    elif has_assignee and target_kind == "issue":
+        action = (
+            f"ASSIGNED: Implemente a issue #{ref.target_number} completa. "
+            f"Crie testes, abra PR. Se já existir PR, continue no branch existente."
+        )
+    elif has_assignee and target_kind == "pr":
+        action = (
+            f"ASSIGNED TO PR: Revise/corrija a PR #{ref.target_number}, "
+            f"teste, commit + push e mergeie."
+        )
+    elif has_comment or has_body:
+        if target_kind == "pr":
+            action = (
+                f"MENTION ON PR: Atenda ao pedido na PR #{ref.target_number}, "
+                f"trabalhe no branch da PR, teste, commit + push, comente resposta."
+            )
+        else:
+            action = (
+                f"MENTION ON ISSUE: Atenda ao pedido na issue #{ref.target_number}. "
+                f"Se a issue já tem PR aberta, trabalhe no branch da PR."
+            )
+    else:
+        action = "Atenda ao contexto acima da forma mais apropriada."
+
+    return (
+        f"Você foi acionado por {trigger_summary} no repositório {repo}.\n\n"
+        f"Contexto:\n{trigger_details}\n\n"
+        f"Ação esperada:\n{action}\n\n"
+        f"IMPORTANTE: Poste a resposta como comentário no GitHub usando gh. "
+        f"Na última linha, escreva a URL relevante."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -26,7 +26,10 @@ from typing import TYPE_CHECKING, Optional
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
 from deile.orchestration.pipeline.follow_up_detector import detect_follow_ups
 from deile.orchestration.pipeline.github_client import (CommentRef,
-                                                        GhCommandError)
+                                                        GhCommandError,
+                                                        IssueRef,
+                                                        MentionTrigger,
+                                                        PrRef)
 from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
                                                  REVIEW_PENDING,
@@ -236,36 +239,147 @@ async def classify_new_prs(monitor: "PipelineMonitor") -> None:
         await monitor.notifier.pr_auto_classified(pr.number, pr.title, pr.url)
 
 
-# ----- mention handling: dispatch @deile-one comments to Claude ----------
+# ----- mention handling: unified trigger polling (issue #253) ----------
 
 async def process_mentions(monitor: "PipelineMonitor") -> None:
-    """Poll issue/PR comments since cursor, dispatch @deile-one mentions to Claude."""
-    since = monitor._load_mention_cursor()
+    """Unified mention processing: poll ALL trigger types and dispatch deduplicated.
+
+    Trigger types monitored (RF1):
+    - Comment mentions (@deile-one in issue/PR comments)
+    - Body mentions (@deile-one in issue/PR body)
+    - Assignee (DEILE assigned to an issue/PR)
+    - Reviewer (DEILE requested as reviewer on a PR)
+
+    Deduplication: triggers targeting the same issue/PR are grouped and dispatched
+    once with full context of ALL trigger types, avoiding duplicate processing
+    across ticks (comment cursor + batch locking) and within the same tick
+    (dedup key on target).
+    """
     handle = monitor.config.mention_handle.lower()
+    gh_login = handle.lstrip("@")  # "deile-one"
+    triggers: list[MentionTrigger] = []
+
+    # ---- 1. Comment mentions (existing cursor-based polling) ------------
+    since = monitor._load_mention_cursor()
     try:
         issue_comments = await monitor.github.list_issue_comments_since(since)
         pr_comments = await monitor.github.list_pr_review_comments_since(since)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("mention poll failed: %s", exc)
-        return
-    all_comments: list[CommentRef] = issue_comments + pr_comments
-    now = datetime.now(tz=timezone.utc)
+        logger.warning("mention poll (comments) failed: %s", exc)
+        issue_comments = []
+        pr_comments = []
+    all_comments: list[CommentRef] = list(issue_comments) + list(pr_comments)
     for ref in all_comments:
         if handle not in ref.body.lower():
             continue
+        triggers.append(MentionTrigger(
+            trigger_type="comment",
+            comment=ref,
+        ))
+
+    # ---- 2. Assignee triggers -------------------------------------------
+    try:
+        assigned_issues = await monitor.github.list_issues_assigned_to(gh_login)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mention poll (assigned issues) failed: %s", exc)
+        assigned_issues = []
+    for issue in assigned_issues:
+        triggers.append(MentionTrigger(
+            trigger_type="assignee",
+            issue=issue,
+        ))
+    try:
+        assigned_prs = await monitor.github.list_prs_assigned_to(gh_login)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mention poll (assigned PRs) failed: %s", exc)
+        assigned_prs = []
+    for pr in assigned_prs:
+        triggers.append(MentionTrigger(
+            trigger_type="assignee",
+            pr=pr,
+        ))
+
+    # ---- 3. Review request triggers -------------------------------------
+    try:
+        review_prs = await monitor.github.list_prs_with_review_requests(gh_login)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mention poll (review requests) failed: %s", exc)
+        review_prs = []
+    for pr in review_prs:
+        triggers.append(MentionTrigger(
+            trigger_type="reviewer",
+            pr=pr,
+        ))
+
+    # ---- 4. Body mentions -----------------------------------------------
+    try:
+        body_issues, body_prs = await monitor.github.search_items_mentioning(handle)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mention poll (body search) failed: %s", exc)
+        body_issues = []
+        body_prs = []
+    for issue in body_issues:
+        triggers.append(MentionTrigger(
+            trigger_type="body",
+            issue=issue,
+        ))
+    for pr in body_prs:
+        triggers.append(MentionTrigger(
+            trigger_type="body",
+            pr=pr,
+        ))
+
+    if not triggers:
+        monitor._save_mention_cursor(datetime.now(tz=timezone.utc))
+        return
+
+    # ---- Deduplicate by target ------------------------------------------
+    groups: dict[str, list[MentionTrigger]] = {}
+    for t in triggers:
+        key = t.dedup_key
+        if key not in groups:
+            groups[key] = []
+        groups[key].append(t)
+
+    # ---- Dispatch each group --------------------------------------------
+    now = datetime.now(tz=timezone.utc)
+    for dedup_key, group in groups.items():
+        # Build a rich context string from all trigger types in this group
+        trigger_types = sorted(set(t.trigger_type for t in group))
+        primary = group[0]
+        logger.info(
+            "mention group %s: triggers=%s",
+            dedup_key, trigger_types,
+        )
+
         try:
-            outcome = await monitor.implementer.mention(monitor, ref)
+            outcome = await monitor.implementer.mention(
+                monitor,
+                primary,
+                trigger_types=trigger_types,
+                all_triggers=group,
+            )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("mention dispatch error for %s: %s", ref.html_url, exc)
+            logger.warning("mention dispatch error for %s: %s", dedup_key, exc)
             continue
+
         if not outcome.ok:
             logger.warning(
-                "mention dispatch failed for %s: %s", ref.html_url, outcome.error
+                "mention dispatch failed for %s: %s", dedup_key, outcome.error
             )
             continue
+
         monitor._stats.mentions_processed += 1
-        logger.info("mention processed: %s by @%s", ref.html_url, ref.author)
-        await monitor.notifier.mention_processed(ref.html_url, ref.author)
+        author = ""
+        for t in group:
+            if t.comment is not None:
+                author = t.comment.author
+                break
+        await monitor.notifier.mention_processed(
+            primary.comment.html_url if primary.comment else dedup_key,
+            author or gh_login,
+        )
+
     monitor._save_mention_cursor(now)
 
 

--- a/deile/tests/orchestration/pipeline/test_github_client.py
+++ b/deile/tests/orchestration/pipeline/test_github_client.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from deile.orchestration.pipeline.github_client import (
-    GhCommandError, GitHubClient, IssueRef, PrRef, compute_batch_id_for_number)
+    CommentRef, GhCommandError, GitHubClient, IssueRef, MentionTrigger,
+    PrRef, compute_batch_id_for_number)
 from deile.orchestration.pipeline.labels import (REVIEW_PENDING, WORKFLOW_NEW,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING)
@@ -262,3 +263,202 @@ class TestEnsureLabelOnClaim:
         assert ensure_idx < add_idx, (
             f"_ensure_label (idx={ensure_idx}) must precede add_labels (idx={add_idx})"
         )
+
+
+# ----- MentionTrigger (issue #253) ----------------------------------------
+
+
+class TestMentionTrigger:
+    def test_dedup_key_groups_by_target(self):
+        """Two triggers on the same issue share a dedup key."""
+        issue = IssueRef(number=42, title="t", url="u", labels=())
+        t1 = MentionTrigger(trigger_type="assignee", issue=issue)
+        t2 = MentionTrigger(trigger_type="body", issue=issue)
+        assert t1.dedup_key == t2.dedup_key == "issue:42"
+
+    def test_dedup_key_different_targets(self):
+        """Triggers on different issues have different dedup keys."""
+        i1 = IssueRef(number=1, title="a", url="u", labels=())
+        i2 = IssueRef(number=2, title="b", url="u", labels=())
+        t1 = MentionTrigger(trigger_type="assignee", issue=i1)
+        t2 = MentionTrigger(trigger_type="body", issue=i2)
+        assert t1.dedup_key != t2.dedup_key
+
+    def test_dedup_key_pr(self):
+        """PR triggers produce 'pr:N' dedup key."""
+        pr = PrRef(number=7, title="t", url="u", labels=())
+        t = MentionTrigger(trigger_type="reviewer", pr=pr)
+        assert t.dedup_key == "pr:7"
+
+    def test_target_kind_from_issue(self):
+        issue = IssueRef(number=1, title="t", url="u", labels=())
+        t = MentionTrigger(trigger_type="assignee", issue=issue)
+        assert t.target_kind == "issue"
+
+    def test_target_kind_from_pr(self):
+        pr = PrRef(number=1, title="t", url="u", labels=())
+        t = MentionTrigger(trigger_type="reviewer", pr=pr)
+        assert t.target_kind == "pr"
+
+    def test_target_kind_from_issue_comment(self):
+        comment = CommentRef(
+            comment_id=1, body="x", html_url="https://github.com/o/r/issues/5#c1",
+            issue_url="https://api.github.com/repos/o/r/issues/5",
+            author="u", kind="issue",
+        )
+        t = MentionTrigger(trigger_type="comment", comment=comment)
+        assert t.target_kind == "issue"
+
+    def test_target_kind_from_pr_comment(self):
+        comment = CommentRef(
+            comment_id=2, body="x", html_url="https://github.com/o/r/pull/8#discussion",
+            issue_url="https://api.github.com/repos/o/r/pulls/8",
+            author="u", kind="pr_review",
+        )
+        t = MentionTrigger(trigger_type="comment", comment=comment)
+        assert t.target_kind == "pr"
+
+    def test_target_number_from_issue(self):
+        issue = IssueRef(number=99, title="t", url="u", labels=())
+        t = MentionTrigger(trigger_type="assignee", issue=issue)
+        assert t.target_number == 99
+
+    def test_target_number_from_pr(self):
+        pr = PrRef(number=55, title="t", url="u", labels=())
+        t = MentionTrigger(trigger_type="reviewer", pr=pr)
+        assert t.target_number == 55
+
+    def test_target_number_from_comment_url(self):
+        comment = CommentRef(
+            comment_id=3, body="x",
+            html_url="https://github.com/o/r/issues/123#issuecomment-456",
+            issue_url="https://api.github.com/repos/o/r/issues/123",
+            author="u", kind="issue",
+        )
+        t = MentionTrigger(trigger_type="comment", comment=comment)
+        assert t.target_number == 123
+
+    def test_unknown_target_kind(self):
+        """Trigger with no issue, pr, or comment returns 'unknown'."""
+        t = MentionTrigger(trigger_type="assignee")
+        assert t.target_kind == "unknown"
+        assert t.target_number == 0
+
+
+# ----- New GitHubClient methods (issue #253) ------------------------------
+
+
+class TestListIssuesAssignedTo:
+    async def test_parses_assigned_issues(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {"number": 10, "title": "bug", "url": "u",
+             "labels": [], "body": "b", "state": "open"},
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            issues = await client.list_issues_assigned_to("deile-one")
+        assert len(issues) == 1
+        assert issues[0].number == 10
+
+    async def test_gh_error_returns_empty(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked",
+                          new=AsyncMock(side_effect=GhCommandError(("x",), 1, "", "err"))):
+            issues = await client.list_issues_assigned_to("deile-one")
+        assert issues == []
+
+
+class TestListPrsAssignedTo:
+    async def test_parses_assigned_prs(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {"number": 20, "title": "feat", "url": "u",
+             "labels": [], "headRefName": "auto/issue-20",
+             "baseRefName": "main", "state": "open", "isDraft": False},
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            prs = await client.list_prs_assigned_to("deile-one")
+        assert len(prs) == 1
+        assert prs[0].number == 20
+
+    async def test_gh_error_returns_empty(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked",
+                          new=AsyncMock(side_effect=GhCommandError(("x",), 1, "", "err"))):
+            prs = await client.list_prs_assigned_to("deile-one")
+        assert prs == []
+
+
+class TestListPrsWithReviewRequests:
+    async def test_parses_review_requested_prs(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {"number": 30, "title": "pr", "url": "u",
+             "labels": [{"name": "bug"}],
+             "headRefName": "feat/x", "baseRefName": "main",
+             "state": "open", "isDraft": False},
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            prs = await client.list_prs_with_review_requests("deile-one")
+        assert len(prs) == 1
+        assert prs[0].number == 30
+
+    async def test_single_object_normalized_to_list(self):
+        """gh api --jq returns a single dict when 1 match; must be normalized."""
+        client = GitHubClient("owner/name")
+        payload = json.dumps({
+            "number": 31, "title": "single", "url": "u",
+            "labels": [{"name": "enhancement"}],
+            "headRefName": "feat/y", "baseRefName": "main",
+            "state": "open", "isDraft": False,
+        })
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            prs = await client.list_prs_with_review_requests("deile-one")
+        assert len(prs) == 1
+        assert prs[0].number == 31
+
+    async def test_string_labels_normalized(self):
+        """String labels like ["bug", "feat"] must be normalized to [{name: ...}]."""
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {"number": 32, "title": "string labels", "url": "u",
+             "labels": ["bug", "feat"],
+             "headRefName": "feat/z", "baseRefName": "main",
+             "state": "open", "isDraft": False},
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            prs = await client.list_prs_with_review_requests("deile-one")
+        assert len(prs) == 1
+        assert "bug" in prs[0].labels
+
+    async def test_gh_error_returns_empty(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked",
+                          new=AsyncMock(side_effect=GhCommandError(("x",), 1, "", "err"))):
+            prs = await client.list_prs_with_review_requests("deile-one")
+        assert prs == []
+
+
+class TestSearchItemsMentioning:
+    async def test_separates_issues_from_prs(self):
+        client = GitHubClient("owner/name")
+        payload = json.dumps([
+            {"number": 5, "title": "issue", "url": "https://github.com/o/r/issues/5",
+             "labels": [], "body": "@deile-one", "state": "open"},
+            {"number": 6, "title": "pr", "url": "https://github.com/o/r/pull/6",
+             "labels": [], "body": "@deile-one", "state": "open"},
+        ])
+        with patch.object(client, "_run_checked", new=AsyncMock(return_value=payload)):
+            issues, prs = await client.search_items_mentioning("@deile-one")
+        assert len(issues) == 1
+        assert issues[0].number == 5
+        assert len(prs) == 1
+        assert prs[0].number == 6
+
+    async def test_gh_error_returns_empty(self):
+        client = GitHubClient("owner/name")
+        with patch.object(client, "_run_checked",
+                          new=AsyncMock(side_effect=GhCommandError(("x",), 1, "", "err"))):
+            issues, prs = await client.search_items_mentioning("@deile-one")
+        assert issues == []
+        assert prs == []

--- a/deile/tests/orchestration/pipeline/test_implementer.py
+++ b/deile/tests/orchestration/pipeline/test_implementer.py
@@ -14,6 +14,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
+from deile.orchestration.pipeline.github_client import (CommentRef,
+                                                        IssueRef,
+                                                        MentionTrigger)
 from deile.orchestration.pipeline.implementer import (ClaudeImplementer,
                                                       WorkerImplementer,
                                                       WorkOutcome,
@@ -57,8 +60,32 @@ def _pr(number=7, title="t", head_ref="auto/issue-242"):
 def _comment():
     return SimpleNamespace(
         html_url="https://github.com/owner/name/issues/1#c1",
-        body="@deile-one olá", author="someone",
+        body="@deile-one ol\u221a\u00b0", author="someone",
     )
+
+
+def _mention_trigger_comment(*, trigger_type: str = "comment") -> MentionTrigger:
+    """Build a MentionTrigger wrapping a synthetic CommentRef."""
+    comment = CommentRef(
+        comment_id=1,
+        body="@deile-one ola",
+        html_url="https://github.com/owner/name/issues/1#issuecomment-1",
+        issue_url="https://api.github.com/repos/owner/name/issues/1",
+        author="someone",
+        kind="issue",
+    )
+    return MentionTrigger(trigger_type=trigger_type, comment=comment)
+
+
+def _mention_trigger_assignee_issue(number: int = 100) -> MentionTrigger:
+    """Build a MentionTrigger for an assignee on an issue."""
+    issue = IssueRef(
+        number=number,
+        title="test issue",
+        url=f"https://github.com/owner/name/issues/{number}",
+        labels=(),
+    )
+    return MentionTrigger(trigger_type="assignee", issue=issue)
 
 
 # ----- factory ------------------------------------------------------------
@@ -111,7 +138,12 @@ class TestClaudeImplementer:
 
     async def test_mention_runs_in_base_repo_path(self):
         monitor = _make_monitor(claude_stdout="done")
-        out = await ClaudeImplementer().mention(monitor, _comment())
+        trigger = _mention_trigger_comment()
+        out = await ClaudeImplementer().mention(
+            monitor, trigger,
+            trigger_types=["comment"],
+            all_triggers=[trigger],
+        )
         assert out.ok is True
         _, kwargs = monitor.claude.run.call_args
         assert kwargs["cwd"] == monitor.config.base_repo_path
@@ -171,11 +203,16 @@ class TestWorkerImplementer:
         assert "merged" in out.text.lower()
         assert client.last_payload["channel_id"] == "pipeline-pr-7"
 
-    async def test_mention_dispatches_to_mentions_channel(self):
+    async def test_mention_dispatches_to_mention_channel(self):
         client = _FakeClient({"ok": True, "summary": "respondido"})
-        out = await WorkerImplementer(client=client).mention(_make_monitor(), _comment())
+        trigger = _mention_trigger_comment()
+        out = await WorkerImplementer(client=client).mention(
+            _make_monitor(), trigger,
+            trigger_types=["comment"],
+            all_triggers=[trigger],
+        )
         assert out.ok is True
-        assert client.last_payload["channel_id"] == "pipeline-mentions"
+        assert client.last_payload["channel_id"] == "pipeline-mention-issue-1"
 
 
 class TestWorkOutcome:

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
-from deile.orchestration.pipeline.github_client import CommentRef
+from deile.orchestration.pipeline.github_client import (CommentRef, IssueRef, PrRef)
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
 
@@ -48,6 +48,10 @@ def _make_monitor(
     github.list_unclassified_prs = AsyncMock(return_value=[])
     github.list_issue_comments_since = AsyncMock(return_value=list(issue_comments or []))
     github.list_pr_review_comments_since = AsyncMock(return_value=list(pr_comments or []))
+    github.list_issues_assigned_to = AsyncMock(return_value=[])
+    github.list_prs_assigned_to = AsyncMock(return_value=[])
+    github.list_prs_with_review_requests = AsyncMock(return_value=[])
+    github.search_items_mentioning = AsyncMock(return_value=([], []))
 
     notifier = MagicMock()
     for attr in (
@@ -163,3 +167,145 @@ class TestProcessMentions:
         monitor.config.enable_pr_triage = False
         await monitor.tick()
         github.list_issue_comments_since.assert_not_called()
+
+
+# ----- Multi-trigger mention handling (issue #253) ------------------------
+
+def _issue_ref(number=100):
+    return IssueRef(
+        number=number, title="test", url=f"https://github.com/o/r/issues/{number}",
+        labels=(),
+    )
+
+
+def _pr_ref(number=200):
+    return PrRef(
+        number=number, title="pr", url=f"https://github.com/o/r/pull/{number}",
+        labels=(), head_ref=f"auto/issue-{number}",
+    )
+
+
+class TestProcessMentionsMultiTrigger:
+    async def test_assignee_issue_dispatches(self):
+        """When DEILE is assigned to an issue, a mention dispatch fires."""
+        monitor, github, notifier = _make_monitor()
+        github.list_issues_assigned_to = AsyncMock(return_value=[_issue_ref(42)])
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_called_once()
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_assignee_pr_dispatches(self):
+        """When DEILE is assigned to a PR, a mention dispatch fires."""
+        monitor, github, notifier = _make_monitor()
+        github.list_prs_assigned_to = AsyncMock(return_value=[_pr_ref(77)])
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_called_once()
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_reviewer_request_dispatches(self):
+        """When DEILE is requested as reviewer, a mention dispatch fires."""
+        monitor, github, notifier = _make_monitor()
+        github.list_prs_with_review_requests = AsyncMock(return_value=[_pr_ref(88)])
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_called_once()
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_body_mention_issue_dispatches(self):
+        """When @deile-one appears in an issue body, a dispatch fires."""
+        monitor, github, notifier = _make_monitor()
+        github.search_items_mentioning = AsyncMock(
+            return_value=([_issue_ref(55)], [])
+        )
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_called_once()
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_body_mention_pr_dispatches(self):
+        """When @deile-one appears in a PR body, a dispatch fires."""
+        monitor, github, notifier = _make_monitor()
+        github.search_items_mentioning = AsyncMock(
+            return_value=([], [_pr_ref(66)])
+        )
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_called_once()
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_dedup_assignee_plus_comment_same_issue(self):
+        """Assignee + mention on the SAME issue = single dispatch with full context."""
+        comment = _comment(50, "Hey @deile-one fix this")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        github.list_issues_assigned_to = AsyncMock(return_value=[_issue_ref(1)])
+        await monitor._process_mentions()
+        # Both triggers target issue #1 → deduped into ONE dispatch
+        assert monitor.stats.mentions_processed == 1
+        notifier.mention_processed.assert_called_once()
+
+    async def test_dedup_two_comments_same_issue(self):
+        """Two @deile-one comments on the same issue = single dispatch."""
+        c1 = _comment(100, "@deile-one do X")
+        c2 = _comment(101, "@deile-one also Y")
+        monitor, github, notifier = _make_monitor(issue_comments=[c1, c2])
+        await monitor._process_mentions()
+        # Both comments target issue #1 → deduped
+        assert monitor.stats.mentions_processed == 1
+
+    async def test_no_dedup_different_issues(self):
+        """Mentions on different issues = separate dispatches."""
+        c1 = _comment(200, "@deile-one", author="a")
+        c2 = _comment(201, "@deile-one", author="b")
+        # Change issue_url so they point to different issues
+        c2 = CommentRef(
+            comment_id=201, body="@deile-one",
+            html_url="https://github.com/o/r/issues/2#issuecomment-201",
+            issue_url="https://api.github.com/repos/o/r/issues/2",
+            author="b", kind="issue",
+        )
+        monitor, github, notifier = _make_monitor(issue_comments=[c1, c2])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 2
+
+    async def test_assignee_exception_does_not_crash(self):
+        """Exception polling assignee must not crash the mention loop."""
+        monitor, github, notifier = _make_monitor()
+        github.list_issues_assigned_to = AsyncMock(side_effect=RuntimeError("boom"))
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 0
+
+    async def test_reviewer_exception_does_not_crash(self):
+        """Exception polling reviewers must not crash the mention loop."""
+        monitor, github, notifier = _make_monitor()
+        github.list_prs_with_review_requests = AsyncMock(side_effect=RuntimeError("boom"))
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 0
+
+    async def test_body_search_exception_does_not_crash(self):
+        """Exception searching bodies must not crash the mention loop."""
+        monitor, github, notifier = _make_monitor()
+        github.search_items_mentioning = AsyncMock(side_effect=RuntimeError("boom"))
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 0
+
+    async def test_cursor_saved_with_new_triggers(self, tmp_path):
+        """Cursor must be saved even when new trigger types are used."""
+        cfg = PipelineConfig(
+            repo="owner/name",
+            base_repo_path=tmp_path,
+            notify_user_id="42",
+        )
+        github = MagicMock()
+        github.list_issue_comments_since = AsyncMock(return_value=[])
+        github.list_pr_review_comments_since = AsyncMock(return_value=[])
+        github.list_issues_assigned_to = AsyncMock(return_value=[])
+        github.list_prs_assigned_to = AsyncMock(return_value=[])
+        github.list_prs_with_review_requests = AsyncMock(return_value=[])
+        github.search_items_mentioning = AsyncMock(return_value=([], []))
+        notifier = MagicMock()
+        for attr in ("mention_processed", "error"):
+            setattr(notifier, attr, AsyncMock())
+        claude = MagicMock()
+        claude.run = AsyncMock(return_value=ClaudeRunResult(
+            returncode=0, stdout="", stderr="", duration_seconds=0.0, cmd=("claude",)
+        ))
+        monitor = PipelineMonitor(cfg, github=github, worktrees=MagicMock(), claude=claude, notifier=notifier)
+        await monitor._process_mentions()
+        assert monitor._mention_cursor_path.exists()


### PR DESCRIPTION
## Resumo

Implementa monitoramento unificado de menções/atribuições no pipeline autônomo (issue #253).

### RF1 — Monitorar todo tipo de menção

- **Comment mentions:**  em comentários de issues/PRs (existente, preservado)
- **Body mentions:**  no corpo de issues/PRs (novo — )
- **Assignee:** DEILE atribuído a uma issue/PR (novo — , )
- **Reviewer:** DEILE solicitado como revisor de PR (novo — )

### Deduplicação

- **Within-tick:**  agrupa múltiplos gatilhos no mesmo alvo (issue/PR) em um único dispatch com contexto completo
- **Cross-tick (comments):** cursor  previne reprocessamento de comentários antigos

### Alterações

| Arquivo | Mudança |
|---|---|
|  | + dataclass, +4 novos métodos de query |
|  |  aceita  com  + ; prompts context-aware |
|  |  reescrito: poll 4 tipos de trigger, dedup, dispatch agrupado |
|  | +~25 testes cobrindo todos os novos fluxos |

### Testes

```
553 passed, 1 skipped — zero regressões na suíte completa de pipeline
```

---

Closes #253.

---

By [DEILE One](mailto:deile@deile.info)