### PR TITLE
refactor(daily): 2026-05-22 — 3 refatorações arquiteturais no pipeline

### DIFF
--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -372,33 +372,27 @@ class WorkerImplementer(PipelineImplementer):
         head = (pr_ref.head_ref if pr_ref else "") or f"pr/{number}"
         pr_url_hint = pr_ref.url if pr_ref else ""
 
+        # review_only / work_merge / address all dispatch under the reviewer
+        # persona with a PR-scoped resume block; they differ only in the brief
+        # renderer and whether a merge is expected (work_merge is the only one
+        # that merges, and the only resume-aware brief).
+        reviewer_brief: Optional[str] = None
+        expect_merge = False
         if mode == "review_only":
-            brief = _render_worker_review_only_brief(repo, main, number)
-            return await self._dispatch(
-                brief, channel_id=channel_id, persona="reviewer",
-                resume_block=_build_resume_block(
-                    repo, main, head, resume=resume, expect_merge=False,
-                    pr_url_hint=pr_url_hint,
-                ),
-            )
-        if mode == "work_merge":
-            brief = (
+            reviewer_brief = _render_worker_review_only_brief(repo, main, number)
+        elif mode == "work_merge":
+            reviewer_brief = (
                 _render_worker_review_resume_brief(repo, main, number)
                 if resume else _render_worker_review_brief(repo, main, number)
             )
+            expect_merge = True
+        elif mode == "address":
+            reviewer_brief = _render_worker_pr_address_brief(repo, main, number)
+        if reviewer_brief is not None:
             return await self._dispatch(
-                brief, channel_id=channel_id, persona="reviewer",
+                reviewer_brief, channel_id=channel_id, persona="reviewer",
                 resume_block=_build_resume_block(
-                    repo, main, head, resume=resume, expect_merge=True,
-                    pr_url_hint=pr_url_hint,
-                ),
-            )
-        if mode == "address":
-            brief = _render_worker_pr_address_brief(repo, main, number)
-            return await self._dispatch(
-                brief, channel_id=channel_id, persona="reviewer",
-                resume_block=_build_resume_block(
-                    repo, main, head, resume=resume, expect_merge=False,
+                    repo, main, head, resume=resume, expect_merge=expect_merge,
                     pr_url_hint=pr_url_hint,
                 ),
             )

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -92,6 +92,57 @@ async def _record_gh_error(
         await monitor.notifier.error(notifier_label, str(exc))
 
 
+async def _claim_for_classify(
+    monitor: "PipelineMonitor",
+    kind: str,
+    number: int,
+    *,
+    error_context: str,
+    notifier_label: Optional[str] = None,
+) -> bool:
+    """Claim the ``~batch:`` lock before classifying ``kind`` #``number``.
+
+    The claim only matters with parallel monitors; a single monitor would
+    add+remove the lock label in the same pass (timeline noise) — and the
+    items are already shard-filtered by the callers — so single-monitor
+    deployments skip the claim entirely and always return ``True``.
+
+    Returns ``True`` when the caller may proceed to label the item, ``False``
+    when it must skip it (already claimed by another monitor, or a gh error was
+    recorded). On ``GhCommandError`` the error is recorded via
+    :func:`_record_gh_error` (using ``error_context`` as the log prefix and the
+    optional ``notifier_label`` for the Discord notification).
+    """
+    if monitor.identity.shard_count <= 1:
+        return True
+    try:
+        batch = await monitor.github.claim_with_batch(kind, number)
+    except GhCommandError as exc:
+        await _record_gh_error(
+            monitor, f"{error_context} #{number} failed", exc,
+            notifier_label=notifier_label,
+        )
+        return False
+    if batch is None:
+        logger.debug("%s #%s already claimed by another monitor; skipping", kind, number)
+        return False
+    return True
+
+
+async def _release_classify_claim(monitor: "PipelineMonitor", kind: str, number: int) -> None:
+    """Release the ``~batch:`` lock so the next stage can re-claim the item.
+
+    Best-effort: the workflow label is already applied, so a clear failure must
+    not abort the loop. No-op for single-monitor deployments (they never claim).
+    """
+    if monitor.identity.shard_count <= 1:
+        return
+    try:
+        await monitor.github.clear_batch_label(kind, number)
+    except Exception as exc:  # noqa: BLE001 — label applied; clear is best-effort
+        logger.warning("%s: could not clear batch on #%s: %s", kind, number, exc)
+
+
 _CLASSIFY_COMMENT = (
     f"🤖 **DEILE auto-classificação** — esta issue foi adicionada à fila do pipeline "
     f"autônomo (`{WORKFLOW_NEW}`).\n\n"
@@ -127,10 +178,6 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
         logger.error("could not list unclassified issues: %s", exc)
         return
 
-    # The ~batch: claim only matters with parallel monitors; a single monitor
-    # would add+remove the lock label in the same pass (timeline noise). Issues
-    # are already shard-filtered below, so the claim is doubly redundant here.
-    multi_monitor = monitor.identity.shard_count > 1
     for issue in issues:
         # Defense-in-depth: never touch an issue that already has a pipeline label.
         if any(lb.startswith("~") for lb in issue.labels):
@@ -148,19 +195,13 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
                 issue.number,
             )
         # Claim before labelling to reduce the TOCTOU window with parallel
-        # monitors (skipped for a single monitor — see multi_monitor above).
-        if multi_monitor:
-            try:
-                batch = await monitor.github.claim_with_batch("issue", issue.number)
-            except GhCommandError as exc:
-                await _record_gh_error(
-                    monitor, f"auto-classify claim #{issue.number} failed", exc,
-                    notifier_label=f"auto-classify claim #{issue.number}",
-                )
-                continue
-            if batch is None:
-                logger.debug("issue #%s already claimed by another monitor; skipping", issue.number)
-                continue
+        # monitors (no-op for a single monitor — see _claim_for_classify).
+        if not await _claim_for_classify(
+            monitor, "issue", issue.number,
+            error_context="auto-classify claim",
+            notifier_label=f"auto-classify claim #{issue.number}",
+        ):
+            continue
         try:
             await monitor.github.add_labels("issue", issue.number, [WORKFLOW_NEW])
         except GhCommandError as exc:
@@ -176,15 +217,9 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
             continue
         # Release the classify claim so Stage 1 (review) can pick the issue up
         # via its own claim — review_one_new_issue only considers issues with
-        # ``batch_id is None``. Mirrors classify_new_prs; without this the
-        # auto-classify → review handoff deadlocks (the issue stays ~nova
-        # forever, batch-locked). Best-effort: the ~workflow:nova label is
-        # already applied, so a clear failure must not abort the loop.
-        if multi_monitor:
-            try:
-                await monitor.github.clear_batch_label("issue", issue.number)
-            except Exception as exc:  # noqa: BLE001 — label applied; clear is best-effort
-                logger.warning("auto-classify: could not clear batch on #%s: %s", issue.number, exc)
+        # ``batch_id is None``. Without this the auto-classify → review handoff
+        # deadlocks (the issue stays ~nova forever, batch-locked).
+        await _release_classify_claim(monitor, "issue", issue.number)
         monitor._stats.issues_classified += 1
         logger.info("auto-classified issue #%s as %s", issue.number, WORKFLOW_NEW)
         await monitor.notifier.issue_auto_classified(issue.number, issue.title, issue.url)
@@ -223,10 +258,6 @@ async def classify_new_prs(monitor: "PipelineMonitor") -> None:
         logger.error("could not list unclassified PRs: %s", exc)
         return
 
-    # Claiming a ~batch: lock only matters with parallel monitors; with a single
-    # monitor it would just add+remove the lock label in the same pass (timeline
-    # noise). Gate it on the shard count.
-    multi_monitor = monitor.identity.shard_count > 1
     for pr in prs:
         if any(lb.startswith("~") for lb in pr.labels):
             continue
@@ -237,17 +268,8 @@ async def classify_new_prs(monitor: "PipelineMonitor") -> None:
         # branches), leaving them stuck "pendente" forever.
         if not monitor._owns_pr_branch(pr.head_ref, pr_number=pr.number):
             continue
-        if multi_monitor:
-            try:
-                batch = await monitor.github.claim_with_batch("pr", pr.number)
-            except GhCommandError as exc:
-                await _record_gh_error(
-                    monitor, f"pr_triage claim #{pr.number} failed", exc,
-                )
-                continue
-            if batch is None:
-                logger.debug("PR #%s already claimed; skipping pr_triage", pr.number)
-                continue
+        if not await _claim_for_classify(monitor, "pr", pr.number, error_context="pr_triage claim"):
+            continue
         try:
             await monitor.github.add_labels("pr", pr.number, [REVIEW_PENDING])
         except GhCommandError as exc:
@@ -256,9 +278,8 @@ async def classify_new_prs(monitor: "PipelineMonitor") -> None:
                 notifier_label=f"pr_triage #{pr.number}",
             )
             continue
-        if multi_monitor:
-            # Release the batch claim so Stage 3 can pick this PR up via its own claim.
-            await monitor.github.clear_batch_label("pr", pr.number)
+        # Release the batch claim so Stage 3 can pick this PR up via its own claim.
+        await _release_classify_claim(monitor, "pr", pr.number)
         monitor._stats.prs_classified += 1
         logger.info("pr_triage: classified PR #%s with %s", pr.number, REVIEW_PENDING)
         await monitor.notifier.pr_auto_classified(pr.number, pr.title, pr.url)

--- a/deile/tests/security/test_shell_security.py
+++ b/deile/tests/security/test_shell_security.py
@@ -12,7 +12,6 @@ import pytest
 from deile.tools._shell_security import assess_risk, is_blocked
 from deile.tools.base import SecurityLevel
 
-
 # ── Comandos inofensivos que NÃO devem ser bloqueados ──────────────────
 
 SAFE_REDIRECT_COMMANDS = [

--- a/deile/tools/bash_tool.py
+++ b/deile/tools/bash_tool.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 # PTY imports for Unix-like systems
 try:
@@ -56,10 +56,6 @@ class BashExecuteTool(SyncTool):
         self.artifact_manager = artifact_manager
         self.platform = platform.system()
 
-    def _assess_security_risk(self, command: str) -> Tuple[str, List[str]]:
-        """Assess security risk of command (delegated to `_shell_security`)."""
-        return assess_risk(command)
-    
     def _should_use_pty(self, command: str, force_pty: Optional[bool] = None) -> bool:
         """Determine if PTY should be used"""
         
@@ -328,7 +324,7 @@ class BashExecuteTool(SyncTool):
                 raise ToolError(f"Working directory does not exist: {working_directory}")
             
             # Security assessment
-            risk_level, security_warnings = self._assess_security_risk(command)
+            risk_level, security_warnings = assess_risk(command)
             
             # Check if risk level is acceptable
             risk_hierarchy = ["safe", "moderate", "dangerous"]


### PR DESCRIPTION
## Refatoração Arquitetural Diária — 2026-05-22

**Modo**: PRs exógenas mergeadas hoje (BRT)
**PRs exógenas base** (arquivos-alvo): #258, #260, #261, #264, #266, #268 (excluídas as PRs `refactor(daily)` #262/#263 para evitar ciclo)
**Resumo arquitetural**: os 8 arquivos-alvo já estão fortemente e competentemente refatorados (helpers compartilhados `_record_gh_error`, `_list_refs`, `_block*`, módulo `_time_utils`, `validate_dispatch_payload`, helpers de menção). Não há violações de Clean Architecture (o `deile_worker_client.py` isola corretamente `httpx`/IO de segredo atrás de um adapter de infraestrutura; orquestração não importa SDKs externos). Sem dead code provado (`is_blocked()` é usado por testes). Os itens reais restantes eram DRY/KISS modestos e de baixo risco, contidos nos próprios arquivos-alvo.

### Plano executado
| # | Tipo | Valor | Status | Descrição |
|---|---|---|---|---|
| 1 | DRY_CROSS | MEDIO | ✅ APPLIED | Extrair fluxo duplicado de claim/release de `~batch:` (multi-monitor) compartilhado por `classify_new_issues` e `classify_new_prs` → `_claim_for_classify()` + `_release_classify_claim()` |
| 2 | DRY_CROSS | MEDIO | ✅ APPLIED | Colapsar três ramos quase idênticos de persona `reviewer` em `WorkerImplementer.mention()` num único `_dispatch` compartilhado |
| 3 | KISS | BAIXO | ✅ APPLIED | Remover wrapper no-op `_assess_security_risk` em `bash_tool.py`; chamar `assess_risk()` direto + remover import `typing.List` órfão |
| 4 | DRY_CROSS | BAIXO | ⏭️ SKIPPED | Dedupe do checklist do revisor em `briefs.py` — premissa falsa: os checklists condensados das linhas 116 (work_merge/resume) e 335 (review_only) **não** são idênticos (diferem em "+ a regressão alegada", "do .dockerignore", "(arquivo:linha + problema)"); unificá-los alteraria a semântica de prompts deliberadamente afinados por modo de review. Nenhum ganho seguro de DRY. |

### Arquivos modificados
- `deile/orchestration/pipeline/stages.py` — extração dos helpers de claim/release (item 1)
- `deile/orchestration/pipeline/implementer.py` — unificação dos ramos `reviewer` (item 2)
- `deile/tools/bash_tool.py` — remoção do wrapper no-op + import órfão (item 3)
- `deile/tests/security/test_shell_security.py` — fix de isort pré-existente (1 linha em branco; arquivo não tocado pelo refactor)

### Arquivos criados
nenhum

### Arquivos removidos
nenhum

### Itens revertidos (regressão ou violação de constraint)
nenhum revertido. Item #4 **pulado** (não revertido) — premissa de duplicação não se confirmou no grep; ver tabela acima.

### Testes gate local
**Baseline**: `1 failed, 3179 passed, 15 skipped, 23 errors`
**Final**:    `1 failed, 3179 passed, 15 skipped, 23 errors`

> A 1 falha + 23 errors são pré-existentes e **ambientais**: `deile/tests/infra/test_worker_resume.py` cria repos git temporários em `/tmp` e o sandbox tem commit-signing que falha nesses repos (não relacionado a nenhuma mudança desta PR; idêntico antes e depois). Nenhum teste antes-passando regrediu.

### Checklist de segurança
- [x] Testes antes-passando continuam passando (gate local idêntico ao baseline)
- [x] Assinaturas públicas inalteradas (helpers novos são privados; `mention()` mantém assinatura)
- [x] Registry pattern respeitado (pilar 03 §3) — sem mudanças em registries
- [x] Arquitetura hexagonal respeitada (pilar 02 + 03 §2) — sem novo import de SDK em core/orchestration
- [x] Sem nova dependência externa
- [x] Sem remoção de código por suposição (dead code não encontrado; nada removido sem prova)
- [x] Sem I/O síncrono novo em async
- [x] `ruff check deile/` limpo
- [x] `isort --check-only deile/` limpo

> ⏳ Aguardando revisão e merge pelo pipeline `deile-issue-dev-pr-review-full`.

🤖 Gerado pelo pipeline DEILE refactor-daily (gate local confirmado verde)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtzV5hrme3DuCPdzrsXiU3)_