### PR TITLE
fix(pipeline): scope PR triage to owned branches and skip batch lock on single monitor

### DIFF
--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -127,6 +127,10 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
         logger.error("could not list unclassified issues: %s", exc)
         return
 
+    # The ~batch: claim only matters with parallel monitors; a single monitor
+    # would add+remove the lock label in the same pass (timeline noise). Issues
+    # are already shard-filtered below, so the claim is doubly redundant here.
+    multi_monitor = monitor.identity.shard_count > 1
     for issue in issues:
         # Defense-in-depth: never touch an issue that already has a pipeline label.
         if any(lb.startswith("~") for lb in issue.labels):
@@ -143,18 +147,20 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
                 "issue #%s has empty body; auto-classifying and requesting template fill",
                 issue.number,
             )
-        # Claim before labelling to reduce the TOCTOU window with parallel monitors.
-        try:
-            batch = await monitor.github.claim_with_batch("issue", issue.number)
-        except GhCommandError as exc:
-            await _record_gh_error(
-                monitor, f"auto-classify claim #{issue.number} failed", exc,
-                notifier_label=f"auto-classify claim #{issue.number}",
-            )
-            continue
-        if batch is None:
-            logger.debug("issue #%s already claimed by another monitor; skipping", issue.number)
-            continue
+        # Claim before labelling to reduce the TOCTOU window with parallel
+        # monitors (skipped for a single monitor — see multi_monitor above).
+        if multi_monitor:
+            try:
+                batch = await monitor.github.claim_with_batch("issue", issue.number)
+            except GhCommandError as exc:
+                await _record_gh_error(
+                    monitor, f"auto-classify claim #{issue.number} failed", exc,
+                    notifier_label=f"auto-classify claim #{issue.number}",
+                )
+                continue
+            if batch is None:
+                logger.debug("issue #%s already claimed by another monitor; skipping", issue.number)
+                continue
         try:
             await monitor.github.add_labels("issue", issue.number, [WORKFLOW_NEW])
         except GhCommandError as exc:
@@ -174,10 +180,11 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
         # auto-classify → review handoff deadlocks (the issue stays ~nova
         # forever, batch-locked). Best-effort: the ~workflow:nova label is
         # already applied, so a clear failure must not abort the loop.
-        try:
-            await monitor.github.clear_batch_label("issue", issue.number)
-        except Exception as exc:  # noqa: BLE001 — label applied; clear is best-effort
-            logger.warning("auto-classify: could not clear batch on #%s: %s", issue.number, exc)
+        if multi_monitor:
+            try:
+                await monitor.github.clear_batch_label("issue", issue.number)
+            except Exception as exc:  # noqa: BLE001 — label applied; clear is best-effort
+                logger.warning("auto-classify: could not clear batch on #%s: %s", issue.number, exc)
         monitor._stats.issues_classified += 1
         logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
         await monitor.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
@@ -216,19 +223,31 @@ async def classify_new_prs(monitor: "PipelineMonitor") -> None:
         logger.error("could not list unclassified PRs: %s", exc)
         return
 
+    # Claiming a ~batch: lock only matters with parallel monitors; with a single
+    # monitor it would just add+remove the lock label in the same pass (timeline
+    # noise). Gate it on the shard count.
+    multi_monitor = monitor.identity.shard_count > 1
     for pr in prs:
         if any(lb.startswith("~") for lb in pr.labels):
             continue
-        try:
-            batch = await monitor.github.claim_with_batch("pr", pr.number)
-        except GhCommandError as exc:
-            await _record_gh_error(
-                monitor, f"pr_triage claim #{pr.number} failed", exc,
-            )
+        # Only triage PRs this monitor would actually review (Stage 3 claims by
+        # branch ownership — ``auto/issue-*`` for default identity, or any branch
+        # when ``enable_review_human_prs``). Without this, ``~review:pendente``
+        # is applied to PRs the pipeline never reviews (e.g. human/foreign
+        # branches), leaving them stuck "pendente" forever.
+        if not monitor._owns_pr_branch(pr.head_ref, pr_number=pr.number):
             continue
-        if batch is None:
-            logger.debug("PR #%s already claimed; skipping pr_triage", pr.number)
-            continue
+        if multi_monitor:
+            try:
+                batch = await monitor.github.claim_with_batch("pr", pr.number)
+            except GhCommandError as exc:
+                await _record_gh_error(
+                    monitor, f"pr_triage claim #{pr.number} failed", exc,
+                )
+                continue
+            if batch is None:
+                logger.debug("PR #%s already claimed; skipping pr_triage", pr.number)
+                continue
         try:
             await monitor.github.add_labels("pr", pr.number, [REVIEW_PENDING])
         except GhCommandError as exc:
@@ -237,8 +256,9 @@ async def classify_new_prs(monitor: "PipelineMonitor") -> None:
                 notifier_label=f"pr_triage #{pr.number}",
             )
             continue
-        # Release the batch claim so Stage 3 can pick this PR up via its own claim.
-        await monitor.github.clear_batch_label("pr", pr.number)
+        if multi_monitor:
+            # Release the batch claim so Stage 3 can pick this PR up via its own claim.
+            await monitor.github.clear_batch_label("pr", pr.number)
         monitor._stats.prs_classified += 1
         logger.info("pr_triage: classified PR #%s with %s", pr.number, REVIEW_PENDING)
         await monitor.notifier.pr_auto_classified(pr.number, pr.title, pr.url)

--- a/deile/tests/orchestration/pipeline/test_gap_regressions.py
+++ b/deile/tests/orchestration/pipeline/test_gap_regressions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import List, Optional, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -255,9 +256,22 @@ class TestGap5EmptyBodyAccepted:
 # ---------------------------------------------------------------------------
 
 class TestGap6Stage0UsesClaim:
-    async def test_classify_claims_before_labelling(self):
+    """Gap #6: with PARALLEL monitors Stage 0 claims a ~batch: lock BEFORE
+    labelling (TOCTOU mitigation). A SINGLE monitor skips the claim entirely so
+    the lock label isn't added+removed in the same pass (timeline noise)."""
+
+    async def test_single_monitor_labels_without_claim(self):
+        issue = _issue(4, ("intent",), body="body")
+        monitor, github, _ = _make_monitor(unclassified=[issue])  # default = 1 monitor
+        await monitor._classify_new_issues()
+        github.claim_with_batch.assert_not_called()
+        github.add_labels.assert_called_once_with("issue", 4, [WORKFLOW_NEW])
+
+    async def test_multi_monitor_claims_before_labelling(self):
         issue = _issue(4, ("intent",), body="body")
         monitor, github, _ = _make_monitor(unclassified=[issue])
+        # Stub a 2-monitor identity that owns everything (decouple from title hash).
+        monitor.identity = SimpleNamespace(shard_count=2, owns=lambda key: True)
         call_order = []
         github.claim_with_batch.side_effect = lambda *a, **_: call_order.append("claim") or "abc"
         github.add_labels.side_effect = lambda *a, **_: call_order.append("label")
@@ -265,9 +279,10 @@ class TestGap6Stage0UsesClaim:
         assert "claim" in call_order
         assert call_order.index("claim") < call_order.index("label")
 
-    async def test_classify_skips_when_claim_returns_none(self):
+    async def test_multi_monitor_skips_when_claim_returns_none(self):
         issue = _issue(5, ("intent",), body="body")
         monitor, github, _ = _make_monitor(unclassified=[issue])
+        monitor.identity = SimpleNamespace(shard_count=2, owns=lambda key: True)
         github.claim_with_batch = AsyncMock(return_value=None)
         await monitor._classify_new_issues()
         github.add_labels.assert_not_called()

--- a/deile/tests/orchestration/pipeline/test_pr_triage.py
+++ b/deile/tests/orchestration/pipeline/test_pr_triage.py
@@ -1,4 +1,10 @@
-"""Tests for PR triage: _classify_new_prs() in PipelineMonitor."""
+"""Tests for PR triage: _classify_new_prs() in PipelineMonitor.
+
+Triage only labels PRs the pipeline would actually review (branch ownership —
+``auto/issue-*`` for default identity, or any branch when
+``enable_review_human_prs``), and only claims a ``~batch:`` lock when more than
+one monitor runs (single-monitor adds the label directly, no lock churn).
+"""
 
 from __future__ import annotations
 
@@ -7,22 +13,30 @@ from unittest.mock import AsyncMock, MagicMock
 
 from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
 from deile.orchestration.pipeline.github_client import GhCommandError, PrRef
+from deile.orchestration.pipeline.identity import MonitorIdentity
 from deile.orchestration.pipeline.labels import REVIEW_PENDING
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
 
 
-def _pr(number: int, labels: tuple = ()) -> PrRef:
+def _pr(number: int, labels: tuple = (), head_ref: str | None = None) -> PrRef:
     return PrRef(
         number=number,
         title=f"PR #{number}",
         url=f"https://github.com/o/r/pull/{number}",
         labels=labels,
-        head_ref=f"feat/pr-{number}",
+        # Default to an owned (auto/issue-*) branch so the default-identity
+        # monitor triages it; tests pass an explicit head_ref for foreign PRs.
+        head_ref=head_ref if head_ref is not None else f"auto/issue-{number}",
     )
 
 
-def _make_monitor(*, unclassified_prs: list | None = None) -> tuple[PipelineMonitor, MagicMock, MagicMock]:
+def _make_monitor(
+    *,
+    unclassified_prs: list | None = None,
+    shard_count: int = 1,
+    review_human_prs: bool = False,
+) -> tuple[PipelineMonitor, MagicMock, MagicMock]:
     cfg = PipelineConfig(
         repo="owner/name",
         base_repo_path=Path("/tmp/fake"),
@@ -59,6 +73,13 @@ def _make_monitor(*, unclassified_prs: list | None = None) -> tuple[PipelineMoni
     ))
 
     monitor = PipelineMonitor(cfg, github=github, worktrees=worktrees, claude=claude, notifier=notifier)
+    # Inject a multi-monitor identity when requested (so the ~batch: claim path
+    # runs); enable_review_human_prs decouples ownership from branch prefix so
+    # the claim tests don't depend on per-monitor branch naming.
+    monitor.identity = MonitorIdentity(
+        monitor_id="default", shard_index=0, shard_count=shard_count
+    )
+    monitor.config.enable_review_human_prs = review_human_prs
     return monitor, github, notifier
 
 
@@ -69,13 +90,36 @@ class TestClassifyNewPrs:
         github.add_labels.assert_not_called()
         notifier.pr_auto_classified.assert_not_called()
 
-    async def test_one_unclassified_pr_gets_label(self):
+    async def test_owned_pr_gets_label_single_monitor(self):
+        """An owned (auto/issue-*) PR is labelled; single monitor doesn't claim."""
         pr = _pr(42)
         monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
         await monitor._classify_new_prs()
         github.add_labels.assert_called_once_with("pr", 42, [REVIEW_PENDING])
-        github.clear_batch_label.assert_called_once_with("pr", 42)
+        # Single monitor: NO ~batch: churn.
+        github.claim_with_batch.assert_not_called()
+        github.clear_batch_label.assert_not_called()
         notifier.pr_auto_classified.assert_called_once_with(42, pr.title, pr.url)
+        assert monitor.stats.prs_classified == 1
+
+    async def test_foreign_branch_pr_not_triaged(self):
+        """A PR on a non-auto branch (human/foreign) is NOT labelled — the
+        pipeline would never review it, so it must not get stuck ~review:pendente."""
+        pr = _pr(43, head_ref="feat/human-change")
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
+        await monitor._classify_new_prs()
+        github.add_labels.assert_not_called()
+        github.claim_with_batch.assert_not_called()
+        assert monitor.stats.prs_classified == 0
+
+    async def test_review_human_prs_triages_foreign_branch(self):
+        """With enable_review_human_prs, even a foreign branch is triaged."""
+        pr = _pr(43, head_ref="feat/human-change")
+        monitor, github, notifier = _make_monitor(
+            unclassified_prs=[pr], review_human_prs=True
+        )
+        await monitor._classify_new_prs()
+        github.add_labels.assert_called_once_with("pr", 43, [REVIEW_PENDING])
         assert monitor.stats.prs_classified == 1
 
     async def test_pr_with_tilde_label_skipped(self):
@@ -86,10 +130,25 @@ class TestClassifyNewPrs:
         github.add_labels.assert_not_called()
         assert monitor.stats.prs_classified == 0
 
+    async def test_multi_monitor_claims_and_clears(self):
+        """With >1 monitor, the ~batch: lock IS claimed and released."""
+        pr = _pr(42)
+        monitor, github, notifier = _make_monitor(
+            unclassified_prs=[pr], shard_count=2, review_human_prs=True
+        )
+        await monitor._classify_new_prs()
+        github.claim_with_batch.assert_called_once_with("pr", 42)
+        github.add_labels.assert_called_once_with("pr", 42, [REVIEW_PENDING])
+        github.clear_batch_label.assert_called_once_with("pr", 42)
+        assert monitor.stats.prs_classified == 1
+
     async def test_claim_returns_none_skips_pr(self):
-        """When claim_with_batch returns None (already claimed), PR is skipped."""
+        """When claim_with_batch returns None (already claimed), PR is skipped
+        (multi-monitor only — single monitor never claims)."""
         pr = _pr(44)
-        monitor, github, notifier = _make_monitor(unclassified_prs=[pr])
+        monitor, github, notifier = _make_monitor(
+            unclassified_prs=[pr], shard_count=2, review_human_prs=True
+        )
         github.claim_with_batch = AsyncMock(return_value=None)
         await monitor._classify_new_prs()
         github.add_labels.assert_not_called()
@@ -105,7 +164,9 @@ class TestClassifyNewPrs:
                 raise GhCommandError(["gh"], 1, "", "network")
             return "abc"
 
-        monitor, github, notifier = _make_monitor(unclassified_prs=[pr1, pr2])
+        monitor, github, notifier = _make_monitor(
+            unclassified_prs=[pr1, pr2], shard_count=2, review_human_prs=True
+        )
         github.claim_with_batch = AsyncMock(side_effect=_claim)
         await monitor._classify_new_prs()
         assert monitor.stats.errors == 1

--- a/deile/tests/orchestration/pipeline/test_pr_triage.py
+++ b/deile/tests/orchestration/pipeline/test_pr_triage.py
@@ -131,11 +131,13 @@ class TestClassifyNewPrs:
         assert monitor.stats.prs_classified == 0
 
     async def test_multi_monitor_claims_and_clears(self):
-        """With >1 monitor, the ~batch: lock IS claimed and released."""
-        pr = _pr(42)
-        monitor, github, notifier = _make_monitor(
-            unclassified_prs=[pr], shard_count=2, review_human_prs=True
-        )
+        """With >1 monitor, the ~batch: lock IS claimed and released.
+
+        Uses an ``auto/default/issue-*`` branch (the prefix a 2-shard identity
+        owns) so this exercises the REAL ownership path, not the
+        ``enable_review_human_prs`` bypass (review note #1 on PR #264)."""
+        pr = _pr(42, head_ref="auto/default/issue-42")
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr], shard_count=2)
         await monitor._classify_new_prs()
         github.claim_with_batch.assert_called_once_with("pr", 42)
         github.add_labels.assert_called_once_with("pr", 42, [REVIEW_PENDING])
@@ -145,10 +147,8 @@ class TestClassifyNewPrs:
     async def test_claim_returns_none_skips_pr(self):
         """When claim_with_batch returns None (already claimed), PR is skipped
         (multi-monitor only — single monitor never claims)."""
-        pr = _pr(44)
-        monitor, github, notifier = _make_monitor(
-            unclassified_prs=[pr], shard_count=2, review_human_prs=True
-        )
+        pr = _pr(44, head_ref="auto/default/issue-44")
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr], shard_count=2)
         github.claim_with_batch = AsyncMock(return_value=None)
         await monitor._classify_new_prs()
         github.add_labels.assert_not_called()
@@ -156,17 +156,15 @@ class TestClassifyNewPrs:
 
     async def test_claim_raises_gh_error_counts_error_and_continues(self):
         """GhCommandError during claim increments error counter and continues loop."""
-        pr1 = _pr(45)
-        pr2 = _pr(46)
+        pr1 = _pr(45, head_ref="auto/default/issue-45")
+        pr2 = _pr(46, head_ref="auto/default/issue-46")
 
         async def _claim(kind, number):
             if number == 45:
                 raise GhCommandError(["gh"], 1, "", "network")
             return "abc"
 
-        monitor, github, notifier = _make_monitor(
-            unclassified_prs=[pr1, pr2], shard_count=2, review_human_prs=True
-        )
+        monitor, github, notifier = _make_monitor(unclassified_prs=[pr1, pr2], shard_count=2)
         github.claim_with_batch = AsyncMock(side_effect=_claim)
         await monitor._classify_new_prs()
         assert monitor.stats.errors == 1


### PR DESCRIPTION
## Problema

Dois incômodos cosméticos/de consistência na triagem automática (observados em produção):

1. **`~review:pendente` preso** — o `pr_triage` rotulava **toda** PR aberta, mas o estágio de review só age em branches que o monitor possui (`auto/issue-*`). PR de branch alheio (humano/refactor) ficava `~review:pendente` **para sempre**, sem nunca ser revisada.
2. **Churn de `~batch:`** — na classificação, o lock `~batch:<sha>` era **adicionado e removido na mesma passada** (`added ~batch:X ~review:pendente and removed ~batch:X`), poluindo a timeline. Num cluster de **monitor único** o lock não protege contra nada.

## Correção

1. `classify_new_prs` agora pula PRs que o monitor não possui (`_owns_pr_branch`) — alinha a triagem com o estágio de review. Respeita `enable_review_human_prs`.
2. `classify_new_issues` e `classify_new_prs` só reivindicam/limpam o `~batch:` quando `shard_count > 1`. Monitor único adiciona o label direto, sem churn.

## Testes

Suíte completa verde. `test_pr_triage` reescrito (branch própria vs alheia, single vs multi-monitor); `TestGap6Stage0UsesClaim` atualizado (single não reivindica; multi mantém o invariante claim-antes-de-rotular).