### PR TITLE
refactor(daily): 2026-05-22 — 6 refatorações arquiteturais (SRP/DRY)

### DIFF
--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -26,6 +26,19 @@ def _safe_summary_values(summary) -> Tuple[int, float]:
     return count, total
 
 
+def _period_range(days: int) -> Tuple[datetime, datetime]:
+    """Return ``(start, end)`` for the trailing ``days``-window ending now.
+
+    Centralises the ``end = datetime.now(); start = end - timedelta(days=N)``
+    pattern repeated by every cost view (summary, categories, forecast,
+    export, top) — keeps a single clock point and a single semantics for
+    the trailing-window so a future migration to an injectable clock has
+    one site to update.
+    """
+    end_time = datetime.now()
+    return end_time - timedelta(days=days), end_time
+
+
 class CostCommand(DirectCommand):
     """Rastreamento de custos, orçamentos e análise financeira"""
 
@@ -141,8 +154,7 @@ EXEMPLOS:
 
     def _show_cost_summary(self, days: int = 30) -> "CommandResult":
         try:
-            end_time = datetime.now()
-            start_time = end_time - timedelta(days=days)
+            start_time, end_time = _period_range(days)
 
             summary = self.cost_tracker.get_cost_summary(start_time, end_time)
             session_cost = self.cost_tracker.get_current_session_cost()
@@ -186,8 +198,7 @@ EXEMPLOS:
 
     def _show_categories(self) -> "CommandResult":
         try:
-            end_time = datetime.now()
-            start_time = end_time - timedelta(days=30)
+            start_time, end_time = _period_range(30)
             summary = self.cost_tracker.get_cost_summary(start_time, end_time)
 
             if not summary.categories:
@@ -253,8 +264,7 @@ EXEMPLOS:
 
     def _show_forecast(self, forecast_days: int = 7) -> "CommandResult":
         try:
-            hist_end = datetime.now()
-            hist_start = hist_end - timedelta(days=30)
+            hist_start, hist_end = _period_range(30)
             summary = self.cost_tracker.get_cost_summary(hist_start, hist_end)
 
             entry_count, total_amount = _safe_summary_values(summary)
@@ -293,8 +303,7 @@ EXEMPLOS:
 
     async def _export_costs(self, fmt: str = "json", days: int = 30) -> "CommandResult":
         try:
-            end_time = datetime.now()
-            start_time = end_time - timedelta(days=days)
+            start_time, end_time = _period_range(days)
             data = self.cost_tracker.export_costs(start_time, end_time, format_type=fmt)
 
             if not data:
@@ -327,8 +336,7 @@ EXEMPLOS:
 
     def _show_top(self, n: int = 5) -> "CommandResult":
         try:
-            end_time = datetime.now()
-            start_time = end_time - timedelta(days=30)
+            start_time, end_time = _period_range(30)
             summary = self.cost_tracker.get_cost_summary(start_time, end_time)
 
             top = summary.top_expenses[:n] if summary.top_expenses else []

--- a/deile/infrastructure/monitoring/cost_repository.py
+++ b/deile/infrastructure/monitoring/cost_repository.py
@@ -1,0 +1,267 @@
+"""SQLite persistence for ``CostTracker`` (SRP extraction).
+
+``CostTracker`` was a god object mixing pricing config, in-memory state,
+budget enforcement, alerts and direct ``sqlite3.connect(...)`` transactions.
+This module owns the SQLite layer exclusively. The public interface uses
+plain tuples/floats so the data shapes used by ``CostTracker`` (the
+dataclasses ``CostEntry`` / ``BudgetLimit``) can evolve without changing
+the repository — and so the repository has no circular dependency on
+``cost_tracker``.
+
+All transactions use parameterised queries; the only ``f"…{where_sql}…"``
+strings build their clauses from hardcoded literals (timestamp/category
+filters) — every value is bound via the ``params`` list.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class CostRepository:
+    """SQLite persistence for ``cost_entries``, ``budget_limits`` and ``cost_alerts``."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+
+    def init_schema(self) -> None:
+        """Create the 3 tables + indices if absent. Idempotent."""
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS cost_entries (
+                    id TEXT PRIMARY KEY,
+                    timestamp REAL NOT NULL,
+                    category TEXT NOT NULL,
+                    subcategory TEXT NOT NULL,
+                    amount REAL NOT NULL,
+                    currency TEXT NOT NULL DEFAULT 'USD',
+                    description TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    session_id TEXT,
+                    user_id TEXT,
+                    created_at REAL DEFAULT (datetime('now'))
+                )
+            """)
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS budget_limits (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    category TEXT NOT NULL,
+                    period TEXT NOT NULL,
+                    limit_amount REAL NOT NULL,
+                    currency TEXT NOT NULL DEFAULT 'USD',
+                    alert_threshold REAL DEFAULT 0.8,
+                    hard_limit BOOLEAN DEFAULT FALSE,
+                    created_at REAL DEFAULT (datetime('now')),
+                    active BOOLEAN DEFAULT TRUE
+                )
+            """)
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS cost_alerts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    alert_type TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    period TEXT,
+                    current_amount REAL NOT NULL,
+                    limit_amount REAL NOT NULL,
+                    threshold_percentage REAL NOT NULL,
+                    triggered_at REAL DEFAULT (datetime('now')),
+                    acknowledged BOOLEAN DEFAULT FALSE
+                )
+            """)
+
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cost_timestamp ON cost_entries(timestamp)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cost_category ON cost_entries(category)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cost_session ON cost_entries(session_id)"
+            )
+
+    def fetch_active_budgets(self) -> List[Tuple]:
+        """Return all active budget rows as raw tuples.
+
+        Columns: ``(category, period, limit_amount, currency, alert_threshold,
+        hard_limit, created_at)``.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute("""
+                SELECT category, period, limit_amount, currency,
+                       alert_threshold, hard_limit, created_at
+                FROM budget_limits
+                WHERE active = TRUE
+            """)
+            return list(cursor.fetchall())
+
+    def insert_cost_entry(
+        self,
+        entry_id: str,
+        timestamp: float,
+        category: str,
+        subcategory: str,
+        amount: float,
+        currency: str,
+        description: str,
+        metadata_json: str,
+        session_id: Optional[str],
+        user_id: Optional[str],
+    ) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO cost_entries
+                (id, timestamp, category, subcategory, amount, currency,
+                 description, metadata, session_id, user_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry_id, timestamp, category, subcategory, amount,
+                    currency, description, metadata_json, session_id, user_id,
+                ),
+            )
+
+    def replace_budget_limit(
+        self,
+        category: str,
+        period: str,
+        limit_amount: float,
+        currency: str,
+        alert_threshold: float,
+        hard_limit: bool,
+    ) -> None:
+        """Deactivate any existing limit for ``(category, period)`` then insert."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE budget_limits SET active = FALSE WHERE category = ? AND period = ?",
+                (category, period),
+            )
+            conn.execute(
+                """
+                INSERT INTO budget_limits
+                (category, period, limit_amount, currency, alert_threshold, hard_limit)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (category, period, limit_amount, currency, alert_threshold, hard_limit),
+            )
+
+    def period_usage_sum(self, category: str, start_timestamp: float) -> float:
+        """Sum of cost ``amount`` for ``category`` from ``start_timestamp`` onward."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT COALESCE(SUM(amount), 0)
+                FROM cost_entries
+                WHERE category = ? AND timestamp >= ?
+                """,
+                (category, start_timestamp),
+            )
+            result = cursor.fetchone()
+            return float(result[0] if result and result[0] else 0)
+
+    def insert_alert(
+        self,
+        alert_type: str,
+        category: str,
+        period: Optional[str],
+        current_amount: float,
+        limit_amount: float,
+        threshold_percentage: float,
+    ) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO cost_alerts
+                (alert_type, category, period, current_amount, limit_amount, threshold_percentage)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (alert_type, category, period, current_amount, limit_amount, threshold_percentage),
+            )
+
+    def summary_aggregates(
+        self,
+        start_timestamp: float,
+        end_timestamp: float,
+        category: Optional[str] = None,
+    ) -> Tuple[float, int, List[Tuple[str, float]], List[Tuple[str, str, float, str, float]]]:
+        """Return aggregates for the period.
+
+        ``(total_amount, entry_count, by_category, top_expenses)`` where:
+          - ``by_category`` is ``[(category, summed_amount), …]`` desc by amount.
+          - ``top_expenses`` is up to 10 rows
+            ``(category, subcategory, amount, description, timestamp)`` desc by amount.
+        """
+        where_clauses = ["timestamp >= ?", "timestamp <= ?"]
+        params: List[Any] = [start_timestamp, end_timestamp]
+        if category:
+            where_clauses.append("category = ?")
+            params.append(category)
+        where_sql = " AND ".join(where_clauses)
+
+        with sqlite3.connect(self.db_path) as conn:
+            # nosec B608 — where_sql is built from hardcoded clause strings only;
+            # all user-controlled values are bound via the `params` list.
+            cursor = conn.execute(
+                f"""
+                SELECT COALESCE(SUM(amount), 0), COUNT(*)
+                FROM cost_entries
+                WHERE {where_sql}
+                """,
+                params,
+            )  # nosec B608
+            total_amount, entry_count = cursor.fetchone()
+
+            cursor = conn.execute(
+                f"""
+                SELECT category, COALESCE(SUM(amount), 0)
+                FROM cost_entries
+                WHERE {where_sql}
+                GROUP BY category
+                ORDER BY SUM(amount) DESC
+                """,
+                params,
+            )  # nosec B608
+            by_category = list(cursor.fetchall())
+
+            cursor = conn.execute(
+                f"""
+                SELECT category, subcategory, amount, description, timestamp
+                FROM cost_entries
+                WHERE {where_sql}
+                ORDER BY amount DESC
+                LIMIT 10
+                """,
+                params,
+            )  # nosec B608
+            top_expenses = list(cursor.fetchall())
+
+        return total_amount, entry_count, by_category, top_expenses
+
+    def fetch_entries_in_range(
+        self, start_timestamp: float, end_timestamp: float
+    ) -> List[Tuple]:
+        """Return raw rows for the export path.
+
+        Columns: ``(id, timestamp, category, subcategory, amount, currency,
+        description, metadata, session_id, user_id)``.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT id, timestamp, category, subcategory, amount, currency,
+                       description, metadata, session_id, user_id
+                FROM cost_entries
+                WHERE timestamp >= ? AND timestamp <= ?
+                ORDER BY timestamp DESC
+                """,
+                (start_timestamp, end_timestamp),
+            )
+            return list(cursor.fetchall())

--- a/deile/infrastructure/monitoring/cost_tracker.py
+++ b/deile/infrastructure/monitoring/cost_tracker.py
@@ -10,7 +10,6 @@ Author: DEILE
 
 import json
 import logging
-import sqlite3
 import threading
 import time
 from dataclasses import asdict, dataclass
@@ -21,6 +20,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from deile.core.context_manager import ContextManager
+from deile.infrastructure.monitoring.cost_repository import CostRepository
 
 logger = logging.getLogger(__name__)
 
@@ -112,78 +112,25 @@ class CostTracker:
     def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path or str(Path.home() / ".deile" / "costs.db")
         self.context_manager = ContextManager()
-        
+
         # In-memory tracking
         self.current_session_costs = {}
         self.budget_limits = {}
         self.cost_alerts = []
         self.alert_callbacks = []
-        
+
         # Thread safety
         self.lock = threading.RLock()
-        
+
         # Pricing configurations
         self.pricing_config = self._load_pricing_config()
-        
-        # Initialize database
-        self._init_database()
-        
+
+        # SQLite persistence (SRP — see cost_repository.py)
+        self.repo = CostRepository(self.db_path)
+        self.repo.init_schema()
+
         # Load budget limits
         self._load_budget_limits()
-    
-    def _init_database(self):
-        """Initialize cost tracking database"""
-        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
-        
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS cost_entries (
-                    id TEXT PRIMARY KEY,
-                    timestamp REAL NOT NULL,
-                    category TEXT NOT NULL,
-                    subcategory TEXT NOT NULL,
-                    amount REAL NOT NULL,
-                    currency TEXT NOT NULL DEFAULT 'USD',
-                    description TEXT NOT NULL,
-                    metadata TEXT NOT NULL DEFAULT '{}',
-                    session_id TEXT,
-                    user_id TEXT,
-                    created_at REAL DEFAULT (datetime('now'))
-                )
-            """)
-            
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS budget_limits (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    category TEXT NOT NULL,
-                    period TEXT NOT NULL,
-                    limit_amount REAL NOT NULL,
-                    currency TEXT NOT NULL DEFAULT 'USD',
-                    alert_threshold REAL DEFAULT 0.8,
-                    hard_limit BOOLEAN DEFAULT FALSE,
-                    created_at REAL DEFAULT (datetime('now')),
-                    active BOOLEAN DEFAULT TRUE
-                )
-            """)
-            
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS cost_alerts (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    alert_type TEXT NOT NULL,
-                    category TEXT NOT NULL,
-                    period TEXT,
-                    current_amount REAL NOT NULL,
-                    limit_amount REAL NOT NULL,
-                    threshold_percentage REAL NOT NULL,
-                    triggered_at REAL DEFAULT (datetime('now')),
-                    acknowledged BOOLEAN DEFAULT FALSE
-                )
-            """)
-            
-            # Create indices for performance
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_cost_timestamp ON cost_entries(timestamp)")
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_cost_category ON cost_entries(category)")
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_cost_session ON cost_entries(session_id)")
     
     def _load_pricing_config(self) -> Dict[str, Any]:
         """Load pricing configuration"""
@@ -244,27 +191,18 @@ class CostTracker:
         """Load budget limits from database"""
         try:
             loaded: Dict[str, BudgetLimit] = {}
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.execute("""
-                    SELECT category, period, limit_amount, currency,
-                           alert_threshold, hard_limit, created_at
-                    FROM budget_limits
-                    WHERE active = TRUE
-                """)
-
-                for row in cursor.fetchall():
-                    budget = BudgetLimit(
-                        category=row[0],
-                        period=row[1],
-                        limit_amount=Decimal(str(row[2])),
-                        currency=row[3],
-                        alert_threshold=row[4],
-                        hard_limit=bool(row[5]),
-                        created_at=row[6]
-                    )
-
-                    key = f"{budget.category}_{budget.period}"
-                    loaded[key] = budget
+            for row in self.repo.fetch_active_budgets():
+                budget = BudgetLimit(
+                    category=row[0],
+                    period=row[1],
+                    limit_amount=Decimal(str(row[2])),
+                    currency=row[3],
+                    alert_threshold=row[4],
+                    hard_limit=bool(row[5]),
+                    created_at=row[6],
+                )
+                key = f"{budget.category}_{budget.period}"
+                loaded[key] = budget
 
             # Atomic full replace under the lock: a reload is authoritative
             # (drops budgets deactivated in the DB) and concurrent readers
@@ -316,38 +254,32 @@ class CostTracker:
             
             # Store in database
             try:
-                with sqlite3.connect(self.db_path) as conn:
-                    conn.execute("""
-                        INSERT INTO cost_entries 
-                        (id, timestamp, category, subcategory, amount, currency, 
-                         description, metadata, session_id, user_id)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """, (
-                        cost_entry.id,
-                        cost_entry.timestamp,
-                        cost_entry.category,
-                        cost_entry.subcategory,
-                        float(cost_entry.amount),
-                        cost_entry.currency,
-                        cost_entry.description,
-                        json.dumps(cost_entry.metadata),
-                        cost_entry.session_id,
-                        cost_entry.user_id
-                    ))
-                
+                self.repo.insert_cost_entry(
+                    entry_id=cost_entry.id,
+                    timestamp=cost_entry.timestamp,
+                    category=cost_entry.category,
+                    subcategory=cost_entry.subcategory,
+                    amount=float(cost_entry.amount),
+                    currency=cost_entry.currency,
+                    description=cost_entry.description,
+                    metadata_json=json.dumps(cost_entry.metadata),
+                    session_id=cost_entry.session_id,
+                    user_id=cost_entry.user_id,
+                )
+
                 # Update session tracking
                 session_key = cost_entry.session_id or "default"
                 if session_key not in self.current_session_costs:
                     self.current_session_costs[session_key] = Decimal('0')
                 self.current_session_costs[session_key] += cost_entry.amount
-                
+
                 # Check budget limits
                 self._check_budget_limits(cost_entry)
-                
+
                 logger.info(f"Tracked cost: {cost_entry.category}/{cost_entry.subcategory} - ${cost_entry.amount}")
-                
+
                 return entry_id
-                
+
             except Exception as e:
                 logger.error(f"Failed to track cost: {e}")
                 raise
@@ -491,28 +423,15 @@ class CostTracker:
             )
             
             # Store in database
-            with sqlite3.connect(self.db_path) as conn:
-                # Deactivate existing limits for same category/period
-                conn.execute("""
-                    UPDATE budget_limits 
-                    SET active = FALSE 
-                    WHERE category = ? AND period = ?
-                """, (category_str, period_str))
-                
-                # Insert new limit
-                conn.execute("""
-                    INSERT INTO budget_limits 
-                    (category, period, limit_amount, currency, alert_threshold, hard_limit)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                """, (
-                    budget.category,
-                    budget.period,
-                    float(budget.limit_amount),
-                    budget.currency,
-                    budget.alert_threshold,
-                    budget.hard_limit
-                ))
-            
+            self.repo.replace_budget_limit(
+                category=budget.category,
+                period=budget.period,
+                limit_amount=float(budget.limit_amount),
+                currency=budget.currency,
+                alert_threshold=budget.alert_threshold,
+                hard_limit=budget.hard_limit,
+            )
+
             # Update in memory
             key = f"{category_str}_{period_str}"
             self.budget_limits[key] = budget
@@ -570,18 +489,9 @@ class CostTracker:
             period_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
         
         start_timestamp = period_start.timestamp()
-        
+
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.execute("""
-                    SELECT COALESCE(SUM(amount), 0)
-                    FROM cost_entries
-                    WHERE category = ? AND timestamp >= ?
-                """, (category, start_timestamp))
-                
-                result = cursor.fetchone()
-                return Decimal(str(result[0] if result and result[0] else 0))
-                
+            return Decimal(str(self.repo.period_usage_sum(category, start_timestamp)))
         except Exception as e:
             logger.error(f"Failed to get period usage: {e}")
             return Decimal('0')
@@ -601,19 +511,14 @@ class CostTracker:
         
         # Store alert
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                conn.execute("""
-                    INSERT INTO cost_alerts 
-                    (alert_type, category, period, current_amount, limit_amount, threshold_percentage)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                """, (
-                    alert_data["alert_type"],
-                    alert_data["category"],
-                    alert_data["period"],
-                    alert_data["current_amount"],
-                    alert_data["limit_amount"],
-                    alert_data["threshold_percentage"]
-                ))
+            self.repo.insert_alert(
+                alert_type=alert_data["alert_type"],
+                category=alert_data["category"],
+                period=alert_data["period"],
+                current_amount=alert_data["current_amount"],
+                limit_amount=alert_data["limit_amount"],
+                threshold_percentage=alert_data["threshold_percentage"],
+            )
         except Exception as e:
             logger.error(f"Failed to store alert: {e}")
         
@@ -645,67 +550,32 @@ class CostTracker:
             start_time = end_time - timedelta(days=30)
         
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                # Base query
-                where_clauses = ["timestamp >= ?", "timestamp <= ?"]
-                params = [start_time.timestamp(), end_time.timestamp()]
-                
-                if category:
-                    where_clauses.append("category = ?")
-                    params.append(category)
-                
-                where_sql = " AND ".join(where_clauses)
-                
-                # nosec B608 — where_sql is built from hardcoded clause strings only;
-                # all user-controlled values are bound via the `params` list (parameterised query).
-                cursor = conn.execute(f"""
-                    SELECT COALESCE(SUM(amount), 0), COUNT(*)
-                    FROM cost_entries
-                    WHERE {where_sql}
-                """, params)  # nosec B608
+            total_amount, entry_count, by_category, top_rows = self.repo.summary_aggregates(
+                start_time.timestamp(), end_time.timestamp(), category
+            )
 
-                total_amount, entry_count = cursor.fetchone()
+            categories = {row[0]: Decimal(str(row[1])) for row in by_category}
+            top_expenses = [
+                {
+                    "category": row[0],
+                    "subcategory": row[1],
+                    "amount": float(row[2]),
+                    "description": row[3],
+                    "timestamp": row[4],
+                }
+                for row in top_rows
+            ]
 
-                cursor = conn.execute(f"""
-                    SELECT category, COALESCE(SUM(amount), 0)
-                    FROM cost_entries
-                    WHERE {where_sql}
-                    GROUP BY category
-                    ORDER BY SUM(amount) DESC
-                """, params)  # nosec B608
+            return CostSummary(
+                period_start=start_time.timestamp(),
+                period_end=end_time.timestamp(),
+                total_amount=Decimal(str(total_amount)),
+                currency="USD",
+                categories=categories,
+                entry_count=entry_count,
+                top_expenses=top_expenses,
+            )
 
-                categories = {}
-                for row in cursor.fetchall():
-                    categories[row[0]] = Decimal(str(row[1]))
-
-                cursor = conn.execute(f"""
-                    SELECT category, subcategory, amount, description, timestamp
-                    FROM cost_entries
-                    WHERE {where_sql}
-                    ORDER BY amount DESC
-                    LIMIT 10
-                """, params)  # nosec B608
-                
-                top_expenses = []
-                for row in cursor.fetchall():
-                    top_expenses.append({
-                        "category": row[0],
-                        "subcategory": row[1],
-                        "amount": float(row[2]),
-                        "description": row[3],
-                        "timestamp": row[4]
-                    })
-                
-                return CostSummary(
-                    period_start=start_time.timestamp(),
-                    period_end=end_time.timestamp(),
-                    total_amount=Decimal(str(total_amount)),
-                    currency="USD",
-                    categories=categories,
-                    entry_count=entry_count,
-                    top_expenses=top_expenses
-                )
-                
         except Exception as e:
             logger.error(f"Failed to get cost summary: {e}")
             # Return empty summary
@@ -740,60 +610,55 @@ class CostTracker:
             start_time = end_time - timedelta(days=30)
         
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.execute("""
-                    SELECT id, timestamp, category, subcategory, amount, currency,
-                           description, metadata, session_id, user_id
-                    FROM cost_entries
-                    WHERE timestamp >= ? AND timestamp <= ?
-                    ORDER BY timestamp DESC
-                """, (start_time.timestamp(), end_time.timestamp()))
-                
-                entries = []
-                for row in cursor.fetchall():
-                    entry = {
-                        "id": row[0],
-                        "timestamp": row[1],
-                        "datetime": datetime.fromtimestamp(row[1]).isoformat(),
-                        "category": row[2],
-                        "subcategory": row[3],
-                        "amount": row[4],
-                        "currency": row[5],
-                        "description": row[6],
-                        "metadata": json.loads(row[7]) if row[7] else {},
-                        "session_id": row[8],
-                        "user_id": row[9]
-                    }
-                    entries.append(entry)
-                
-                if format_type == "json":
-                    return json.dumps({
-                        "export_timestamp": datetime.now().isoformat(),
-                        "period_start": start_time.isoformat(),
-                        "period_end": end_time.isoformat(),
-                        "total_entries": len(entries),
-                        "entries": entries
-                    }, indent=2)
-                elif format_type == "csv":
-                    # Simple CSV export
-                    import csv
-                    import io
-                    
-                    output = io.StringIO()
-                    writer = csv.DictWriter(output, fieldnames=[
-                        "id", "datetime", "category", "subcategory", 
-                        "amount", "currency", "description", "session_id"
-                    ])
-                    
-                    writer.writeheader()
-                    for entry in entries:
-                        writer.writerow({
-                            k: v for k, v in entry.items() 
-                            if k in writer.fieldnames
-                        })
-                    
-                    return output.getvalue()
-                
+            rows = self.repo.fetch_entries_in_range(
+                start_time.timestamp(), end_time.timestamp()
+            )
+
+            entries = [
+                {
+                    "id": row[0],
+                    "timestamp": row[1],
+                    "datetime": datetime.fromtimestamp(row[1]).isoformat(),
+                    "category": row[2],
+                    "subcategory": row[3],
+                    "amount": row[4],
+                    "currency": row[5],
+                    "description": row[6],
+                    "metadata": json.loads(row[7]) if row[7] else {},
+                    "session_id": row[8],
+                    "user_id": row[9],
+                }
+                for row in rows
+            ]
+
+            if format_type == "json":
+                return json.dumps({
+                    "export_timestamp": datetime.now().isoformat(),
+                    "period_start": start_time.isoformat(),
+                    "period_end": end_time.isoformat(),
+                    "total_entries": len(entries),
+                    "entries": entries
+                }, indent=2)
+            elif format_type == "csv":
+                # Simple CSV export
+                import csv
+                import io
+
+                output = io.StringIO()
+                writer = csv.DictWriter(output, fieldnames=[
+                    "id", "datetime", "category", "subcategory",
+                    "amount", "currency", "description", "session_id"
+                ])
+
+                writer.writeheader()
+                for entry in entries:
+                    writer.writerow({
+                        k: v for k, v in entry.items()
+                        if k in writer.fieldnames
+                    })
+
+                return output.getvalue()
+
         except Exception as e:
             logger.error(f"Failed to export costs: {e}")
             return ""

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -188,6 +188,40 @@ class ClaudeImplementer(PipelineImplementer):
 
     name = "claude"
 
+    async def _run_in_worktree(
+        self,
+        monitor: "PipelineMonitor",
+        branch: str | None,
+        prompt: str,
+        *,
+        label: str,
+        force_recreate: bool = False,
+    ) -> WorkOutcome:
+        """Setup a worktree (if ``branch`` is given), then run ``claude``.
+
+        ``branch=None`` skips worktree setup and runs ``claude`` at
+        ``monitor.config.base_repo_path`` — used by the mention path which
+        has no per-issue branch.
+
+        Worktree creation failures become a failed ``WorkOutcome`` with the
+        ``worktree:`` prefix; ``label`` is used in the exception log.
+        """
+        if branch is None:
+            cwd = monitor.config.base_repo_path
+        else:
+            try:
+                worktree = await monitor.worktrees.create_branch_worktree(
+                    branch, force_recreate=force_recreate
+                )
+            except Exception as exc:  # noqa: BLE001 — surface as failed outcome
+                logger.exception("worktree setup for %s failed", label)
+                return WorkOutcome(
+                    ok=False, text="", error=f"worktree: {type(exc).__name__}: {exc}"
+                )
+            cwd = worktree.path
+        result = await monitor.claude.run(prompt, cwd=cwd)
+        return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
+
     async def implement(
         self, monitor: "PipelineMonitor", issue: "IssueRef", *, resume: bool = False
     ) -> WorkOutcome:
@@ -197,31 +231,21 @@ class ClaudeImplementer(PipelineImplementer):
         # ground-truth contract (that lives in the deile-worker path), so the
         # flag does not change behaviour here beyond the existing reuse.
         branch = monitor.branch_for_issue(issue.number)
-        try:
-            worktree = await monitor.worktrees.create_branch_worktree(
-                branch, force_recreate=False
-            )
-        except Exception as exc:  # noqa: BLE001 — surface as a failed outcome
-            logger.exception("worktree setup for #%s failed", issue.number)
-            return WorkOutcome(ok=False, text="", error=f"worktree: {type(exc).__name__}: {exc}")
         prompt = render_implement_prompt(
             monitor.config.repo, issue.number, issue.title, issue.body
         )
-        result = await monitor.claude.run(prompt, cwd=worktree.path)
-        return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
+        return await self._run_in_worktree(
+            monitor, branch, prompt, label=f"#{issue.number}"
+        )
 
     async def review(
         self, monitor: "PipelineMonitor", pr: "PrRef", *, resume: bool = False
     ) -> WorkOutcome:
         worktree_branch = pr.head_ref or f"pr/{pr.number}"
-        try:
-            wt = await monitor.worktrees.create_branch_worktree(worktree_branch)
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("PR worktree #%s failed", pr.number)
-            return WorkOutcome(ok=False, text="", error=f"worktree: {type(exc).__name__}: {exc}")
         prompt = render_review_prompt(monitor.config.repo, pr.number, pr.title)
-        result = await monitor.claude.run(prompt, cwd=wt.path)
-        return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
+        return await self._run_in_worktree(
+            monitor, worktree_branch, prompt, label=f"PR #{pr.number}"
+        )
 
     async def mention(
         self,
@@ -238,8 +262,8 @@ class ClaudeImplementer(PipelineImplementer):
         prompt = _render_claude_mention_prompt(
             monitor.config.repo, ref, trigger_types or [], all_triggers or []
         )
-        result = await monitor.claude.run(prompt, cwd=monitor.config.base_repo_path)
-        return WorkOutcome(ok=result.ok, text=result.stdout, error=result.stderr.strip())
+        # mention runs at base_repo_path; no per-issue branch worktree.
+        return await self._run_in_worktree(monitor, None, prompt, label="mention")
 
 
 # ---------------------------------------------------------------------------

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -508,61 +508,57 @@ class PipelineMonitor:
 
             if schedule.recurring:
                 scheduled_actions = {e.action for e in schedule.recurring if e.enabled}
-                if self.config.enable_classify and "classify" not in scheduled_actions:
-                    logger.debug("classify not in schedule; running legacy fallback")
-                    await self._classify_new_issues()
-                if self.config.enable_review and "review" not in scheduled_actions:
-                    logger.debug("review not in schedule; running legacy fallback")
-                    await self._review_one_new_issue()
-                # Refinement loop (issue #257): a per-tick sweep like resume, not
-                # a cron action — runs after critique so an issue judged POOR is
-                # refined on the NEXT tick, then re-critiqued.
-                if self.config.enable_refinement_gate:
-                    await self._refine_one_issue()
-                # Resume parked, continuable work BEFORE claiming new issues
-                # (issue #254). Running it first is what stops a freshly-claimed
-                # issue (revisada → em_implementacao THIS tick) from being
-                # re-dispatched again in the SAME tick: its first resume happens
-                # on the NEXT tick — exactly the "immediate = next free tick"
-                # cadence. Gated by enable_resume; never on the schedule (it is a
-                # per-tick sweep, not a cron action).
-                if self.config.enable_resume:
-                    await self._resume_in_progress_issues()
-                if self.config.enable_implement and "implement" not in scheduled_actions:
-                    logger.debug("implement not in schedule; running legacy fallback")
-                    await self._implement_one_reviewed_issue()
-                # Decompose CLEAR intents into derived issues (issue #257).
-                if self.config.enable_refinement_gate:
-                    await self._decompose_one_reviewed_intent()
-                if self.config.enable_pr_review and "pr_review" not in scheduled_actions:
-                    logger.debug("pr_review not in schedule; running legacy fallback")
-                    await self._review_one_open_pr()
-                if self.config.enable_pr_triage:
-                    await self._classify_new_prs()
-                if self.config.enable_mention_handling:
-                    await self._process_mentions()
+                await self._dispatch_stages(skip=scheduled_actions)
             return
 
-        if self.config.enable_classify:
+        await self._dispatch_stages()
+
+    async def _dispatch_stages(self, skip: set[str] | None = None) -> None:
+        """Run the per-tick stage sequence.
+
+        Stages whose key is in ``skip`` are bypassed because the scheduler
+        has already run them in this tick. Stages without a schedule key
+        (refinement_gate, resume, decompose, pr_triage, mention_handling)
+        always run when their feature flag is enabled.
+
+        ``skip=None`` is the legacy "every action every tick" mode used
+        when there is no schedule file with recurring entries.
+        """
+        skip = skip or set()
+        scheduled_mode = bool(skip)
+        cfg = self.config
+
+        if cfg.enable_classify and "classify" not in skip:
+            if scheduled_mode:
+                logger.debug("classify not in schedule; running legacy fallback")
             await self._classify_new_issues()
-        if self.config.enable_review:
+        if cfg.enable_review and "review" not in skip:
+            if scheduled_mode:
+                logger.debug("review not in schedule; running legacy fallback")
             await self._review_one_new_issue()
-        if self.config.enable_refinement_gate:
+        # Refinement loop (issue #257): per-tick sweep, not a cron action —
+        # runs after critique so a POOR issue is refined on the NEXT tick.
+        if cfg.enable_refinement_gate:
             await self._refine_one_issue()
-        # Resume parked work BEFORE claiming new issues (issue #254) so a
-        # freshly-claimed issue is not re-dispatched again in the same tick;
-        # its first resume lands on the next tick.
-        if self.config.enable_resume:
+        # Resume parked, continuable work BEFORE claiming new issues
+        # (issue #254) so a freshly-claimed issue is not re-dispatched in
+        # the same tick; its first resume lands on the next tick.
+        if cfg.enable_resume:
             await self._resume_in_progress_issues()
-        if self.config.enable_implement:
+        if cfg.enable_implement and "implement" not in skip:
+            if scheduled_mode:
+                logger.debug("implement not in schedule; running legacy fallback")
             await self._implement_one_reviewed_issue()
-        if self.config.enable_refinement_gate:
+        # Decompose CLEAR intents into derived issues (issue #257).
+        if cfg.enable_refinement_gate:
             await self._decompose_one_reviewed_intent()
-        if self.config.enable_pr_review:
+        if cfg.enable_pr_review and "pr_review" not in skip:
+            if scheduled_mode:
+                logger.debug("pr_review not in schedule; running legacy fallback")
             await self._review_one_open_pr()
-        if self.config.enable_pr_triage:
+        if cfg.enable_pr_triage:
             await self._classify_new_prs()
-        if self.config.enable_mention_handling:
+        if cfg.enable_mention_handling:
             await self._process_mentions()
 
     # ------------------------------------------------------------------

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -21,9 +21,9 @@ import asyncio
 import logging
 import re
 import time
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
 
+from deile.orchestration.pipeline._time_utils import now_utc
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
 from deile.orchestration.pipeline.follow_up_detector import detect_follow_ups
 from deile.orchestration.pipeline.github_client import (CommentRef,
@@ -326,7 +326,7 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
 
     triggers = await _collect_mention_triggers(monitor, handle, gh_login)
     if not triggers:
-        monitor._save_mention_cursor(datetime.now(tz=timezone.utc))
+        monitor._save_mention_cursor(now_utc())
         return
 
     # ---- Deduplicate by target ------------------------------------------
@@ -334,7 +334,7 @@ async def process_mentions(monitor: "PipelineMonitor") -> None:
     for t in triggers:
         groups.setdefault(t.dedup_key, []).append(t)
 
-    now = datetime.now(tz=timezone.utc)
+    now = now_utc()
     mono = _monotonic()
     for dedup_key, group in groups.items():
         await _dispatch_mention_group(monitor, dedup_key, group, gh_login, mono)

--- a/deile/tests/security/test_security_audit_84.py
+++ b/deile/tests/security/test_security_audit_84.py
@@ -134,10 +134,19 @@ def test_no_os_system(rel_path: str) -> None:
 # 3. cost_tracker.py — SQL parameterisation safety
 # ---------------------------------------------------------------------------
 
+# The SQL persistence layer was extracted from cost_tracker.py into
+# cost_repository.py; both files are audited so the guarantee follows the code.
+_COST_SQL_FILES = (
+    "deile/infrastructure/monitoring/cost_tracker.py",
+    "deile/infrastructure/monitoring/cost_repository.py",
+)
+
+
 @pytest.mark.security
-def test_cost_tracker_sql_uses_params() -> None:
-    """cost_tracker.py must pass a `params` list to every f-string execute call."""
-    source = _source("deile/infrastructure/monitoring/cost_tracker.py")
+@pytest.mark.parametrize("rel_path", _COST_SQL_FILES)
+def test_cost_sql_uses_params(rel_path: str) -> None:
+    """Every f-string execute call must also pass a `params` list."""
+    source = _source(rel_path)
     tree = ast.parse(source)
 
     for node in ast.walk(tree):
@@ -153,16 +162,17 @@ def test_cost_tracker_sql_uses_params() -> None:
         # If the first arg is an f-string (JoinedStr), ensure a second arg (params) exists
         if isinstance(first_arg, ast.JoinedStr):
             assert len(node.args) >= 2, (
-                f"cost_tracker.py line {node.lineno}: "
+                f"{rel_path} line {node.lineno}: "
                 "f-string passed to .execute() without a params argument — "
                 "this is a SQL injection risk."
             )
 
 
 @pytest.mark.security
-def test_cost_tracker_where_clauses_hardcoded() -> None:
-    """where_clauses in cost_tracker.py must only append string literals."""
-    source = _source("deile/infrastructure/monitoring/cost_tracker.py")
+@pytest.mark.parametrize("rel_path", _COST_SQL_FILES)
+def test_cost_where_clauses_hardcoded(rel_path: str) -> None:
+    """where_clauses must only append string literals (no user-controlled SQL)."""
+    source = _source(rel_path)
 
     # Find all where_clauses.append(...) calls in the source
     pattern = re.compile(r'where_clauses\.append\(([^)]+)\)')
@@ -174,7 +184,7 @@ def test_cost_tracker_where_clauses_hardcoded() -> None:
             or (arg.startswith("'") and arg.endswith("'"))
         )
         assert is_string_literal, (
-            f"where_clauses.append() called with non-literal argument: {arg!r}. "
+            f"{rel_path}: where_clauses.append() called with non-literal argument: {arg!r}. "
             "Only hardcoded SQL clause strings are allowed."
         )
 

--- a/deile/tools/execution_tools.py
+++ b/deile/tools/execution_tools.py
@@ -14,6 +14,46 @@ from .base import SyncTool, ToolContext, ToolResult, ToolStatus
 logger = logging.getLogger(__name__)
 
 
+def _run_subprocess(
+    cmd: list[str],
+    *,
+    timeout: int,
+    cwd: str | None,
+    timeout_msg: str,
+    timeout_error_msg: str,
+    generic_err_prefix: str,
+) -> tuple[subprocess.CompletedProcess | None, ToolResult | None]:
+    """Run ``cmd`` capturing stdout/stderr.
+
+    Returns ``(proc, None)`` on a successful spawn (regardless of returncode),
+    or ``(None, error_result)`` when the subprocess timed out or raised any
+    other exception — in which case the caller just returns ``error_result``.
+
+    Keeps the timeout/exception envelope identical across the three execution
+    tools so each tool only has to interpret ``returncode`` to build its
+    success/error ``ToolResult``.
+    """
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+        )
+        return proc, None
+    except subprocess.TimeoutExpired:
+        return None, ToolResult.error_result(
+            message=timeout_msg,
+            error=TimeoutError(timeout_error_msg),
+        )
+    except Exception as exc:  # noqa: BLE001 — every path returns an error result
+        return None, ToolResult.error_result(
+            message=f"{generic_err_prefix}: {exc}",
+            error=exc,
+        )
+
+
 class PythonExecutionTool(SyncTool):
     """Run a Python snippet in a subprocess with timeout.
 
@@ -43,65 +83,55 @@ class PythonExecutionTool(SyncTool):
                 error=ValidationError("code is required"),
             )
 
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(code)
+            temp_file = f.name
+
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".py", delete=False, encoding="utf-8"
-            ) as f:
-                f.write(code)
-                temp_file = f.name
+            result, err = _run_subprocess(
+                [sys.executable, temp_file],
+                timeout=timeout,
+                cwd=context.working_directory,
+                timeout_msg=f"Python code timed out after {timeout} seconds",
+                timeout_error_msg=f"Execution timeout: {timeout}s",
+                generic_err_prefix="Error executing Python code",
+            )
+            if err is not None:
+                return err
 
-            try:
-                result = subprocess.run(
-                    [sys.executable, temp_file],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                    cwd=context.working_directory,
-                )
+            stdout = result.stdout or ""
+            stderr = result.stderr or ""
 
-                stdout = result.stdout or ""
-                stderr = result.stderr or ""
-
-                if result.returncode == 0:
-                    return ToolResult(
-                        status=ToolStatus.SUCCESS,
-                        data=stdout.strip(),
-                        message=stdout.strip() or "Python executed successfully (no stdout)",
-                        metadata={
-                            "exit_code": result.returncode,
-                            "stdout": stdout,
-                            "stderr": stderr,
-                        },
-                    )
-                return ToolResult.error_result(
-                    data=stderr.strip(),
-                    message=(
-                        f"Python failed with exit code {result.returncode}.\n"
-                        f"stderr:\n{stderr.strip()}"
-                    ),
+            if result.returncode == 0:
+                return ToolResult(
+                    status=ToolStatus.SUCCESS,
+                    data=stdout.strip(),
+                    message=stdout.strip() or "Python executed successfully (no stdout)",
                     metadata={
                         "exit_code": result.returncode,
                         "stdout": stdout,
                         "stderr": stderr,
                     },
                 )
-
-            finally:
-                try:
-                    os.unlink(temp_file)
-                except OSError:
-                    pass
-
-        except subprocess.TimeoutExpired:
             return ToolResult.error_result(
-                message=f"Python code timed out after {timeout} seconds",
-                error=TimeoutError(f"Execution timeout: {timeout}s"),
+                data=stderr.strip(),
+                message=(
+                    f"Python failed with exit code {result.returncode}.\n"
+                    f"stderr:\n{stderr.strip()}"
+                ),
+                metadata={
+                    "exit_code": result.returncode,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                },
             )
-        except Exception as e:
-            return ToolResult.error_result(
-                message=f"Error executing Python code: {str(e)}",
-                error=e,
-            )
+        finally:
+            try:
+                os.unlink(temp_file)
+            except OSError:
+                pass
 
 
 class PipInstallTool(SyncTool):
@@ -206,24 +236,16 @@ class PipInstallTool(SyncTool):
             cmd.append("--upgrade")
         cmd.append(spec)
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                cwd=context.working_directory,
-            )
-        except subprocess.TimeoutExpired:
-            return ToolResult.error_result(
-                message=f"pip install {spec} timed out after {timeout} seconds",
-                error=TimeoutError(f"pip timeout: {timeout}s"),
-            )
-        except Exception as e:
-            return ToolResult.error_result(
-                message=f"Failed to invoke pip: {e}",
-                error=e,
-            )
+        result, err = _run_subprocess(
+            cmd,
+            timeout=timeout,
+            cwd=context.working_directory,
+            timeout_msg=f"pip install {spec} timed out after {timeout} seconds",
+            timeout_error_msg=f"pip timeout: {timeout}s",
+            generic_err_prefix="Failed to invoke pip",
+        )
+        if err is not None:
+            return err
 
         stdout = result.stdout or ""
         stderr = result.stderr or ""
@@ -313,57 +335,48 @@ class TestRunnerTool(SyncTool):
                 error=ValidationError(f"test_type must be one of: {list(test_commands.keys())}")
             )
 
-        try:
-            cmd = test_commands[test_type].copy()
+        cmd = test_commands[test_type].copy()
 
-            if test_path and test_path != ".":
-                cmd.append(test_path)
+        if test_path and test_path != ".":
+            cmd.append(test_path)
 
-            if verbose and test_type == "pytest":
-                cmd.append("-v")
+        if verbose and test_type == "pytest":
+            cmd.append("-v")
 
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=300,
-                cwd=context.working_directory
-            )
+        result, err = _run_subprocess(
+            cmd,
+            timeout=300,
+            cwd=context.working_directory,
+            timeout_msg="Tests timed out after 5 minutes",
+            timeout_error_msg="Test execution timeout",
+            generic_err_prefix="Error running tests",
+        )
+        if err is not None:
+            return err
 
-            output = result.stdout.strip() if result.stdout else ""
-            error_output = result.stderr.strip() if result.stderr else ""
+        output = result.stdout.strip() if result.stdout else ""
+        error_output = result.stderr.strip() if result.stderr else ""
 
-            if test_type == "pytest":
-                if "failed" in output.lower() or result.returncode != 0:
-                    status = ToolStatus.ERROR
-                    message = "Tests failed"
-                else:
-                    status = ToolStatus.SUCCESS
-                    message = "All tests passed"
+        if test_type == "pytest":
+            if "failed" in output.lower() or result.returncode != 0:
+                status = ToolStatus.ERROR
+                message = "Tests failed"
             else:
-                status = ToolStatus.SUCCESS if result.returncode == 0 else ToolStatus.ERROR
-                message = "Tests completed" if result.returncode == 0 else "Tests failed"
+                status = ToolStatus.SUCCESS
+                message = "All tests passed"
+        else:
+            status = ToolStatus.SUCCESS if result.returncode == 0 else ToolStatus.ERROR
+            message = "Tests completed" if result.returncode == 0 else "Tests failed"
 
-            return ToolResult(
-                status=status,
-                data=output,
-                message=message,
-                metadata={
-                    "test_type": test_type,
-                    "test_path": test_path,
-                    "exit_code": result.returncode,
-                    "stdout": output,
-                    "stderr": error_output
-                }
-            )
-
-        except subprocess.TimeoutExpired:
-            return ToolResult.error_result(
-                message="Tests timed out after 5 minutes",
-                error=TimeoutError("Test execution timeout")
-            )
-        except Exception as e:
-            return ToolResult.error_result(
-                message=f"Error running tests: {str(e)}",
-                error=e
-            )
+        return ToolResult(
+            status=status,
+            data=output,
+            message=message,
+            metadata={
+                "test_type": test_type,
+                "test_path": test_path,
+                "exit_code": result.returncode,
+                "stdout": output,
+                "stderr": error_output
+            }
+        )


### PR DESCRIPTION
## Refatoração Arquitetural Diária — 2026-05-22

**Modo**: PRs-do-dia (PRs mergeadas em 2026-05-21 / 2026-05-22 BRT, excluindo `simplify/*`)

**PRs exogêneas base**: #243, #246, #248, #250, #252, #255, #256, #258, #260, #261, #264, #265, #266, #268, #270, #272, #273, #274, #275, #276

**Resumo arquitetural**: O codebase está maduro — refatorações recentes (#262/#263/#269/#275) já consolidaram helpers (`_shared.py`, `_cost_views`, `_status_collectors`, `_time_utils`, `_shell_security`). Os hotspots remanescentes identificados nesta varredura foram (a) `PipelineMonitor.tick()` duplicando a sequência de 9 estágios entre o ramo schedule-with-gaps e o ramo legacy, (b) `ClaudeImplementer.{implement,review,mention}` repetindo o padrão worktree-setup + `claude.run` + `WorkOutcome`, (c) os três `SyncTool`s em `execution_tools.py` (Python / pip / pytest) repetindo o invólucro `subprocess.run` + `TimeoutExpired` + `Exception` sem helper, (d) `CostTracker` (885 linhas) como god object misturando schema/pricing/budgets/tracking/alertas/persistência sqlite numa única classe.

### Plano executado

| # | Tipo | Valor | Status | Descrição |
|---|---|---|---|---|
| 1 | DRY_CROSS | ALTO | APPLIED | `PipelineMonitor.tick()` → extrair `_dispatch_stages(skip)` (elimina duplicação dos 9 estágios entre ramo schedule e ramo legacy) |
| 2 | DRY_CROSS | MEDIO | APPLIED | `ClaudeImplementer` → extrair `_run_in_worktree()` (centraliza worktree-setup + `claude.run` + mapeamento de `WorkOutcome`) |
| 3 | DRY_CROSS | MEDIO | APPLIED | `execution_tools.py` → extrair `_run_subprocess()` (dedupa envelope de timeout/exception nas 3 tools) |
| 4 | KISS | MEDIO | APPLIED | `stages.py` → trocar `datetime.now(tz=timezone.utc)` inline por `now_utc()` de `_time_utils` (consistente com demais módulos do pipeline) |
| 5 | DRY_CROSS | MEDIO | APPLIED | `cost_command.py` → extrair `_period_range(days)` (dedupa `end=now(); start=end-timedelta` em 5 views) |
| 6 | SRP | MEDIO | APPLIED | `CostTracker` → extrair `CostRepository` para a camada sqlite (god object → fachada + repositório) |

### Arquivos modificados
- `deile/orchestration/pipeline/monitor.py` — refatora `tick()` em volta de `_dispatch_stages()` (-45 / +41 linhas)
- `deile/orchestration/pipeline/implementer.py` — adiciona `_run_in_worktree()`, simplifica os 3 métodos (-18 / +42 linhas)
- `deile/orchestration/pipeline/stages.py` — usa `now_utc()` em vez de `datetime.now(tz=timezone.utc)`
- `deile/tools/execution_tools.py` — adiciona `_run_subprocess()`, simplifica `execute_sync` das 3 tools (-113 / +126 linhas)
- `deile/commands/builtin/cost_command.py` — adiciona `_period_range()`, atualiza 5 callers
- `deile/infrastructure/monitoring/cost_tracker.py` — remove import de `sqlite3`, compõe `CostRepository`, 7 métodos delegam ao repo
- `deile/tests/security/test_security_audit_84.py` — parametriza testes SQL-safety sobre `cost_tracker.py` + `cost_repository.py` (segue o código)

### Arquivos criados
- `deile/infrastructure/monitoring/cost_repository.py` (267 linhas) — todas as transações sqlite que viviam em `CostTracker`

### Arquivos removidos
nenhum

### Itens revertidos
nenhum (todos os 6 itens passaram nos testes em primeira aplicação)

### Testes gate local

**Baseline (main)**: 1 failed, 3226 passed, 15 skipped, 23 errors (todas pré-existentes — `infra/test_worker_resume.py` git-subprocess sandbox + 1 misc fail)

**Final (branch)**: 1 failed, 3228 passed, 15 skipped, 23 errors

Diff vs baseline: zero novos failures/errors. +2 tests passando (variantes parametrizadas do `test_security_audit_84.py` que estendi para também auditar o `cost_repository.py`).

### Checklist de segurança
- [x] Testes antes-passando continuam passando (diff de failures vazio)
- [x] Assinaturas públicas de `PipelineImplementer`, `CostTracker`, `Tool` inalteradas
- [x] Registry pattern respeitado (pilar 03 §3) — nenhuma `Tool`/`Command` renomeada
- [x] Arquitetura hexagonal respeitada (pilar 02 + 03 §2) — `CostRepository` está em `infrastructure/`, não em `core/`
- [x] Sem nova dependência externa (apenas mudança interna)
- [x] Dead code: nenhum removido nesta PR
- [x] Sem I/O síncrono em async (todas as 3 tools já eram `SyncTool`; o helper preserva a propriedade)
- [x] `ruff check` em arquivos modificados: limpo. Pré-existentes em `deile/tests/commands/test_version_fastpath.py` (PR #274) não tocados.
- [x] `isort --check-only` em arquivos modificados: limpo. Mesmo pré-existente acima inalterado.
- [x] Security audit (`test_security_audit_84.py`) parametrizado para auditar também `cost_repository.py` — invariante SQL-safety preservada com a movimentação do código.

> ⏳ Aguardando revisão e merge pelo pipeline `deile-issue-dev-pr-review-full`.

Gerado pelo pipeline DEILE refactor-daily (gate local confirmado verde).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnwoyr3prAcj2wUjCx8SL)_