### PR TITLE
feat: comando /todo — lista TODO/FIXME/HACK/XXX em tabela Rich

### DIFF
--- a/deile/commands/builtin/todo_command.py
+++ b/deile/commands/builtin/todo_command.py
@@ -1,0 +1,270 @@
+"""Comando /todo — listar TODO/FIXME/HACK/XXX do código numa tabela Rich.
+
+Varre os arquivos versionados do projeto (via ``git ls-files``), encontra
+comentários com os marcadores TODO, FIXME, HACK e XXX (case-insensitive,
+palavra completa) e apresenta-os numa tabela Rich agrupada por arquivo,
+com linha, autor (via ``git blame``) e idade em dias.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import time
+from pathlib import Path
+
+from rich.table import Table
+from rich.text import Text
+
+from ...core.exceptions import CommandError
+from ..base import CommandContext, CommandResult, DirectCommand
+from ._shared import wrap_command_errors
+
+logger = logging.getLogger(__name__)
+
+# Marcadores reconhecidos: case-insensitive, palavra completa.
+_MARKER_PATTERN = re.compile(
+    r"\b(TODO|FIXME|HACK|XXX)\b",
+    re.IGNORECASE,
+)
+
+# Linhas que são comentários em Python, shell, YAML, toml, etc.
+# Cobrimos também C-style (// e /*) pois o repo pode ter JS/TS.
+_COMMENT_GUARD = re.compile(
+    r"^\s*(#|//|/\*|\*|REM\s)",
+)
+
+
+def _is_comment_line(line: str) -> bool:
+    """Heurística: linha começa com prefixo de comentário conhecido."""
+    return bool(_COMMENT_GUARD.match(line))
+
+
+class TodoCommand(DirectCommand):
+    """Comando /todo — tabela de débito técnico do código."""
+
+    cli_flag = "--todo"
+    cli_help = "List TODO/FIXME/HACK/XXX markers in versioned source files."
+    cli_requires_provider = False
+
+    def __init__(self):
+        from ...config.manager import CommandConfig
+
+        config = CommandConfig(
+            name="todo",
+            description="Lista TODO/FIXME/HACK/XXX do código numa tabela Rich.",
+            action="list_todos",
+        )
+        super().__init__(config)
+        self.category = "code_quality"
+
+    @wrap_command_errors("todo", message_template="Falha ao executar /{name}: {exc}")
+    async def execute(self, context: CommandContext) -> CommandResult:
+        repo_root = self._resolve_repo_root()
+        markers = self._scan_markers(repo_root)
+        if not markers:
+            msg = Text(
+                "Nenhum TODO/FIXME/HACK/XXX encontrado 🎉",
+                style="green",
+            )
+            return CommandResult.success_result(msg, "rich", marker_count=0)
+
+        table = self._build_table(markers)
+        header = Text(
+            f"Encontrei {len(markers)} marcador{'es' if len(markers) > 1 else ''} "
+            f"em {len({m['file'] for m in markers})} arquivo{'s' if len({m['file'] for m in markers}) > 1 else ''}:",
+            style="bold",
+        )
+        from rich.console import Group
+        return CommandResult.success_result(
+            Group(header, table), "rich", marker_count=len(markers)
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_repo_root() -> Path:
+        """Encontra a raiz do repo git a partir do CWD."""
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                return Path(result.stdout.strip())
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            raise CommandError(f"git rev-parse falhou: {exc}") from exc
+        raise CommandError("Não foi possível determinar a raiz do repositório git")
+
+    def _scan_markers(self, repo_root: Path) -> list[dict]:
+        """Varre os arquivos versionados e retorna lista de marcadores encontrados.
+
+        Cada entrada: {"file": rel_path, "line": int, "marker": str, "author": str, "age_days": int}
+        """
+        # 1. Lista arquivos versionados
+        files = self._git_ls_files(repo_root)
+
+        # 2. Encontra marcadores em cada arquivo
+        markers: list[dict] = []
+        for rel_path in files:
+            abs_path = repo_root / rel_path
+            if not abs_path.is_file():
+                continue
+            # Pula binários (heurística: null byte nas primeiras 8KB)
+            try:
+                text = abs_path.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+
+            # Pula se parece binário
+            if "\0" in text[:8192]:
+                continue
+
+            file_markers = self._find_markers_in_text(rel_path, text)
+            if not file_markers:
+                continue
+
+            # 3. Obtém blame info para este arquivo
+            blame_info = self._git_blame_file(repo_root, rel_path)
+
+            for m in file_markers:
+                line_no = m["line"]
+                blame = blame_info.get(line_no, {})
+                author = blame.get("author", "?")
+                age_days = self._calc_age_days(blame.get("committer_time"))
+                markers.append({
+                    "file": rel_path,
+                    "line": line_no,
+                    "marker": m["marker"],
+                    "author": author,
+                    "age_days": age_days,
+                })
+
+        return markers
+
+    @staticmethod
+    def _git_ls_files(repo_root: Path) -> list[str]:
+        """Retorna lista de paths relativos versionados via ``git ls-files``."""
+        try:
+            result = subprocess.run(
+                ["git", "ls-files"],
+                capture_output=True, text=True, timeout=30,
+                cwd=str(repo_root),
+            )
+            if result.returncode != 0:
+                raise CommandError(f"git ls-files falhou: {result.stderr.strip()}")
+            lines = result.stdout.strip().split("\n")
+            return [l for l in lines if l]
+        except subprocess.TimeoutExpired as exc:
+            raise CommandError(f"git ls-files timeout: {exc}") from exc
+        except FileNotFoundError as exc:
+            raise CommandError(f"git não encontrado: {exc}") from exc
+
+    @staticmethod
+    def _find_markers_in_text(rel_path: str, text: str) -> list[dict]:
+        """Encontra marcadores em ``text``, retorna lista de {"line": int, "marker": str}."""
+        found: list[dict] = []
+        for line_no, line in enumerate(text.split("\n"), start=1):
+            # Só considera linhas que parecem comentários
+            if not _is_comment_line(line):
+                continue
+            for match in _MARKER_PATTERN.finditer(line):
+                found.append({"line": line_no, "marker": match.group(1).upper()})
+        return found
+
+    @staticmethod
+    def _git_blame_file(repo_root: Path, rel_path: str) -> dict[int, dict]:
+        """Executa ``git blame --line-porcelain`` e retorna mapa linha → info de autor.
+
+        Retorna: {line_no: {"author": str, "committer_time": int or None}, ...}
+        """
+        blame_map: dict[int, dict] = {}
+        try:
+            result = subprocess.run(
+                ["git", "blame", "--line-porcelain", rel_path],
+                capture_output=True, text=True, timeout=30,
+                cwd=str(repo_root),
+            )
+            if result.returncode != 0:
+                logger.debug("git blame falhou para %s: %s", rel_path, result.stderr.strip())
+                return blame_map
+
+            # Parse do formato --line-porcelain:
+            # Cada bloco começa com: <hash> <orig_lineno> <final_lineno> <num_lines>
+            # Seguido por pares key value (ex: "author João", "committer-time 1234567890")
+            current_line = None
+            current_info: dict[str, str] = {}
+            for raw_line in result.stdout.split("\n"):
+                if raw_line.startswith("\t"):
+                    # Linha de conteúdo (ignoramos)
+                    if current_line is not None:
+                        blame_map[current_line] = dict(current_info)
+                    current_line = None
+                    current_info = {}
+                    continue
+
+                if not raw_line.strip():
+                    continue
+
+                # Pode ser header (hash orig final nlines) ou key-value
+                parts = raw_line.split()
+                if not parts:
+                    continue
+
+                if len(parts) >= 4 and all(p.isdigit() for p in parts[1:4]) and len(parts[0]) == 40:
+                    # Header: commit_hash orig_line final_line num_lines
+                    current_line = int(parts[2])
+                    current_info = {}
+                elif " " in raw_line:
+                    # key-value (primeiro espaço separa chave do valor)
+                    idx = raw_line.index(" ")
+                    key = raw_line[:idx]
+                    value = raw_line[idx + 1:]
+                    if current_line is not None:
+                        current_info[key] = value
+
+            # Último bloco (sem \t final? improvável mas seguro)
+            if current_line is not None and current_info:
+                blame_map[current_line] = dict(current_info)
+
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            logger.debug("git blame exceção para %s: %s", rel_path, exc)
+
+        return blame_map
+
+    @staticmethod
+    def _calc_age_days(committer_time: str | None) -> int | str:
+        """Calcula idade em dias a partir do timestamp Unix do committer."""
+        if committer_time is None:
+            return "?"
+        try:
+            ts = int(committer_time)
+            age_seconds = int(time.time()) - ts
+            return max(0, age_seconds // 86400)
+        except (ValueError, TypeError):
+            return "?"
+
+    def _build_table(self, markers: list[dict]) -> Table:
+        """Constrói tabela Rich com os marcadores."""
+        table = Table(show_header=True, header_style="bold cyan")
+        table.add_column("Arquivo", style="cyan", no_wrap=False, max_width=55)
+        table.add_column("Linha", style="yellow", justify="right", width=6)
+        table.add_column("Autor", style="green", width=18)
+        table.add_column("Idade", style="magenta", justify="right", width=8)
+        table.add_column("Marcador", style="bold red", width=8)
+
+        # Ordena por arquivo, depois linha
+        for m in sorted(markers, key=lambda x: (x["file"], x["line"])):
+            age_str = f"{m['age_days']}d" if isinstance(m["age_days"], int) else "?"
+            table.add_row(
+                str(m["file"]),
+                str(m["line"]),
+                m["author"],
+                age_str,
+                m["marker"],
+            )
+
+        return table

--- a/deile/tests/commands/test_todo_command.py
+++ b/deile/tests/commands/test_todo_command.py
@@ -1,0 +1,327 @@
+"""Testes do comando /todo (issue #287).
+
+Cobre:
+  - Git repo com 2 TODOs em 2 arquivos → comando lista os 2
+  - Repo sem marcadores → mensagem amigável
+  - Case-insensitive: FIXME, fixme, FixMe todos reconhecidos
+  - Marcadores HACK e XXX
+  - Arquivo sem comentários → ignorado
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from deile.commands.base import CommandContext
+from deile.commands.builtin.todo_command import (
+    _is_comment_line,
+    TodoCommand,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _render(content) -> str:
+    buf = StringIO()
+    console = Console(file=buf, no_color=True, width=200)
+    console.print(content)
+    return buf.getvalue()
+
+
+def _ctx(args: str = "") -> CommandContext:
+    return CommandContext(user_input="/todo", args=args)
+
+
+def _cmd() -> TodoCommand:
+    return TodoCommand()
+
+
+def _run_git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git"] + list(args),
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "Test User",
+             "GIT_AUTHOR_EMAIL": "test@example.com",
+             "GIT_COMMITTER_NAME": "Test User",
+             "GIT_COMMITTER_EMAIL": "test@example.com"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_repo_with_todos(tmp_path: Path) -> Path:
+    """Cria um repo git temporário com arquivos contendo TODOs."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    _run_git(repo, "init")
+
+    # Arquivo 1: dois TODOs
+    (repo / "main.py").write_text(
+        '# TODO: add error handling\n'
+        'def main():\n'
+        '    print("hello")\n'
+        '    # FIXME: this is slow\n'
+        '    pass\n'
+    )
+    _run_git(repo, "add", "main.py")
+    _run_git(repo, "commit", "-m", "initial commit with todos")
+
+    # Arquivo 2: um HACK
+    (repo / "utils.py").write_text(
+        '"""Utils module."""\n'
+        '# HACK: workaround for bug #42\n'
+        'def util():\n'
+        '    return True\n'
+    )
+    _run_git(repo, "add", "utils.py")
+    _run_git(repo, "commit", "-m", "add utils with hack")
+
+    return repo
+
+
+@pytest.fixture
+def git_repo_no_markers(tmp_path: Path) -> Path:
+    """Repo sem marcadores."""
+    repo = tmp_path / "clean_repo"
+    repo.mkdir()
+    _run_git(repo, "init")
+
+    (repo / "clean.py").write_text(
+        '"""Clean module with no TODOs."""\n'
+        'def func():\n'
+        '    # just a regular comment\n'
+        '    pass\n'
+    )
+    _run_git(repo, "add", "clean.py")
+    _run_git(repo, "commit", "-m", "clean commit")
+    return repo
+
+
+@pytest.fixture
+def git_repo_case_sensitivity(tmp_path: Path) -> Path:
+    """Repo com marcadores em diferentes capitalizações."""
+    repo = tmp_path / "case_repo"
+    repo.mkdir()
+    _run_git(repo, "init")
+
+    (repo / "mixed.py").write_text(
+        '# TODO: normal\n'
+        '# todo: lowercase\n'
+        '# Todo: title case\n'
+        '# FIXME: normal\n'
+        '# fixme: lowercase\n'
+        '# FixMe: mixed\n'
+        '# HACK: normal\n'
+        '# XXX: normal\n'
+        'print("test")\n'
+    )
+    _run_git(repo, "add", "mixed.py")
+    _run_git(repo, "commit", "-m", "mixed case todos")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Testes unitários — _is_comment_line
+# ---------------------------------------------------------------------------
+
+
+class TestIsCommentLine:
+    def test_python_comment(self):
+        assert _is_comment_line("# TODO: fix this")
+
+    def test_shell_comment(self):
+        assert _is_comment_line("# FIXME: broken")
+
+    def test_js_comment(self):
+        assert _is_comment_line("// HACK: workaround")
+
+    def test_block_comment(self):
+        assert _is_comment_line("/* XXX: danger */")
+
+    def test_non_comment(self):
+        assert not _is_comment_line("print('TODO')")
+
+    def test_indented_comment(self):
+        assert _is_comment_line("    # FIXME: bug")
+
+    def test_empty(self):
+        assert not _is_comment_line("")
+
+
+# ---------------------------------------------------------------------------
+# Testes de integração
+# ---------------------------------------------------------------------------
+
+
+class TestTodoWithMarkers:
+    async def test_lists_all_markers(self, git_repo_with_todos: Path):
+        """Repo com 2 arquivos e 3 marcadores → lista todos."""
+        with _cd(git_repo_with_todos):
+            result = await _cmd().execute(_ctx())
+        assert result.success
+        assert result.content_type == "rich"
+        rendered = _render(result.content)
+        assert "TODO" in rendered
+        assert "FIXME" in rendered
+        assert "HACK" in rendered
+        assert "main.py" in rendered
+        assert "utils.py" in rendered
+        assert result.metadata["marker_count"] == 3
+
+    async def test_marker_count_in_metadata(self, git_repo_with_todos: Path):
+        with _cd(git_repo_with_todos):
+            result = await _cmd().execute(_ctx())
+        assert result.metadata["marker_count"] == 3
+
+
+class TestTodoEmptyRepo:
+    async def test_no_markers_friendly_message(self, git_repo_no_markers: Path):
+        """Repo sem marcadores → mensagem amigável."""
+        with _cd(git_repo_no_markers):
+            result = await _cmd().execute(_ctx())
+        assert result.success
+        rendered = _render(result.content)
+        assert "Nenhum" in rendered
+        assert "🎉" in rendered
+        assert result.metadata["marker_count"] == 0
+
+    async def test_no_markers_content_type(self, git_repo_no_markers: Path):
+        with _cd(git_repo_no_markers):
+            result = await _cmd().execute(_ctx())
+        assert result.content_type == "rich"
+
+
+class TestCaseInsensitive:
+    async def test_all_variants_recognized(self, git_repo_case_sensitivity: Path):
+        """Todas as capitalizações são reconhecidas."""
+        with _cd(git_repo_case_sensitivity):
+            result = await _cmd().execute(_ctx())
+        assert result.success
+        rendered = _render(result.content)
+        # Deve encontrar todos os 8 marcadores
+        assert result.metadata["marker_count"] == 8
+        for marker in ["TODO", "FIXME", "HACK", "XXX"]:
+            assert marker in rendered
+
+    async def test_lowercase_todo_recognized(self, git_repo_case_sensitivity: Path):
+        with _cd(git_repo_case_sensitivity):
+            result = await _cmd().execute(_ctx())
+        rendered = _render(result.content)
+        # "todo" minúsculo deve ser normalizado para "TODO" na coluna Marcador
+        assert "TODO" in rendered
+
+
+class TestTodoOutsideGit:
+    async def test_command_error_when_not_in_git(self, tmp_path: Path):
+        """Fora de repo git → CommandError."""
+        with _cd(tmp_path):
+            with pytest.raises(Exception):
+                await _cmd().execute(_ctx())
+
+
+class TestContentType:
+    async def test_content_type_is_rich(self, git_repo_with_todos: Path):
+        with _cd(git_repo_with_todos):
+            result = await _cmd().execute(_ctx())
+        assert result.content_type == "rich"
+
+    async def test_content_not_string(self, git_repo_with_todos: Path):
+        with _cd(git_repo_with_todos):
+            result = await _cmd().execute(_ctx())
+        assert not isinstance(result.content, str)
+
+
+class TestTableColumns:
+    async def test_table_has_correct_columns(self, git_repo_with_todos: Path):
+        with _cd(git_repo_with_todos):
+            result = await _cmd().execute(_ctx())
+        rendered = _render(result.content)
+        assert "Arquivo" in rendered
+        assert "Linha" in rendered
+        assert "Autor" in rendered
+        assert "Idade" in rendered
+        assert "Marcador" in rendered
+
+
+class TestIntegrationWithGit:
+    async def test_git_ls_files_respects_gitignore(self, tmp_path: Path):
+        """Arquivos em .gitignore não são escaneados."""
+        repo = tmp_path / "ignored_repo"
+        repo.mkdir()
+        _run_git(repo, "init")
+
+        (repo / ".gitignore").write_text("ignored/\n")
+        (repo / "tracked.py").write_text("# TODO: visible\n")
+        (repo / "ignored").mkdir()
+        (repo / "ignored" / "hidden.py").write_text("# TODO: should not appear\n")
+
+        _run_git(repo, "add", ".gitignore", "tracked.py")
+        _run_git(repo, "commit", "-m", "with gitignore")
+
+        with _cd(repo):
+            result = await _cmd().execute(_ctx())
+        assert result.success
+        rendered = _render(result.content)
+        assert "tracked.py" in rendered
+        assert "hidden.py" not in rendered
+        assert result.metadata["marker_count"] == 1
+
+
+class TestHACKandXXX:
+    async def test_hack_marker(self, git_repo_with_todos: Path):
+        with _cd(git_repo_with_todos):
+            result = await _cmd().execute(_ctx())
+        rendered = _render(result.content)
+        assert "HACK" in rendered
+
+    async def test_xxx_marker(self, tmp_path: Path):
+        """Testa o marcador XXX especificamente."""
+        repo = tmp_path / "xxx_repo"
+        repo.mkdir()
+        _run_git(repo, "init")
+        (repo / "code.py").write_text("# XXX: dangerous code path\nprint('hi')\n")
+        _run_git(repo, "add", "code.py")
+        _run_git(repo, "commit", "-m", "xxx test")
+
+        with _cd(repo):
+            result = await _cmd().execute(_ctx())
+        assert result.success
+        rendered = _render(result.content)
+        assert "XXX" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Helper: change directory as context manager
+# ---------------------------------------------------------------------------
+
+
+class _cd:
+    """Context manager para mudar temporariamente de diretório."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._prev = None
+
+    def __enter__(self):
+        self._prev = os.getcwd()
+        os.chdir(str(self.path))
+        return self
+
+    def __exit__(self, *args):
+        os.chdir(self._prev)


### PR DESCRIPTION
Adiciona o comando slash `/todo` que varre os arquivos versionados do projeto via `git ls-files` e apresenta comentários `TODO`, `FIXME`, `HACK` e `XXX` numa tabela Rich.

### Funcionalidades
- **Marcadores reconhecidos**: TODO, FIXME, HACK, XXX (case-insensitive, word boundary)
- **Varredura**: `git ls-files` (respeita `.gitignore`)
- **Tabela Rich**: colunas Arquivo, Linha, Autor (via `git blame`), Idade (dias), Marcador
- **Mensagem amigável**: "Nenhum TODO/FIXME/HACK/XXX encontrado 🎉" quando não há marcadores

### Arquivos
- `deile/commands/builtin/todo_command.py` — implementação do comando (herda de `DirectCommand`)
- `deile/tests/commands/test_todo_command.py` — 20 testes unitários e de integração

### Testes
- Suíte completa: **3350 passed, 17 skipped, 0 failures**
- Cobertura: fixture com marcadores → lista todos; fixture vazia → mensagem amigável; case-insensitive; `git ls-files` respeita `.gitignore`; marcadores HACK e XXX

Closes #287.

---

By [DEILE-One](mailto:deile@deile.info)