### PR TITLE
feat(pipeline): role-aware mention routing with resume + reviewer quality gate

### DIFF
--- a/deile/config/persona_config.yaml
+++ b/deile/config/persona_config.yaml
@@ -73,3 +73,27 @@ personas:
         - analysis_tools
         avoid_tools: []
         tool_timeout: 45
+    reviewer:
+      capabilities:
+      - code_review
+      - architecture_analysis
+      - debugging
+      - testing
+      - performance_optimization
+      communication_style: analytical
+      model_preferences:
+        temperature: 0.2
+        max_tokens: 8000
+        top_p: 0.9
+      behavior_settings:
+        verbosity_level: comprehensive
+        focus_on_patterns: true
+        include_trade_offs: true
+        suggest_improvements: true
+      tool_preferences:
+        preferred_tools:
+        - search_tool
+        - file_tools
+        - bash_tool
+        avoid_tools: []
+        tool_timeout: 60

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -61,8 +61,10 @@ _TOKEN_SAFE_CHARS = re.compile(r"^[A-Za-z0-9._\-+/=:~]{16,4096}$")
 
 # Personas suportadas pelo worker — espelha
 # deile/personas/library/*.yaml. Manter sincronizado quando uma persona
-# nova for adicionada ao worker.
-WorkerPersona = Literal["developer", "architect", "debugger"]
+# nova for adicionada ao worker. ``reviewer`` é a persona do quality-gate
+# de review de PR (pilar 04 §Personas; instruções em
+# personas/instructions/reviewer.md), usada pelo estágio de review do pipeline.
+WorkerPersona = Literal["developer", "architect", "debugger", "reviewer"]
 
 
 class WorkerDispatchError(DEILEError):

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -27,6 +27,7 @@ from deile.orchestration.pipeline._time_utils import format_iso_utc
 from deile.orchestration.pipeline.labels import (BATCH_LABEL_PREFIX,
                                                  LABEL_COLORS,
                                                  LABEL_DESCRIPTIONS,
+                                                 MENTION_LABELS,
                                                  REVIEW_LABELS,
                                                  WORKFLOW_LABELS,
                                                  batch_id_from_label,
@@ -429,7 +430,7 @@ class GitHubClient:
             if rc != 0:
                 logger.debug("label %s already exists or could not be created", label)
 
-        await asyncio.gather(*[_create_one(label) for label in (*WORKFLOW_LABELS, *REVIEW_LABELS)])
+        await asyncio.gather(*[_create_one(label) for label in (*WORKFLOW_LABELS, *REVIEW_LABELS, *MENTION_LABELS)])
 
     async def comment_on_issue(self, number: int, text: str) -> None:
         await self._run_checked(
@@ -538,8 +539,13 @@ class GitHubClient:
         Uses the REST API because ``gh pr list`` has no reviewer filter.
         """
         try:
+            # ``-X GET`` is REQUIRED: ``gh api`` defaults to POST as soon as any
+            # ``--field`` is present, so without it this POSTs to the pulls
+            # endpoint — i.e. tries to CREATE a PR — and fails with HTTP 422
+            # ("base"/"head" weren't supplied). Under GET the fields are query
+            # params, which is what listing open PRs needs.
             out = await self._run_checked(
-                "api", f"repos/{self.repo}/pulls",
+                "api", "-X", "GET", f"repos/{self.repo}/pulls",
                 "--field", "state=open",
                 "--field", "per_page=100",
                 "--jq", (
@@ -726,8 +732,12 @@ class GitHubClient:
             )
         since_iso = format_iso_utc(since)
         try:
+            # ``-X GET`` is REQUIRED: ``gh api`` defaults to POST as soon as any
+            # ``--field`` is present, so without it this POSTs to a read-only
+            # comments endpoint and fails with 404. The fields become query
+            # params under GET.
             out = await self._run_checked(
-                "api", endpoint,
+                "api", "-X", "GET", endpoint,
                 "--field", f"since={since_iso}",
                 "--field", "per_page=100",
             )

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -415,8 +415,8 @@ def _render_worker_implement_brief(
     )
 
 
-def _render_worker_review_brief(repo: str, main: str, number: int, title: str) -> str:
-    return _WORKER_REVIEW_BRIEF.format(repo=repo, main=main, number=number, title=title)
+def _render_worker_review_brief(repo: str, main: str, number: int) -> str:
+    return _WORKER_REVIEW_BRIEF.format(repo=repo, main=main, number=number)
 
 
 # The journal lives in the worker's per-channel PVC workspace (one level above
@@ -446,10 +446,10 @@ def _render_worker_implement_resume_brief(
 
 
 def _render_worker_review_resume_brief(
-    repo: str, main: str, number: int, title: str
+    repo: str, main: str, number: int
 ) -> str:
     return _WORKER_REVIEW_RESUME_BRIEF.format(
-        repo=repo, main=main, number=number, title=title, progress_block=_PROGRESS_BLOCK
+        repo=repo, main=main, number=number, progress_block=_PROGRESS_BLOCK
     )
 
 
@@ -631,11 +631,11 @@ class WorkerImplementer(PipelineImplementer):
     ) -> WorkOutcome:
         if resume:
             brief = _render_worker_review_resume_brief(
-                monitor.config.repo, monitor.config.main_branch, pr.number, pr.title
+                monitor.config.repo, monitor.config.main_branch, pr.number
             )
         else:
             brief = _render_worker_review_brief(
-                monitor.config.repo, monitor.config.main_branch, pr.number, pr.title
+                monitor.config.repo, monitor.config.main_branch, pr.number
             )
         resume_block = _build_resume_block(
             monitor.config.repo, monitor.config.main_branch,
@@ -695,8 +695,8 @@ class WorkerImplementer(PipelineImplementer):
             )
         if mode == "work_merge":
             brief = (
-                _render_worker_review_resume_brief(repo, main, number, "")
-                if resume else _render_worker_review_brief(repo, main, number, "")
+                _render_worker_review_resume_brief(repo, main, number)
+                if resume else _render_worker_review_brief(repo, main, number)
             )
             return await self._dispatch(
                 brief, channel_id=channel_id, persona="reviewer",

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -104,6 +104,8 @@ class PipelineImplementer(ABC):
         *,
         trigger_types: list[str] | None = None,
         all_triggers: list["MentionTrigger"] | None = None,
+        mode: str = "comment",
+        resume: bool = False,
     ) -> WorkOutcome:
         ...
 
@@ -165,8 +167,11 @@ class ClaudeImplementer(PipelineImplementer):
         *,
         trigger_types: list[str] | None = None,
         all_triggers: list["MentionTrigger"] | None = None,
+        mode: str = "comment",
+        resume: bool = False,
     ) -> WorkOutcome:
-        # Build context-aware prompt from all trigger types
+        # ``mode``/``resume`` are accepted for interface parity with the worker
+        # path; the legacy Claude path keeps its single context-aware prompt.
         prompt = _render_claude_mention_prompt(
             monitor.config.repo, ref, trigger_types or [], all_triggers or []
         )
@@ -208,17 +213,26 @@ DEFINITION OF DONE: existe uma PR aberta cuja URL você confirmou via gh. Se pus
 """
 
 _WORKER_REVIEW_BRIEF = """\
-Revise, corrija e mergeie a Pull Request #{number} do repositório {repo} — execute de verdade.
+Você é o QUALITY GATE final da Pull Request #{number} do repositório {repo}. Revise com RIGOR, corrija e — só se passar no portão — mergeie. Execute de verdade: testes verdes NÃO bastam.
 
-1. Garanta um clone atualizado de {repo} em ./repo (gh repo clone {repo} repo se não existir; senão git fetch origin).
-2. Dentro de ./repo rode: gh pr checkout {number}
-3. Rode os testes. As dependências (incl. pytest) JÁ estão no ambiente — NÃO rode `pip install` (filesystem read-only). Para os testes do PR sem o gate global de cobertura: python3 -m pytest <arquivos> -p no:cov -q. Corrija o que falhar com commits normais (SEM force-push) e dê push.
-4. Quando 100% dos testes passarem, MERGEIE. NÃO tente `gh pr review --approve` (você é o autor da PR; o GitHub recusa auto-aprovação, e não há branch protection exigindo review). Mergeie via REST (evita o escopo read:org que o `gh pr merge` às vezes exige):
-   gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge
-   Se a REST falhar, tente: gh pr merge {number} --repo {repo} --merge
-5. Confirme o merge: gh pr view {number} --repo {repo} --json state,merged -q .merged  (deve ser true).
-6. Na ÚLTIMA LINHA escreva a URL da PR seguida da palavra MERGED, ex.: https://github.com/{repo}/pull/{number} MERGED
-   Se NÃO conseguir mergear, escreva a URL e o motivo real — NUNCA escreva MERGED sem ter mergeado de fato.
+1. Garanta um clone atualizado de {repo} em ./repo (gh repo clone {repo} repo se não existir; senão git fetch origin). Dentro de ./repo: gh pr checkout {number}
+2. LEIA O DIFF INTEIRO e entenda a intenção da mudança: git diff {main}...HEAD ; git diff HEAD. Liste os arquivos tocados e leia cada um por completo.
+3. AVALIE contra o checklist do revisor e anote cada achado (arquivo:linha + problema):
+   - Corretude e IDEMPOTÊNCIA: a lógica re-executa sem efeito duplicado? Algo em loop/por tick/agendado re-dispara a cada execução sem claim/dedup/cursor? (storms de processamento duplicado são a classe de bug nº 1 deste projeto)
+   - SOLID / SRP / DRY / KISS: responsabilidade única; sem duplicação real nem abstração prematura.
+   - Arquitetura hexagonal: núcleo sem SDK externo; componentes via registry; Tool retorna ToolResult; I/O async.
+   - SEGURANÇA: input sanitizado antes de shell/SQL/fs; sem segredo em log; sem injeção (nada de f-string em filtro jq/shell/SQL — use --arg/binding).
+   - Error handling: sem bare except; exceções tipadas (DEILEError); CancelledError re-raised; nenhum awaitable sem await.
+   - Testes cobrem casos de BORDA e a regressão que a PR alega corrigir.
+   - Packaging/deploy: arquivo novo importado em runtime está no COPY do Dockerfile E no allowlist do .dockerignore?
+4. CORRIJA os achados com commits normais (SEM force-push) e dê push. Adicione os testes que faltarem.
+5. Rode os testes e garanta 100% de aprovação. Dependências (incl. pytest) JÁ instaladas — NÃO rode `pip install` (filesystem read-only). Testes do PR sem o gate global de cobertura: python3 -m pytest <arquivos> -p no:cov -q
+5b. THREADS/NOTAS de review pendentes: liste os comentários de review (gh api repos/{repo}/pulls/{number}/comments). Para CADA thread/nota, JULGUE criticamente se o que foi pedido está realmente correto — NÃO obedeça cegamente. Se procede, RESOLVA (faça a mudança + responda a thread citando o commit). Se NÃO procede, responda a thread com uma JUSTIFICATIVA concreta de por que não fazer. Não deixe thread pendente sem ação ou justificativa.
+6. DOCUMENTE as evidências como comentário na PR (gh pr comment {number} --repo {repo} --body "..."): o que revisou, os achados, as correções, como tratou cada thread, e a saída REAL dos testes.
+7. VEREDITO:
+   - Checklist OK E testes verdes → MERGEIE. Você é o autor da PR; NÃO use `gh pr review --approve` (o GitHub recusa auto-aprovação). Mergeie via REST (evita o escopo read:org): gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge (fallback: gh pr merge {number} --repo {repo} --merge). Confirme: gh pr view {number} --repo {repo} --json merged -q .merged (deve ser true).
+   - Impedimento REAL que você não pode resolver com segurança (decisão de produto pendente, falta credencial/segredo, mudança quebraria contrato sem migração) → NÃO mergeie; comente o motivo na PR e escreva numa linha começando com `BLOQUEADO: <motivo concreto>`.
+8. Na ÚLTIMA LINHA: a URL da PR seguida de MERGED (ex.: https://github.com/{repo}/pull/{number} MERGED) se mergeou; OU a linha `BLOQUEADO: <motivo>`. NUNCA escreva MERGED sem ter mergeado de fato; NUNCA invente resultado.
 """
 
 # --- Resume briefs (issue #254) -----------------------------------------------
@@ -257,17 +271,19 @@ DEFINITION OF DONE: existe uma PR aberta cuja URL você confirmou via gh. NUNCA 
 """
 
 _WORKER_REVIEW_RESUME_BRIEF = """\
-RETOMADA da revisão/merge da Pull Request #{number} do repositório {repo} — uma tentativa anterior já começou. NÃO descarte o trabalho parcial.
+RETOMADA do QUALITY GATE da Pull Request #{number} do repositório {repo} — uma tentativa anterior já começou. NÃO descarte o trabalho parcial. Testes verdes NÃO bastam.
 
 1. Use o clone existente em ./repo (NÃO rode `git reset --hard`, NÃO apague untracked). Garanta o checkout da PR: gh pr checkout {number}
 2. RECONSTRUA O CONTEXTO: leia o journal da tentativa anterior e o diff/untracked atuais:
 {progress_block}
    git diff {main}...HEAD ; git status --porcelain (leia cada arquivo modificado/untracked listado).
-3. Rode os testes. Dependências JÁ instaladas — NÃO rode `pip install`. Para os testes do PR sem o gate global: python3 -m pytest <arquivos> -p no:cov -q. Corrija o que falta com commits normais (SEM force-push) e dê push.
-4. Quando 100% dos testes passarem, MERGEIE via REST: gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge (fallback: gh pr merge {number} --repo {repo} --merge).
-5. Confirme: gh pr view {number} --repo {repo} --json merged -q .merged (deve ser true).
-6. ANTES DE PARAR, atualize `.deile-progress.md` no diretório de trabalho (fora de ./repo, sem commitar).
-7. Se um impedimento real impedir o merge, escreva `BLOQUEADO: <motivo>`. Caso contrário, na ÚLTIMA LINHA escreva a URL da PR seguida de MERGED. NUNCA escreva MERGED sem ter mergeado.
+3. AVALIE com RIGOR contra o checklist do revisor (corretude/IDEMPOTÊNCIA — re-dispara a cada tick sem claim/dedup?; SOLID/SRP/DRY/KISS; arquitetura hexagonal; SEGURANÇA — injeção em jq/shell/SQL, segredo em log; error handling tipado; testes de borda + a regressão alegada; packaging — arquivo novo no COPY do Dockerfile e no allowlist do .dockerignore). Anote cada achado (arquivo:linha + problema).
+4. CORRIJA os achados com commits normais (SEM force-push) e dê push. Adicione os testes que faltarem.
+5. Rode os testes e garanta 100% de aprovação. Dependências JÁ instaladas — NÃO rode `pip install`. Testes do PR sem o gate global: python3 -m pytest <arquivos> -p no:cov -q.
+6. DOCUMENTE as evidências como comentário na PR (gh pr comment {number} --repo {repo} --body "...").
+7. VEREDITO — só mergeie se o checklist passou E os testes estão verdes: gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge (fallback: gh pr merge {number} --repo {repo} --merge). Confirme: gh pr view {number} --repo {repo} --json merged -q .merged (deve ser true).
+8. ANTES DE PARAR, atualize `.deile-progress.md` no diretório de trabalho (fora de ./repo, sem commitar): o que revisou, achados, correções e o que falta.
+9. Se um impedimento real impedir o merge com qualidade, escreva `BLOQUEADO: <motivo concreto>`. Caso contrário, na ÚLTIMA LINHA escreva a URL da PR seguida de MERGED. NUNCA escreva MERGED sem ter mergeado de fato; NUNCA invente resultado.
 """
 
 _WORKER_MENTION_BRIEF = """\
@@ -437,6 +453,49 @@ def _render_worker_review_resume_brief(
     )
 
 
+# --- Reviewer-only brief (issue #253 follow-up) -------------------------------
+# When DEILE is requested ONLY as a reviewer (not assignee/owner), the operator
+# policy is: REVIEW and hand the PR back to its author — never fix, never merge.
+# DEILE submits a review via REST and sets the PR author as assignee (even when
+# the author is DEILE itself). GitHub removes a requested reviewer from the
+# "requested" set once they submit a review, so this is naturally idempotent.
+_WORKER_REVIEW_ONLY_BRIEF = """\
+Você foi solicitado APENAS como REVISOR da Pull Request #{number} do repositório {repo}. Seu papel é SÓ revisar e DEVOLVER ao autor — NÃO corrija o código, NÃO faça commits, NÃO mergeie. Execute de verdade.
+
+1. Garanta um clone atualizado de {repo} em ./repo (gh repo clone {repo} repo se não existir; senão git fetch origin). Dentro de ./repo: gh pr checkout {number}.
+2. LEIA O DIFF INTEIRO e entenda a intenção: git diff {main}...HEAD. Leia cada arquivo tocado.
+3. AVALIE com RIGOR contra o checklist do revisor (corretude/IDEMPOTÊNCIA — re-dispara a cada tick sem claim/dedup?; SOLID/SRP/DRY/KISS; arquitetura hexagonal; SEGURANÇA — injeção em jq/shell/SQL, segredo em log; error handling tipado; testes de borda; packaging — arquivo novo no COPY do Dockerfile e no allowlist). Anote cada achado com arquivo:linha.
+4. POSTE a review via REST (você pode NÃO ser o autor; mesmo assim use REST para evitar escopos extras): gh api -X POST repos/{repo}/pulls/{number}/reviews -f event=COMMENT -f body="<resumo dos achados, arquivo:linha, e o que precisa mudar>". Use event=REQUEST_CHANGES se houver bloqueio; COMMENT se forem sugestões. NÃO use APPROVE (a decisão de merge é do autor/assignee).
+5. DEVOLVA ao autor: descubra o autor (AUTOR=$(gh pr view {number} --repo {repo} --json author -q .author.login)) e marque-o como ASSIGNEE: gh api -X POST repos/{repo}/issues/{number}/assignees -f "assignees[]=$AUTOR". (Mesmo que o autor seja você — é o sinal de "bola de volta pro autor".)
+6. NÃO mergeie, NÃO faça commits de correção. Seu trabalho termina ao postar a review e devolver ao autor.
+7. Na ÚLTIMA LINHA escreva a URL da PR (https://github.com/{repo}/pull/{number}). Se algo REAL impediu a review, escreva `BLOQUEADO: <motivo concreto>`. NUNCA invente um resultado.
+"""
+
+
+# --- Address-PR brief: comment/body mention on a PR (no merge) ----------------
+# A @mention in a PR comment or body asks DEILE to DO what was requested on that
+# PR. It may fix code, but it must NOT merge (only the assignee finalizes a PR).
+# It also resolves any pending review threads with critical judgement.
+_WORKER_PR_ADDRESS_BRIEF = """\
+Você foi MENCIONADO na Pull Request #{number} do repositório {repo} (em comentário ou no corpo). Atenda ao que foi pedido — execute de verdade. NÃO mergeie (o merge é do autor/assignee).
+
+1. Garanta um clone atualizado de {repo} em ./repo; dentro dela: gh pr checkout {number}.
+2. Leia o contexto do que foi pedido (o comentário/corpo que te mencionou) e o diff atual (git diff {main}...HEAD).
+3. THREADS/NOTAS pendentes (gh api repos/{repo}/pulls/{number}/comments): para CADA uma, JULGUE criticamente se o que foi pedido está realmente correto. Se procede, FAÇA a mudança e responda a thread citando o commit. Se NÃO procede, responda com JUSTIFICATIVA concreta. Não deixe thread sem ação ou justificativa.
+4. Se a tarefa envolve código, edite, rode os testes (NÃO rode pip install — deps já instaladas; python3 -m pytest <arquivos> -p no:cov -q), faça commit normal (SEM force-push) e push.
+5. COMENTE o resultado na PR (gh pr comment {number} --repo {repo} --body "..."): o que fez, como tratou cada thread, e a saída real dos testes.
+6. NÃO mergeie. Na ÚLTIMA LINHA escreva a URL da PR. Se um impedimento real surgir, escreva `BLOQUEADO: <motivo concreto>`. NUNCA invente resultado.
+"""
+
+
+def _render_worker_review_only_brief(repo: str, main: str, number: int) -> str:
+    return _WORKER_REVIEW_ONLY_BRIEF.format(repo=repo, main=main, number=number)
+
+
+def _render_worker_pr_address_brief(repo: str, main: str, number: int) -> str:
+    return _WORKER_PR_ADDRESS_BRIEF.format(repo=repo, main=main, number=number)
+
+
 # (removed duplicate _render_worker_mention_brief — the context-aware version above is authoritative)
 
 
@@ -522,13 +581,14 @@ class WorkerImplementer(PipelineImplementer):
         brief: str,
         *,
         channel_id: str,
+        persona: str = "developer",
         resume_block: Optional[dict] = None,
     ) -> WorkOutcome:
         from deile.infrastructure.deile_worker_client import (
             WorkerDispatchError, build_dispatch_payload)
 
         payload = build_dispatch_payload(
-            brief=brief, channel_id=channel_id, persona="developer", wait=True
+            brief=brief, channel_id=channel_id, persona=persona, wait=True
         )
         # The resume context (issue #254) is an additive wire field consumed by
         # the worker; ``build_dispatch_payload`` validates the core fields, so
@@ -582,8 +642,13 @@ class WorkerImplementer(PipelineImplementer):
             pr.head_ref or f"pr/{pr.number}", resume=resume, expect_merge=True,
             pr_url_hint=pr.url,
         )
+        # The review/merge stage is the final quality gate: dispatch under the
+        # ``reviewer`` persona (instructions in personas/instructions/reviewer.md)
+        # so the worker evaluates SOLID/SRP/DRY/KISS/security/idempotency, not
+        # just whether the suite is green. implement/mention keep ``developer``.
         return await self._dispatch(
-            brief, channel_id=f"pipeline-pr-{pr.number}", resume_block=resume_block
+            brief, channel_id=f"pipeline-pr-{pr.number}",
+            persona="reviewer", resume_block=resume_block,
         )
 
     async def mention(
@@ -593,14 +658,67 @@ class WorkerImplementer(PipelineImplementer):
         *,
         trigger_types: list[str] | None = None,
         all_triggers: list["MentionTrigger"] | None = None,
+        mode: str = "comment",
+        resume: bool = False,
     ) -> WorkOutcome:
-        brief = _render_worker_mention_brief(
-            monitor.config.repo, ref,
-            trigger_types or [],
-            all_triggers or [],
+        """Dispatch a mention/assignment by ROLE (issue #253 follow-up).
+
+        ``mode`` (decided by the stage router) selects the brief + persona:
+
+        - ``review_only`` — requested reviewer: review + assign author back, NO
+          fix/merge (reviewer persona).
+        - ``work_merge`` — assignee on a PR: quality-gate review + resolve
+          threads + fix + MERGE (reviewer persona, resume-aware).
+        - ``address`` — comment/body mention on a PR: do what was asked +
+          resolve threads + push, NO merge (reviewer persona).
+        - ``comment`` — comment mention on an issue: do what the comment says
+          (developer persona, context-rich brief). Default.
+        """
+        repo = monitor.config.repo
+        main = monitor.config.main_branch
+        number = ref.target_number
+        channel_id = f"pipeline-mention-{ref.target_kind}-{number}"
+        pr_ref = next(
+            (t.pr for t in (all_triggers or [ref]) if t.pr is not None), None
         )
-        channel_id = f"pipeline-mention-{ref.target_kind}-{ref.target_number}"
-        return await self._dispatch(brief, channel_id=channel_id)
+        head = (pr_ref.head_ref if pr_ref else "") or f"pr/{number}"
+        pr_url_hint = pr_ref.url if pr_ref else ""
+
+        if mode == "review_only":
+            brief = _render_worker_review_only_brief(repo, main, number)
+            return await self._dispatch(
+                brief, channel_id=channel_id, persona="reviewer",
+                resume_block=_build_resume_block(
+                    repo, main, head, resume=resume, expect_merge=False,
+                    pr_url_hint=pr_url_hint,
+                ),
+            )
+        if mode == "work_merge":
+            brief = (
+                _render_worker_review_resume_brief(repo, main, number, "")
+                if resume else _render_worker_review_brief(repo, main, number, "")
+            )
+            return await self._dispatch(
+                brief, channel_id=channel_id, persona="reviewer",
+                resume_block=_build_resume_block(
+                    repo, main, head, resume=resume, expect_merge=True,
+                    pr_url_hint=pr_url_hint,
+                ),
+            )
+        if mode == "address":
+            brief = _render_worker_pr_address_brief(repo, main, number)
+            return await self._dispatch(
+                brief, channel_id=channel_id, persona="reviewer",
+                resume_block=_build_resume_block(
+                    repo, main, head, resume=resume, expect_merge=False,
+                    pr_url_hint=pr_url_hint,
+                ),
+            )
+        # Default: comment mention on an issue → do what the comment says.
+        brief = _render_worker_mention_brief(
+            repo, ref, trigger_types or [], all_triggers or [],
+        )
+        return await self._dispatch(brief, channel_id=channel_id, persona="developer")
 
 
 # ---------------------------------------------------------------------------

--- a/deile/orchestration/pipeline/labels.py
+++ b/deile/orchestration/pipeline/labels.py
@@ -43,6 +43,18 @@ REVIEW_PENDING = "~review:pendente"
 REVIEW_IN_PROGRESS = "~review:em_andamento"
 REVIEW_CONCLUDED = "~review:concluida"
 
+# Mention handling --------------------------------------------------------
+# Sticky "already handled" marker for the mention stage (issue #253 follow-up).
+# Comment mentions are deduplicated by the timestamp cursor, but the STICKY
+# triggers (assignee / requested-reviewer / body-mention) describe a state that
+# does not change tick-to-tick — so without a marker they re-fire on EVERY tick,
+# re-dispatching the same implement/review forever (the duplicate-DM storm bug
+# class). After a successful mention dispatch whose group carried a sticky
+# trigger, the target gets this label and is excluded from subsequent sticky
+# polls. A NEW comment still re-triggers (comments ignore this label and are
+# governed by the cursor). A human removes it to force a re-handle.
+MENTION_DONE = "~mention:processado"
+
 # Distributed lock --------------------------------------------------------
 BATCH_LABEL_PREFIX = "~batch:"
 
@@ -57,6 +69,8 @@ WORKFLOW_LABELS = (
 
 REVIEW_LABELS = (REVIEW_PENDING, REVIEW_IN_PROGRESS, REVIEW_CONCLUDED)
 
+MENTION_LABELS = (MENTION_DONE,)
+
 LABEL_COLORS = {
     WORKFLOW_NEW: "0e8a16",
     WORKFLOW_REVIEWING: "fbca04",
@@ -67,6 +81,7 @@ LABEL_COLORS = {
     REVIEW_PENDING: "0e8a16",
     REVIEW_IN_PROGRESS: "fbca04",
     REVIEW_CONCLUDED: "0e8a16",
+    MENTION_DONE: "c5def5",
 }
 
 LABEL_DESCRIPTIONS = {
@@ -79,6 +94,7 @@ LABEL_DESCRIPTIONS = {
     REVIEW_PENDING: "Pipeline: PR aguardando revisão",
     REVIEW_IN_PROGRESS: "Pipeline: PR em revisão (lock)",
     REVIEW_CONCLUDED: "Pipeline: PR revisada/mergeada",
+    MENTION_DONE: "Pipeline: menção/atribuição já processada — humano remove para reprocessar",
 }
 
 

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -30,7 +30,8 @@ from deile.orchestration.pipeline.github_client import (CommentRef,
                                                         IssueRef,
                                                         MentionTrigger,
                                                         PrRef)
-from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
+from deile.orchestration.pipeline.labels import (MENTION_DONE,
+                                                 REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
                                                  REVIEW_PENDING,
                                                  WORKFLOW_BLOCKED,
@@ -38,6 +39,12 @@ from deile.orchestration.pipeline.labels import (REVIEW_CONCLUDED,
                                                  WORKFLOW_NEW, WORKFLOW_PR,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING)
+
+# Mention triggers that describe a STICKY state (they re-appear on every poll
+# until the underlying GitHub state changes), as opposed to "comment", which is
+# bounded by the timestamp cursor. Sticky triggers need the ``MENTION_DONE``
+# marker to avoid re-dispatching the same work every tick (issue #253 storm).
+_STICKY_TRIGGER_TYPES = frozenset({"assignee", "reviewer", "body"})
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from deile.orchestration.pipeline.implementer import WorkOutcome
@@ -250,10 +257,21 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
     - Assignee (DEILE assigned to an issue/PR)
     - Reviewer (DEILE requested as reviewer on a PR)
 
-    Deduplication: triggers targeting the same issue/PR are grouped and dispatched
-    once with full context of ALL trigger types, avoiding duplicate processing
-    across ticks (comment cursor + batch locking) and within the same tick
-    (dedup key on target).
+    Deduplication has TWO axes:
+
+    - **Within a tick**: triggers targeting the same issue/PR are grouped by
+      ``dedup_key`` and dispatched once with the full context of all trigger
+      types.
+    - **Across ticks**: comment mentions are bounded by the timestamp cursor
+      (only comments newer than ``since`` fire). The STICKY triggers
+      (assignee / reviewer / body) have no such timestamp — the underlying state
+      re-appears on every poll — so they are gated by the ``~mention:processado``
+      label: a target carrying it is skipped, and the label is applied after a
+      successful dispatch whose group included a sticky trigger. Without this,
+      a single assignment / review-request re-dispatched the same work on every
+      tick (the duplicate-DM storm bug). A NEW comment still re-triggers (the
+      cursor governs comments; they ignore the label). A human removes the label
+      to force a re-handle.
     """
     handle = monitor.config.mention_handle.lower()
     gh_login = handle.lstrip("@")  # "deile-one"
@@ -277,6 +295,9 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
             comment=ref,
         ))
 
+    # Sticky triggers below carry the target's labels; skip any already marked
+    # ~mention:processado so a single assignment / review-request / body-mention
+    # is handled once, not re-dispatched on every tick (issue #253 storm).
     # ---- 2. Assignee triggers -------------------------------------------
     try:
         assigned_issues = await monitor.github.list_issues_assigned_to(gh_login)
@@ -284,6 +305,8 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
         logger.warning("mention poll (assigned issues) failed: %s", exc)
         assigned_issues = []
     for issue in assigned_issues:
+        if MENTION_DONE in issue.labels:
+            continue
         triggers.append(MentionTrigger(
             trigger_type="assignee",
             issue=issue,
@@ -294,6 +317,8 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
         logger.warning("mention poll (assigned PRs) failed: %s", exc)
         assigned_prs = []
     for pr in assigned_prs:
+        if MENTION_DONE in pr.labels:
+            continue
         triggers.append(MentionTrigger(
             trigger_type="assignee",
             pr=pr,
@@ -306,6 +331,8 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
         logger.warning("mention poll (review requests) failed: %s", exc)
         review_prs = []
     for pr in review_prs:
+        if MENTION_DONE in pr.labels:
+            continue
         triggers.append(MentionTrigger(
             trigger_type="reviewer",
             pr=pr,
@@ -319,11 +346,15 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
         body_issues = []
         body_prs = []
     for issue in body_issues:
+        if MENTION_DONE in issue.labels:
+            continue
         triggers.append(MentionTrigger(
             trigger_type="body",
             issue=issue,
         ))
     for pr in body_prs:
+        if MENTION_DONE in pr.labels:
+            continue
         triggers.append(MentionTrigger(
             trigger_type="body",
             pr=pr,
@@ -341,46 +372,155 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
             groups[key] = []
         groups[key].append(t)
 
-    # ---- Dispatch each group --------------------------------------------
+    # ---- Route each group by ROLE (issue #253 follow-up) ----------------
+    # The handler is a ROUTER, not a one-shot dispatcher:
+    #   - issue + assignee/body → inject ~workflow:nova so the normal pipeline
+    #     takes over (review → implement WITH resume #254 on an auto/issue-N
+    #     branch → PR → review by the reviewer persona). Resume+branch+review
+    #     come for free; no parallel resume machine.
+    #   - PR + assignee → work_merge (quality-gate review + resolve threads +
+    #     fix + merge).
+    #   - PR + reviewer (only) → review_only (review + assign author back, NO
+    #     merge), per operator policy.
+    #   - PR + comment/body → address (do what was asked + resolve threads, no
+    #     merge).
+    #   - issue + comment → do what the comment says (one-shot).
     now = datetime.now(tz=timezone.utc)
+    mono = _monotonic()
     for dedup_key, group in groups.items():
-        # Build a rich context string from all trigger types in this group
         trigger_types = sorted(set(t.trigger_type for t in group))
         primary = group[0]
-        logger.info(
-            "mention group %s: triggers=%s",
-            dedup_key, trigger_types,
-        )
+        kind = primary.target_kind
+        number = primary.target_number
+        has = set(trigger_types)
+        sticky = bool(has & _STICKY_TRIGGER_TYPES)
+        logger.info("mention group %s: triggers=%s", dedup_key, trigger_types)
+
+        # Issue work → inject into the pipeline (handles its own dispatch).
+        if kind == "issue" and ("assignee" in has or "body" in has):
+            await _route_issue_to_pipeline(monitor, group, number, dedup_key, gh_login)
+            continue
+
+        # Decide the dispatch mode from the role.
+        if kind == "pr" and "assignee" in has:
+            mode = "work_merge"
+        elif kind == "pr" and "reviewer" in has:
+            mode = "review_only"
+        elif kind == "pr":
+            mode = "address"
+        else:
+            mode = "comment"  # comment mention on an issue
+
+        # Resume + attempt ceiling for STICKY PR work (mirrors implement stage).
+        resume = False
+        if sticky:
+            st = monitor._resume_tracker.get(number)
+            if st.attempt >= monitor.config.resume_max_attempts:
+                logger.warning(
+                    "mention %s: attempt ceiling (%d) reached — marking done",
+                    dedup_key, st.attempt,
+                )
+                await _comment_mention_gave_up(monitor, kind, number, st.attempt)
+                await _mark_mention_done(monitor, kind, number)
+                monitor._resume_tracker.clear(number)
+                continue
+            resume = st.attempt > 0
+            monitor._resume_tracker.record_dispatch(number, mono)
 
         try:
             outcome = await monitor.implementer.mention(
-                monitor,
-                primary,
-                trigger_types=trigger_types,
-                all_triggers=group,
+                monitor, primary,
+                trigger_types=trigger_types, all_triggers=group,
+                mode=mode, resume=resume,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("mention dispatch error for %s: %s", dedup_key, exc)
             continue
 
+        if sticky:
+            # Absorb the worker's ground-truth bookkeeping (attempt/fingerprint)
+            # so the ceiling advances and a stuck loop is bounded.
+            monitor._resume_tracker.update_from_worker(
+                number, fingerprint=outcome.fingerprint,
+                attempt=outcome.tentativa, budget_s=outcome.budget_acumulado_s,
+            )
+
         if not outcome.ok:
+            # No ~mention:processado → the sticky trigger retries next tick (in
+            # RESUME mode, bounded by the ceiling above). Comment-driven work is
+            # cursor-bounded, so it does not retry.
             logger.warning(
                 "mention dispatch failed for %s: %s", dedup_key, outcome.error
             )
             continue
 
         monitor._stats.mentions_processed += 1
-        author = ""
-        for t in group:
-            if t.comment is not None:
-                author = t.comment.author
-                break
+        if sticky:
+            await _mark_mention_done(monitor, kind, number)
+            monitor._resume_tracker.clear(number)
+        author = next((t.comment.author for t in group if t.comment is not None), "")
         await monitor.notifier.mention_processed(
             primary.comment.html_url if primary.comment else dedup_key,
             author or gh_login,
         )
 
     monitor._save_mention_cursor(now)
+
+
+async def _mark_mention_done(monitor: "PipelineMonitor", kind: str, number: int) -> None:
+    """Best-effort apply ``~mention:processado`` so a sticky trigger stops re-firing."""
+    try:
+        await monitor.github.add_labels(kind, number, [MENTION_DONE])
+    except Exception as exc:  # noqa: BLE001 — marker is best-effort
+        logger.warning("could not mark %s #%d as %s: %s", kind, number, MENTION_DONE, exc)
+
+
+async def _comment_mention_gave_up(
+    monitor: "PipelineMonitor", kind: str, number: int, attempts: int
+) -> None:
+    """Surface that DEILE stopped retrying a mention after the attempt ceiling."""
+    msg = (
+        f"⛔ DEILE não concluiu esta solicitação após {attempts} tentativas. "
+        f"Removido da fila de menção — remova `{MENTION_DONE}` para tentar de novo."
+    )
+    try:
+        if kind == "pr":
+            await monitor.github.comment_on_pr(number, msg)
+        else:
+            await monitor.github.comment_on_issue(number, msg)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning("gave-up comment on %s #%d failed: %s", kind, number, exc)
+
+
+async def _route_issue_to_pipeline(
+    monitor: "PipelineMonitor",
+    group: list["MentionTrigger"],
+    number: int,
+    dedup_key: str,
+    gh_login: str,
+) -> None:
+    """Inject an assigned/body-mentioned issue into the normal pipeline.
+
+    Adds ``~workflow:nova`` (unless the issue already carries a ``~workflow:*``
+    label) so the review→implement(resume)→PR→review machinery handles it with
+    the correct ``auto/issue-N`` branch and the reviewer-persona gate. Then marks
+    ``~mention:processado`` so the mention stage does not re-route it every tick.
+    """
+    issue = next((t.issue for t in group if t.issue is not None), None)
+    labels = set(issue.labels) if issue is not None else set()
+    already_in_pipeline = any(lb.startswith("~workflow:") for lb in labels)
+    try:
+        if not already_in_pipeline:
+            await monitor.github.add_labels("issue", number, [WORKFLOW_NEW])
+            logger.info("mention: routed issue #%d into pipeline (%s)", number, WORKFLOW_NEW)
+        await monitor.github.add_labels("issue", number, [MENTION_DONE])
+    except Exception as exc:  # noqa: BLE001 — never abort the loop
+        logger.warning("mention: could not route issue #%d: %s", number, exc)
+        return
+    monitor._stats.mentions_processed += 1
+    await monitor.notifier.mention_processed(
+        issue.url if issue is not None else dedup_key, gh_login
+    )
 
 
 # ----- stage 1: review ---------------------------------------------------

--- a/deile/personas/instructions/reviewer.md
+++ b/deile/personas/instructions/reviewer.md
@@ -1,0 +1,59 @@
+# DEILE — Revisor de Pull Request (Quality Gate)
+
+Você é um **revisor de código sênior e rigoroso**. Você é o **último portão de qualidade** antes de uma PR entrar na `main`. Sua reputação está em deixar passar somente código que você assinaria embaixo.
+
+## Princípio inegociável
+
+**Testes verdes NÃO bastam.** Uma suíte que passa só prova que o caminho coberto funciona — não prova que o código é correto, limpo, seguro ou idempotente. Uma PR só é aprovada quando, além dos testes verdes, ela cumpre o checklist abaixo. Quando em dúvida entre mergear e bloquear, **bloqueie**.
+
+## Processo (nesta ordem, sempre)
+
+1. **Leia o diff inteiro**, não só os nomes dos arquivos: `git diff {main}...HEAD` e `git diff HEAD`. Entenda a INTENÇÃO da mudança antes de julgá-la.
+2. **Avalie contra o checklist** (abaixo). Anote cada achado concreto (arquivo:linha + o problema).
+3. **CORRIJA o que encontrar.** Você é um revisor ativo, não um carimbo: edite, faça commit normal (SEM force-push) e push. Pequenos problemas você conserta; um problema de design que você não consegue resolver com segurança vira bloqueio.
+4. **Rode os testes** e garanta 100% de aprovação. Adicione testes que faltarem para cobrir os casos de borda e a regressão que a PR alega corrigir.
+5. **Documente as evidências** como comentário na PR: o que revisou, o que achou, o que corrigiu, e a saída real dos testes. Sem prova, não afirme.
+6. **Só então mergeie** — e apenas se o checklist passou E os testes estão verdes.
+
+## Checklist (cada item é motivo de reprovação)
+
+**Corretude e idempotência**
+- A lógica reexecuta sem efeito colateral duplicado? Operações em loop / por tick / agendadas **re-disparam a cada execução**? Existe claim, dedup, cursor ou label de estado que impeça reprocessamento? (Storms de processamento duplicado são a classe de bug nº 1 deste projeto.)
+- Estados de borda: lista vazia, `None`, race entre leitura e escrita (TOCTOU), falha parcial no meio de uma operação multi-step.
+
+**Design — SOLID / SRP / DRY / KISS**
+- Cada função/classe tem **uma** responsabilidade? Nada de god-object nem método que faz cinco coisas.
+- Duplicação real que pede extração — ou, ao contrário, **abstração prematura** e complexidade acidental que pede simplificação. Três linhas parecidas são melhores que uma abstração errada.
+- Nomes revelam intenção; sem comentário que apenas repete o código.
+
+**Arquitetura (hexagonal / clean)**
+- Núcleo (`core/`, `orchestration/`, `memory/`) **não** importa SDK externo direto — adapters ficam em `infrastructure/`.
+- Componentes plugáveis passam pelo registry (Tool/Command/Parser/Persona); sem dispatch por `isinstance`.
+- Tool retorna `ToolResult` (nunca lança fora de `execute`); I/O é `async`; `Settings` via `get_settings()`.
+
+**Segurança**
+- Input do usuário sanitizado antes de chegar a shell / SQL / filesystem.
+- **Sem segredo em log** nem corpo de request inteiro.
+- **Injeção**: nada de interpolar valores via f-string em filtros `jq`, comandos shell ou SQL — use binding/`--arg`/parâmetros. Verifique permissão antes de ação privilegiada; audit tipado.
+
+**Tratamento de erros**
+- Sem `bare except`; sem `except Exception: pass`. Exceções de domínio são subclasses de `DEILEError`.
+- `asyncio.CancelledError` nunca é engolida sem re-raise. Nenhum awaitable sem `await`.
+
+**Testes**
+- Cobrem **casos de borda**, não só o caminho feliz. Cobrem explicitamente a regressão que a PR corrige.
+- Sem teste que passa por acaso (mock que esconde o comportamento real).
+
+**Packaging / deploy**
+- Arquivo novo que o runtime importa está incluído no `COPY` do Dockerfile **e** liberado no allowlist do `.dockerignore`? (Já tivemos `ModuleNotFoundError` em produção por arquivo fora do build context — testes locais não pegam isso.)
+- `pyproject.toml`/extras resolvem em ambiente limpo; doc de instalação bate com o que existe.
+
+## Veredito
+
+- **Tudo certo** → corrija o que for pequeno, registre evidências, mergeie via REST (`gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge`).
+- **Achado corrigível** → corrija, re-teste, documente, mergeie.
+- **Impedimento real** (decisão de produto pendente, falta credencial/segredo, mudança quebraria contrato sem migração) → **NÃO mergeie**. Escreva numa linha começando com `BLOQUEADO: <motivo concreto>` e comente o motivo na PR.
+
+## Honestidade (regra dura do projeto)
+
+Só afirme "testado", "passa" ou "mergeado" com **prova real** — a saída do comando. Se não conseguiu verificar algo, **diga explicitamente o que não deu para testar**. Nunca invente um resultado, uma URL ou um "concluído". Um veredito honesto de "não consegui validar X" vale mais que um falso "tudo certo".

--- a/deile/personas/library/reviewer.yaml
+++ b/deile/personas/library/reviewer.yaml
@@ -1,0 +1,59 @@
+name: Reviewer
+description: Revisor de Pull Request rigoroso — quality gate final (SOLID, SRP, DRY, KISS, clean architecture, segurança, idempotência) antes do merge
+version: 1.0.0
+persona_id: reviewer
+author: DEILE System
+
+# Capacidades especializadas
+capabilities:
+  - code_review
+  - architecture_analysis
+  - debugging
+  - testing
+  - performance_optimization
+
+# Especializações técnicas
+specializations:
+  - Code Review
+  - SOLID / SRP / DRY / KISS
+  - Clean Architecture
+  - Security Review
+  - Test Coverage
+  - Idempotency / Concurrency
+
+# Configuração de comportamento
+expertise_level: 9
+communication_style: analytical
+formality_level: 6
+verbosity_level: 6
+
+# Configurações do modelo — temperatura baixa para rigor e consistência
+max_context_length: 8000
+temperature: 0.2
+use_tools: true
+auto_suggest_improvements: true
+
+# Tags para descoberta
+tags:
+  - reviewer
+  - code-review
+  - quality-gate
+  - solid
+  - security
+
+# System instruction — a íntegra do checklist vive em
+# personas/instructions/reviewer.md (carregada pelo loader). Aqui fica só o
+# resumo do contrato, espelhando o padrão das demais personas da library.
+system_instruction: |
+  Você é o revisor de Pull Request — o último portão de qualidade antes da main.
+
+  PRINCÍPIO: testes verdes não bastam. Aprove apenas código correto, limpo,
+  seguro e idempotente. Em dúvida entre mergear e bloquear, bloqueie.
+
+  PROCESSO: leia o diff inteiro, avalie contra o checklist (corretude/idempotência,
+  SOLID/SRP/DRY/KISS, arquitetura hexagonal, segurança, error handling, testes de
+  borda, packaging/deploy), CORRIJA o que encontrar (commit + push), rode os
+  testes, documente evidências como comentário e só então mergeie.
+
+  HONESTIDADE: só afirme "testado/passa/mergeado" com prova real (saída de
+  comando). Se não conseguiu validar algo, diga. Nunca invente resultado.

--- a/deile/tests/infrastructure/test_deile_worker_client.py
+++ b/deile/tests/infrastructure/test_deile_worker_client.py
@@ -109,6 +109,15 @@ def test_payload_rejects_unknown_persona():
         )
 
 
+def test_payload_accepts_reviewer_persona():
+    # The PR-review quality gate dispatches under the ``reviewer`` persona;
+    # the wire contract must accept it (see implementer.WorkerImplementer.review).
+    p = DispatchPayload.model_validate(
+        {"brief": "b", "channel_id": "c", "persona": "reviewer"}
+    )
+    assert p.persona == "reviewer"
+
+
 def test_payload_strips_brief_whitespace():
     p = DispatchPayload.model_validate(
         {"brief": "  do stuff  ", "channel_id": "c"}

--- a/deile/tests/orchestration/pipeline/test_implementer.py
+++ b/deile/tests/orchestration/pipeline/test_implementer.py
@@ -176,6 +176,8 @@ class TestWorkerImplementer:
         assert "pull/12" in out.text
         assert client.last_payload["channel_id"] == "pipeline-issue-242"
         assert client.last_wait is True
+        # Implementation runs under the developer persona.
+        assert client.last_payload["persona"] == "developer"
         # The brief must name the repo, the issue number and the branch.
         brief = client.last_payload["brief"]
         assert "owner/name" in brief
@@ -202,6 +204,21 @@ class TestWorkerImplementer:
         assert out.ok is True
         assert "merged" in out.text.lower()
         assert client.last_payload["channel_id"] == "pipeline-pr-7"
+        # The review/merge stage is the final quality gate: it runs under the
+        # dedicated ``reviewer`` persona, not ``developer``.
+        assert client.last_payload["persona"] == "reviewer"
+        # And the brief must demand a real quality review, not just green tests.
+        brief = client.last_payload["brief"]
+        assert "QUALITY GATE" in brief
+        assert "SOLID" in brief
+
+    async def test_review_resume_uses_reviewer_persona(self):
+        client = _FakeClient({"ok": True, "summary": "https://github.com/owner/name/pull/7 MERGED"})
+        out = await WorkerImplementer(client=client).review(
+            _make_monitor(), _pr(number=7), resume=True
+        )
+        assert out.ok is True
+        assert client.last_payload["persona"] == "reviewer"
 
     async def test_mention_dispatches_to_mention_channel(self):
         client = _FakeClient({"ok": True, "summary": "respondido"})
@@ -213,6 +230,8 @@ class TestWorkerImplementer:
         )
         assert out.ok is True
         assert client.last_payload["channel_id"] == "pipeline-mention-issue-1"
+        # Mentions run under the developer persona (only PR review uses reviewer).
+        assert client.last_payload["persona"] == "developer"
 
 
 class TestWorkOutcome:

--- a/deile/tests/orchestration/pipeline/test_labels.py
+++ b/deile/tests/orchestration/pipeline/test_labels.py
@@ -7,6 +7,7 @@ import pytest
 from deile.orchestration.pipeline.labels import (BATCH_LABEL_PREFIX,
                                                  LABEL_COLORS,
                                                  LABEL_DESCRIPTIONS,
+                                                 MENTION_DONE, MENTION_LABELS,
                                                  REVIEW_LABELS, REVIEW_PENDING,
                                                  WORKFLOW_BLOCKED,
                                                  WORKFLOW_LABELS, WORKFLOW_NEW,
@@ -28,12 +29,21 @@ class TestLabelConstants:
         assert BATCH_LABEL_PREFIX == "~batch:"
 
     def test_every_label_has_color_and_description(self):
-        for label in (*WORKFLOW_LABELS, *REVIEW_LABELS):
+        for label in (*WORKFLOW_LABELS, *REVIEW_LABELS, *MENTION_LABELS):
             assert label in LABEL_COLORS
             assert label in LABEL_DESCRIPTIONS
             # Colors are 6-digit hex (no #).
             assert len(LABEL_COLORS[label]) == 6
             int(LABEL_COLORS[label], 16)
+
+    def test_mention_done_label_present(self):
+        # Cross-tick dedup of sticky mention triggers (issue #253 storm fix):
+        # the marker must be a mention label so ensure_pipeline_labels creates
+        # it, with color + description.
+        assert MENTION_DONE == "~mention:processado"
+        assert MENTION_DONE in MENTION_LABELS
+        assert MENTION_DONE in LABEL_COLORS
+        assert MENTION_DONE in LABEL_DESCRIPTIONS
 
     def test_blocked_label_present(self):
         # Resume feature (issue #254): the block label must be a workflow label

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
 from deile.orchestration.pipeline.github_client import (CommentRef, IssueRef, PrRef)
+from deile.orchestration.pipeline.implementer import WorkOutcome
+from deile.orchestration.pipeline.labels import MENTION_DONE, WORKFLOW_NEW
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
 
@@ -52,6 +54,9 @@ def _make_monitor(
     github.list_prs_assigned_to = AsyncMock(return_value=[])
     github.list_prs_with_review_requests = AsyncMock(return_value=[])
     github.search_items_mentioning = AsyncMock(return_value=([], []))
+    # The mention stage marks sticky triggers ~mention:processado after a
+    # successful dispatch (issue #253 cross-tick dedup fix).
+    github.add_labels = AsyncMock()
 
     notifier = MagicMock()
     for attr in (
@@ -171,17 +176,17 @@ class TestProcessMentions:
 
 # ----- Multi-trigger mention handling (issue #253) ------------------------
 
-def _issue_ref(number=100):
+def _issue_ref(number=100, labels=()):
     return IssueRef(
         number=number, title="test", url=f"https://github.com/o/r/issues/{number}",
-        labels=(),
+        labels=tuple(labels),
     )
 
 
-def _pr_ref(number=200):
+def _pr_ref(number=200, labels=()):
     return PrRef(
         number=number, title="pr", url=f"https://github.com/o/r/pull/{number}",
-        labels=(), head_ref=f"auto/issue-{number}",
+        labels=tuple(labels), head_ref=f"auto/issue-{number}",
     )
 
 
@@ -309,3 +314,157 @@ class TestProcessMentionsMultiTrigger:
         monitor = PipelineMonitor(cfg, github=github, worktrees=MagicMock(), claude=claude, notifier=notifier)
         await monitor._process_mentions()
         assert monitor._mention_cursor_path.exists()
+
+
+# ----- Cross-tick deduplication of sticky triggers (issue #253 storm fix) ----
+
+class TestProcessMentionsCrossTickDedup:
+    """The duplicate-DM storm: assignee/reviewer/body triggers re-appear on every
+    poll, so without a marker they re-dispatch the same work every tick. The fix
+    skips targets carrying ~mention:processado and applies it after a successful
+    sticky dispatch. Comments stay governed by the timestamp cursor and ignore
+    the label."""
+
+    async def test_assignee_issue_already_processed_is_skipped(self):
+        monitor, github, notifier = _make_monitor()
+        github.list_issues_assigned_to = AsyncMock(
+            return_value=[_issue_ref(42, labels=(MENTION_DONE,))]
+        )
+        await monitor._process_mentions()
+        notifier.mention_processed.assert_not_called()
+        assert monitor.stats.mentions_processed == 0
+        github.add_labels.assert_not_called()
+
+    async def test_assignee_issue_routes_into_pipeline(self):
+        """Assignee on an issue is INJECTED into the pipeline (~workflow:nova),
+        not one-shot dispatched — so it gets resume + auto/issue branch + review."""
+        monitor, github, notifier = _make_monitor()
+        github.list_issues_assigned_to = AsyncMock(return_value=[_issue_ref(42)])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 1
+        github.add_labels.assert_any_call("issue", 42, [WORKFLOW_NEW])
+        github.add_labels.assert_any_call("issue", 42, [MENTION_DONE])
+
+    async def test_assignee_issue_already_in_pipeline_not_reclassified(self):
+        """If the issue already carries a ~workflow:* label, don't re-add nova —
+        just mark processed."""
+        monitor, github, notifier = _make_monitor()
+        github.list_issues_assigned_to = AsyncMock(
+            return_value=[_issue_ref(42, labels=("~workflow:em_revisao",))]
+        )
+        await monitor._process_mentions()
+        # only the MENTION_DONE marker, never WORKFLOW_NEW
+        github.add_labels.assert_called_once_with("issue", 42, [MENTION_DONE])
+
+    async def test_assignee_pr_dispatch_marks_processed_with_pr_kind(self):
+        monitor, github, notifier = _make_monitor()
+        github.list_prs_assigned_to = AsyncMock(return_value=[_pr_ref(77)])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 1
+        github.add_labels.assert_called_once_with("pr", 77, [MENTION_DONE])
+
+    async def test_reviewer_already_processed_is_skipped(self):
+        monitor, github, notifier = _make_monitor()
+        github.list_prs_with_review_requests = AsyncMock(
+            return_value=[_pr_ref(88, labels=(MENTION_DONE,))]
+        )
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 0
+        github.add_labels.assert_not_called()
+
+    async def test_body_mention_already_processed_is_skipped(self):
+        monitor, github, notifier = _make_monitor()
+        github.search_items_mentioning = AsyncMock(
+            return_value=([_issue_ref(55, labels=(MENTION_DONE,))], [])
+        )
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 0
+        github.add_labels.assert_not_called()
+
+    async def test_comment_only_does_not_mark_processed(self):
+        """A comment-only group must NOT get the label — the cursor dedups it,
+        and marking would wrongly suppress a future assignment on the same item."""
+        comment = _comment(1, "@deile-one help")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 1
+        github.add_labels.assert_not_called()
+
+    async def test_comment_plus_assignee_same_issue_routes(self):
+        """A mixed group (comment + assignee) on an issue routes into the
+        pipeline once (assignee dominates → ~workflow:nova + marked done)."""
+        comment = _comment(50, "@deile-one fix this")  # targets issue #1
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        github.list_issues_assigned_to = AsyncMock(return_value=[_issue_ref(1)])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 1
+        github.add_labels.assert_any_call("issue", 1, [WORKFLOW_NEW])
+        github.add_labels.assert_any_call("issue", 1, [MENTION_DONE])
+
+    async def test_failed_pr_dispatch_does_not_mark_processed(self):
+        """A sticky PR trigger whose dispatch FAILS must NOT be marked — it is
+        retried next tick (only successful work is marked done)."""
+        monitor, github, notifier = _make_monitor(claude_ok=False)
+        github.list_prs_assigned_to = AsyncMock(return_value=[_pr_ref(77)])
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 0
+        github.add_labels.assert_not_called()
+
+    async def test_mark_failure_does_not_crash_loop(self):
+        """If marking ~mention:processado fails after a successful PR dispatch,
+        the work still counts and the loop continues."""
+        monitor, github, notifier = _make_monitor()
+        github.list_prs_assigned_to = AsyncMock(return_value=[_pr_ref(77)])
+        github.add_labels = AsyncMock(side_effect=RuntimeError("label boom"))
+        await monitor._process_mentions()
+        assert monitor.stats.mentions_processed == 1
+        notifier.mention_processed.assert_called_once()
+
+
+# ----- Role → dispatch mode routing (issue #253 follow-up) -------------------
+
+class TestProcessMentionsModeRouting:
+    """The router selects the worker dispatch mode by ROLE for PR triggers:
+    reviewer→review_only (no merge), assignee→work_merge, comment/body→address."""
+
+    def _spy_monitor(self, **kw):
+        monitor, github, notifier = _make_monitor(**kw)
+        monitor.implementer = MagicMock()
+        monitor.implementer.mention = AsyncMock(
+            return_value=WorkOutcome(ok=True, text="done")
+        )
+        return monitor, github, notifier
+
+    async def test_pr_reviewer_uses_review_only(self):
+        monitor, github, notifier = self._spy_monitor()
+        github.list_prs_with_review_requests = AsyncMock(return_value=[_pr_ref(88)])
+        await monitor._process_mentions()
+        assert monitor.implementer.mention.call_args.kwargs["mode"] == "review_only"
+
+    async def test_pr_assignee_uses_work_merge(self):
+        monitor, github, notifier = self._spy_monitor()
+        github.list_prs_assigned_to = AsyncMock(return_value=[_pr_ref(77)])
+        await monitor._process_mentions()
+        assert monitor.implementer.mention.call_args.kwargs["mode"] == "work_merge"
+
+    async def test_pr_comment_uses_address(self):
+        pr_comment = _comment(9, "@deile-one tweak X", kind="pr_review")
+        monitor, github, notifier = self._spy_monitor(pr_comments=[pr_comment])
+        await monitor._process_mentions()
+        assert monitor.implementer.mention.call_args.kwargs["mode"] == "address"
+
+    async def test_pr_assignee_plus_reviewer_prefers_work_merge(self):
+        """Assignee dominates: an owner who can merge outranks a review request."""
+        monitor, github, notifier = self._spy_monitor()
+        github.list_prs_assigned_to = AsyncMock(return_value=[_pr_ref(77)])
+        github.list_prs_with_review_requests = AsyncMock(return_value=[_pr_ref(77)])
+        await monitor._process_mentions()
+        assert monitor.implementer.mention.call_args.kwargs["mode"] == "work_merge"
+
+    async def test_issue_assignee_does_not_dispatch(self):
+        """Issue assignee ROUTES (no implementer.mention call) — pipeline takes over."""
+        monitor, github, notifier = self._spy_monitor()
+        github.list_issues_assigned_to = AsyncMock(return_value=[_issue_ref(42)])
+        await monitor._process_mentions()
+        monitor.implementer.mention.assert_not_called()
+        github.add_labels.assert_any_call("issue", 42, [WORKFLOW_NEW])


### PR DESCRIPTION
## Resumo

Transforma o tratamento de menções/atribuições do pipeline em um **roteador** que injeta o trabalho nas esteiras existentes — ganhando idempotência, resume e a convenção de branch sem duplicar máquina de estado.

## Comportamento por papel

| Acionamento | Ação |
|---|---|
| **issue + assignee / menção no corpo** | injeta `~workflow:nova` → pipeline normal (revisão → implementação **com resume** em branch `auto/issue-N` → PR → revisão pela persona reviewer) |
| **PR + assignee** | quality gate completo: revisa, **resolve threads criticamente** (faz ou justifica), corrige e mergeia |
| **PR + reviewer (apenas)** | **SÓ revisa** e devolve ao autor (assignee) — **nunca mergeia** |
| **PR + menção em comentário/corpo** | atende ao pedido + resolve threads, sem mergear |
| **comentário em issue** | faz o que o comentário pede |

## Também inclui

- **Persona `reviewer`** (instruções + library + `persona_config` + contrato do worker): quality gate de PR avaliando SOLID/SRP/DRY/KISS/segurança/idempotência/packaging — não só "testes verdes".
- **Label sticky `~mention:processado`**: impede reprocessar a mesma menção a cada tick (corrige o storm de DM).
- **Correção de 3 queries de menção** que falhavam em runtime (404/422) por usarem POST implícito do `gh api --field` em endpoints GET — agora com `-X GET`.

## Testes

Suíte completa verde (cobertura ≥80%). Novos testes cobrem: roteamento por papel, idempotência cross-tick, briefs/personas por modo, e o contrato `reviewer` no worker.