### PR TITLE
fix(pipeline): reviewer verdict APPROVE/REQUEST_CHANGES + DEILE-authored PR self-completes

### DIFF
--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -333,7 +333,10 @@ Você foi solicitado APENAS como REVISOR da Pull Request #{number} do repositór
 1. Garanta um clone atualizado de {repo} em ./repo (gh repo clone {repo} repo se não existir; senão git fetch origin). Dentro de ./repo: gh pr checkout {number}.
 2. LEIA O DIFF INTEIRO e entenda a intenção: git diff {main}...HEAD. Leia cada arquivo tocado.
 3. AVALIE com RIGOR contra o checklist do revisor (corretude/IDEMPOTÊNCIA — re-dispara a cada tick sem claim/dedup?; SOLID/SRP/DRY/KISS; arquitetura hexagonal; SEGURANÇA — injeção em jq/shell/SQL, segredo em log; error handling tipado; testes de borda; packaging — arquivo novo no COPY do Dockerfile e no allowlist). Anote cada achado com arquivo:linha.
-4. POSTE a review via REST (você pode NÃO ser o autor; mesmo assim use REST para evitar escopos extras): gh api -X POST repos/{repo}/pulls/{number}/reviews -f event=COMMENT -f body="<resumo dos achados, arquivo:linha, e o que precisa mudar>". Use event=REQUEST_CHANGES se houver bloqueio; COMMENT se forem sugestões. NÃO use APPROVE (a decisão de merge é do autor/assignee).
+4. POSTE a review via REST com o VEREDITO explícito: gh api -X POST repos/{repo}/pulls/{number}/reviews -f event=<EVENT> -f body="<resumo dos achados, arquivo:linha>". Escolha o EVENT:
+   - **APPROVE** — se NÃO houver nada bloqueante (a PR está pronta para merge). EXCEÇÃO: se VOCÊ for o autor da PR (`gh pr view {number} --json author -q .author.login` == você), o GitHub recusa self-approve — nesse caso use `COMMENT` (o assignee-autor finalizará o merge no próximo tick).
+   - **REQUEST_CHANGES** — se houver QUALQUER problema bloqueante que precise ser corrigido antes do merge.
+   Você ainda NÃO mergeia — quem mergeia é o autor/assignee (Decisão #32).
 5. DEVOLVA ao autor: descubra o autor (AUTOR=$(gh pr view {number} --repo {repo} --json author -q .author.login)) e marque-o como ASSIGNEE: gh api -X POST repos/{repo}/issues/{number}/assignees -f "assignees[]=$AUTOR". (Mesmo que o autor seja você — é o sinal de "bola de volta pro autor".)
 6. NÃO mergeie, NÃO faça commits de correção. Seu trabalho termina ao postar a review e devolver ao autor.
 7. Na ÚLTIMA LINHA escreva a URL da PR (https://github.com/{repo}/pull/{number}). Se algo REAL impediu a review, escreva `BLOQUEADO: <motivo concreto>`. NUNCA invente um resultado.

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -458,7 +458,15 @@ async def _dispatch_mention_group(
 
     monitor._stats.mentions_processed += 1
     if sticky:
-        await _mark_mention_done(monitor, kind, number)
+        # ``review_only`` is deliberately NOT marked ~mention:processado: once
+        # DEILE submits the review, GitHub removes it from requested_reviewers
+        # (natural idempotency for the reviewer trigger), and leaving the marker
+        # OFF lets the *assignee* trigger — the author DEILE just assigned back —
+        # fire on the next tick, so a DEILE-authored PR self-completes
+        # (assignee → work_merge → merge) without a human removing a label
+        # (Decisão #32). Other sticky modes still get the marker.
+        if mode != "review_only":
+            await _mark_mention_done(monitor, kind, number)
         monitor._resume_tracker.clear(number)
     author = next((t.comment.author for t in group if t.comment is not None), "")
     await monitor.notifier.mention_processed(

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -469,3 +469,23 @@ class TestProcessMentionsModeRouting:
         await monitor._process_mentions()
         monitor.implementer.mention.assert_not_called()
         github.add_labels.assert_any_call("issue", 42, [WORKFLOW_NEW])
+
+    async def test_review_only_does_not_mark_processed(self):
+        """review_only must NOT apply ~mention:processado: GitHub removes the
+        requested-reviewer once the review is submitted, and leaving the marker
+        OFF lets the assignee trigger (author assigned back) fire next tick so a
+        DEILE-authored PR self-completes (Decisão #32)."""
+        monitor, github, notifier = self._spy_monitor()
+        github.list_prs_with_review_requests = AsyncMock(return_value=[_pr_ref(88)])
+        await monitor._process_mentions()
+        assert monitor.implementer.mention.call_args.kwargs["mode"] == "review_only"
+        assert monitor.stats.mentions_processed == 1
+        github.add_labels.assert_not_called()  # no ~mention:processado on review_only
+
+    async def test_work_merge_marks_processed(self):
+        """Contrast with review_only: assignee (work_merge) DOES mark processed."""
+        monitor, github, notifier = self._spy_monitor()
+        github.list_prs_assigned_to = AsyncMock(return_value=[_pr_ref(77)])
+        await monitor._process_mentions()
+        assert monitor.implementer.mention.call_args.kwargs["mode"] == "work_merge"
+        github.add_labels.assert_called_once_with("pr", 77, [MENTION_DONE])


### PR DESCRIPTION
Realiza o modelo de merge alinhado (Decisão #32):

1. **Veredito explícito no review_only** — APPROVE (limpo) / REQUEST_CHANGES (bloqueio), em vez de COMMENT fixo. Se o próprio DEILE for autor (GitHub recusa self-approve), usa COMMENT. Continua **sem mergear** — quem mergeia é o autor/assignee.
2. **Auto-loop do DEILE-autor** — review_only não marca mais `~mention:processado`; o GitHub remove o DEILE de requested_reviewers ao submeter a review, e sem o marcador o gatilho **assignee** (autor devolvido) dispara no próximo tick → work_merge → merge. Sem depender de humano remover label.

Testes: suíte completa verde (3090); novos testes cobrem 'review_only não marca processado' e 'work_merge marca'.