### PR TITLE
feat: interceptar --version/--help antes do bootstrap (#270)

### DIFF
--- a/deile.py
+++ b/deile.py
@@ -277,7 +277,71 @@ def _start_deile() -> None:
 # Entry point
 # -----------------------------------------------------------------------------
 
+def _handle_preflight_flag() -> bool:
+    """Handle --version / --help BEFORE any venv/bootstrap.
+
+    Returns True if a preflight flag was handled (caller should exit),
+    False otherwise (proceed with normal startup).
+    """
+    argv = sys.argv[1:]
+
+    if "--version" in argv:
+        _print_version()
+        return True
+
+    if "--help" in argv or "-h" in argv:
+        _print_help()
+        return True
+
+    return False
+
+
+def _print_version() -> None:
+    """Print DEILE version from deile/__version__.py (zero external deps)."""
+    import importlib.util
+
+    version_path = PROJECT_ROOT / "deile" / "__version__.py"
+    spec = importlib.util.spec_from_file_location(
+        "_deile_version", str(version_path)
+    )
+    if spec is None or spec.loader is None:
+        print("DEILE (version unknown)", file=sys.stderr)
+        sys.exit(1)
+
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    version = getattr(mod, "__version__", "unknown")
+    build = getattr(mod, "__build_number__", "unknown")
+    print(f"DEILE v{version} (build {build})")
+
+
+def _print_help() -> None:
+    """Print basic usage help (zero external deps)."""
+    print(
+        f"{_BOLD}DEILE{_RESET} \u2014 Development Environment Intelligence & Learning Engine\n"
+        f"\n"
+        f"Uso:\n"
+        f"  python3 deile.py                  # modo interativo\n"
+        f"  python3 deile.py \"mensagem\"       # modo one-shot\n"
+        f"  python3 deile.py --version         # exibe a vers\u00e3o\n"
+        f"  python3 deile.py --help            # esta ajuda\n"
+        f"  python3 deile.py --install         # instala globalmente (user)\n"
+        f"  python3 deile.py --model PROVIDER:ID \"msg\"\n"
+        f"\n"
+        f"Reposit\u00f3rio: https://github.com/elimarcavalli/deile\n"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Entry point
+# -----------------------------------------------------------------------------
+
 def main() -> None:
+    # Preflight flags that need NO venv, NO provider, NO bootstrap.
+    if _handle_preflight_flag():
+        sys.exit(0)
+
     # --install must run in the current interpreter (no venv redirect),
     # so the installation target matches what the user invoked.
     if "--install" in sys.argv[1:]:

--- a/deile.py
+++ b/deile.py
@@ -309,7 +309,11 @@ def _print_version() -> None:
         sys.exit(1)
 
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"DEILE (version unknown: {exc})", file=sys.stderr)
+        sys.exit(1)
 
     version = getattr(mod, "__version__", "unknown")
     build = getattr(mod, "__build_number__", "unknown")

--- a/deile/tests/test_deile_py_preflight.py
+++ b/deile/tests/test_deile_py_preflight.py
@@ -1,0 +1,242 @@
+"""Tests: deile.py preflight flags (--version, --help) — issue #270.
+
+These flags must work BEFORE any venv bootstrap, without side-effects.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).parents[2]  # repo/
+_DEILE_PY = _PROJECT_ROOT / "deile.py"
+
+
+def _run_deile_py(*args: str, timeout: int = 15) -> subprocess.CompletedProcess:
+    """Run deile.py with the given args and return the completed process."""
+    env = os.environ.copy()
+    # Remove any API keys so we don't accidentally trigger a successful venv bootstrap
+    for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DEEPSEEK_API_KEY",
+                "GOOGLE_API_KEY"):
+        env.pop(key, None)
+    return subprocess.run(
+        [sys.executable, str(_DEILE_PY), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=str(_PROJECT_ROOT),
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# --version flag
+# ---------------------------------------------------------------------------
+
+class TestVersionFlag:
+    """Tests for --version preflight flag."""
+
+    def test_version_prints_version_and_exits_zero(self):
+        """--version should print version string and exit 0."""
+        result = _run_deile_py("--version")
+        assert result.returncode == 0, (
+            f"Expected exit 0, got {result.returncode}. "
+            f"stderr: {result.stderr}"
+        )
+        assert "DEILE v" in result.stdout, (
+            f"Expected 'DEILE v...' in stdout, got: {result.stdout}"
+        )
+        assert "build" in result.stdout, (
+            f"Expected 'build' in stdout, got: {result.stdout}"
+        )
+
+    def test_version_output_format(self):
+        """--version output should match 'DEILE vX.Y.Z (build YYYYMMDD)'."""
+        result = _run_deile_py("--version")
+        # Must start with "DEILE v" and contain "(build "
+        stdout = result.stdout.strip()
+        assert stdout.startswith("DEILE v"), (
+            f"Output should start with 'DEILE v': {stdout}"
+        )
+        assert "(build " in stdout and stdout.endswith(")"), (
+            f"Output should contain '(build NNNNNNNN)': {stdout}"
+        )
+
+    def test_version_exit_code_zero(self):
+        """--version must exit with code 0."""
+        result = _run_deile_py("--version")
+        assert result.returncode == 0
+
+    def test_version_no_stderr(self):
+        """--version should not produce stderr output."""
+        result = _run_deile_py("--version")
+        assert result.stderr == "", (
+            f"Expected empty stderr, got: {result.stderr}"
+        )
+
+    def test_version_no_venv_created(self):
+        """--version must NOT create .venv directory."""
+        venv_path = _PROJECT_ROOT / ".venv"
+        # Record whether .venv existed before
+        existed_before = venv_path.exists()
+        _run_deile_py("--version")
+        # .venv should not have been created if it didn't exist
+        if not existed_before:
+            assert not venv_path.exists(), (
+                ".venv was created by --version flag — this is a side-effect!"
+            )
+
+    def test_version_does_not_require_api_keys(self):
+        """--version must work even without any API keys set."""
+        env = os.environ.copy()
+        for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DEEPSEEK_API_KEY",
+                    "GOOGLE_API_KEY", "DEILE_API_KEY"):
+            env.pop(key, None)
+        result = subprocess.run(
+            [sys.executable, str(_DEILE_PY), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(_PROJECT_ROOT),
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"--version failed without API keys. "
+            f"exit={result.returncode} stderr={result.stderr}"
+        )
+
+    def test_version_with_other_args_still_works(self):
+        """--version should be detected even with extra args."""
+        result = _run_deile_py("--version", "some message")
+        assert result.returncode == 0
+        assert "DEILE v" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# --help flag
+# ---------------------------------------------------------------------------
+
+class TestHelpFlag:
+    """Tests for --help preflight flag."""
+
+    def test_help_prints_usage_and_exits_zero(self):
+        """--help should print usage and exit 0."""
+        result = _run_deile_py("--help")
+        assert result.returncode == 0, (
+            f"Expected exit 0, got {result.returncode}. "
+            f"stderr: {result.stderr}"
+        )
+        assert "DEILE" in result.stdout
+        assert "Uso:" in result.stdout or "uso:" in result.stdout.lower()
+
+    def test_help_exit_code_zero(self):
+        """--help must exit with code 0."""
+        result = _run_deile_py("--help")
+        assert result.returncode == 0
+
+    def test_help_no_venv_created(self):
+        """--help must NOT create .venv directory."""
+        venv_path = _PROJECT_ROOT / ".venv"
+        existed_before = venv_path.exists()
+        _run_deile_py("--help")
+        if not existed_before:
+            assert not venv_path.exists(), (
+                ".venv was created by --help flag — this is a side-effect!"
+            )
+
+    def test_help_no_stderr(self):
+        """--help should not produce stderr output."""
+        result = _run_deile_py("--help")
+        assert result.stderr == "", (
+            f"Expected empty stderr, got: {result.stderr}"
+        )
+
+    def test_help_mentions_version_flag(self):
+        """--help output should mention --version flag."""
+        result = _run_deile_py("--help")
+        assert "--version" in result.stdout, (
+            f"--help output should mention --version: {result.stdout}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# -h shorthand
+# ---------------------------------------------------------------------------
+
+class TestHShorthand:
+    """Tests for -h shorthand flag."""
+
+    def test_h_prints_usage_and_exits_zero(self):
+        """-h should print usage (same as --help) and exit 0."""
+        result = _run_deile_py("-h")
+        assert result.returncode == 0, (
+            f"Expected exit 0, got {result.returncode}. "
+            f"stderr: {result.stderr}"
+        )
+        assert "DEILE" in result.stdout
+
+    def test_h_no_venv_created(self):
+        """-h must NOT create .venv directory."""
+        venv_path = _PROJECT_ROOT / ".venv"
+        existed_before = venv_path.exists()
+        _run_deile_py("-h")
+        if not existed_before:
+            assert not venv_path.exists(), (
+                ".venv was created by -h flag — this is a side-effect!"
+            )
+
+    def test_h_exit_code_zero(self):
+        """-h must exit with code 0."""
+        result = _run_deile_py("-h")
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Preflight priority: flags handled BEFORE venv/bootstrap
+# ---------------------------------------------------------------------------
+
+class TestPreflightPriority:
+    """Tests that --version/--help are handled BEFORE bootstrap."""
+
+    def test_version_is_fast(self):
+        """--version should complete quickly (no venv creation)."""
+        import time
+        start = time.monotonic()
+        result = _run_deile_py("--version", timeout=10)
+        elapsed = time.monotonic() - start
+        assert result.returncode == 0
+        # Should complete in well under 5 seconds (no pip install)
+        assert elapsed < 5.0, (
+            f"--version took {elapsed:.1f}s — too slow, "
+            f"bootstrap may have been triggered"
+        )
+
+    def test_help_is_fast(self):
+        """--help should complete quickly (no venv creation)."""
+        import time
+        start = time.monotonic()
+        result = _run_deile_py("--help", timeout=10)
+        elapsed = time.monotonic() - start
+        assert result.returncode == 0
+        assert elapsed < 5.0, (
+            f"--help took {elapsed:.1f}s — too slow, "
+            f"bootstrap may have been triggered"
+        )
+
+    def test_no_arg_still_reaches_bootstrap_path(self):
+        """Running with no args should NOT exit 0 via preflight (should
+        attempt bootstrap or venv redirect). This test verifies preflight
+        doesn't intercept normal operation."""
+        result = _run_deile_py(timeout=10)
+        # Without flags, it should NOT match preflight.
+        # The script should NOT print the version banner (that's bootstrap).
+        assert "DEILE v" not in result.stdout.split("\n")[0:3], (
+            "No-arg run should not trigger version output"
+        )
+        # It should NOT exit 0 from preflight (it'll fail somewhere in
+        # bootstrap due to missing API keys, or redirect to venv).
+        # Either way, the important assertion: stdout doesn't match
+        # the preflight version output.

--- a/deile/tests/test_deile_py_preflight.py
+++ b/deile/tests/test_deile_py_preflight.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from subprocess import TimeoutExpired
 
 
 _PROJECT_ROOT = Path(__file__).parents[2]  # repo/
@@ -229,14 +230,27 @@ class TestPreflightPriority:
     def test_no_arg_still_reaches_bootstrap_path(self):
         """Running with no args should NOT exit 0 via preflight (should
         attempt bootstrap or venv redirect). This test verifies preflight
-        doesn't intercept normal operation."""
-        result = _run_deile_py(timeout=10)
-        # Without flags, it should NOT match preflight.
-        # The script should NOT print the version banner (that's bootstrap).
-        assert "DEILE v" not in result.stdout.split("\n")[0:3], (
-            "No-arg run should not trigger version output"
+        doesn't intercept normal operation.
+
+        The timeout is EXPECTED: without flags, the script enters
+        bootstrap (venv creation / pip install / interactive prompt)
+        or re-execs into the venv and starts the agent — all of which
+        take time or block without a TTY. The timeout IS the proof
+        that preflight did NOT intercept and exit(0) quickly."""
+        try:
+            result = _run_deile_py(timeout=10)
+        except TimeoutExpired:
+            # Timeout proves the script entered bootstrap / venv redirect
+            # and did NOT exit quickly via preflight. This is the
+            # expected success case.
+            return
+        # If it did return (very fast env or pre-existing venv that fails
+        # quickly), ensure it didn't exit via preflight.
+        first_lines = result.stdout.split("\n")[0:3]
+        assert "DEILE v" not in first_lines, (
+            f"No-arg run should not trigger version output. "
+            f"stdout[0:3]={first_lines}"
         )
-        # It should NOT exit 0 from preflight (it'll fail somewhere in
-        # bootstrap due to missing API keys, or redirect to venv).
-        # Either way, the important assertion: stdout doesn't match
-        # the preflight version output.
+        # It should NOT exit 0 from preflight (exit 0 would mean
+        # preflight handled it, which is wrong for no-arg runs).
+        # If it exits non-zero, that's bootstrap failing — also fine.


### PR DESCRIPTION
## O que foi feito

Adiciona interceptação de flags `--version`, `--help` e `-h` no entry point `deile.py` **antes** de qualquer lógica de bootstrap (venv, dependências, chaves de API).

### Comportamento antes
`python3 deile.py --version` disparava o instalador completo (criação de `.venv/`, `pip install`, wizard interativo de chaves) antes de mostrar a versão.

### Comportamento depois
`python3 deile.py --version` imprime `DEILE v5.1.0 (build 20250914)` e sai com exit code 0, **sem side-effects**.

### Detalhes técnicos
- `--version` lê direto de `deile/__version__.py` via `importlib.util` — zero dependências externas
- `--help` e `-h` também reconhecidos no preflight
- Nenhum efeito colateral: sem criar `.venv/`, sem tocar `.env`, sem prompt interativo
- O fluxo normal de bootstrap (sem flags) permanece inalterado

### Testes
18 testes novos cobrindo:
- Formato e exit code de `--version`
- Independência de chaves de API
- Garantia de não-criação de `.venv`
- Velocidade (< 5s, provando que bootstrap não foi disparado)
- `--help` e `-h` corretos
- Regressão: operação normal sem flags preservada

Closes #270.

---
By [DEILE-One](mailto:deile@deile.info)