### PR TITLE
fix: format_iso_utc promove datetime naive com replace(tzinfo=utc), não astimezone

### DIFF
--- a/deile/orchestration/pipeline/_time_utils.py
+++ b/deile/orchestration/pipeline/_time_utils.py
@@ -22,7 +22,11 @@ def format_iso_utc(dt: Optional[datetime]) -> Optional[str]:
     """Format ``dt`` as ``YYYY-MM-DDTHH:MM:SSZ`` (UTC). ``None`` passes through."""
     if dt is None:
         return None
-    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def parse_iso_utc(value) -> Optional[datetime]:

--- a/deile/tests/orchestration/pipeline/test_time_utils.py
+++ b/deile/tests/orchestration/pipeline/test_time_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -70,3 +70,11 @@ def test_parse_iso_utc_rejects_empty_string():
 def test_parse_iso_utc_rejects_bare_z():
     with pytest.raises(ValueError, match="invalid ISO datetime"):
         parse_iso_utc("Z")
+
+
+def test_format_iso_utc_converts_aware_to_utc():
+    """Aware datetime in a non-UTC zone must be converted to UTC."""
+    brt = timezone(offset=timedelta(hours=-3))
+    dt = datetime(2026, 1, 2, 6, 4, 5, tzinfo=brt)  # 06:04 BRT = 09:04 UTC
+    s = format_iso_utc(dt)
+    assert s == "2026-01-02T09:04:05Z"


### PR DESCRIPTION
## O que foi corrigido

`format_iso_utc` usava `dt.astimezone(timezone.utc)` indiscriminadamente. Em datetimes **naive** (sem tzinfo), `astimezone` assume o fuso local do SO — em `America/Sao_Paulo` (UTC−3), a hora era adiantada em 3h.

### Correção

- **naive** (`dt.tzinfo is None`) → `dt.replace(tzinfo=timezone.utc)` — apenas anexa UTC, sem conversão.
- **aware** (`dt.tzinfo is not None`) → `dt.astimezone(timezone.utc)` — converte corretamente de qualquer fuso para UTC.

### Testes

- `test_format_iso_utc_promotes_naive_to_utc` — já existia e agora passa (antes falhava em qualquer máquina fuso ≠ UTC).
- `test_format_iso_utc_converts_aware_to_utc` — **novo**: cobre o caminho aware (datetime BRT → UTC).

### Prova

```
11 passed in 0.92s
```

Closes #259

---

By [DEILE-One](mailto:deile@deile.info)
Co-authored-by: DEILE-One <deile@deile.info>