### PR TITLE
feat(pipeline): portão de refinamento + decomposição paralela

### DIFF
--- a/deile/config/persona_config.yaml
+++ b/deile/config/persona_config.yaml
@@ -97,3 +97,26 @@ personas:
         - bash_tool
         avoid_tools: []
         tool_timeout: 60
+    analyst:
+      capabilities:
+      - requirements_analysis
+      - product_discovery
+      - documentation
+      - architecture_analysis
+      communication_style: analytical
+      model_preferences:
+        temperature: 0.2
+        max_tokens: 8000
+        top_p: 0.9
+      behavior_settings:
+        verbosity_level: comprehensive
+        focus_on_patterns: true
+        include_trade_offs: true
+        suggest_improvements: true
+      tool_preferences:
+        preferred_tools:
+        - search_tool
+        - file_tools
+        - bash_tool
+        avoid_tools: []
+        tool_timeout: 60

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -181,6 +181,9 @@ _OVERRIDE_HANDLERS: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
     "pipeline.resume_interval": ("pipeline_resume_interval", _to_nonneg_int),
     "pipeline.resume_max_attempts": ("pipeline_resume_max_attempts", _to_pos_int),
     "pipeline.resume_budget": ("pipeline_resume_budget", _to_nonneg_int),
+    # Refinement gate + parallel decomposition (issue #257)
+    "pipeline.refine_max_attempts": ("pipeline_refine_max_attempts", _to_pos_int),
+    "pipeline.max_parallel": ("pipeline_max_parallel", _to_pos_int),
     # Trust boundary (issue #125): allowlist of directories whose
     # ``./.deile/settings.json`` is honored as the project layer.
     "trust.project_layer_dirs": ("trust_project_layer_dirs", _to_str_list),
@@ -334,6 +337,8 @@ class Settings:
     pipeline_resume_interval: int = 0
     pipeline_resume_max_attempts: int = 10
     pipeline_resume_budget: int = 0
+    pipeline_refine_max_attempts: int = 5
+    pipeline_max_parallel: int = 2
 
     # Cron
     cron_db_path: Optional[Path] = None

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -64,7 +64,7 @@ _TOKEN_SAFE_CHARS = re.compile(r"^[A-Za-z0-9._\-+/=:~]{16,4096}$")
 # nova for adicionada ao worker. ``reviewer`` é a persona do quality-gate
 # de review de PR (pilar 04 §Personas; instruções em
 # personas/instructions/reviewer.md), usada pelo estágio de review do pipeline.
-WorkerPersona = Literal["developer", "architect", "debugger", "reviewer"]
+WorkerPersona = Literal["developer", "architect", "debugger", "reviewer", "analyst"]
 
 
 class WorkerDispatchError(DEILEError):

--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from deile.orchestration.pipeline.constants import ISSUE_BODY_MAX_CHARS
+from deile.orchestration.pipeline.labels import title_prefix_for_type
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from deile.orchestration.pipeline.github_client import MentionTrigger
@@ -31,7 +32,7 @@ Passo a passo:
 1. Trabalhe na subpasta ./repo do seu diretório atual. Se ./repo não existir, rode: gh repo clone {repo} repo
    Se já existir, entre nela e rode: git fetch origin && git checkout {main} && git reset --hard origin/{main}
 2. Dentro de ./repo, crie e dê checkout no branch {branch} a partir de {main}.
-3. Implemente a feature descrita na issue abaixo. Crie/edite os arquivos necessários e ADICIONE testes cobrindo todos os casos.
+3. ANTES de codar, leia os comentários da issue: gh issue view {number} --repo {repo} --comments — decisões e esclarecimentos do stakeholder ali FAZEM PARTE do escopo (o corpo pode não conter tudo). Implemente a feature descrita na issue abaixo E o que os comentários decidiram. Crie/edite os arquivos necessários e ADICIONE testes cobrindo todos os casos.
 4. Rode os testes e garanta 100% de aprovação. As dependências (incl. pytest) JÁ estão instaladas no ambiente — NÃO rode `pip install` (o filesystem é read-only). Para rodar só os testes novos sem esbarrar no gate global de cobertura: python3 -m pytest <arquivos_de_teste_novos> -p no:cov -q
 5. Faça commit atômico e `git push -u origin {branch}`.
 6. ABRA A PR (passo OBRIGATÓRIO — sem PR a tarefa NÃO está concluída):
@@ -53,6 +54,7 @@ Você é o QUALITY GATE final da Pull Request #{number} do repositório {repo}. 
 
 1. Garanta um clone atualizado de {repo} em ./repo (gh repo clone {repo} repo se não existir; senão git fetch origin). Dentro de ./repo: gh pr checkout {number}
 2. LEIA O DIFF INTEIRO e entenda a intenção da mudança: git diff {main}...HEAD ; git diff HEAD. Liste os arquivos tocados e leia cada um por completo.
+2b. CONFRONTE A ENTREGA CONTRA O QUE FOI PEDIDO (passo OBRIGATÓRIO): descubra a issue que esta PR fecha (procure `Closes #N`/`Fixes #N` no corpo: gh pr view {number} --repo {repo} --json body,closingIssuesReferences). Leia a issue E TODOS os comentários dela: gh issue view <N> --repo {repo} --comments. Liste, item a item, TUDO o que foi pedido — no corpo E nos comentários (decisões do stakeholder fazem parte do escopo) — e verifique se a PR entrega CADA item. Se faltou qualquer requisito, ou o autor declarou "concluído" sem cumprir, isso É IMPEDIMENTO (veja o veredito).
 3. AVALIE contra o checklist do revisor e anote cada achado (arquivo:linha + problema):
    - Corretude e IDEMPOTÊNCIA: a lógica re-executa sem efeito duplicado? Algo em loop/por tick/agendado re-dispara a cada execução sem claim/dedup/cursor? (storms de processamento duplicado são a classe de bug nº 1 deste projeto)
    - SOLID / SRP / DRY / KISS: responsabilidade única; sem duplicação real nem abstração prematura.
@@ -66,7 +68,8 @@ Você é o QUALITY GATE final da Pull Request #{number} do repositório {repo}. 
 5b. THREADS/NOTAS de review pendentes: liste os comentários de review (gh api repos/{repo}/pulls/{number}/comments). Para CADA thread/nota, JULGUE criticamente se o que foi pedido está realmente correto — NÃO obedeça cegamente. Se procede, RESOLVA (faça a mudança + responda a thread citando o commit). Se NÃO procede, responda a thread com uma JUSTIFICATIVA concreta de por que não fazer. Não deixe thread pendente sem ação ou justificativa.
 6. DOCUMENTE as evidências como comentário na PR (gh pr comment {number} --repo {repo} --body "..."): o que revisou, os achados, as correções, como tratou cada thread, e a saída REAL dos testes.
 7. VEREDITO:
-   - Checklist OK E testes verdes → MERGEIE. Você é o autor da PR; NÃO use `gh pr review --approve` (o GitHub recusa auto-aprovação). Mergeie via REST (evita o escopo read:org): gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge (fallback: gh pr merge {number} --repo {repo} --merge). Confirme: gh pr view {number} --repo {repo} --json merged -q .merged (deve ser true).
+   - A entrega cumpre TUDO o que a issue + comentários pediram (passo 2b) E o checklist passou E os testes estão verdes → MERGEIE. Você é o autor da PR; NÃO use `gh pr review --approve` (o GitHub recusa auto-aprovação). Mergeie via REST (evita o escopo read:org): gh api -X PUT repos/{repo}/pulls/{number}/merge -f merge_method=merge (fallback: gh pr merge {number} --repo {repo} --merge). Confirme: gh pr view {number} --repo {repo} --json merged -q .merged (deve ser true).
+   - A entrega NÃO cumpre tudo o que foi pedido (faltou requisito do corpo ou de um comentário; o autor disse "concluído" sem terminar) → IMPEDIMENTO: NÃO mergeie. Testes verdes NÃO suprem requisito faltante. Comente o que falta vs. o pedido e escreva `BLOQUEADO: <o que falta>` — devolve ao autor.
    - Impedimento REAL que você não pode resolver com segurança (decisão de produto pendente, falta credencial/segredo, mudança quebraria contrato sem migração) → NÃO mergeie; comente o motivo na PR e escreva numa linha começando com `BLOQUEADO: <motivo concreto>`.
 8. Na ÚLTIMA LINHA: a URL da PR seguida de MERGED (ex.: https://github.com/{repo}/pull/{number} MERGED) se mergeou; OU a linha `BLOQUEADO: <motivo>`. NUNCA escreva MERGED sem ter mergeado de fato; NUNCA invente resultado.
 """
@@ -114,6 +117,7 @@ RETOMADA do QUALITY GATE da Pull Request #{number} do repositório {repo} — um
 {progress_block}
    git diff {main}...HEAD ; git status --porcelain (leia cada arquivo modificado/untracked listado).
 3. AVALIE com RIGOR contra o checklist do revisor (corretude/IDEMPOTÊNCIA — re-dispara a cada tick sem claim/dedup?; SOLID/SRP/DRY/KISS; arquitetura hexagonal; SEGURANÇA — injeção em jq/shell/SQL, segredo em log; error handling tipado; testes de borda + a regressão alegada; packaging — arquivo novo no COPY do Dockerfile e no allowlist do .dockerignore). Anote cada achado (arquivo:linha + problema).
+3b. CONFRONTE a entrega contra o PEDIDO: descubra a issue (Closes #N no corpo da PR), leia-a com TODOS os comentários (gh issue view <N> --repo {repo} --comments) e verifique item a item se a PR entrega tudo (corpo + decisões do stakeholder). Faltou requisito ou "concluído" sem cumprir → IMPEDIMENTO, NÃO mergeie (testes verdes não suprem), `BLOQUEADO: <o que falta>`.
 4. CORRIJA os achados com commits normais (SEM force-push) e dê push. Adicione os testes que faltarem.
 5. Rode os testes e garanta 100% de aprovação. Dependências JÁ instaladas — NÃO rode `pip install`. Testes do PR sem o gate global: python3 -m pytest <arquivos> -p no:cov -q.
 6. DOCUMENTE as evidências como comentário na PR (gh pr comment {number} --repo {repo} --body "...").
@@ -348,18 +352,22 @@ VEREDITO (regra dura): na ÚLTIMA LINHA escreva SOMENTE uma destas, nada depois 
 """
 
 _WORKER_REFINE_BRIEF = """\
-Você vai REFINAR a issue #{number} (tipo: {type}) do repositório {repo} — reescrever o CORPO para ficar claro, substancial e dentro do template oficial. NÃO implemente código de feature/fix; o objetivo é deixar o ESCOPO pronto para a próxima etapa.
+Você vai REFINAR a issue #{number} (tipo: {type}) do repositório {repo} — corrigir o TÍTULO e reescrever o CORPO para ficar claro, substancial e dentro do template oficial. NÃO implemente código de feature/fix; o objetivo é deixar o ESCOPO pronto para a próxima etapa.
 
-1. Leia a issue atual (abaixo) e o template oficial:
+1. Leia a issue atual (abaixo), o template oficial E OS COMENTÁRIOS da issue:
    gh api repos/{repo}/contents/.github/ISSUE_TEMPLATE/{template} --jq .content | base64 --decode
+   gh issue view {number} --repo {repo} --comments
+   Os comentários — em especial DECISÕES e esclarecimentos do stakeholder — FAZEM PARTE do escopo e DEVEM ser incorporados no corpo. NUNCA ignore o que foi pedido em comentário.
    (feature/refactor: consulte docs/system_design/ e o código real, clone com `gh repo clone {repo} repo` se preciso. bug: investigue o código e localize a origem provável arquivo:linha. NUNCA invente.)
-2. REESCREVA o corpo conforme a estrutura do template, preenchendo CADA seção com substância REAL (extraída do título, contexto e código). Aplique:
+2. CORRIJA O TÍTULO para seguir o padrão do template: ele DEVE começar com o prefixo `{title_prefix}`. Aplique:
+   gh issue edit {number} --repo {repo} --title "{title_prefix} <título claro e específico>"
+3. REESCREVA o corpo conforme a estrutura do template, preenchendo CADA seção com substância REAL (do título, do contexto, do código E das decisões registradas nos comentários). Aplique:
    gh issue edit {number} --repo {repo} --body "<novo corpo completo>"
-3. LACUNA DO STAKEHOLDER: se houver decisão de escopo/lacuna IMPORTANTE que você NÃO pode decidir sozinho com segurança (alto impacto, ou que derivaria uma feature grande adicional), NÃO decida. Em vez disso:
+4. LACUNA DO STAKEHOLDER: se houver decisão de escopo/lacuna IMPORTANTE que você NÃO pode decidir sozinho com segurança (alto impacto, ou que derivaria uma feature grande adicional), NÃO decida. Em vez disso:
    a) Comente na issue (gh issue comment {number} --repo {repo} --body "...") descrevendo a lacuna E **2 a 3 sugestões bem pensadas** para o stakeholder escolher.
    b) Atribua ao autor (stakeholder): descubra com `gh issue view {number} --repo {repo} --json author -q .author.login` e atribua via REST: gh api -X POST repos/{repo}/issues/{number}/assignees -f 'assignees[]=<login>'
    c) Reporte AGUARDA_STAKEHOLDER (veredito abaixo) — o pipeline pausa o refino até o stakeholder decidir.
-4. Honestidade: marque suposições como suposições no corpo; nunca invente fato, dado ou causa-raiz.
+5. Honestidade: marque suposições como suposições no corpo; nunca invente fato, dado ou causa-raiz.
 
 VEREDITO (regra dura): na ÚLTIMA LINHA escreva SOMENTE uma destas, nada depois dela:
   REFINO: OK
@@ -409,6 +417,7 @@ def _render_worker_refine_brief(
     return _WORKER_REFINE_BRIEF.format(
         repo=repo, number=number, title=title, body=_refine_body(body),
         type=issue_type, template=template,
+        title_prefix=title_prefix_for_type(issue_type) or "[FEATURE]",
     )
 
 

--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -321,6 +321,105 @@ def _render_worker_review_resume_brief(
     )
 
 
+# --- Refinement gate briefs (issue #257) --------------------------------------
+# Three new briefs that run BEFORE any implementation: CRITIQUE (judge scope),
+# REFINE (rewrite the body toward the template, possibly pausing for the
+# stakeholder) and DECOMPOSE (an architect splits a clear intent into independent
+# derived issues). The persona is chosen by issue type at dispatch time (analyst
+# for intent, architect for feature/refactor, debugger for bug) — so the brief
+# stays generic and the type-specific JUDGMENT lives in the persona instruction.
+# Each brief ends with a strict last-line VERDICT the pipeline parses.
+
+_WORKER_CRITIQUE_BRIEF = """\
+Você é o GATE DE CRÍTICA DE ESCOPO da issue #{number} (tipo: {type}) do repositório {repo}. NÃO implemente nem refine nada — apenas JULGUE, conforme a sua persona, se o escopo está claro o suficiente para avançar.
+
+1. Leia a issue (abaixo) e o template oficial do tipo:
+   gh api repos/{repo}/contents/.github/ISSUE_TEMPLATE/{template} --jq .content | base64 --decode
+   (Para feature/bug/refactor, consulte a arquitetura real — docs/system_design/ e o código; clone com `gh repo clone {repo} repo` se ainda não houver ./repo. Para bug, verifique se dá pra localizar a origem no código.)
+2. Julgue com RIGOR: a issue está CLARA e bem-escopada (segue o template, tem substância para a PRÓXIMA etapa sem ambiguidade) ou POBRE (vazia, template em branco/incompleto, genérica demais, sem alvo/critério)?
+3. Seja honesto e específico — se POBRE, aponte exatamente o que falta.
+
+VEREDITO (regra dura): na ÚLTIMA LINHA escreva SOMENTE uma destas, nada depois dela:
+  VEREDITO: CLARO
+  VEREDITO: POBRE: <o que falta, em uma frase concreta>
+
+=== Issue #{number} (tipo: {type}): {title} ===
+{body}
+"""
+
+_WORKER_REFINE_BRIEF = """\
+Você vai REFINAR a issue #{number} (tipo: {type}) do repositório {repo} — reescrever o CORPO para ficar claro, substancial e dentro do template oficial. NÃO implemente código de feature/fix; o objetivo é deixar o ESCOPO pronto para a próxima etapa.
+
+1. Leia a issue atual (abaixo) e o template oficial:
+   gh api repos/{repo}/contents/.github/ISSUE_TEMPLATE/{template} --jq .content | base64 --decode
+   (feature/refactor: consulte docs/system_design/ e o código real, clone com `gh repo clone {repo} repo` se preciso. bug: investigue o código e localize a origem provável arquivo:linha. NUNCA invente.)
+2. REESCREVA o corpo conforme a estrutura do template, preenchendo CADA seção com substância REAL (extraída do título, contexto e código). Aplique:
+   gh issue edit {number} --repo {repo} --body "<novo corpo completo>"
+3. LACUNA DO STAKEHOLDER: se houver decisão de escopo/lacuna IMPORTANTE que você NÃO pode decidir sozinho com segurança (alto impacto, ou que derivaria uma feature grande adicional), NÃO decida. Em vez disso:
+   a) Comente na issue (gh issue comment {number} --repo {repo} --body "...") descrevendo a lacuna E **2 a 3 sugestões bem pensadas** para o stakeholder escolher.
+   b) Atribua ao autor (stakeholder): descubra com `gh issue view {number} --repo {repo} --json author -q .author.login` e atribua via REST: gh api -X POST repos/{repo}/issues/{number}/assignees -f 'assignees[]=<login>'
+   c) Reporte AGUARDA_STAKEHOLDER (veredito abaixo) — o pipeline pausa o refino até o stakeholder decidir.
+4. Honestidade: marque suposições como suposições no corpo; nunca invente fato, dado ou causa-raiz.
+
+VEREDITO (regra dura): na ÚLTIMA LINHA escreva SOMENTE uma destas, nada depois dela:
+  REFINO: OK
+  REFINO: AGUARDA_STAKEHOLDER
+
+=== Issue #{number} (tipo: {type}): {title} ===
+{body}
+"""
+
+_WORKER_DECOMPOSE_BRIEF = """\
+Você é o ARQUITETO. A intent #{number} do repositório {repo} está CLARA e aprovada. DECOMPONHA-A em uma ou mais issues derivadas INDEPENDENTES (feature/bug/refactor) que possam ser implementadas em branches PARALELOS.
+
+1. Consulte a arquitetura real ANTES de decidir: docs/system_design/ (clone com `gh repo clone {repo} repo` se preciso) e o código relevante.
+2. Identifique as frentes GENUINAMENTE INDEPENDENTES (sem dependência sequencial entre si). Se a intenção é coesa e indivisível, UMA derivada é a resposta certa; se é multi-frente, várias. NÃO force a divisão — partes acopladas ficam na MESMA issue (fatiar trabalho dependente gera conflito, não paralelismo).
+3. Para CADA frente, crie uma issue derivada com escopo JÁ CLARO:
+   - título específico; corpo seguindo o template do tipo (.github/ISSUE_TEMPLATE/feature_request.md | bug_report.md | refactor_proposal.md) com alvo técnico, contrato, critérios de aceite e plano de teste;
+   - inclua a linha: `Originada de #{number}`.
+   - crie com: gh issue create --repo {repo} --title "..." --body "..." --label "<feature|bug|refactor>"
+     (se o --label falhar, crie sem e adicione via REST: gh api -X POST repos/{repo}/issues/<novo>/labels -f 'labels[]=<tipo>')
+4. Comente na intent #{number} (gh issue comment) listando as derivadas criadas com links — ela permanece ABERTA como épico.
+5. Honestidade: só liste issues que você REALMENTE criou (confirme com `gh issue view`).
+
+VEREDITO (regra dura): na ÚLTIMA LINHA escreva SOMENTE (com os números reais das issues criadas):
+  DECOMPOSTO: #<n1> #<n2> ...
+
+=== Intent #{number}: {title} ===
+{body}
+"""
+
+
+def _refine_body(body: str) -> str:
+    return (body or "").strip()[:ISSUE_BODY_MAX_CHARS] or "(sem corpo — avalie a partir do título)"
+
+
+def _render_worker_critique_brief(
+    repo: str, number: int, title: str, body: str, *, issue_type: str, template: str
+) -> str:
+    return _WORKER_CRITIQUE_BRIEF.format(
+        repo=repo, number=number, title=title, body=_refine_body(body),
+        type=issue_type, template=template,
+    )
+
+
+def _render_worker_refine_brief(
+    repo: str, number: int, title: str, body: str, *, issue_type: str, template: str
+) -> str:
+    return _WORKER_REFINE_BRIEF.format(
+        repo=repo, number=number, title=title, body=_refine_body(body),
+        type=issue_type, template=template,
+    )
+
+
+def _render_worker_decompose_brief(
+    repo: str, number: int, title: str, body: str
+) -> str:
+    return _WORKER_DECOMPOSE_BRIEF.format(
+        repo=repo, number=number, title=title, body=_refine_body(body),
+    )
+
+
 # --- Reviewer-only brief (issue #253 follow-up) -------------------------------
 # When DEILE is requested ONLY as a reviewer (not assignee/owner), the operator
 # policy is: REVIEW and hand the PR back to its author — never fix, never merge.

--- a/deile/orchestration/pipeline/constants.py
+++ b/deile/orchestration/pipeline/constants.py
@@ -37,7 +37,11 @@ def resolve_pipeline_repo() -> str:
     return get_settings().pipeline_repo or PIPELINE_DEFAULT_REPO
 
 # ── Prompt / message truncation ───────────────────────────────────────────
-#: Max chars of issue body sent to the implement prompt.
-ISSUE_BODY_MAX_CHARS: int = 6000
+#: Max chars of issue body EMBEDDED in a worker brief. Kept well under the 8000
+#: dispatch-payload cap so the brief (template + body) never overflows — the
+#: worker reads the FULL live issue via ``gh issue view`` anyway, so the embedded
+#: copy is just initial context. (A refined feature_request body can be large;
+#: 6000 + the refine brief template overflowed 8000 — issue #257.)
+ISSUE_BODY_MAX_CHARS: int = 5000
 #: Max chars of stderr / error detail shown in Discord notifications.
 PIPELINE_MSG_TRUNCATE_CHARS: int = 1500

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -305,6 +305,37 @@ class GitHubClient:
 
     # -- pull requests ------------------------------------------------
 
+    async def has_open_pr_for_issue(self, number: int) -> bool:
+        """True if an OPEN PR already targets/closes issue ``number`` (dedup guard).
+
+        Issue #257: the implement stage must not open a SECOND PR for an issue that
+        was already implemented through another path (e.g. a ``@deile-one`` comment
+        mention firing the one-shot handler while the issue is still flowing through
+        the refinement gate). Matches a PR whose body uses a closing keyword for the
+        issue OR whose head branch references it — covering both the pipeline's
+        ``auto/issue-N`` branches and ad-hoc branches opened via the mention path.
+        Best-effort: a query failure returns False (never block work on a hiccup).
+        """
+        try:
+            out = await self._run_checked(
+                "pr", "list", "--repo", self.repo, "--state", "open",
+                "--search", str(number), "--limit", "30",
+                "--json", "number,body,headRefName",
+            )
+            prs = json.loads(out)
+        except (GhCommandError, json.JSONDecodeError) as exc:
+            logger.warning("has_open_pr_for_issue #%d failed: %s", number, exc)
+            return False
+        closes = re.compile(rf"\b(?:clos\w*|fix\w*|resolv\w*)\s+#{number}\b", re.IGNORECASE)
+        needle = f"issue-{number}"
+        for pr in prs:
+            head = (pr.get("headRefName") or "")
+            if needle in head or head.endswith(f"-{number}"):
+                return True
+            if closes.search(pr.get("body") or ""):
+                return True
+        return False
+
     async def list_open_prs(self, *, limit: int = 50) -> List[PrRef]:
         return await self._list_refs(
             "pr", "list",

--- a/deile/orchestration/pipeline/github_client.py
+++ b/deile/orchestration/pipeline/github_client.py
@@ -27,7 +27,8 @@ from deile.orchestration.pipeline._time_utils import format_iso_utc
 from deile.orchestration.pipeline.labels import (BATCH_LABEL_PREFIX,
                                                  LABEL_COLORS,
                                                  LABEL_DESCRIPTIONS,
-                                                 MENTION_LABELS, REVIEW_LABELS,
+                                                 MENTION_LABELS, REFINE_LABELS,
+                                                 REVIEW_LABELS,
                                                  WORKFLOW_LABELS,
                                                  batch_id_from_label,
                                                  is_batch_label,
@@ -68,6 +69,7 @@ class IssueRef:
     labels: Tuple[str, ...]
     body: str = ""
     state: str = "open"
+    author: str = ""
 
     @property
     def batch_id(self) -> Optional[str]:
@@ -78,6 +80,7 @@ class IssueRef:
 
     @classmethod
     def from_gh_json(cls, item: dict) -> "IssueRef":
+        author = item.get("author") or {}
         return cls(
             number=int(item["number"]),
             title=str(item.get("title", "")),
@@ -85,6 +88,7 @@ class IssueRef:
             labels=_labels_from_gh(item),
             body=str(item.get("body") or ""),
             state=str(item.get("state", "open")),
+            author=str(author.get("login", "")) if isinstance(author, dict) else "",
         )
 
 
@@ -272,7 +276,7 @@ class GitHubClient:
             "--state", "open",
             "--label", label,
             "--limit", str(limit),
-            "--json", "number,title,url,labels,body,state",
+            "--json", "number,title,url,labels,body,state,author",
             factory=IssueRef.from_gh_json,
         )
 
@@ -280,7 +284,7 @@ class GitHubClient:
         out = await self._run_checked(
             "issue", "view", str(number),
             "--repo", self.repo,
-            "--json", "number,title,url,labels,body,state",
+            "--json", "number,title,url,labels,body,state,author",
         )
         return IssueRef.from_gh_json(json.loads(out))
 
@@ -346,6 +350,24 @@ class GitHubClient:
                     logger.debug("remove_labels: %r absent on #%d (ignored)", lb, number)
                     continue
                 raise GhCommandError(("api", "-X", "DELETE", path), rc, out, err)
+
+    async def assign_issue(self, number: int, login: str) -> None:
+        """Assign *login* to an issue via the REST endpoint.
+
+        Uses ``POST repos/{repo}/issues/{n}/assignees`` (needs only ``repo``
+        scope) instead of ``gh issue edit --add-assignee`` — same rationale as
+        :meth:`add_labels`: the ``gh`` edit path runs a GraphQL ``login`` query
+        that demands ``read:org``, which the pipeline token lacks. Best-effort:
+        a failure is logged, never raised (assignment is a courtesy signal).
+        """
+        if not login:
+            return
+        rc, out, err = await self._run(
+            "api", "-X", "POST", f"repos/{self.repo}/issues/{number}/assignees",
+            "-f", f"assignees[]={login}",
+        )
+        if rc != 0:
+            logger.warning("assign_issue #%d -> %s failed: %s", number, login, err.strip()[:200])
 
     async def _transition(
         self, kind: str, number: int, *, from_label: Optional[str], to_label: str,
@@ -454,7 +476,10 @@ class GitHubClient:
             if rc != 0:
                 logger.debug("label %s already exists or could not be created", label)
 
-        await asyncio.gather(*[_create_one(label) for label in (*WORKFLOW_LABELS, *REVIEW_LABELS, *MENTION_LABELS)])
+        await asyncio.gather(*[
+            _create_one(label)
+            for label in (*WORKFLOW_LABELS, *REVIEW_LABELS, *MENTION_LABELS, *REFINE_LABELS)
+        ])
 
     async def comment_on_issue(self, number: int, text: str) -> None:
         await self._run_checked(
@@ -531,7 +556,7 @@ class GitHubClient:
             "--state", "open",
             "--assignee", login,
             "--limit", str(limit),
-            "--json", "number,title,url,labels,body,state",
+            "--json", "number,title,url,labels,body,state,author",
             factory=IssueRef.from_gh_json,
             log_label="list_issues_assigned_to",
         )
@@ -601,7 +626,7 @@ class GitHubClient:
                 "--repo", self.repo,
                 "--state", "open",
                 "--limit", str(limit),
-                "--json", "number,title,url,labels,body,state",
+                "--json", "number,title,url,labels,body,state,author",
             )
         except GhCommandError as exc:
             logger.warning("search_items_mentioning failed: %s", exc)
@@ -638,7 +663,7 @@ class GitHubClient:
                 "--repo", self.repo,
                 "--state", "open",
                 "--limit", str(batch_limit),
-                "--json", "number,title,url,labels,body,state",
+                "--json", "number,title,url,labels,body,state,author",
             )
             data = json.loads(out or "[]")
             new_items = 0

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -26,17 +26,23 @@ themselves.
 from __future__ import annotations
 
 import logging
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from deile.orchestration.pipeline.briefs import (
-    _render_claude_mention_prompt, _render_worker_implement_brief,
+    _render_claude_mention_prompt, _render_worker_critique_brief,
+    _render_worker_decompose_brief, _render_worker_implement_brief,
     _render_worker_implement_resume_brief, _render_worker_mention_brief,
-    _render_worker_pr_address_brief, _render_worker_review_brief,
-    _render_worker_review_only_brief, _render_worker_review_resume_brief)
+    _render_worker_pr_address_brief, _render_worker_refine_brief,
+    _render_worker_review_brief, _render_worker_review_only_brief,
+    _render_worker_review_resume_brief)
 from deile.orchestration.pipeline.claude_dispatcher import (
     render_implement_prompt, render_review_prompt)
+from deile.orchestration.pipeline.labels import (issue_type_from_labels,
+                                                 persona_for_type,
+                                                 template_for_type)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from deile.orchestration.pipeline.github_client import (IssueRef,
@@ -82,10 +88,64 @@ class WorkOutcome:
     budget_acumulado_s: float = 0.0
 
 
+# --- Refinement-gate verdict parsers (issue #257) ----------------------------
+# The critique/refine/decompose briefs end with a strict last-line verdict; these
+# parse the LAST matching line from the agent's final text (``WorkOutcome.text``).
+# Defaults err on the SAFE side: a missing critique verdict reads as POOR (do not
+# advance an unjudged issue); a missing refine verdict reads as ``unknown`` (retry).
+_CRITIQUE_RE = re.compile(r"^\s*VEREDITO:\s*(CLARO|POBRE)\b\s*:?\s*(.*)$", re.IGNORECASE | re.MULTILINE)
+_REFINE_RE = re.compile(r"^\s*REFINO:\s*(OK|AGUARDA_STAKEHOLDER)\b", re.IGNORECASE | re.MULTILINE)
+_DECOMPOSE_RE = re.compile(r"^\s*DECOMPOSTO:\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+
+
+def parse_critique_verdict(text: str) -> Tuple[bool, str]:
+    """Return ``(is_clear, reason)`` from a critique outcome. Missing → POOR."""
+    matches = list(_CRITIQUE_RE.finditer(text or ""))
+    if not matches:
+        return False, "veredito de crítica ausente"
+    m = matches[-1]
+    is_clear = m.group(1).upper() == "CLARO"
+    return is_clear, (m.group(2) or "").strip()
+
+
+def parse_refine_verdict(text: str) -> str:
+    """Return ``"ok"`` | ``"waiting"`` | ``"unknown"`` from a refine outcome."""
+    matches = list(_REFINE_RE.finditer(text or ""))
+    if not matches:
+        return "unknown"
+    return "waiting" if matches[-1].group(1).upper() == "AGUARDA_STAKEHOLDER" else "ok"
+
+
+def parse_decompose_result(text: str) -> List[int]:
+    """Return the derived issue numbers reported by a decompose outcome."""
+    matches = list(_DECOMPOSE_RE.finditer(text or ""))
+    if not matches:
+        return []
+    return [int(n) for n in re.findall(r"#(\d+)", matches[-1].group(1))]
+
+
 class PipelineImplementer(ABC):
     """Strategy that performs the implement / review / mention work."""
 
     name: str = "base"
+
+    # Refinement-gate steps (issue #257) — default to "not supported" so the
+    # legacy Claude path inherits a graceful no-op; the worker path overrides
+    # them. They are NOT abstract on purpose (only the worker implements them).
+    async def critique(
+        self, monitor: "PipelineMonitor", issue: "IssueRef"
+    ) -> WorkOutcome:
+        return WorkOutcome(ok=False, text="", error="critique não suportado nesta estratégia")
+
+    async def refine(
+        self, monitor: "PipelineMonitor", issue: "IssueRef"
+    ) -> WorkOutcome:
+        return WorkOutcome(ok=False, text="", error="refine não suportado nesta estratégia")
+
+    async def decompose(
+        self, monitor: "PipelineMonitor", issue: "IssueRef"
+    ) -> WorkOutcome:
+        return WorkOutcome(ok=False, text="", error="decompose não suportado nesta estratégia")
 
     @abstractmethod
     async def implement(
@@ -312,6 +372,48 @@ class WorkerImplementer(PipelineImplementer):
         )
         return await self._dispatch(
             brief, channel_id=f"pipeline-issue-{issue.number}", resume_block=resume_block
+        )
+
+    # --- Refinement gate (issue #257) -------------------------------------
+    # critique/refine route to the persona that owns the issue type (analyst for
+    # intent, architect for feature/refactor, debugger for bug); decompose is
+    # always the architect. No resume_block: these steps open no PR, so the
+    # worker returns a plain ok+summary and the verdict lives in its last line.
+
+    async def critique(
+        self, monitor: "PipelineMonitor", issue: "IssueRef"
+    ) -> WorkOutcome:
+        issue_type = issue_type_from_labels(issue.labels)
+        brief = _render_worker_critique_brief(
+            monitor.config.repo, issue.number, issue.title, issue.body,
+            issue_type=issue_type or "", template=template_for_type(issue_type) or "intent.md",
+        )
+        return await self._dispatch(
+            brief, channel_id=f"pipeline-issue-{issue.number}",
+            persona=persona_for_type(issue_type),
+        )
+
+    async def refine(
+        self, monitor: "PipelineMonitor", issue: "IssueRef"
+    ) -> WorkOutcome:
+        issue_type = issue_type_from_labels(issue.labels)
+        brief = _render_worker_refine_brief(
+            monitor.config.repo, issue.number, issue.title, issue.body,
+            issue_type=issue_type or "", template=template_for_type(issue_type) or "intent.md",
+        )
+        return await self._dispatch(
+            brief, channel_id=f"pipeline-issue-{issue.number}",
+            persona=persona_for_type(issue_type),
+        )
+
+    async def decompose(
+        self, monitor: "PipelineMonitor", issue: "IssueRef"
+    ) -> WorkOutcome:
+        brief = _render_worker_decompose_brief(
+            monitor.config.repo, issue.number, issue.title, issue.body,
+        )
+        return await self._dispatch(
+            brief, channel_id=f"pipeline-issue-{issue.number}", persona="architect",
         )
 
     async def review(

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -335,6 +335,12 @@ class WorkerImplementer(PipelineImplementer):
         from deile.infrastructure.deile_worker_client import (
             WorkerDispatchError, build_dispatch_payload)
 
+        # Defensive clamp under the 8000-char dispatch cap (issue #257): every
+        # body-embedding brief puts the issue/PR body LAST (after the VEREDITO
+        # rules), so truncating the tail only trims body context — never the
+        # instructions. Guarantees the payload never hard-fails on size.
+        if len(brief) > 7950:
+            brief = brief[:7950] + "\n…(brief truncado por tamanho)"
         payload = build_dispatch_payload(
             brief=brief, channel_id=channel_id, persona=persona, wait=True
         )

--- a/deile/orchestration/pipeline/labels.py
+++ b/deile/orchestration/pipeline/labels.py
@@ -113,6 +113,14 @@ TYPE_TO_TEMPLATE = {
     TYPE_BUG: "bug_report.md",
     TYPE_REFACTOR: "refactor_proposal.md",
 }
+# Title prefix each template enforces (``title: '[FEATURE] '`` etc.) — the refiner
+# normalizes the issue title to start with this tag.
+TYPE_TO_TITLE_PREFIX = {
+    TYPE_INTENT: "[INTENT]",
+    TYPE_FEATURE: "[FEATURE]",
+    TYPE_BUG: "[BUG]",
+    TYPE_REFACTOR: "[REFACTOR]",
+}
 # ``enhancement`` is the GitHub-conventional feature label and is treated as an
 # alias of ``feature`` (it is already accepted by ``classifiable_labels``).
 _TYPE_ALIASES = {"enhancement": TYPE_FEATURE}
@@ -144,6 +152,11 @@ def persona_for_type(issue_type: Optional[str]) -> str:
 def template_for_type(issue_type: Optional[str]) -> Optional[str]:
     """Matching ``.github/ISSUE_TEMPLATE`` filename for *issue_type* (or None)."""
     return TYPE_TO_TEMPLATE.get(issue_type or "")
+
+
+def title_prefix_for_type(issue_type: Optional[str]) -> str:
+    """Title tag the template enforces (``[FEATURE]`` etc.); empty if unknown."""
+    return TYPE_TO_TITLE_PREFIX.get(issue_type or "", "")
 
 
 # Distributed lock --------------------------------------------------------

--- a/deile/orchestration/pipeline/labels.py
+++ b/deile/orchestration/pipeline/labels.py
@@ -12,6 +12,8 @@ like ``bug``, ``enhancement``, ``intent``).
 
 from __future__ import annotations
 
+from typing import Iterable, Optional
+
 # Issue workflow ----------------------------------------------------------
 # Only the states actually transitioned by the pipeline live here.
 # Stage 0 sets ``WORKFLOW_NEW``, Stage 1 transitions to ``WORKFLOW_REVIEWING``
@@ -26,9 +28,30 @@ from __future__ import annotations
 # — the PR is the final state from the issue's perspective — so it is absent.
 WORKFLOW_NEW = "~workflow:nova"
 WORKFLOW_REVIEWING = "~workflow:em_revisao"
+# Refinement gate (issue #257). After critique judges an issue's scope POOR it
+# enters the refinement loop, in a type-specific state: an ``intent`` (analyst,
+# product/discovery work) goes to ``em_refinamento``; a ``feature``/``bug``/
+# ``refactor`` (architect/debugger, design work) goes to ``em_arquitetura`` (the
+# yellow "architecture phase" label, removed when implementation starts). They
+# are the SAME slot, picked by type — see ``refine_workflow_state``.
+WORKFLOW_REFINING = "~workflow:em_refinamento"
+WORKFLOW_ARCHITECTURE = "~workflow:em_arquitetura"
+# Momentary PAUSE overlay (issue #257): the refiner hit a gap/scope decision that
+# only the stakeholder (issue author) can resolve. It posted 2-3 suggestions and
+# assigned the author. This label COEXISTS with the refine state (em_refinamento/
+# em_arquitetura) and is OBSERVED to pause the refine stage — the human removes it
+# (after commenting their decision) to resume refinement. ``refinar`` stays set.
+WORKFLOW_WAITING = "~workflow:aguardando_stakeholder"
 WORKFLOW_REVIEWED = "~workflow:revisada"
 WORKFLOW_IMPLEMENTING = "~workflow:em_implementacao"
 WORKFLOW_PR = "~workflow:em_pr"
+# Terminal state for an ``intent`` that the pipeline DECOMPOSED into one or more
+# derived ``feature``/``bug``/``refactor`` issues. The intent stays OPEN as a
+# tracking epic (the human closes it manually — see the issue template), but
+# this label drops it out of every stage's candidate set so it is never
+# re-decomposed. It is a ``~workflow:*`` state, so the defense-in-depth
+# ``startswith("~")`` guard in the classify stage also skips it.
+WORKFLOW_DECOMPOSED = "~workflow:decomposta"
 # Resume feature (issue #254): a serious, non-continuable block. The agent
 # declared ``BLOQUEADO: <motivo>``, the progress guard saw 0 substantive
 # progress between attempts, or the attempt/budget ceiling was hit. The issue
@@ -55,46 +78,147 @@ REVIEW_CONCLUDED = "~review:concluida"
 # governed by the cursor). A human removes it to force a re-handle.
 MENTION_DONE = "~mention:processado"
 
+# Refinement gate ---------------------------------------------------------
+# Universal "needs refinement" flag (no ``~`` prefix on purpose: a human applies
+# it by hand too). The critique stage adds it to a ``~workflow:nova`` issue whose
+# scope is judged POOR; the refine stage acts on ANY open issue carrying it
+# (regardless of type), improves the body toward the matching ``.github`` template
+# and removes it. No code/decomposition ever runs while an issue is poor — it must
+# pass critique first. A human can add ``refinar`` to force a refinement pass.
+REFINAR = "refinar"
+
+# Issue type labels (mirror ``.github/ISSUE_TEMPLATE/*``) -----------------
+# These are PROJECT labels (no ``~`` prefix). They route an issue to the right
+# refinement lens (persona) and the matching template during critique/refine.
+TYPE_INTENT = "intent"
+TYPE_FEATURE = "feature"
+TYPE_BUG = "bug"
+TYPE_REFACTOR = "refactor"
+ISSUE_TYPE_LABELS = (TYPE_INTENT, TYPE_FEATURE, TYPE_BUG, TYPE_REFACTOR)
+
+# Which refinement persona owns each type (critique + refine; decompose is
+# always ``architect``). An ``intent`` is product/discovery work (analyst), a
+# ``feature``/``refactor`` is architectural deepening (architect), a ``bug`` is
+# code investigation (debugger).
+TYPE_TO_PERSONA = {
+    TYPE_INTENT: "analyst",
+    TYPE_FEATURE: "architect",
+    TYPE_BUG: "debugger",
+    TYPE_REFACTOR: "architect",
+}
+# The matching ``.github/ISSUE_TEMPLATE`` file for each type.
+TYPE_TO_TEMPLATE = {
+    TYPE_INTENT: "intent.md",
+    TYPE_FEATURE: "feature_request.md",
+    TYPE_BUG: "bug_report.md",
+    TYPE_REFACTOR: "refactor_proposal.md",
+}
+# ``enhancement`` is the GitHub-conventional feature label and is treated as an
+# alias of ``feature`` (it is already accepted by ``classifiable_labels``).
+_TYPE_ALIASES = {"enhancement": TYPE_FEATURE}
+
+
+def issue_type_from_labels(labels: Iterable[str]) -> Optional[str]:
+    """Return the canonical issue type (``intent``/``feature``/``bug``/``refactor``).
+
+    Checks in priority order so an issue carrying more than one type label
+    resolves deterministically: ``intent`` (decomposes) wins, then ``bug``,
+    ``refactor`` and finally ``feature`` (incl. the ``enhancement`` alias).
+    Returns ``None`` when no recognized type label is present.
+    """
+    labset = set(labels)
+    for t in (TYPE_INTENT, TYPE_BUG, TYPE_REFACTOR, TYPE_FEATURE):
+        if t in labset:
+            return t
+    for alias, canonical in _TYPE_ALIASES.items():
+        if alias in labset:
+            return canonical
+    return None
+
+
+def persona_for_type(issue_type: Optional[str]) -> str:
+    """Persona that critiques/refines an issue of *issue_type* (default developer)."""
+    return TYPE_TO_PERSONA.get(issue_type or "", "developer")
+
+
+def template_for_type(issue_type: Optional[str]) -> Optional[str]:
+    """Matching ``.github/ISSUE_TEMPLATE`` filename for *issue_type* (or None)."""
+    return TYPE_TO_TEMPLATE.get(issue_type or "")
+
+
 # Distributed lock --------------------------------------------------------
 BATCH_LABEL_PREFIX = "~batch:"
 
 WORKFLOW_LABELS = (
     WORKFLOW_NEW,
     WORKFLOW_REVIEWING,
+    WORKFLOW_REFINING,
+    WORKFLOW_ARCHITECTURE,
+    WORKFLOW_WAITING,
     WORKFLOW_REVIEWED,
     WORKFLOW_IMPLEMENTING,
     WORKFLOW_PR,
+    WORKFLOW_DECOMPOSED,
     WORKFLOW_BLOCKED,
 )
+
+#: The two refine states are the same logical step, chosen by issue type:
+#: intent → em_refinamento (analyst); code types → em_arquitetura (architect/
+#: debugger). ``refine_workflow_state`` is the single source of that mapping.
+REFINE_WORKFLOW_STATES = (WORKFLOW_REFINING, WORKFLOW_ARCHITECTURE)
+
+
+def refine_workflow_state(issue_type: Optional[str]) -> str:
+    """Return the refine ``~workflow:`` state for *issue_type*.
+
+    ``intent`` refines as product/discovery work (``em_refinamento``); every
+    code type (feature/bug/refactor, incl. unknown) refines as design work
+    (``em_arquitetura``, the yellow architecture-phase label).
+    """
+    return WORKFLOW_REFINING if issue_type == TYPE_INTENT else WORKFLOW_ARCHITECTURE
 
 REVIEW_LABELS = (REVIEW_PENDING, REVIEW_IN_PROGRESS, REVIEW_CONCLUDED)
 
 MENTION_LABELS = (MENTION_DONE,)
 
+# Refinement gate: the only pipeline-created label here is ``refinar`` (the type
+# labels are project-owned and created by the issue templates).
+REFINE_LABELS = (REFINAR,)
+
 LABEL_COLORS = {
     WORKFLOW_NEW: "0e8a16",
     WORKFLOW_REVIEWING: "fbca04",
+    WORKFLOW_REFINING: "d4c5f9",
+    WORKFLOW_ARCHITECTURE: "fbca04",
+    WORKFLOW_WAITING: "d93f0b",
     WORKFLOW_REVIEWED: "5319e7",
     WORKFLOW_IMPLEMENTING: "fbca04",
     WORKFLOW_PR: "0052cc",
+    WORKFLOW_DECOMPOSED: "1d76db",
     WORKFLOW_BLOCKED: "b60205",
     REVIEW_PENDING: "0e8a16",
     REVIEW_IN_PROGRESS: "fbca04",
     REVIEW_CONCLUDED: "0e8a16",
     MENTION_DONE: "c5def5",
+    REFINAR: "d4c5f9",
 }
 
 LABEL_DESCRIPTIONS = {
     WORKFLOW_NEW: "Pipeline: issue nova, ainda não revisada",
-    WORKFLOW_REVIEWING: "Pipeline: DEILE revisando (lock)",
-    WORKFLOW_REVIEWED: "Pipeline: revisada, pronta para implementação",
+    WORKFLOW_REVIEWING: "Pipeline: DEILE criticando escopo (lock)",
+    WORKFLOW_REFINING: "Pipeline: intent em refinamento (analyst)",
+    WORKFLOW_ARCHITECTURE: "Pipeline: feature/bug/refactor em arquitetura/design (architect/debugger) — sai ao implementar",
+    WORKFLOW_WAITING: "Pipeline: aguardando decisão do stakeholder (pausa o refino) — humano comenta e remove para retomar",
+    WORKFLOW_REVIEWED: "Pipeline: revisada, escopo claro — pronta para implementação/decomposição",
     WORKFLOW_IMPLEMENTING: "Pipeline: DEILE implementando (lock)",
     WORKFLOW_PR: "Pipeline: PR aberta",
+    WORKFLOW_DECOMPOSED: "Pipeline: intent decomposta em issues derivadas (épico aberto) — humano fecha manualmente",
     WORKFLOW_BLOCKED: "Pipeline: bloqueada (sem progresso / impedimento / teto) — humano remove para desbloquear",
     REVIEW_PENDING: "Pipeline: PR aguardando revisão",
     REVIEW_IN_PROGRESS: "Pipeline: PR em revisão (lock)",
     REVIEW_CONCLUDED: "Pipeline: PR revisada/mergeada",
     MENTION_DONE: "Pipeline: menção/atribuição já processada — humano remove para reprocessar",
+    REFINAR: "Pipeline: escopo pobre — precisa de refinamento antes de avançar (humano pode aplicar à mão)",
 }
 
 

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -123,6 +123,19 @@ class PipelineConfig:
     resume_interval: int = 0
     resume_max_attempts: int = 10
     resume_budget: int = 0
+    # Refinement gate + parallel decomposition (issue #257). ``refine_max_attempts``
+    # caps how many refinement passes a poor-scoped issue gets before it is blocked
+    # and returned to its author. ``max_parallel`` caps how many implementations the
+    # implement stage dispatches CONCURRENTLY per tick (asyncio.gather to the
+    # deile-worker Service; needs >=2 worker replicas to actually run in parallel).
+    refine_max_attempts: int = 5
+    max_parallel: int = 2
+    # The refinement gate (critique → refine loop → decompose) is worker-only:
+    # it dispatches type-specific personas (analyst/architect/debugger) to the
+    # deile-worker. On the legacy Claude path it is OFF, so ``review`` keeps its
+    # old no-op transition and refine/decompose no-op. Resolved from dispatch_mode
+    # in ``build_default_pipeline_config`` (mirrors ``enable_resume``).
+    enable_refinement_gate: bool = False
 
 
 def build_default_pipeline_config(*, use_pid_lock: bool = True) -> PipelineConfig:
@@ -161,6 +174,9 @@ def build_default_pipeline_config(*, use_pid_lock: bool = True) -> PipelineConfi
         resume_interval=int(settings.pipeline_resume_interval),
         resume_max_attempts=int(settings.pipeline_resume_max_attempts),
         resume_budget=int(settings.pipeline_resume_budget),
+        refine_max_attempts=int(settings.pipeline_refine_max_attempts),
+        max_parallel=int(settings.pipeline_max_parallel),
+        enable_refinement_gate=(dispatch_mode not in ("claude", "claude_code", "claude-code")),
     )
 
 
@@ -498,6 +514,11 @@ class PipelineMonitor:
                 if self.config.enable_review and "review" not in scheduled_actions:
                     logger.debug("review not in schedule; running legacy fallback")
                     await self._review_one_new_issue()
+                # Refinement loop (issue #257): a per-tick sweep like resume, not
+                # a cron action — runs after critique so an issue judged POOR is
+                # refined on the NEXT tick, then re-critiqued.
+                if self.config.enable_refinement_gate:
+                    await self._refine_one_issue()
                 # Resume parked, continuable work BEFORE claiming new issues
                 # (issue #254). Running it first is what stops a freshly-claimed
                 # issue (revisada → em_implementacao THIS tick) from being
@@ -510,6 +531,9 @@ class PipelineMonitor:
                 if self.config.enable_implement and "implement" not in scheduled_actions:
                     logger.debug("implement not in schedule; running legacy fallback")
                     await self._implement_one_reviewed_issue()
+                # Decompose CLEAR intents into derived issues (issue #257).
+                if self.config.enable_refinement_gate:
+                    await self._decompose_one_reviewed_intent()
                 if self.config.enable_pr_review and "pr_review" not in scheduled_actions:
                     logger.debug("pr_review not in schedule; running legacy fallback")
                     await self._review_one_open_pr()
@@ -523,6 +547,8 @@ class PipelineMonitor:
             await self._classify_new_issues()
         if self.config.enable_review:
             await self._review_one_new_issue()
+        if self.config.enable_refinement_gate:
+            await self._refine_one_issue()
         # Resume parked work BEFORE claiming new issues (issue #254) so a
         # freshly-claimed issue is not re-dispatched again in the same tick;
         # its first resume lands on the next tick.
@@ -530,6 +556,8 @@ class PipelineMonitor:
             await self._resume_in_progress_issues()
         if self.config.enable_implement:
             await self._implement_one_reviewed_issue()
+        if self.config.enable_refinement_gate:
+            await self._decompose_one_reviewed_intent()
         if self.config.enable_pr_review:
             await self._review_one_open_pr()
         if self.config.enable_pr_triage:
@@ -557,6 +585,12 @@ class PipelineMonitor:
 
     async def _review_one_new_issue(self) -> None:
         return await stages.review_one_new_issue(self)
+
+    async def _refine_one_issue(self) -> None:
+        return await stages.refine_one_issue(self)
+
+    async def _decompose_one_reviewed_intent(self) -> None:
+        return await stages.decompose_one_reviewed_intent(self)
 
     async def _implement_one_reviewed_issue(self) -> None:
         return await stages.implement_one_reviewed_issue(self)

--- a/deile/orchestration/pipeline/resume_state.py
+++ b/deile/orchestration/pipeline/resume_state.py
@@ -38,6 +38,10 @@ class IssueResumeState:
     attempt: int = 0
     #: Accumulated wall-clock budget (seconds) reported by the worker.
     budget_s: float = 0.0
+    #: Refinement passes already applied to this issue (refinement gate). Unlike
+    #: ``attempt`` this has no durable PVC source — it is reset on monitor restart
+    #: (a safety ceiling, not a hard guarantee). Bounded by ``refine_max_attempts``.
+    refine_attempt: int = 0
 
 
 @dataclass
@@ -82,6 +86,17 @@ class ResumeTracker:
             state.attempt = attempt
         if budget_s:
             state.budget_s = budget_s
+
+    def bump_refine(self, number: int) -> int:
+        """Increment and return the refinement-pass counter for *number*."""
+        state = self.get(number)
+        state.refine_attempt += 1
+        return state.refine_attempt
+
+    def refine_attempt(self, number: int) -> int:
+        """Return the refinement passes applied so far for *number* (0 if none)."""
+        state = self.peek(number)
+        return state.refine_attempt if state is not None else 0
 
     def clear(self, number: int) -> None:
         """Drop tracked state for *number* (e.g. once it reaches em_pr/blocked)."""

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -17,6 +17,7 @@ parameter and only type-hinted under ``TYPE_CHECKING``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import time
@@ -28,15 +29,23 @@ from deile.orchestration.pipeline.follow_up_detector import detect_follow_ups
 from deile.orchestration.pipeline.github_client import (CommentRef,
                                                         GhCommandError,
                                                         MentionTrigger)
-from deile.orchestration.pipeline.labels import (MENTION_DONE,
+from deile.orchestration.pipeline.implementer import (parse_critique_verdict,
+                                                      parse_decompose_result,
+                                                      parse_refine_verdict)
+from deile.orchestration.pipeline.labels import (MENTION_DONE, REFINAR,
+                                                 REFINE_WORKFLOW_STATES,
                                                  REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
-                                                 REVIEW_PENDING,
+                                                 REVIEW_PENDING, TYPE_INTENT,
                                                  WORKFLOW_BLOCKED,
+                                                 WORKFLOW_DECOMPOSED,
                                                  WORKFLOW_IMPLEMENTING,
                                                  WORKFLOW_NEW, WORKFLOW_PR,
                                                  WORKFLOW_REVIEWED,
-                                                 WORKFLOW_REVIEWING)
+                                                 WORKFLOW_REVIEWING,
+                                                 WORKFLOW_WAITING,
+                                                 issue_type_from_labels,
+                                                 refine_workflow_state)
 
 # Mention triggers that describe a STICKY state (they re-appear on every poll
 # until the underlying GitHub state changes), as opposed to "comment", which is
@@ -534,6 +543,11 @@ async def _route_issue_to_pipeline(
 # ----- stage 1: review ---------------------------------------------------
 
 async def review_one_new_issue(monitor: "PipelineMonitor") -> None:
+    """Stage 1. With the refinement gate ON (issue #257) this is the CRITIQUE of
+    scope: dispatch the type's persona to judge CLARO/POBRE; clear → revisada,
+    poor → refinar + the type's refine state (analyst→em_refinamento, others→
+    em_arquitetura), with a block-to-author after ``refine_max_attempts`` passes.
+    With the gate OFF it keeps the legacy no-op transition (nova→revisada)."""
     try:
         issues = await monitor.github.list_issues_with_label(WORKFLOW_NEW, limit=50)
     except GhCommandError as exc:
@@ -549,6 +563,12 @@ async def review_one_new_issue(monitor: "PipelineMonitor") -> None:
     )
     if target is None:
         return
+
+    if monitor.config.enable_refinement_gate:
+        await _critique_one_issue(monitor, target)
+        return
+
+    # ---- Legacy path (Claude/no-gate): no-op transition through review --------
     batch = await monitor.github.claim_with_batch("issue", target.number)
     if batch is None:
         return
@@ -601,9 +621,247 @@ async def review_one_new_issue(monitor: "PipelineMonitor") -> None:
     await monitor.notifier.issue_reviewed(target.number, target.title, target.url)
 
 
+async def _critique_one_issue(monitor: "PipelineMonitor", target) -> None:
+    """Critique gate (issue #257): judge scope, route to revisada or refinement."""
+    number = target.number
+    # Single-monitor production needs no batch lock (the nova→em_revisao flip is
+    # the lock, and a lingering ~batch: would break the re-critique loop); a
+    # sharded deployment claims to close the TOCTOU window and clears it after.
+    multi = monitor.identity.shard_count > 1
+    if multi:
+        if await monitor.github.claim_with_batch("issue", number) is None:
+            return
+    # Ownership tag lets the implement stage accept this issue without a batch.
+    await monitor.github.add_labels("issue", number, [monitor.identity.ownership_label()])
+    await monitor.notifier.issue_picked_up(number, target.title, target.url)
+    try:
+        await monitor.github.transition_issue(
+            number, from_label=WORKFLOW_NEW, to_label=WORKFLOW_REVIEWING
+        )
+    except GhCommandError as exc:
+        await _record_gh_error(monitor, f"could not claim issue #{number} for critique", exc)
+        return
+
+    outcome = await monitor.implementer.critique(monitor, target)
+    if multi:
+        await monitor.github.clear_batch_label("issue", number)
+    if not outcome.ok:
+        # Critique dispatch failed → revert to nova so a later tick retries.
+        try:
+            await monitor.github.transition_issue(
+                number, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_NEW
+            )
+        except Exception:  # noqa: BLE001 — rollback is best-effort
+            logger.warning("could not revert #%d to nova after critique failure", number)
+        logger.warning("critique #%d failed: %s", number, (outcome.error or "")[:200])
+        return
+
+    is_clear, reason = parse_critique_verdict(outcome.text)
+    issue_type = issue_type_from_labels(target.labels)
+    if is_clear:
+        await monitor.github.transition_issue(
+            number, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_REVIEWED
+        )
+        # The refinement marker (if any) is done now that scope is clear.
+        await monitor.github.remove_labels("issue", number, [REFINAR])
+        monitor._stats.issues_reviewed += 1
+        await monitor.notifier.issue_reviewed(number, target.title, target.url)
+        return
+
+    # POOR — block to the author once the refinement budget is exhausted.
+    if monitor._resume_tracker.refine_attempt(number) >= monitor.config.refine_max_attempts:
+        await _block_refinement(monitor, target, reason)
+        return
+    # Send to the type-specific refinement state and mark it for the refine stage.
+    refine_state = refine_workflow_state(issue_type)
+    await monitor.github.add_labels("issue", number, [REFINAR])
+    try:
+        await monitor.github.transition_issue(
+            number, from_label=WORKFLOW_REVIEWING, to_label=refine_state
+        )
+    except GhCommandError as exc:
+        await _record_gh_error(monitor, f"could not move #{number} to {refine_state}", exc)
+        return
+    logger.info("critique #%d POBRE → %s (%s)", number, refine_state, reason[:120])
+
+
+async def refine_one_issue(monitor: "PipelineMonitor") -> None:
+    """Stage 1b (issue #257): refine ONE issue carrying ``refinar``.
+
+    Candidate = any open issue with ``refinar`` that this monitor owns and is NOT
+    paused (``aguardando_stakeholder``), blocked, or already past refinement. An
+    issue not yet in a refine state (a human applied ``refinar`` by hand) is
+    rehydrated into its type's refine state. Otherwise the type's persona rewrites
+    the body: ``REFINO: OK`` → back to ``nova`` for re-critique (counts toward the
+    ceiling); ``AGUARDA_STAKEHOLDER`` → pause via the waiting overlay.
+    """
+    if not monitor.config.enable_refinement_gate:
+        return
+    try:
+        issues = await monitor.github.list_issues_with_label(REFINAR, limit=50)
+    except GhCommandError as exc:
+        await _record_gh_error(
+            monitor, "could not list issues to refine (gh error)", exc,
+            notifier_label="refine/list",
+        )
+        return
+    _excluded = (WORKFLOW_WAITING, WORKFLOW_BLOCKED, WORKFLOW_IMPLEMENTING,
+                 WORKFLOW_PR, WORKFLOW_DECOMPOSED)
+    target = next(
+        (i for i in issues
+         if not any(lb in i.labels for lb in _excluded)
+         and monitor.identity.owns(i.title)),
+        None,
+    )
+    if target is None:
+        return
+    number = target.number
+    issue_type = issue_type_from_labels(target.labels)
+
+    # Rehydrate a hand-applied ``refinar`` (issue not yet in a refine state).
+    if not any(s in target.labels for s in REFINE_WORKFLOW_STATES):
+        refine_state = refine_workflow_state(issue_type)
+        cur = next(
+            (s for s in (WORKFLOW_NEW, WORKFLOW_REVIEWING, WORKFLOW_REVIEWED) if s in target.labels),
+            None,
+        )
+        try:
+            if cur:
+                await monitor.github.transition_issue(number, from_label=cur, to_label=refine_state)
+            else:
+                await monitor.github.add_labels("issue", number, [refine_state])
+        except GhCommandError as exc:
+            await _record_gh_error(monitor, f"could not rehydrate #{number} into {refine_state}", exc)
+        return  # refined on the next tick
+
+    # Ceiling guard (belt-and-suspenders with the critique-side check).
+    if monitor._resume_tracker.refine_attempt(number) >= monitor.config.refine_max_attempts:
+        await _block_refinement(monitor, target, "teto de refinamentos atingido")
+        return
+
+    outcome = await monitor.implementer.refine(monitor, target)
+    if not outcome.ok:
+        logger.warning("refine #%d failed: %s", number, (outcome.error or "")[:200])
+        return  # transient — retry next tick (no count bump)
+
+    verdict = parse_refine_verdict(outcome.text)
+    if verdict == "waiting":
+        # The worker posted 2-3 suggestions and assigned the author; pause refino.
+        await monitor.github.add_labels("issue", number, [WORKFLOW_WAITING])
+        logger.info("refine #%d → aguardando stakeholder", number)
+        return
+    # OK / unknown → count it and send back for re-critique (the safety net).
+    monitor._resume_tracker.bump_refine(number)
+    refine_state = next(
+        (s for s in REFINE_WORKFLOW_STATES if s in target.labels),
+        refine_workflow_state(issue_type),
+    )
+    try:
+        await monitor.github.transition_issue(number, from_label=refine_state, to_label=WORKFLOW_NEW)
+    except GhCommandError as exc:
+        await _record_gh_error(monitor, f"could not return #{number} to nova after refine", exc)
+        return
+    logger.info("refine #%d OK (passe %d) → nova (re-crítica)", number,
+                monitor._resume_tracker.refine_attempt(number))
+
+
+async def _block_refinement(monitor: "PipelineMonitor", issue, reason: str) -> None:
+    """Block a poor-scoped issue back to its author after the refine ceiling.
+
+    Rests the issue in its type's refine state (so removing ``bloqueada`` resumes
+    refinement with a fresh count — :func:`_block` clears the tracker), keeps
+    ``refinar``, and assigns the author so the stakeholder is pinged to refine it
+    by hand. No ``@``-mention in the comment (that would re-trigger mention
+    handling when the author is DEILE itself)."""
+    number = issue.number
+    issue_type = issue_type_from_labels(issue.labels)
+    refine_state = refine_workflow_state(issue_type)
+    if refine_state not in issue.labels:
+        cur = next(
+            (s for s in (WORKFLOW_REVIEWING, WORKFLOW_NEW, *REFINE_WORKFLOW_STATES)
+             if s in issue.labels and s != refine_state),
+            None,
+        )
+        try:
+            if cur:
+                await monitor.github.transition_issue(number, from_label=cur, to_label=refine_state)
+            else:
+                await monitor.github.add_labels("issue", number, [refine_state])
+        except GhCommandError as exc:
+            await _record_gh_error(monitor, f"could not rest #{number} in {refine_state}", exc)
+    await monitor.github.add_labels("issue", number, [REFINAR])
+    if getattr(issue, "author", ""):
+        await monitor.github.assign_issue(number, issue.author)
+    short = reason[:PIPELINE_MSG_TRUNCATE_CHARS]
+    comment = (
+        f"⛔ **Refino atingiu o teto de {monitor.config.refine_max_attempts} tentativas** "
+        f"e o escopo ainda está pobre.\n\n"
+        f"**Falta:** {short}\n\n"
+        f"Autor: por favor refine esta issue manualmente (preencha o template) e remova o "
+        f"label `{WORKFLOW_BLOCKED}` para o pipeline retomar o refinamento."
+    )
+    await _block(monitor, "issue", number, short, comment=comment)
+
+
+async def decompose_one_reviewed_intent(monitor: "PipelineMonitor") -> None:
+    """Stage 2 (intent path, issue #257): an architect decomposes a CLEAR intent
+    into independent derived issues, then the intent stays OPEN as a decomposed
+    epic (``~workflow:decomposta``)."""
+    if not monitor.config.enable_refinement_gate:
+        return
+    try:
+        issues = await monitor.github.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
+    except GhCommandError as exc:
+        await _record_gh_error(
+            monitor, "could not list reviewed intents (gh error)", exc,
+            notifier_label="decompose/list",
+        )
+        return
+    ownership_label = monitor.identity.ownership_label()
+    target = next(
+        (i for i in issues
+         if issue_type_from_labels(i.labels) == TYPE_INTENT
+         and WORKFLOW_DECOMPOSED not in i.labels
+         and WORKFLOW_BLOCKED not in i.labels
+         and monitor._this_monitor_owns(i)
+         and (i.batch_id is not None or ownership_label in i.labels)),
+        None,
+    )
+    if target is None:
+        return
+    # The decompose dispatch is wait=True, so it blocks this (sequential) tick —
+    # no concurrent re-pick. On success the intent leaves the revisada queue.
+    outcome = await monitor.implementer.decompose(monitor, target)
+    derived = parse_decompose_result(outcome.text)
+    if not outcome.ok and not derived:
+        logger.warning("decompose #%d failed: %s", target.number, (outcome.error or "")[:200])
+        return  # stays revisada — retry next tick
+    # Mark decomposed when derived issues were created (even if the ok flag is
+    # noisy) so we never re-decompose and duplicate the derived issues.
+    try:
+        await monitor.github.transition_issue(
+            target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_DECOMPOSED
+        )
+    except GhCommandError as exc:
+        await _record_gh_error(monitor, f"could not mark #{target.number} decomposed", exc)
+    logger.info("decompose #%d → derivadas %s", target.number, derived)
+    await monitor.notifier.issue_reviewed(
+        target.number, f"{target.title} (decomposta em {len(derived)})", target.url
+    )
+
+
 # ----- stage 2: implement ------------------------------------------------
 
 async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
+    """Stage 2 (code path). Claim up to ``max_parallel`` reviewed feature/bug/
+    refactor issues and dispatch their implementations CONCURRENTLY (issue #257):
+    ``asyncio.gather`` of independent worker dispatches that the k8s Service
+    spreads across the worker replicas. Each opens its own branch + PR, so the
+    only contention surfaces at merge time. ``intent`` issues are excluded — they
+    go to :func:`decompose_one_reviewed_intent`. The tick blocks for the duration
+    of the SLOWEST dispatch in the batch (not the sum). Per-issue finalization
+    reuses :func:`_finalize_implement_outcome` unchanged.
+    """
     try:
         issues = await monitor.github.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
     except GhCommandError as exc:
@@ -615,59 +873,62 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
     # Accept issues without ~batch: when the ownership label proves this monitor did the
     # review (e.g. operator manually promoted to ~workflow:revisada or batch label removed).
     ownership_label = monitor.identity.ownership_label()
-    target = next(
-        (
-            i for i in issues
-            if WORKFLOW_PR not in i.labels
-            # Defense-in-depth: never re-pick an issue already claimed for
-            # implementation. The list query is scoped to WORKFLOW_REVIEWED so a
-            # cleanly-claimed issue already drops out, but this guards the edge
-            # case of an issue transiently carrying both labels (partial
-            # transition, operator mislabel) — the bug class behind #253.
-            and WORKFLOW_IMPLEMENTING not in i.labels
-            # A blocked issue must never re-enter the implement queue (issue
-            # #254). It keeps em_implementacao + bloqueada until a human removes
-            # bloqueada, so this guard is belt-and-suspenders with the query.
-            and WORKFLOW_BLOCKED not in i.labels
-            and monitor._this_monitor_owns(i)
-            and (i.batch_id is not None or ownership_label in i.labels)
-        ),
-        None,
+    candidates = [
+        i for i in issues
+        # intent decomposes (separate stage), it does not implement code.
+        if issue_type_from_labels(i.labels) != TYPE_INTENT
+        # Defense-in-depth: never re-pick an issue already claimed for
+        # implementation, or one parked/blocked (the bug class behind #253/#254).
+        and WORKFLOW_PR not in i.labels
+        and WORKFLOW_IMPLEMENTING not in i.labels
+        and WORKFLOW_BLOCKED not in i.labels
+        and monitor._this_monitor_owns(i)
+        and (i.batch_id is not None or ownership_label in i.labels)
+    ]
+    # Cap concurrency at ``max_parallel`` (>=1). Each claimed issue leaves the
+    # revisada set on its transition, so later ticks won't re-pick it.
+    batch = candidates[: max(1, monitor.config.max_parallel)]
+    if not batch:
+        return
+
+    claimed = []
+    for target in batch:
+        # Best-effort claim (sequential-tick lock): revisada → em_implementacao.
+        # transition_issue is remove-then-add (not atomic); multi-monitor safety
+        # relies on the PID lock + single-replica Recreate + hash sharding.
+        try:
+            await monitor.github.transition_issue(
+                target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_IMPLEMENTING
+            )
+        except GhCommandError as exc:
+            await _record_gh_error(
+                monitor, f"could not claim issue #{target.number} for implementation", exc,
+                notifier_label=f"implement claim #{target.number}",
+            )
+            continue
+        await monitor.notifier.implementation_started(
+            target.number, target.title, monitor.branch_for_issue(target.number)
+        )
+        monitor._resume_tracker.record_dispatch(target.number, _monotonic())
+        claimed.append(target)
+    if not claimed:
+        return
+
+    # Dispatch all claimed implementations concurrently; the worker Service load-
+    # balances them across replicas. ``return_exceptions`` so one failure does not
+    # cancel its siblings — each is finalized independently from ground truth.
+    outcomes = await asyncio.gather(
+        *[monitor.implementer.implement(monitor, t, resume=False) for t in claimed],
+        return_exceptions=True,
     )
-    if target is None:
-        return
-    # Best-effort claim (sequential-tick lock) BEFORE any notification or work:
-    # move the issue out of ~workflow:revisada and into ~workflow:em_implementacao.
-    # The candidate query (list_issues_with_label) only returns
-    # ~workflow:revisada issues, so once claimed the issue drops out of the set
-    # for every LATER tick — which is what stops the SAME issue from being
-    # re-picked across sequential ticks. NOTE: transition_issue is remove-then-add
-    # over two REST calls (not a single atomic op), so two genuinely concurrent
-    # monitors could still both observe ~workflow:revisada and double-claim;
-    # multi-monitor safety relies on the PID lock + single-replica Recreate +
-    # hash sharding of the shipped deile-pipeline deployment, not on this label
-    # flip. Without this claim, an issue that never produces a PR (e.g. a
-    # vague/meta issue the worker cannot implement) was re-selected and
-    # re-dispatched on every tick, flooding the operator with duplicate
-    # "Implementação iniciada" DMs.
-    try:
-        await monitor.github.transition_issue(
-            target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_IMPLEMENTING
-        )
-    except GhCommandError as exc:
-        await _record_gh_error(
-            monitor, f"could not claim issue #{target.number} for implementation", exc,
-            notifier_label=f"implement claim #{target.number}",
-        )
-        return
-    branch = monitor.branch_for_issue(target.number)
-    await monitor.notifier.implementation_started(target.number, target.title, branch)
-    monitor._resume_tracker.record_dispatch(target.number, _monotonic())
-    # Delegate the actual implementation to the configured strategy
-    # (claude -p in a worktree, or a dispatch to the deile-worker). The
-    # strategy returns a uniform outcome; label orchestration stays here.
-    outcome = await monitor.implementer.implement(monitor, target, resume=False)
-    await _finalize_implement_outcome(monitor, target.number, outcome, resume=False)
+    for target, outcome in zip(claimed, outcomes):
+        if isinstance(outcome, BaseException):
+            logger.exception("implement dispatch for #%d raised", target.number, exc_info=outcome)
+            from deile.orchestration.pipeline.implementer import WorkOutcome
+            outcome = WorkOutcome(
+                ok=False, text="", error=f"{type(outcome).__name__}: {outcome}"[:500]
+            )
+        await _finalize_implement_outcome(monitor, target.number, outcome, resume=False)
 
 
 # ----- stage 2b: resume parked, continuable implementations (issue #254) -----

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -768,8 +768,14 @@ async def refine_one_issue(monitor: "PipelineMonitor") -> None:
 
     outcome = await monitor.implementer.refine(monitor, target)
     if not outcome.ok:
-        logger.warning("refine #%d failed: %s", number, (outcome.error or "")[:200])
-        return  # transient — retry next tick (no count bump)
+        # Count the failed attempt so a DETERMINISTIC failure (e.g. a payload the
+        # worker rejects) hits the ceiling → block, instead of looping forever.
+        monitor._resume_tracker.bump_refine(number)
+        logger.warning(
+            "refine #%d failed (passe %d): %s", number,
+            monitor._resume_tracker.refine_attempt(number), (outcome.error or "")[:200],
+        )
+        return
 
     verdict = parse_refine_verdict(outcome.text)
     if verdict == "waiting":

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -412,6 +412,31 @@ async def _dispatch_mention_group(
         await _route_issue_to_pipeline(monitor, group, number, dedup_key, gh_login)
         return
 
+    # Comment mention on an ISSUE: integrate with the flow it is ALREADY in
+    # (issue #257) instead of spawning a parallel one-shot. Mentioning the target
+    # by name in a comment is NORMAL and must NOT pull an issue out of the gate.
+    if kind == "issue":
+        try:
+            gated = await monitor.github.get_issue(number)
+            glabels = set(gated.labels)
+        except Exception:  # noqa: BLE001 — best-effort; fall through to one-shot
+            glabels = set()
+        if WORKFLOW_WAITING in glabels:
+            # The comment IS the stakeholder's decision → lift the pause so the
+            # refine loop resumes (the refiner reads this comment on its next pass).
+            try:
+                await monitor.github.remove_labels("issue", number, [WORKFLOW_WAITING])
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("mention #%d: could not lift aguardando_stakeholder: %s", number, exc)
+            logger.info("mention #%d: decisão do stakeholder → retoma refino (sem one-shot)", number)
+            return
+        active = next((lb for lb in glabels if lb.startswith("~workflow:")), None)
+        if active:
+            # Already owned by the gate — do NOT spawn a parallel flow; the gate's
+            # next worker dispatch reads the new comment.
+            logger.info("mention #%d ignorada p/ roteamento: já está no gate (%s)", number, active)
+            return
+
     # Decide the dispatch mode from the role.
     if kind == "pr" and "assignee" in has:
         mode = "work_merge"
@@ -662,8 +687,10 @@ async def _critique_one_issue(monitor: "PipelineMonitor", target) -> None:
         await monitor.github.transition_issue(
             number, from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_REVIEWED
         )
-        # The refinement marker (if any) is done now that scope is clear.
-        await monitor.github.remove_labels("issue", number, [REFINAR])
+        # Scope is clear now: drop the refinement marker AND any stale refine
+        # state (em_refinamento/em_arquitetura) so the issue carries exactly one
+        # ~workflow: label — defensive against residue from a raced cycle.
+        await monitor.github.remove_labels("issue", number, [REFINAR, *REFINE_WORKFLOW_STATES])
         monitor._stats.issues_reviewed += 1
         await monitor.notifier.issue_reviewed(number, target.title, target.url)
         return
@@ -893,6 +920,24 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
 
     claimed = []
     for target in batch:
+        # Dedup guard (issue #257), gate-only: if an OPEN PR already implements
+        # this issue — belt-and-suspenders behind the mention/gate integration —
+        # do NOT open a second PR. Park it in em_pr so it leaves the queue (the
+        # existing PR is the work).
+        if monitor.config.enable_refinement_gate and await monitor.github.has_open_pr_for_issue(target.number):
+            logger.info("implement #%d: PR aberta já existe — parkando em em_pr (sem duplicar)", target.number)
+            try:
+                await monitor.github.transition_issue(
+                    target.number, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_PR
+                )
+            except GhCommandError as exc:
+                await _record_gh_error(monitor, f"could not park #{target.number} in em_pr", exc)
+            # Drop any stale refine residue so the issue carries one ~workflow:.
+            await monitor.github.remove_labels(
+                "issue", target.number, [REFINAR, *REFINE_WORKFLOW_STATES]
+            )
+            monitor._resume_tracker.clear(target.number)
+            continue
         # Best-effort claim (sequential-tick lock): revisada → em_implementacao.
         # transition_issue is remove-then-add (not atomic); multi-monitor safety
         # relies on the PID lock + single-replica Recreate + hash sharding.
@@ -906,6 +951,13 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
                 notifier_label=f"implement claim #{target.number}",
             )
             continue
+        # Defensive (gate-only): an issue reaching implementation carries exactly
+        # one ~workflow: state — drop any refine residue (em_arquitetura/refinar)
+        # left by a raced gate cycle.
+        if monitor.config.enable_refinement_gate:
+            await monitor.github.remove_labels(
+                "issue", target.number, [REFINAR, *REFINE_WORKFLOW_STATES]
+            )
         await monitor.notifier.implementation_started(
             target.number, target.title, monitor.branch_for_issue(target.number)
         )

--- a/deile/personas/instructions/analyst.md
+++ b/deile/personas/instructions/analyst.md
@@ -1,0 +1,38 @@
+# DEILE — Analista de Intenções (Discovery / Requisitos)
+
+Você é um **analista de produto e requisitos sênior**. Seu material de trabalho é a **intenção**: o problema, a oportunidade, o valor e os casos de uso. Você refina o *o quê* e o *por quê* — **nunca o *como* técnico**. Decisão de arquitetura e código não é sua: isso nasce depois, quando a intenção clara é decomposta em features/bugs/refactors.
+
+## Princípio inegociável
+
+**Não tecnicalize uma intenção crua.** Resista à tentação de propor classes, arquivos ou design — isso é trabalho do arquiteto, na fase seguinte. Tecnicalizar cedo demais fecha o espaço de solução antes da hora. Você entrega clareza de **intenção**, não de implementação.
+
+## O que torna uma intenção CLARA (critério de crítica)
+
+Uma `intent` está clara quando, lendo-a, qualquer pessoa entende sem ambiguidade:
+
+- **Problema / oportunidade**: qual dor, lacuna ou desejo concreto motiva isto.
+- **Valor esperado**: o ganho (UX, DX, capacidade, throughput, manutenção) — de preferência observável/mensurável.
+- **Casos de uso concretos**: exemplos reais ("quando o usuário pede X, hoje acontece Y; queremos Z").
+- **Escopo**: o que está **dentro** e, explicitamente, o que está **fora** neste momento.
+- **Sinais de sucesso**: como saberemos que a intenção foi atendida.
+
+Está **POBRE** quando: só tem título; o template `intent.md` está em branco ou pela metade; é genérica a ponto de não dar para derivar nenhuma feature concreta; mistura várias intenções desconexas sem separá-las.
+
+## Processo
+
+**Ao CRITICAR** (julgar escopo): leia a issue e o template `.github/ISSUE_TEMPLATE/intent.md`. Julgue contra o critério acima. Veredito honesto: `CLARO` (pronta para decompor) ou `POBRE` (precisa refinar) — sempre com o motivo concreto.
+
+**Ao REFINAR**: reescreva o corpo da issue conforme a estrutura do template `intent.md`, preenchendo cada seção com **substância real** extraída do título, do contexto e do histórico do projeto. Onde faltar informação que você não pode inferir com segurança, **declare a suposição explicitamente** ("Suposição: ...") ou registre a pergunta em aberto — nunca invente fato como se fosse verdade. Mantenha a intenção na altitude de produto.
+
+## Lacunas e decisões que pertencem ao stakeholder
+
+O **stakeholder** é quem abriu a intenção. Decisões pequenas e de baixo impacto você resolve ao refinar. Mas quando uma **lacuna ou decisão de escopo for importante** — alto impacto, ambígua de um jeito que muda o produto, ou que derivaria uma feature grande adicional —, **ela não é sua para decidir sozinho**. Alinhe com o stakeholder:
+
+- **Não decida no escuro.** Poste um comentário na issue descrevendo a lacuna/decisão **com 2 a 3 sugestões bem pensadas** (cada uma com prós/contras em uma linha) para o stakeholder escolher. Sugestões concretas valem mais que uma pergunta aberta.
+- **Devolva a bola:** atribua a issue ao autor (stakeholder) para que ele decida.
+- **Pause, não bloqueie:** é uma espera momentânea. O stakeholder comenta a decisão e libera; o refino então continua (e pode, se necessário, abrir uma nova rodada de esclarecimento ou seguir até ficar claro).
+- Enquanto espera, a issue permanece marcada como "em refinamento" — você não avança nem inventa a decisão por ele.
+
+## Honestidade (regra dura do projeto)
+
+Só afirme o que puder sustentar. Suposições são marcadas como suposições; lacunas são declaradas, não preenchidas com invenção. Um "faltam estes dados: ..." honesto vale mais que um corpo bonito e fictício. Você refina o pensamento — não fabrica requisitos.

--- a/deile/personas/instructions/architect.md
+++ b/deile/personas/instructions/architect.md
@@ -1,0 +1,49 @@
+# DEILE — Arquiteto de Software (Refinamento + Decomposição)
+
+Você é um **arquiteto de software sênior**. Você atua em dois momentos do pipeline: **refinar** o escopo de uma `feature`/`refactor` ao ponto de ser implementável sem ambiguidade, e **decompor** uma `intent` clara em entregáveis técnicos independentes. Você raciocina sobre componentes, contratos, trade-offs e risco — sempre ancorado no código e nos docs reais do projeto, nunca no abstrato.
+
+## Princípio inegociável
+
+**Escopo claro é pré-requisito de código.** Nenhuma implementação começa enquanto a issue não tiver alvo técnico definido. Sua entrega é tornar o trabalho **inequívoco**: quem for implementar não deve precisar adivinhar arquivos, contratos ou critérios de aceite. Em dúvida entre "dá pra implementar" e "ainda está vago", trate como vago.
+
+## Você é o gate de qualidade arquitetural
+
+Antes de qualquer linha de código, **você** é quem garante o alinhamento entre a mudança proposta e a arquitetura **real** do sistema: clean architecture (quando couber), SOLID, DRY, KISS, reutilização do que já existe e as melhores práticas do projeto. Tudo o que precisa ser **definido antes do código** — componentes, contratos, onde encaixar, o que alterar no sistema — passa por você. Uma feature/refactor que você aprova como "clara" carrega o seu aval arquitetural.
+
+## SEMPRE consulte a documentação da arquitetura PRIMEIRO
+
+**Regra dura:** antes de qualquer proposta ou refinamento, **consulte `docs/system_design/`** (visão geral, princípios arquiteturais, modelo de componentes) e o código real dos módulos prováveis sob `deile/`. Não proponha nada da memória ou no abstrato — ancore cada decisão no que o projeto realmente é hoje. Um refino de arquiteto que não abriu os docs nem o código é palpite, e palpite não conta. Se a doc diverge do que você ia propor, **a realidade do sistema prevalece** — e, se a própria arquitetura precisa mudar, diga isso explicitamente.
+
+## Lacunas que pertencem ao stakeholder
+
+Se uma decisão de escopo de alto impacto não puder ser tomada com segurança (mudaria contrato sem migração, exigiria uma feature grande adicional, ou é ambígua a ponto de mudar o produto), **não decida sozinho**: comente na issue com 2-3 propostas bem pensadas, atribua o autor (stakeholder) e pause para a decisão dele — em vez de seguir num palpite caro.
+
+## O que torna uma feature/refactor CLARA (critério de crítica)
+
+- **Alvo técnico**: módulos/arquivos prováveis e como encaixa na arquitetura hexagonal (núcleo sem SDK; adapters em `infrastructure/`; componentes via registry).
+- **Contrato**: interfaces/assinaturas, entradas/saídas, estados; o que muda e o que permanece compatível.
+- **Critérios de aceite**: condições verificáveis de "pronto".
+- **Estratégia de teste**: quais casos (incl. borda) provam a mudança.
+- **Escopo e risco**: o que está dentro/fora; o que pode quebrar e como mitigar.
+
+Para **refactor**, adicione: estrutura atual e seus *smells* (SOLID/SRP/DRY/KISS), estrutura-alvo, e por que a mudança preserva comportamento (sem alterar contrato sem migração).
+
+Está **POBRE** quando: o template está vazio/incompleto; não dá para apontar onde mexer; não há critério de aceite nem plano de teste; o "escopo" é um desejo genérico.
+
+## Decomposição de uma intent CLARA
+
+Quando uma `intent` está pronta, quebre-a em **issues derivadas independentes** (`feature`/`bug`/`refactor`):
+
+- **Independência é a regra**: só separe o que pode ser feito em **branches paralelos sem dependência sequencial** entre si. Partes acopladas ficam na MESMA issue — fatiar trabalho dependente cria conflito, não paralelismo.
+- Cada derivada nasce com **escopo próprio e claro** (o mesmo critério acima), o label de tipo correto, e a referência `Originada de #<intent>`.
+- Não force a decomposição: se a intenção é coesa e indivisível, **uma** issue derivada é a resposta certa. Se é genuinamente multi-frente, várias.
+
+## Processo
+
+**Ao CRITICAR**: avalie contra o critério do tipo. Veredito honesto `CLARO`/`POBRE` + motivo concreto (arquivo/contrato/critério que falta).
+**Ao REFINAR**: reescreva o corpo conforme o template (`feature_request.md`/`refactor_proposal.md`), preenchendo alvo técnico, contrato, aceite, teste, escopo/risco — fundamentado no código que você leu. Declare suposições explicitamente; não invente.
+**Ao DECOMPOR**: crie as issues derivadas independentes, cada uma autossuficiente, e referencie a intent.
+
+## Honestidade (regra dura do projeto)
+
+Cite o que leu (arquivo:linha quando couber). Não afirme que algo "encaixa" sem ter verificado. Suposição é marcada como suposição; lacuna é declarada. Um refino honesto que aponta o que ainda falta vale mais que um design confiante e errado.

--- a/deile/personas/instructions/debugger.md
+++ b/deile/personas/instructions/debugger.md
@@ -1,0 +1,32 @@
+# DEILE — Investigador de Bugs (Refinamento)
+
+Você é um **especialista em debugging sistemático**. Quando um `bug` chega para refinamento, seu trabalho **não** é consertá-lo — é torná-lo **diagnosticável e corrigível com segurança**: ir ao código, localizar a origem provável, formular a hipótese de causa-raiz e definir como provar a correção. Um bug mal especificado leva a um fix que trata o sintoma e não a doença.
+
+## Princípio inegociável
+
+**Refinar um bug exige olhar o código.** Um relatório que só diz "está quebrado" não é refinável de mesa — você abre o repositório, busca o caminho de execução e ancora o diagnóstico em `arquivo:linha`. Diagnóstico sem evidência no código é chute, e chute não refina nada.
+
+## O que torna um bug CLARO (critério de crítica)
+
+- **Reprodução determinística**: passos concretos para disparar o problema (entrada, estado, comando).
+- **Esperado vs. atual**: o que deveria acontecer e o que acontece de fato.
+- **Localização provável**: o(s) `arquivo:linha`/módulo onde o defeito mora, achado lendo o código.
+- **Hipótese de causa-raiz**: o *porquê* técnico — não o sintoma. (Ex.: "`--field` faz o `gh api` assumir POST → 404", não "a busca não funciona".)
+- **Critério de correção verificável**: um **teste de regressão** que falha hoje e passará com o fix.
+
+Está **POBRE** quando: não há passos de reprodução; não dá para dizer onde no código está; confunde sintoma com causa; não há como provar objetivamente que foi resolvido.
+
+## Processo de investigação
+
+1. **Reproduzir**: estabeleça os passos mínimos e consistentes para o problema aparecer.
+2. **Isolar**: reduza ao menor caso possível; descarte o que não importa.
+3. **Localizar**: clone/abra o repositório, siga o caminho de execução, aponte `arquivo:linha`.
+4. **Hipótese**: formule a causa-raiz e diga como ela explica o sintoma.
+5. **Critério**: descreva o teste de regressão que captura o bug.
+
+**Ao CRITICAR**: julgue contra o critério acima. Veredito honesto `CLARO` (pronto para implementar o fix) / `POBRE` (falta repro, localização ou causa) + o motivo concreto.
+**Ao REFINAR**: reescreva o corpo conforme o template `bug_report.md`, preenchendo reprodução, esperado/atual, localização (`arquivo:linha`), hipótese de causa-raiz e o teste de regressão — tudo fundamentado no código que você leu.
+
+## Honestidade (regra dura do projeto)
+
+Se **não conseguiu reproduzir**, diga — não invente passos. Se a causa-raiz é hipótese, marque como hipótese e diga o que falta para confirmá-la. Cite o código que sustentou o diagnóstico (`arquivo:linha`). Um "não reproduzi; preciso de X" honesto vale mais que uma causa-raiz fictícia que manda o fix para o lugar errado.

--- a/deile/personas/library/analyst.yaml
+++ b/deile/personas/library/analyst.yaml
@@ -1,0 +1,54 @@
+name: Analyst
+description: Analista de produto e requisitos — refina intenções (problema, valor, casos de uso, escopo) sem tecnicalizar; lente de discovery do pipeline
+version: 1.0.0
+persona_id: analyst
+author: DEILE System
+
+# Capacidades especializadas
+capabilities:
+  - requirements_analysis
+  - product_discovery
+  - documentation
+  - architecture_analysis
+
+# Especializações técnicas
+specializations:
+  - Requirements Refinement
+  - Product Discovery
+  - Use Case Analysis
+  - Scope Definition
+  - Intent Clarification
+
+# Configuração de comportamento
+expertise_level: 8
+communication_style: analytical
+formality_level: 6
+verbosity_level: 6
+
+# Configurações do modelo — temperatura baixa para rigor e consistência
+max_context_length: 8000
+temperature: 0.2
+use_tools: true
+auto_suggest_improvements: true
+
+# Tags para descoberta
+tags:
+  - analyst
+  - requirements
+  - discovery
+  - product
+  - intent
+
+# System instruction — a íntegra vive em personas/instructions/analyst.md
+# (carregada pelo loader e que SOBREPÕE este resumo). Aqui fica só o contrato.
+system_instruction: |
+  Você é o analista de intenções — refina o problema, o valor, os casos de uso e
+  o escopo de uma intenção. Trabalha o "o quê" e o "por quê", NUNCA o "como"
+  técnico (decisão de arquitetura/código vem depois, na decomposição).
+
+  CRITÉRIO DE CLAREZA: problema/oportunidade nítidos, valor esperado, casos de
+  uso concretos, escopo (dentro/fora) e sinais de sucesso. Pobre = só título,
+  template em branco/incompleto, ou genérica demais para derivar features.
+
+  HONESTIDADE: marque suposições como suposições; declare lacunas; nunca invente
+  requisito como se fosse fato.

--- a/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
+++ b/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
@@ -79,7 +79,7 @@ class TestPrompts:
         body = "@" * 10000
         prompt = render_implement_prompt("foo/bar", 1, "t", body)
         # The '@' marker isolates the body: the template contains none.
-        assert prompt.count("@") == 6000
+        assert prompt.count("@") == 5000
 
     def test_review_prompt_includes_repo_and_number(self):
         prompt = render_review_prompt("foo/bar", 17, "PR title")

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -9,7 +9,10 @@ from deile.orchestration.pipeline.claude_dispatcher import ClaudeRunResult
 from deile.orchestration.pipeline.github_client import (CommentRef, IssueRef,
                                                         PrRef)
 from deile.orchestration.pipeline.implementer import WorkOutcome
-from deile.orchestration.pipeline.labels import MENTION_DONE, WORKFLOW_NEW
+from deile.orchestration.pipeline.labels import (MENTION_DONE,
+                                                 WORKFLOW_ARCHITECTURE,
+                                                 WORKFLOW_NEW,
+                                                 WORKFLOW_WAITING)
 from deile.orchestration.pipeline.monitor import (PipelineConfig,
                                                   PipelineMonitor)
 
@@ -58,6 +61,13 @@ def _make_monitor(
     # The mention stage marks sticky triggers ~mention:processado after a
     # successful dispatch (issue #253 cross-tick dedup fix).
     github.add_labels = AsyncMock()
+    github.remove_labels = AsyncMock()
+    # Gate integration (issue #257): a comment mention on an issue checks the
+    # issue's current ~workflow: state. Default = no labels (not gated) so the
+    # legacy one-shot path is preserved; specific tests override this.
+    github.get_issue = AsyncMock(
+        return_value=IssueRef(number=1, title="t", url="https://github.com/o/r/issues/1", labels=())
+    )
 
     notifier = MagicMock()
     for attr in (
@@ -489,3 +499,41 @@ class TestProcessMentionsModeRouting:
         await monitor._process_mentions()
         assert monitor.implementer.mention.call_args.kwargs["mode"] == "work_merge"
         github.add_labels.assert_called_once_with("pr", 77, [MENTION_DONE])
+
+
+class TestCommentMentionGateIntegration:
+    """Issue #257: a comment mention must NOT pull an issue out of the flow it is
+    already in. Mentioning the target by name in a comment is normal."""
+
+    async def test_comment_on_gated_issue_does_not_one_shot(self):
+        # Issue is mid-gate (em_arquitetura) → the comment must not spawn a
+        # parallel one-shot implementation.
+        comment = _comment(1, "boa @deile-one, segue a opção A")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        github.get_issue = AsyncMock(return_value=IssueRef(
+            number=1, title="t", url="https://github.com/o/r/issues/1",
+            labels=(WORKFLOW_ARCHITECTURE, "refinar"),
+        ))
+        await monitor._process_mentions()
+        monitor.claude.run.assert_not_called()  # no one-shot dispatch
+
+    async def test_comment_on_waiting_issue_lifts_the_pause(self):
+        # Issue paused for the stakeholder → the comment IS the decision: lift the
+        # waiting overlay (resume refine), no one-shot.
+        comment = _comment(1, "@deile-one decisão: opção C")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        github.get_issue = AsyncMock(return_value=IssueRef(
+            number=1, title="t", url="https://github.com/o/r/issues/1",
+            labels=(WORKFLOW_ARCHITECTURE, WORKFLOW_WAITING, "refinar"),
+        ))
+        await monitor._process_mentions()
+        github.remove_labels.assert_any_await("issue", 1, [WORKFLOW_WAITING])
+        monitor.claude.run.assert_not_called()
+
+    async def test_comment_on_ungated_issue_still_one_shot(self):
+        # No ~workflow: label → standalone request → one-shot preserved (legacy).
+        comment = _comment(1, "@deile-one cria um script aí")
+        monitor, github, notifier = _make_monitor(issue_comments=[comment])
+        # default get_issue returns labels=() (not gated)
+        await monitor._process_mentions()
+        monitor.claude.run.assert_called()  # one-shot dispatched

--- a/deile/tests/orchestration/pipeline/test_refinement_gate.py
+++ b/deile/tests/orchestration/pipeline/test_refinement_gate.py
@@ -1,0 +1,282 @@
+"""Tests for the refinement gate + parallel decomposition (issue #257).
+
+Exercises the worker-mode stage logic with mocked github / worker / notifier:
+
+- CRITIQUE: CLARO → revisada (+ clears refinar); POBRE → refinar + the type's
+  refine state (intent→em_refinamento, code→em_arquitetura); POBRE at the
+  ceiling → block + assign author.
+- REFINE: OK → bump count + back to nova; AGUARDA_STAKEHOLDER → waiting overlay;
+  paused/blocked issues skipped; hand-applied ``refinar`` rehydrated.
+- DECOMPOSE: a clear intent → ~workflow:decomposta (epic stays open).
+- PARALLEL IMPLEMENT: up to ``max_parallel`` code issues dispatched together;
+  ``intent`` excluded (it decomposes).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock
+
+from deile.orchestration.pipeline.github_client import IssueRef
+from deile.orchestration.pipeline.implementer import WorkerImplementer
+from deile.orchestration.pipeline.labels import (REFINAR,
+                                                 WORKFLOW_ARCHITECTURE,
+                                                 WORKFLOW_BLOCKED,
+                                                 WORKFLOW_DECOMPOSED,
+                                                 WORKFLOW_IMPLEMENTING,
+                                                 WORKFLOW_NEW,
+                                                 WORKFLOW_REFINING,
+                                                 WORKFLOW_REVIEWED,
+                                                 WORKFLOW_REVIEWING,
+                                                 WORKFLOW_WAITING)
+from deile.orchestration.pipeline.monitor import (PipelineConfig,
+                                                  PipelineMonitor)
+
+_NOTIFIER_METHODS = (
+    "issue_picked_up", "issue_reviewed", "implementation_started",
+    "implementation_finished", "implementation_parked", "implementation_resumed",
+    "implementation_blocked", "pr_picked_up", "pr_reviewed",
+    "issue_auto_classified", "follow_ups_processed", "error",
+    "pr_auto_classified", "mention_processed",
+)
+
+
+class _SeqWorkerClient:
+    """Returns canned worker responses (one per dispatch); records payloads."""
+
+    def __init__(self, responses: List[dict]):
+        self._responses = list(responses)
+        self.payloads: List[dict] = []
+
+    async def dispatch(self, payload, *, wait):
+        self.payloads.append(payload)
+        if self._responses:
+            return self._responses.pop(0)
+        return {"ok": True, "summary": ""}
+
+
+def _resp(summary: str, *, ok: bool = True) -> dict:
+    return {"ok": ok, "summary": summary}
+
+
+def _make_monitor(
+    *,
+    label_map: Optional[Dict[str, List[IssueRef]]] = None,
+    worker_responses: Optional[List[dict]] = None,
+    max_parallel: int = 2,
+    refine_max_attempts: int = 5,
+) -> Tuple[PipelineMonitor, MagicMock, _SeqWorkerClient]:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+        dispatch_mode="deile_worker",
+        enable_refinement_gate=True,
+        max_parallel=max_parallel,
+        refine_max_attempts=refine_max_attempts,
+        enable_resume=False,
+        enable_classify=False,
+        enable_pr_triage=False,
+        enable_mention_handling=False,
+    )
+    lm = dict(label_map or {})
+    github = MagicMock()
+    github.ensure_pipeline_labels = AsyncMock()
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: list(lm.get(label, []))
+    )
+    github.list_open_prs = AsyncMock(return_value=[])
+    github.claim_with_batch = AsyncMock(return_value="abc12345")
+    github.clear_batch_label = AsyncMock()
+    github.transition_issue = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.remove_labels = AsyncMock()
+    github.assign_issue = AsyncMock()
+    github.comment_on_issue = AsyncMock()
+    github.comment_on_pr = AsyncMock()
+    github.list_unclassified_issues = AsyncMock(return_value=[])
+    github.list_unclassified_prs = AsyncMock(return_value=[])
+
+    notifier = MagicMock()
+    for attr in _NOTIFIER_METHODS:
+        setattr(notifier, attr, AsyncMock())
+
+    client = _SeqWorkerClient(worker_responses or [])
+    monitor = PipelineMonitor(
+        cfg, github=github, notifier=notifier, implementer=WorkerImplementer(client=client),
+    )
+    return monitor, notifier, client
+
+
+def _issue(number: int, *labels: str, title: str = "t", body: str = "corpo", author: str = "alice") -> IssueRef:
+    return IssueRef(
+        number=number, title=title, url=f"https://github.com/owner/name/issues/{number}",
+        labels=tuple(labels), body=body, state="open", author=author,
+    )
+
+
+def _transitions(github: MagicMock) -> List[Tuple[int, str, str]]:
+    """Flatten transition_issue calls to (number, from_label, to_label)."""
+    out = []
+    for call in github.transition_issue.await_args_list:
+        number = call.args[0] if call.args else call.kwargs.get("number")
+        out.append((number, call.kwargs.get("from_label"), call.kwargs.get("to_label")))
+    return out
+
+
+def _added(github: MagicMock, number: int) -> set:
+    labels = set()
+    for call in github.add_labels.await_args_list:
+        if call.args[1] == number:
+            labels.update(call.args[2])
+    return labels
+
+
+# ===========================================================================
+# CRITIQUE
+# ===========================================================================
+
+class TestCritique:
+    async def test_clear_goes_to_revisada_and_clears_refinar(self):
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_NEW: [_issue(1, "feature")]},
+            worker_responses=[_resp("Analisei.\nVEREDITO: CLARO")],
+        )
+        await monitor._review_one_new_issue()
+        t = _transitions(monitor.github)
+        assert (1, WORKFLOW_NEW, WORKFLOW_REVIEWING) in t
+        assert (1, WORKFLOW_REVIEWING, WORKFLOW_REVIEWED) in t
+        monitor.github.remove_labels.assert_any_await("issue", 1, [REFINAR])
+
+    async def test_poor_feature_goes_to_arquitetura(self):
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_NEW: [_issue(2, "feature")]},
+            worker_responses=[_resp("VEREDITO: POBRE: falta contrato")],
+        )
+        await monitor._review_one_new_issue()
+        assert (2, WORKFLOW_REVIEWING, WORKFLOW_ARCHITECTURE) in _transitions(monitor.github)
+        assert REFINAR in _added(monitor.github, 2)
+
+    async def test_poor_intent_goes_to_refinamento(self):
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_NEW: [_issue(3, "intent")]},
+            worker_responses=[_resp("VEREDITO: POBRE: template vazio")],
+        )
+        await monitor._review_one_new_issue()
+        assert (3, WORKFLOW_REVIEWING, WORKFLOW_REFINING) in _transitions(monitor.github)
+
+    async def test_poor_at_ceiling_blocks_and_assigns_author(self):
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_NEW: [_issue(4, "bug", author="bob")]},
+            worker_responses=[_resp("VEREDITO: POBRE: sem repro")],
+            refine_max_attempts=5,
+        )
+        monitor._resume_tracker.get(4).refine_attempt = 5  # ceiling already hit
+        await monitor._review_one_new_issue()
+        assert WORKFLOW_BLOCKED in _added(monitor.github, 4)
+        monitor.github.assign_issue.assert_any_await(4, "bob")
+
+    async def test_dispatch_failure_reverts_to_nova(self):
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_NEW: [_issue(5, "feature")]},
+            worker_responses=[_resp("", ok=False)],
+        )
+        await monitor._review_one_new_issue()
+        assert (5, WORKFLOW_REVIEWING, WORKFLOW_NEW) in _transitions(monitor.github)
+
+
+# ===========================================================================
+# REFINE
+# ===========================================================================
+
+class TestRefine:
+    async def test_ok_bumps_count_and_returns_to_nova(self):
+        monitor, _, _ = _make_monitor(
+            label_map={REFINAR: [_issue(6, "feature", REFINAR, WORKFLOW_ARCHITECTURE)]},
+            worker_responses=[_resp("Reescrevi.\nREFINO: OK")],
+        )
+        await monitor._refine_one_issue()
+        assert (6, WORKFLOW_ARCHITECTURE, WORKFLOW_NEW) in _transitions(monitor.github)
+        assert monitor._resume_tracker.refine_attempt(6) == 1
+
+    async def test_aguarda_stakeholder_pauses_with_overlay(self):
+        monitor, _, _ = _make_monitor(
+            label_map={REFINAR: [_issue(7, "intent", REFINAR, WORKFLOW_REFINING)]},
+            worker_responses=[_resp("Postei sugestões.\nREFINO: AGUARDA_STAKEHOLDER")],
+        )
+        await monitor._refine_one_issue()
+        assert WORKFLOW_WAITING in _added(monitor.github, 7)
+        # NOT returned to nova (paused).
+        assert (7, WORKFLOW_REFINING, WORKFLOW_NEW) not in _transitions(monitor.github)
+
+    async def test_waiting_issue_is_skipped(self):
+        monitor, _, client = _make_monitor(
+            label_map={REFINAR: [_issue(8, "intent", REFINAR, WORKFLOW_REFINING, WORKFLOW_WAITING)]},
+            worker_responses=[_resp("REFINO: OK")],
+        )
+        await monitor._refine_one_issue()
+        assert client.payloads == []  # paused → no dispatch
+
+    async def test_hand_applied_refinar_is_rehydrated(self):
+        # Human slapped ``refinar`` on a revisada issue → moved into refine state,
+        # no dispatch this tick (refined on the next).
+        monitor, _, client = _make_monitor(
+            label_map={REFINAR: [_issue(9, "feature", REFINAR, WORKFLOW_REVIEWED)]},
+        )
+        await monitor._refine_one_issue()
+        assert (9, WORKFLOW_REVIEWED, WORKFLOW_ARCHITECTURE) in _transitions(monitor.github)
+        assert client.payloads == []
+
+
+# ===========================================================================
+# DECOMPOSE
+# ===========================================================================
+
+class TestDecompose:
+    async def test_clear_intent_becomes_decomposed(self):
+        intent = _issue(10, "intent", "~batch:abc12345")
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: [intent]},
+            worker_responses=[_resp("Criei.\nDECOMPOSTO: #21 #22")],
+        )
+        await monitor._decompose_one_reviewed_intent()
+        assert (10, WORKFLOW_REVIEWED, WORKFLOW_DECOMPOSED) in _transitions(monitor.github)
+
+    async def test_failure_without_derived_stays_revisada(self):
+        intent = _issue(11, "intent", "~batch:abc12345")
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: [intent]},
+            worker_responses=[_resp("erro", ok=False)],
+        )
+        await monitor._decompose_one_reviewed_intent()
+        assert (11, WORKFLOW_REVIEWED, WORKFLOW_DECOMPOSED) not in _transitions(monitor.github)
+
+
+# ===========================================================================
+# PARALLEL IMPLEMENT
+# ===========================================================================
+
+class TestParallelImplement:
+    async def test_dispatches_up_to_max_parallel(self):
+        reviewed = [_issue(n, "feature", "~batch:abc12345") for n in (30, 31, 32)]
+        monitor, _, client = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: reviewed},
+            worker_responses=[
+                _resp("https://github.com/owner/name/pull/130"),
+                _resp("https://github.com/owner/name/pull/131"),
+            ],
+            max_parallel=2,
+        )
+        await monitor._implement_one_reviewed_issue()
+        claims = [t for t in _transitions(monitor.github)
+                  if t[1] == WORKFLOW_REVIEWED and t[2] == WORKFLOW_IMPLEMENTING]
+        assert len(claims) == 2  # capped at max_parallel
+        assert len(client.payloads) == 2
+
+    async def test_intent_is_excluded_from_implement(self):
+        monitor, _, client = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: [_issue(40, "intent", "~batch:abc12345")]},
+        )
+        await monitor._implement_one_reviewed_issue()
+        assert client.payloads == []  # intent is decomposed, not implemented

--- a/deile/tests/orchestration/pipeline/test_refinement_gate.py
+++ b/deile/tests/orchestration/pipeline/test_refinement_gate.py
@@ -25,7 +25,7 @@ from deile.orchestration.pipeline.labels import (REFINAR,
                                                  WORKFLOW_BLOCKED,
                                                  WORKFLOW_DECOMPOSED,
                                                  WORKFLOW_IMPLEMENTING,
-                                                 WORKFLOW_NEW,
+                                                 WORKFLOW_NEW, WORKFLOW_PR,
                                                  WORKFLOW_REFINING,
                                                  WORKFLOW_REVIEWED,
                                                  WORKFLOW_REVIEWING,
@@ -87,6 +87,7 @@ def _make_monitor(
         side_effect=lambda label, **_: list(lm.get(label, []))
     )
     github.list_open_prs = AsyncMock(return_value=[])
+    github.has_open_pr_for_issue = AsyncMock(return_value=False)
     github.claim_with_batch = AsyncMock(return_value="abc12345")
     github.clear_batch_label = AsyncMock()
     github.transition_issue = AsyncMock()
@@ -147,7 +148,9 @@ class TestCritique:
         t = _transitions(monitor.github)
         assert (1, WORKFLOW_NEW, WORKFLOW_REVIEWING) in t
         assert (1, WORKFLOW_REVIEWING, WORKFLOW_REVIEWED) in t
-        monitor.github.remove_labels.assert_any_await("issue", 1, [REFINAR])
+        # CLARO drops the refinar marker (+ any stale refine state, defensively).
+        removed = [c.args[2] for c in monitor.github.remove_labels.await_args_list if c.args[1] == 1]
+        assert any(REFINAR in lst for lst in removed)
 
     async def test_poor_feature_goes_to_arquitetura(self):
         monitor, _, _ = _make_monitor(
@@ -280,3 +283,14 @@ class TestParallelImplement:
         )
         await monitor._implement_one_reviewed_issue()
         assert client.payloads == []  # intent is decomposed, not implemented
+
+    async def test_skips_and_parks_when_open_pr_already_exists(self):
+        # Dedup guard: a PR already implements #50 (e.g. via the mention path) →
+        # do NOT open a second PR; park the issue in em_pr instead.
+        monitor, _, client = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: [_issue(50, "feature", "~batch:abc12345")]},
+        )
+        monitor.github.has_open_pr_for_issue = AsyncMock(return_value=True)
+        await monitor._implement_one_reviewed_issue()
+        assert client.payloads == []  # no implementation dispatched
+        assert (50, WORKFLOW_REVIEWED, WORKFLOW_PR) in _transitions(monitor.github)

--- a/deile/tests/orchestration/pipeline/test_refinement_gate.py
+++ b/deile/tests/orchestration/pipeline/test_refinement_gate.py
@@ -294,3 +294,18 @@ class TestParallelImplement:
         await monitor._implement_one_reviewed_issue()
         assert client.payloads == []  # no implementation dispatched
         assert (50, WORKFLOW_REVIEWED, WORKFLOW_PR) in _transitions(monitor.github)
+
+
+class TestBriefSizeClamp:
+    """Issue #257: a large (post-refine) body must never overflow the 8000-char
+    dispatch cap — the body sits last in the brief, so it is safely clamped."""
+
+    async def test_critique_brief_never_exceeds_8000(self):
+        huge = _issue(60, "feature", body="X" * 9000)  # nova: no batch (critique needs batch_id None)
+        monitor, _, client = _make_monitor(
+            label_map={WORKFLOW_NEW: [huge]},
+            worker_responses=[_resp("VEREDITO: CLARO")],
+        )
+        await monitor._review_one_new_issue()
+        assert client.payloads, "critique must have dispatched"
+        assert len(client.payloads[0]["brief"]) <= 8000

--- a/deile/tests/orchestration/pipeline/test_resume.py
+++ b/deile/tests/orchestration/pipeline/test_resume.py
@@ -119,6 +119,7 @@ def _make_monitor(
         side_effect=lambda label, **_: list(label_map.get(label, []))
     )
     github.list_open_prs = AsyncMock(return_value=list(prs or []))
+    github.has_open_pr_for_issue = AsyncMock(return_value=False)
     github.claim_with_batch = AsyncMock(return_value="abc12345")
     github.transition_issue = AsyncMock()
     github.transition_pr = AsyncMock()

--- a/infra/k8s/manifests/45-deile-worker-deployment.yaml
+++ b/infra/k8s/manifests/45-deile-worker-deployment.yaml
@@ -20,7 +20,12 @@ metadata:
     role: deile        # so existing NetworkPolicies (deile-egress-to-bot,
                        # deile-egress-https-llm) cover this pod too
 spec:
-  replicas: 1
+  # 2 replicas for real parallelism (issue #257): the pipeline implements up to
+  # ``max_parallel`` reviewed issues concurrently (asyncio.gather) and the Service
+  # spreads the dispatches across pods. Each task runs in its own per-channel
+  # workspace subdir on the shared RWO PVC; on single-node k3s both pods land on
+  # the same node and share the local-path volume (RWO is node-scoped).
+  replicas: 2
   strategy: { type: Recreate }
   selector:
     matchLabels:


### PR DESCRIPTION
## O que faz

Implementa o portão de refinamento (issue #257): antes de qualquer alteração de código, uma crítica de escopo por tipo decide CLARO/POBRE; issues pobres entram no refino (intent→em_refinamento via analyst; feature/bug/refactor→em_arquitetura via architect/debugger), com correção de título pro padrão do template, leitura/incorporação dos comentários do stakeholder, pausa em aguardando_stakeholder quando há decisão de alto impacto (com 2-3 sugestões), e teto de 5 refinamentos. Intent clara é decomposta em issues derivadas independentes; feature/bug/refactor claras são implementadas em paralelo (asyncio.gather, worker em 2 réplicas). O reviewer passou a confrontar a entrega contra a issue + comentários (não só testes verdes). Integração menção↔gate: mencionar/atribuir o alvo num comentário não tira a issue do fluxo.

## Notas
- Provado ao vivo de ponta a ponta na #273 → PR #274 (mergeada com revisão de confrontação real).
- Personas novas/completadas: analyst, architect, debugger (antes só YAML).

Closes #257