### PR TITLE
feat: comando /loc para estatísticas do código-base

### DIFF
--- a/deile/commands/builtin/loc_command.py
+++ b/deile/commands/builtin/loc_command.py
@@ -86,7 +86,8 @@ class LocCommand(DirectCommand):
                     try:
                         with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
                             for line in f:
-                                if line.strip().startswith("def test_"):
+                                stripped = line.strip()
+                                if stripped.startswith("def test_") or stripped.startswith("async def test_"):
                                     count += 1
                     except Exception:
                         pass
@@ -165,5 +166,7 @@ class LocCommand(DirectCommand):
             "rich",
             total_files=total_files,
             total_lines=total_lines,
-            total_tests=total_tests
+            total_tests=total_tests,
+            lang_stats=dict(lang_stats),
+            top_files=top_files
         )

--- a/deile/commands/builtin/loc_command.py
+++ b/deile/commands/builtin/loc_command.py
@@ -1,0 +1,169 @@
+"""Comando /loc — exibe estatísticas do código-base (issue #285)."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from ..base import CommandContext, CommandResult, DirectCommand
+
+logger = logging.getLogger(__name__)
+
+class LocCommand(DirectCommand):
+    """``/loc`` — exibe estatísticas do código-base."""
+
+    cli_flag = "--loc"
+    cli_help = "Exibe estatísticas do código-base e sai."
+    cli_requires_provider = False
+
+    def __init__(self) -> None:
+        from ...config.manager import CommandConfig
+        config = CommandConfig(
+            name="loc",
+            description="Exibe estatísticas do código-base (linhas, arquivos, testes).",
+            aliases=["estatisticas"],
+        )
+        super().__init__(config)
+        self.category = "system"
+
+    def _get_git_files(self, cwd: str) -> list[str]:
+        try:
+            result = subprocess.run(
+                ["git", "ls-files"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            return [f for f in result.stdout.splitlines() if f.strip()]
+        except subprocess.CalledProcessError as exc:
+            logger.warning("Falha ao executar git ls-files: %s", exc)
+            return []
+        except FileNotFoundError:
+            logger.warning("Git não encontrado no sistema.")
+            return []
+
+    def _count_lines(self, filepath: str) -> int:
+        try:
+            with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+                return sum(1 for _ in f)
+        except Exception:
+            return 0
+
+    def _get_language(self, filename: str) -> str:
+        ext = os.path.splitext(filename)[1].lower()
+        if ext == ".py":
+            return "Python"
+        elif ext == ".md":
+            return "Markdown"
+        elif ext in (".yaml", ".yml"):
+            return "YAML"
+        elif ext == ".json":
+            return "JSON"
+        elif ext == ".sh":
+            return "Shell"
+        else:
+            return "Other"
+
+    def _count_tests(self, cwd: str) -> int:
+        test_dir = Path(cwd) / "deile" / "tests"
+        if not test_dir.exists():
+            return 0
+        
+        count = 0
+        for root, _, files in os.walk(test_dir):
+            for file in files:
+                if file.endswith(".py"):
+                    filepath = os.path.join(root, file)
+                    try:
+                        with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+                            for line in f:
+                                if line.strip().startswith("def test_"):
+                                    count += 1
+                    except Exception:
+                        pass
+        return count
+
+    async def execute(self, context: CommandContext) -> CommandResult:
+        """Renderiza estatísticas do código-base."""
+        cwd = context.working_directory or os.getcwd()
+        
+        files = self._get_git_files(cwd)
+        
+        lang_stats = defaultdict(lambda: {"files": 0, "lines": 0})
+        file_sizes = []
+        
+        total_files = 0
+        total_lines = 0
+        
+        for file in files:
+            filepath = os.path.join(cwd, file)
+            if not os.path.isfile(filepath):
+                continue
+                
+            lines = self._count_lines(filepath)
+            lang = self._get_language(file)
+            
+            lang_stats[lang]["files"] += 1
+            lang_stats[lang]["lines"] += lines
+            
+            file_sizes.append((file, lines))
+            
+            total_files += 1
+            total_lines += lines
+            
+        # Ordenar linguagens por número de linhas (decrescente)
+        sorted_langs = sorted(lang_stats.items(), key=lambda x: x[1]["lines"], reverse=True)
+        
+        # Top 5 maiores arquivos
+        top_files = sorted(file_sizes, key=lambda x: x[1], reverse=True)[:5]
+        
+        # Total de testes
+        total_tests = self._count_tests(cwd)
+        
+        # --- Tabela de Linguagens ---
+        table = Table(title="Linhas por linguagem", title_justify="left")
+        table.add_column("Linguagem", style="cyan")
+        table.add_column("Arquivos", justify="right", style="green")
+        table.add_column("Linhas", justify="right", style="yellow")
+        
+        for lang, stats in sorted_langs:
+            table.add_row(lang, str(stats["files"]), str(stats["lines"]))
+            
+        # --- Top 5 Arquivos ---
+        top_files_text = Text()
+        top_files_text.append("Top 5 maiores arquivos\n", style="bold")
+        for file, lines in top_files:
+            top_files_text.append(f"- {file} — {lines} linhas\n")
+            
+        # --- Resumo ---
+        summary_text = Text(f"\nTotal: {total_files} arquivos · {total_lines} linhas · {total_tests} testes pytest", style="bold")
+        
+        content = Group(
+            table,
+            Text(""),
+            top_files_text,
+            summary_text
+        )
+        
+        panel = Panel(
+            content,
+            title="[bold]📊 DEILE — Estatísticas do código-base[/bold]",
+            border_style="blue",
+        )
+        
+        return CommandResult.success_result(
+            panel,
+            "rich",
+            total_files=total_files,
+            total_lines=total_lines,
+            total_tests=total_tests
+        )

--- a/deile/tests/commands/builtin/test_loc_command.py
+++ b/deile/tests/commands/builtin/test_loc_command.py
@@ -1,0 +1,71 @@
+"""Testes para o comando /loc."""
+
+import os
+from unittest.mock import patch, MagicMock
+import pytest
+
+from deile.commands.base import CommandContext, CommandStatus
+from deile.commands.builtin.loc_command import LocCommand
+
+@pytest.fixture
+def loc_command():
+    return LocCommand()
+
+@pytest.mark.asyncio
+async def test_loc_command_execute(loc_command, tmp_path):
+    # Setup a fake repository
+    repo_dir = tmp_path / "fake_repo"
+    repo_dir.mkdir()
+    
+    # Create some fake files
+    (repo_dir / "file1.py").write_text("print('hello')\nprint('world')\n")
+    (repo_dir / "file2.md").write_text("# Title\n\nSome text\n")
+    (repo_dir / "file3.yaml").write_text("key: value\n")
+    
+    # Create a fake test file
+    test_dir = repo_dir / "deile" / "tests"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_fake.py").write_text("def test_something():\n    pass\n")
+    
+    # Mock git ls-files
+    def mock_run(*args, **kwargs):
+        mock_result = MagicMock()
+        mock_result.stdout = "file1.py\nfile2.md\nfile3.yaml\ndeile/tests/test_fake.py\n"
+        return mock_result
+        
+    with patch("subprocess.run", side_effect=mock_run):
+        ctx = CommandContext(user_input="/loc", working_directory=str(repo_dir))
+        result = await loc_command.execute(ctx)
+        
+        assert result.status == CommandStatus.SUCCESS
+        assert result.content_type == "rich"
+        
+        # Check metadata
+        assert result.metadata["total_files"] == 4
+        assert result.metadata["total_lines"] == 8
+        assert result.metadata["total_tests"] == 1
+
+@pytest.mark.asyncio
+async def test_loc_command_git_error(loc_command, tmp_path):
+    import subprocess
+    
+    def mock_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(128, "git")
+        
+    with patch("subprocess.run", side_effect=mock_run):
+        ctx = CommandContext(user_input="/loc", working_directory=str(tmp_path))
+        result = await loc_command.execute(ctx)
+        
+        assert result.status == CommandStatus.SUCCESS
+        assert result.metadata["total_files"] == 0
+        assert result.metadata["total_lines"] == 0
+        assert result.metadata["total_tests"] == 0
+
+def test_get_language(loc_command):
+    assert loc_command._get_language("test.py") == "Python"
+    assert loc_command._get_language("README.md") == "Markdown"
+    assert loc_command._get_language("config.yaml") == "YAML"
+    assert loc_command._get_language("config.yml") == "YAML"
+    assert loc_command._get_language("data.json") == "JSON"
+    assert loc_command._get_language("script.sh") == "Shell"
+    assert loc_command._get_language("unknown.txt") == "Other"

--- a/deile/tests/commands/builtin/test_loc_command.py
+++ b/deile/tests/commands/builtin/test_loc_command.py
@@ -1,7 +1,7 @@
 """Testes para o comando /loc."""
 
-import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from deile.commands.base import CommandContext, CommandStatus
@@ -25,7 +25,7 @@ async def test_loc_command_execute(loc_command, tmp_path):
     # Create a fake test file
     test_dir = repo_dir / "deile" / "tests"
     test_dir.mkdir(parents=True)
-    (test_dir / "test_fake.py").write_text("def test_something():\n    pass\n")
+    (test_dir / "test_fake.py").write_text("def test_something():\n    pass\nasync def test_async_something():\n    pass\n")
     
     # Mock git ls-files
     def mock_run(*args, **kwargs):
@@ -42,8 +42,25 @@ async def test_loc_command_execute(loc_command, tmp_path):
         
         # Check metadata
         assert result.metadata["total_files"] == 4
-        assert result.metadata["total_lines"] == 8
-        assert result.metadata["total_tests"] == 1
+        assert result.metadata["total_lines"] == 10
+        assert result.metadata["total_tests"] == 2
+        
+        # Check lang_stats
+        lang_stats = result.metadata["lang_stats"]
+        assert lang_stats["Python"]["files"] == 2
+        assert lang_stats["Python"]["lines"] == 6
+        assert lang_stats["Markdown"]["files"] == 1
+        assert lang_stats["Markdown"]["lines"] == 3
+        assert lang_stats["YAML"]["files"] == 1
+        assert lang_stats["YAML"]["lines"] == 1
+        
+        # Check top_files
+        top_files = result.metadata["top_files"]
+        assert len(top_files) == 4
+        assert top_files[0] == ("deile/tests/test_fake.py", 4)
+        assert top_files[1] == ("file2.md", 3)
+        assert top_files[2] == ("file1.py", 2)
+        assert top_files[3] == ("file3.yaml", 1)
 
 @pytest.mark.asyncio
 async def test_loc_command_git_error(loc_command, tmp_path):


### PR DESCRIPTION
Adiciona o comando `/loc` que exibe um painel Rich com estatísticas do código-base (linhas por linguagem, total de arquivos, top 5 maiores arquivos e número de testes).

Closes #285.

---
By [DEILE-One](mailto:deile@deile.info)