### PR TITLE
refactor(messaging): mensagens de erro diagnósticas e amigáveis em _map_exception()

### DIFF
--- a/deile/tests/tools/messaging/test_discord_send_message.py
+++ b/deile/tests/tools/messaging/test_discord_send_message.py
@@ -110,3 +110,209 @@ async def test_security_level_is_moderate():
     from deile.tools.base import SecurityLevel
 
     assert tool.schema.security_level == SecurityLevel.MODERATE
+
+
+# ── Error-message refactor tests (issue #280) ───────────────────────────────
+
+
+def _make_error_client(exc: Exception):
+    """Return a FakeBotClient that raises `exc` on channel_post."""
+    from .conftest import FakeBotClient
+
+    return FakeBotClient(raise_on={"channel_post": exc})
+
+
+def _assert_error_details(result, *, error_code: str, recoverable: bool):
+    """Assert that ToolResult.metadata contains well-formed error_details."""
+    assert result.is_error
+    details = result.metadata.get("error_details")
+    assert isinstance(details, dict), f"error_details missing or not dict: {details}"
+    assert details.get("error_code") == error_code
+    assert isinstance(details.get("suggestion"), str)
+    assert len(details["suggestion"]) > 0
+    assert details.get("recoverable") == recoverable
+
+
+async def test_auth_error_format(fake_permission, fake_audit):
+    """BotClientAuthError → message with tool_name + suggestion + error_details."""
+    from deile.integrations.bot.client import BotClientAuthError
+
+    tool = DiscordSendMessageTool()
+    ctx = make_context(
+        args={"channel_id": "100", "text": "x"},
+        fake_client=_make_error_client(BotClientAuthError("bad token")),
+        permission=fake_permission,
+        audit=fake_audit,
+    )
+    result = await tool.execute(ctx)
+    _assert_error_details(result, error_code="BOT_AUTH_ERROR", recoverable=False)
+    assert "discord_send_message" in result.message
+    assert "autenticação" in result.message.lower()
+    assert "DEILE_BOT_AUTH_TOKEN" in result.message
+    # Sensitive check: no raw token value leaked
+    assert "bad token" not in result.message
+
+
+async def test_rate_limited_format(fake_permission, fake_audit):
+    """BotClientRateLimited → message + suggestion + error_details (no retry_after)."""
+    from deile.integrations.bot.client import BotClientRateLimited
+
+    tool = DiscordSendMessageTool()
+    ctx = make_context(
+        args={"channel_id": "200", "text": "x"},
+        fake_client=_make_error_client(BotClientRateLimited("slow down")),
+        permission=fake_permission,
+        audit=fake_audit,
+    )
+    result = await tool.execute(ctx)
+    _assert_error_details(result, error_code="BOT_RATE_LIMITED", recoverable=True)
+    assert "discord_send_message" in result.message
+    assert "rate-limited" in result.message.lower()
+    assert "Aguarde" in result.message
+    # retry_after not set → key absent
+    assert "retry_after" not in result.metadata["error_details"]
+
+
+async def test_rate_limited_with_retry_after(fake_permission, fake_audit):
+    """BotClientRateLimited with retry_after attribute → included in error_details."""
+    from deile.integrations.bot.client import BotClientRateLimited
+
+    exc = BotClientRateLimited("slow down")
+    exc.retry_after = 5.0  # simulate real client attribute
+
+    tool = DiscordSendMessageTool()
+    ctx = make_context(
+        args={"channel_id": "200", "text": "x"},
+        fake_client=_make_error_client(exc),
+        permission=fake_permission,
+        audit=fake_audit,
+    )
+    result = await tool.execute(ctx)
+    _assert_error_details(result, error_code="BOT_RATE_LIMITED", recoverable=True)
+    assert result.metadata["error_details"]["retry_after"] == 5.0
+    assert "5.0s" in result.message
+
+
+async def test_not_ready_format(fake_permission, fake_audit):
+    """BotClientNotReady → message + suggestion + error_details."""
+    from deile.integrations.bot.client import BotClientNotReady
+
+    tool = DiscordSendMessageTool()
+    ctx = make_context(
+        args={"channel_id": "300", "text": "x"},
+        fake_client=_make_error_client(BotClientNotReady("starting")),
+        permission=fake_permission,
+        audit=fake_audit,
+    )
+    result = await tool.execute(ctx)
+    _assert_error_details(result, error_code="BOT_NOT_READY", recoverable=True)
+    assert "discord_send_message" in result.message
+    assert "pronto" in result.message.lower()
+    assert "Tente novamente" in result.message
+
+
+async def test_timeout_format(fake_permission, fake_audit):
+    """BotClientTimeoutError → message + suggestion + error_details."""
+    from deile.integrations.bot.client import BotClientTimeoutError
+
+    tool = DiscordSendMessageTool()
+    ctx = make_context(
+        args={"channel_id": "400", "text": "x"},
+        fake_client=_make_error_client(BotClientTimeoutError("timed out")),
+        permission=fake_permission,
+        audit=fake_audit,
+    )
+    result = await tool.execute(ctx)
+    _assert_error_details(result, error_code="BOT_TIMEOUT", recoverable=True)
+    assert "discord_send_message" in result.message
+    assert "timeout" in result.message.lower()
+    assert "saudável" in result.message.lower()
+
+
+async def test_upstream_error_format_with_channel(fake_permission, fake_audit):
+    """BotClientUpstreamError → includes channel_id when available."""
+    from deile.integrations.bot.client import BotClientUpstreamError
+
+    tool = DiscordSendMessageTool()
+    ctx = make_context(
+        args={"channel_id": "999", "text": "test"},
+        fake_client=_make_error_client(BotClientUpstreamError("discord 500")),
+        permission=fake_permission,
+        audit=fake_audit,
+    )
+    result = await tool.execute(ctx)
+    _assert_error_details(result, error_code="BOT_UPSTREAM", recoverable=True)
+    assert "discord_send_message" in result.message
+    assert "999" in result.message  # channel_id present
+    assert "instabilidade" in result.message.lower()
+    assert "Tente novamente" in result.message
+
+
+def test_upstream_error_without_channel_direct():
+    """BotClientUpstreamError without channel_id → generic channel reference.
+
+    Tests _map_exception directly because discord_send_message._perform
+    requires channel_id (KeyError before the bot client is reached).
+    """
+    from deile.integrations.bot.client import BotClientUpstreamError
+
+    tool = DiscordSendMessageTool()
+    result = tool._map_exception(
+        BotClientUpstreamError("discord 500"), args={}
+    )
+    _assert_error_details(result, error_code="BOT_UPSTREAM", recoverable=True)
+    assert "discord_send_message" in result.message
+    # Without channel_id, no "canal <id>" in message — but "Discord" should appear
+    assert "Discord" in result.message
+    assert "falha" in result.message.lower()
+
+
+async def test_unknown_error_format(fake_permission, fake_audit):
+    """Unmapped exception → BOT_UNREACHABLE with diagnostic message."""
+    tool = DiscordSendMessageTool()
+    ctx = make_context(
+        args={"channel_id": "500", "text": "x"},
+        fake_client=_make_error_client(ValueError("unexpected")),
+        permission=fake_permission,
+        audit=fake_audit,
+    )
+    result = await tool.execute(ctx)
+    _assert_error_details(result, error_code="BOT_UNREACHABLE", recoverable=False)
+    assert "discord_send_message" in result.message
+    assert "ValueError" in result.message
+    assert "inesperada" in result.message.lower()
+
+
+async def test_error_messages_never_leak_sensitive_data(fake_permission, fake_audit):
+    """All error messages must be free of sensitive values (token, full text)."""
+    from deile.integrations.bot.client import (BotClientAuthError,
+                                                BotClientNotReady,
+                                                BotClientRateLimited,
+                                                BotClientTimeoutError,
+                                                BotClientUpstreamError)
+
+    exceptions = [
+        BotClientAuthError("tok_ABC123_secret"),
+        BotClientRateLimited("rate limit"),
+        BotClientNotReady("not ready"),
+        BotClientTimeoutError("timeout"),
+        BotClientUpstreamError("error"),
+        ValueError("unknown"),
+    ]
+    tool = DiscordSendMessageTool()
+    for exc in exceptions:
+        ctx = make_context(
+            args={"channel_id": "1", "text": "my-secret-payload"},
+            fake_client=_make_error_client(exc),
+            permission=fake_permission,
+            audit=fake_audit,
+            # clean audit between iterations
+        )
+        result = await tool.execute(ctx)
+        # The full message text must never appear in the error message
+        assert "my-secret-payload" not in result.message, (
+            f"{type(exc).__name__} message leaked text payload"
+        )
+        # The raw exception message with token-like content must not leak
+        if isinstance(exc, BotClientAuthError):
+            assert "tok_ABC123" not in result.message

--- a/deile/tools/messaging/_base.py
+++ b/deile/tools/messaging/_base.py
@@ -213,7 +213,7 @@ class MessagingTool(Tool, abc.ABC):
         try:
             data = await self._perform(facade, args)
         except Exception as exc:
-            err = self._map_exception(exc)
+            err = self._map_exception(exc, args)
             self._emit_audit(
                 audit,
                 "failed",
@@ -313,48 +313,148 @@ class MessagingTool(Tool, abc.ABC):
         )
         return None
 
-    def _map_exception(self, exc: Exception) -> ToolResult:
+    def _map_exception(
+        self, exc: Exception, args: Optional[Dict[str, Any]] = None
+    ) -> ToolResult:
         from ...integrations.bot.client import (BotClientAuthError,
                                                 BotClientNotReady,
                                                 BotClientRateLimited,
                                                 BotClientTimeoutError,
                                                 BotClientUpstreamError)
 
+        # Log full traceback at ERROR level for diagnostics.
+        logger.error("%s: erro mapeado — %s", self.tool_name, type(exc).__name__,
+                     exc_info=exc)
+
+        tool = self.tool_name
+        args = args or {}
+        channel_id = args.get("channel_id", "")
+
+        # ── BotClientAuthError ──────────────────────────────────────────
         if isinstance(exc, BotClientAuthError):
+            msg = (
+                f"{tool}: token de autenticação do deilebot rejeitado. "
+                f"O daemon deilebot não aceitou o token configurado. "
+                f"Verifique DEILE_BOT_AUTH_TOKEN."
+            )
             return ToolResult.error_result(
-                "control-plane rejected the auth token",
+                msg,
                 error=exc,
                 error_code="BOT_AUTH_ERROR",
+                metadata={
+                    "error_details": {
+                        "error_code": "BOT_AUTH_ERROR",
+                        "suggestion": "Verifique DEILE_BOT_AUTH_TOKEN",
+                        "recoverable": False,
+                    }
+                },
             )
+
+        # ── BotClientRateLimited ────────────────────────────────────────
         if isinstance(exc, BotClientRateLimited):
+            retry_after = getattr(exc, "retry_after", None)
+            if retry_after is not None:
+                suggestion = f"Aguarde {retry_after}s antes de reenviar."
+            else:
+                suggestion = "Aguarde antes de reenviar."
+            msg = (
+                f"{tool}: rate-limited pela API do Discord. "
+                f"O daemon deilebot foi limitado pela API do Discord. "
+                f"{suggestion}"
+            )
+            details: Dict[str, Any] = {
+                "error_code": "BOT_RATE_LIMITED",
+                "suggestion": suggestion,
+                "recoverable": True,
+            }
+            if retry_after is not None:
+                details["retry_after"] = retry_after
             return ToolResult.error_result(
-                "control-plane rate-limited the request",
+                msg,
                 error=exc,
                 error_code="BOT_RATE_LIMITED",
+                metadata={"error_details": details},
             )
+
+        # ── BotClientNotReady ───────────────────────────────────────────
         if isinstance(exc, BotClientNotReady):
+            msg = (
+                f"{tool}: deilebot não está pronto. "
+                f"O daemon pode estar iniciando ou indisponível. "
+                f"Tente novamente em alguns segundos."
+            )
             return ToolResult.error_result(
-                "deilebot adapter not ready",
+                msg,
                 error=exc,
                 error_code="BOT_NOT_READY",
+                metadata={
+                    "error_details": {
+                        "error_code": "BOT_NOT_READY",
+                        "suggestion": "Tente novamente em alguns segundos",
+                        "recoverable": True,
+                    }
+                },
             )
+
+        # ── BotClientTimeoutError ───────────────────────────────────────
         if isinstance(exc, BotClientTimeoutError):
+            msg = (
+                f"{tool}: timeout ao enviar requisição. "
+                f"O daemon deilebot não respondeu a tempo. "
+                f"Verifique se o serviço deilebot está saudável e tente novamente."
+            )
             return ToolResult.error_result(
-                "control-plane timed out",
+                msg,
                 error=exc,
                 error_code="BOT_TIMEOUT",
+                metadata={
+                    "error_details": {
+                        "error_code": "BOT_TIMEOUT",
+                        "suggestion": "Verifique se o serviço deilebot está saudável",
+                        "recoverable": True,
+                    }
+                },
             )
+
+        # ── BotClientUpstreamError ──────────────────────────────────────
         if isinstance(exc, BotClientUpstreamError):
+            if channel_id:
+                prefix = f"{tool}: falha ao postar no canal {channel_id}."
+            else:
+                prefix = f"{tool}: falha ao comunicar com o Discord."
+            msg = (
+                f"{prefix} "
+                f"O daemon deilebot recebeu erro da API do Discord "
+                f"(possível instabilidade temporária ou payload inválido). "
+                f"Tente novamente em alguns segundos."
+            )
             return ToolResult.error_result(
-                "control-plane upstream error (Discord side?)",
+                msg,
                 error=exc,
                 error_code="BOT_UPSTREAM",
+                metadata={
+                    "error_details": {
+                        "error_code": "BOT_UPSTREAM",
+                        "suggestion": "Tente novamente em alguns segundos",
+                        "recoverable": True,
+                    }
+                },
             )
-        # Unknown error → BOT_UNREACHABLE so the surface stays uniform.
+
+        # ── Unknown error → BOT_UNREACHABLE ────────────────────────────
         return ToolResult.error_result(
-            f"messaging tool failed: {type(exc).__name__}",
+            f"{tool}: falha inesperada ({type(exc).__name__}). "
+            f"Erro não classificado na comunicação com o deilebot. "
+            f"Verifique os logs do daemon para diagnóstico.",
             error=exc,
             error_code="BOT_UNREACHABLE",
+            metadata={
+                "error_details": {
+                    "error_code": "BOT_UNREACHABLE",
+                    "suggestion": "Verifique os logs do daemon para diagnóstico",
+                    "recoverable": False,
+                }
+            },
         )
 
     def _success_message(self, data: Dict[str, Any], args: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Resumo

Reescreve `MessagingTool._map_exception()` para produzir mensagens de erro diagnósticas, amigáveis e acionáveis — substituindo strings genéricas como "control-plane upstream error" por mensagens que incluem causa provável, sugestão de ação e metadados estruturados.

## Mudanças

### `deile/tools/messaging/_base.py`
- **`_map_exception()`** agora produz mensagens no formato: `[tool_name] <descrição>. <causa provável>. <sugestão>`
- Cada `ToolResult.error_result()` inclui `error_details` no metadata: `{error_code, suggestion, recoverable, retry_after?}`
- Log em nível ERROR com traceback completo para diagnóstico
- Aceita `args` opcional para incluir `channel_id` na mensagem de `BotClientUpstreamError`
- O `error_code` permanece no metadata para consumo programático (backward-compatible)

### `deile/tests/tools/messaging/test_discord_send_message.py`
- 9 novos testes unitários cobrindo todos os tipos de erro
- Testes de formato: mensagem contém tool_name, sugestão, causa provável
- Teste de `retry_after` em `BotClientRateLimited`
- Teste de sanitização: mensagens NÃO vazam dados sensíveis (token, payload)

## Testes

```
3270 passed, 16 skipped, 0 warnings in 73.60s
```

---

Closes #280.

By [DEILE-One](mailto:deile@deile.info)