### PR TITLE
feat(panel): live TUI monitoring panel for the DEILE stack

### DIFF
--- a/deile/core/agent.py
+++ b/deile/core/agent.py
@@ -1776,12 +1776,32 @@ class DeileAgent:
                     logger.info("Sent message with %d file attachments", len(context["file_data_parts"]))
 
                 try:
-                    content, tool_results = await model_provider._gemini_chat_with_tools(
+                    # `_gemini_chat_with_tools` agora devolve 3-tuple:
+                    # (text, tool_results, ModelUsage agregado). Antes desse
+                    # fix, retornava só 2-tuple e o usage era descartado —
+                    # gemini nunca registrava nada na DB de custos.
+                    content, tool_results, _gemini_usage = await model_provider._gemini_chat_with_tools(
                         chat=chat,
                         message=message_content,
                         working_directory=str(session.working_directory),
                         session_data=session.context_data,
                     )
+                    # Persiste o usage agregado — sem isso, o caminho legado
+                    # (que ainda é o default no agent) seguiria sem registrar
+                    # nada mesmo com o helper preenchendo os tokens corretos.
+                    try:
+                        latency_ms = int((time.time() - _t0) * 1000)
+                        await model_provider._record_usage(
+                            session_id=str(session.session_id),
+                            usage=_gemini_usage,
+                            latency_ms=latency_ms,
+                            success=True,
+                        )
+                    except Exception as _rec_err:  # noqa: BLE001 — telemetry must never block
+                        logger.debug(
+                            "gemini usage record (agent path) failed: %s",
+                            _rec_err,
+                        )
                     _self_record_circuit(model_provider.provider_id, success=True)
                 except Exception as _gemini_err:
                     _self_record_circuit(model_provider.provider_id, success=False)

--- a/deile/core/models/gemini_provider.py
+++ b/deile/core/models/gemini_provider.py
@@ -292,10 +292,10 @@ class GeminiProvider(ModelProvider):
             response = await self._generate_with_new_sdk(
                 processed_messages, system_instruction, config
             )
-            
+
             # Calcula tempo de execução
             execution_time = time.time() - start_time
-            
+
             # Log response se debug ativo
             if is_debug_enabled():
                 await self.debug_logger.log_response(
@@ -303,7 +303,23 @@ class GeminiProvider(ModelProvider):
                     execution_time=execution_time,
                     request_id=self.debug_logger.request_count
                 )
-            
+
+            # Persiste usage (idêntico ao contrato dos demais providers).
+            # `_generate_with_new_sdk` já preencheu `response.usage` com
+            # cost_estimate via `_extract_gemini_usage`; aqui só ajustamos
+            # `request_time` e gravamos.
+            try:
+                if response.usage is not None:
+                    response.usage.request_time = execution_time
+                    await self._record_usage(
+                        session_id=kwargs.get("session_id", "default"),
+                        usage=response.usage,
+                        latency_ms=int(execution_time * 1000),
+                        success=True,
+                    )
+            except Exception as exc:  # noqa: BLE001 — telemetry must never block
+                logger.debug("gemini usage record (generate) failed: %s", exc)
+
             return response
             
         except genai_errors.APIError as e:
@@ -320,6 +336,17 @@ class GeminiProvider(ModelProvider):
                     "error_type": envelope.error_type,
                 })
 
+            # Registra falha pra reports não esconderem custo de tentativas
+            # que erraram no meio (request foi enviado, o provedor cobra
+            # mesmo se a resposta veio com erro tipado).
+            await self._record_failed_usage(
+                session_id=kwargs.get("session_id", "default"),
+                start_time=start_time,
+                prompt_tokens=0,
+                completion_tokens=0,
+                cached_tokens=0,
+                error_envelope=envelope,
+            )
             raise ProviderInvocationError(envelope) from e
 
         except ProviderInvocationError:
@@ -414,13 +441,29 @@ class GeminiProvider(ModelProvider):
                     arguments=dict(call.get("args") or {}),
                 )
 
-            usage_metadata = getattr(response, "usage_metadata", None)
-            if usage_metadata is not None:
+            # Antes deste fix: `cached_tokens=0` e `cost_usd=0.0` hardcoded,
+            # e o `_record_usage` não era chamado — o snapshot ia pro
+            # USAGE_FINAL só pra ser ignorado pelo consumer no agent.py
+            # ("consumed silently"). Agora computa custo via _compute_cost,
+            # lê cached_content_token_count, e persiste antes do yield.
+            usage = self._extract_gemini_usage(response)
+            if usage.prompt_tokens or usage.completion_tokens:
+                try:
+                    await self._record_usage(
+                        session_id=kwargs.get("session_id", "default"),
+                        usage=usage,
+                        latency_ms=int(usage.request_time * 1000),
+                        success=True,
+                    )
+                except Exception as exc:  # noqa: BLE001 — telemetry must never block
+                    logger.debug(
+                        "gemini usage record (stream/tools) failed: %s", exc,
+                    )
                 snap = ModelUsageSnapshot(
-                    input_tokens=getattr(usage_metadata, "prompt_token_count", 0) or 0,
-                    output_tokens=getattr(usage_metadata, "candidates_token_count", 0) or 0,
-                    cached_tokens=0,
-                    cost_usd=0.0,
+                    input_tokens=usage.prompt_tokens,
+                    output_tokens=usage.completion_tokens,
+                    cached_tokens=usage.cached_tokens,
+                    cost_usd=usage.cost_estimate,
                     model=f"{self.provider_id}:{self.model_name}",
                 )
                 yield UnifiedStreamEvent(type=StreamEventType.USAGE_FINAL, usage=snap)
@@ -723,10 +766,16 @@ class GeminiProvider(ModelProvider):
 
         Creates an ephemeral in-process chat session (not cached in _chat_sessions) so
         the unified router can call this without needing to manage session lifecycle.
+
+        Persiste usage via `_record_usage` (sucesso) ou `_record_failed_usage`
+        (erro) seguindo o mesmo contrato dos Anthropic/OpenAI providers — sem
+        isso, a tabela `usage_records` nunca recebia entrada de
+        `provider_id='gemini'`.
         """
         import time as _time
 
         start = _time.time()
+        session_id = kwargs.get("session_id", "default")
         sys_instr = self._extract_system(messages, system_instruction)
         user_msg = self._messages_to_gemini_user_input(messages)
 
@@ -735,20 +784,41 @@ class GeminiProvider(ModelProvider):
             session_id=_session_key,
             system_instruction=sys_instr,
         )
-        text, tool_results = await self._gemini_chat_with_tools(
-            chat=chat,
-            message=user_msg,
-            working_directory=kwargs.get("working_directory", "."),
-            session_data=kwargs.get("session_data"),
-        )
+        try:
+            text, tool_results, usage = await self._gemini_chat_with_tools(
+                chat=chat,
+                message=user_msg,
+                working_directory=kwargs.get("working_directory", "."),
+                session_data=kwargs.get("session_data"),
+            )
+        except Exception as exc:
+            envelope = make_gemini_envelope(exc, self.provider_id, self.model_name)
+            await self._record_failed_usage(
+                session_id=session_id,
+                start_time=start,
+                prompt_tokens=0,
+                completion_tokens=0,
+                cached_tokens=0,
+                error_envelope=envelope,
+            )
+            self._chat_sessions.pop(_session_key, None)
+            # Preserva o contrato de exception do método: ProviderInvocationError
+            # com envelope tipado, igual aos demais providers.
+            raise ProviderInvocationError(envelope) from exc
+
         # Clean up the ephemeral session entry
         self._chat_sessions.pop(_session_key, None)
 
-        usage = ModelUsage(
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
-            request_time=_time.time() - start,
+        # Garante `request_time` aplicado mesmo se o loop não viu nenhum
+        # turno (caso degenerado: 0 iterations).
+        usage.request_time = _time.time() - start
+        latency_ms = int(usage.request_time * 1000)
+
+        await self._record_usage(
+            session_id=session_id,
+            usage=usage,
+            latency_ms=latency_ms,
+            success=True,
         )
         return text, tool_results, usage
 
@@ -764,7 +834,7 @@ class GeminiProvider(ModelProvider):
         working_directory: str = ".",
         max_iterations: Optional[int] = None,
         session_data: Optional[Dict[str, Any]] = None,
-    ) -> tuple[str, list]:
+    ) -> Tuple[str, list, "ModelUsage"]:
         """Envia ``message`` ao chat e roda o loop manual de function calling.
 
         Substitui o uso de AFC do SDK por um loop controlado:
@@ -790,6 +860,11 @@ class GeminiProvider(ModelProvider):
         cap = max_iterations if max_iterations is not None else self.MAX_TOOL_ITERATIONS
         tool_results: list = []
         text_chunks: list[str] = []
+        # Agregador de usage: somamos input/output/cached/cost de CADA
+        # `chat.send_message`. Cada turno traz o histórico inteiro de novo,
+        # então o `prompt_token_count` cresce monotonicamente — refletir
+        # isso fielmente no custo é justamente o que estava faltando antes.
+        agg_usage = ModelUsage()
         guard = make_guard(
             session_id=str((session_data or {}).get("session_id", "")) or None
         )
@@ -797,6 +872,9 @@ class GeminiProvider(ModelProvider):
 
         # send_message é síncrono no SDK — usamos to_thread para não bloquear o loop.
         response = await asyncio.to_thread(chat.send_message, message)
+        agg_usage = self._aggregate_usage(
+            agg_usage, self._extract_gemini_usage(response),
+        )
 
         for iteration in range(cap):
             function_calls = self._extract_function_calls(response)
@@ -844,6 +922,9 @@ class GeminiProvider(ModelProvider):
                 # appended will surface to the user.
                 break
             response = await asyncio.to_thread(chat.send_message, function_response_parts)
+            agg_usage = self._aggregate_usage(
+                agg_usage, self._extract_gemini_usage(response),
+            )
         else:
             # Loop esgotou o cap sem terminar — o modelo continua querendo chamar tools.
             logger.warning(
@@ -864,7 +945,62 @@ class GeminiProvider(ModelProvider):
             )
 
         final_text = "\n".join(t for t in text_chunks if t).strip()
-        return final_text, tool_results
+        # Caller decide o que fazer com `agg_usage` (persistir? agregar mais?).
+        return final_text, tool_results, agg_usage
+
+    # ---- usage / cost helpers (Gemini) -------------------------------------
+    #
+    # Antes destes helpers, GeminiProvider nunca chamava `_record_usage` nem
+    # computava `cost_estimate` — a tabela `usage_records` ficava sem
+    # nenhuma entrada de `provider_id='gemini'` e o painel TUI mostrava
+    # custos zerados. Estes helpers casam o que Anthropic/OpenAI fazem:
+    # extrai usage_metadata completo (incluindo cached_content_token_count),
+    # calcula custo via `_compute_cost` do catálogo, e permite somar
+    # ao longo do loop multi-turn de function calling.
+
+    def _extract_gemini_usage(
+        self, response: Any, request_time: float = 0.0,
+    ) -> ModelUsage:
+        """Converte `usage_metadata` do SDK Google GenAI num `ModelUsage`
+        com `cost_estimate` calculado.
+
+        Lê 4 campos da API do Gemini:
+        - prompt_token_count       → prompt_tokens
+        - candidates_token_count   → completion_tokens
+        - total_token_count        → total_tokens (fallback p/ prompt+comp)
+        - cached_content_token_count → cached_tokens (context caching)
+        """
+        md = getattr(response, "usage_metadata", None)
+        pt = (getattr(md, "prompt_token_count", 0) or 0) if md is not None else 0
+        ct = (getattr(md, "candidates_token_count", 0) or 0) if md is not None else 0
+        tt = (getattr(md, "total_token_count", 0) or 0) if md is not None else 0
+        cached = (
+            getattr(md, "cached_content_token_count", 0) or 0
+        ) if md is not None else 0
+        usage = ModelUsage(
+            prompt_tokens=int(pt),
+            completion_tokens=int(ct),
+            total_tokens=int(tt) or (int(pt) + int(ct)),
+            cached_tokens=int(cached),
+            request_time=float(request_time),
+        )
+        try:
+            usage.cost_estimate = self._compute_cost(usage)
+        except Exception as exc:  # noqa: BLE001 — never break the request on cost calc
+            logger.debug("Gemini cost calc failed: %s", exc)
+        return usage
+
+    @staticmethod
+    def _aggregate_usage(a: ModelUsage, b: ModelUsage) -> ModelUsage:
+        """Soma dois `ModelUsage` (multi-turn function calling)."""
+        return ModelUsage(
+            prompt_tokens=a.prompt_tokens + b.prompt_tokens,
+            completion_tokens=a.completion_tokens + b.completion_tokens,
+            total_tokens=a.total_tokens + b.total_tokens,
+            cached_tokens=a.cached_tokens + b.cached_tokens,
+            request_time=a.request_time + b.request_time,
+            cost_estimate=(a.cost_estimate or 0.0) + (b.cost_estimate or 0.0),
+        )
 
     @staticmethod
     def _extract_function_calls(response: Any) -> list[Dict[str, Any]]:
@@ -919,13 +1055,11 @@ class GeminiProvider(ModelProvider):
                 config=config,  # types.GenerateContentConfig(...) ou dict compatível
             )
             
-            # Extrai informações de uso
-            usage_metadata = getattr(response, 'usage_metadata', None)
-            usage = ModelUsage(
-                prompt_tokens=usage_metadata.prompt_token_count if usage_metadata else 0,
-                completion_tokens=usage_metadata.candidates_token_count if usage_metadata else 0,
-                total_tokens=usage_metadata.total_token_count if usage_metadata else 0
-            )
+            # Usa helper compartilhado: extrai prompt/candidates/cached, e
+            # calcula `cost_estimate` via `_compute_cost` do catálogo.
+            # Antes a montagem era inline e descartava
+            # `cached_content_token_count` (cache hits ficavam fora do custo).
+            usage = self._extract_gemini_usage(response)
             
             # Extrai conteúdo via helper que itera ``candidates[*].content.parts``
             # e pula parts não-textuais (thought_signature, function_call, etc.).

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -36,8 +36,7 @@ logger = logging.getLogger(__name__)
 #: chance to finish (regression observed on PR #293: server raised to 900s, but
 #: client was stuck at 600s+60s buffer = 660s — review timed out client-side
 #: while the worker was still working).
-import os as _os
-DEFAULT_TIMEOUT_S: float = float(_os.environ.get("DEILE_WORKER_TASK_TIMEOUT_S", "600"))
+DEFAULT_TIMEOUT_S: float = float(os.environ.get("DEILE_WORKER_TASK_TIMEOUT_S", "600"))
 # Budget máximo permitido para um dispatch ``wait=True`` — compartilhado
 # entre o ``max_execution_time`` da tool e o timeout do cliente httpx, de
 # modo que um cancel upstream não mascare ``WORKER_TIMEOUT`` como

--- a/deile/tests/cli/test_cli_cleanup.py
+++ b/deile/tests/cli/test_cli_cleanup.py
@@ -1,6 +1,5 @@
-import asyncio
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/deile/tests/commands/builtin/test_loc_command.py
+++ b/deile/tests/commands/builtin/test_loc_command.py
@@ -7,6 +7,7 @@ import pytest
 from deile.commands.base import CommandContext, CommandStatus
 from deile.commands.builtin.loc_command import LocCommand
 
+
 @pytest.fixture
 def loc_command():
     return LocCommand()

--- a/deile/tests/commands/test_standup_command.py
+++ b/deile/tests/commands/test_standup_command.py
@@ -24,18 +24,13 @@ from rich.console import Console
 
 from deile.commands.base import CommandContext, CommandResult
 from deile.commands.builtin import standup_command as sc
-from deile.commands.builtin.standup_command import (
-    StandupCommand,
-    StandupData,
-    build_prompt,
-    collect_commits,
-    collect_issues,
-    collect_prs,
-    parse_args,
-    parse_since,
-)
+from deile.commands.builtin.standup_command import (StandupCommand,
+                                                    StandupData, build_prompt,
+                                                    collect_commits,
+                                                    collect_issues,
+                                                    collect_prs, parse_args,
+                                                    parse_since)
 from deile.core.exceptions import CommandError
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/deile/tests/core/models/test_gemini_provider_usage.py
+++ b/deile/tests/core/models/test_gemini_provider_usage.py
@@ -1,0 +1,229 @@
+"""Tests para captura/persistência de usage no GeminiProvider.
+
+Cobre o bug histórico em que `gemini_provider.py` nunca chamava
+`_record_usage` nem `_record_failed_usage`, deixando a tabela
+`usage_records` sem nenhuma entrada de `provider_id='gemini'`. Os fixes
+adicionaram dois helpers (`_extract_gemini_usage`, `_aggregate_usage`)
+e ligaram o record nos caminhos `generate`, `chat_with_tools` e
+`generate_stream`. Estes testes lockam o contrato sem depender do SDK
+do Google nem de cluster real.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.core.models.base import ModelUsage
+from deile.core.models.gemini_provider import GeminiProvider
+
+
+# -------- helpers de fixture -------------------------------------------------
+
+def _fake_usage_md(prompt=0, candidates=0, total=0, cached=0):
+    return SimpleNamespace(
+        prompt_token_count=prompt,
+        candidates_token_count=candidates,
+        total_token_count=total,
+        cached_content_token_count=cached,
+    )
+
+
+def _fake_response(usage_md=None):
+    return SimpleNamespace(usage_metadata=usage_md)
+
+
+# -------- _extract_gemini_usage ---------------------------------------------
+
+class TestExtractGeminiUsage:
+    def test_reads_all_four_token_fields(self):
+        prov = MagicMock(spec=GeminiProvider)
+        prov._compute_cost = lambda u: 0.0  # ignore cost in this test
+        resp = _fake_response(_fake_usage_md(
+            prompt=1500, candidates=380, total=1880, cached=200,
+        ))
+        usage = GeminiProvider._extract_gemini_usage(prov, resp, request_time=2.5)
+        assert usage.prompt_tokens == 1500
+        assert usage.completion_tokens == 380
+        assert usage.total_tokens == 1880
+        # cached_content_token_count → cached_tokens (era hardcoded 0)
+        assert usage.cached_tokens == 200
+        assert usage.request_time == 2.5
+
+    def test_missing_usage_metadata_returns_zeros(self):
+        prov = MagicMock(spec=GeminiProvider)
+        prov._compute_cost = lambda u: 0.0
+        resp = _fake_response(usage_md=None)
+        usage = GeminiProvider._extract_gemini_usage(prov, resp)
+        assert usage.prompt_tokens == 0
+        assert usage.completion_tokens == 0
+        assert usage.cached_tokens == 0
+
+    def test_total_falls_back_to_sum_when_zero(self):
+        prov = MagicMock(spec=GeminiProvider)
+        prov._compute_cost = lambda u: 0.0
+        resp = _fake_response(_fake_usage_md(prompt=100, candidates=50, total=0))
+        usage = GeminiProvider._extract_gemini_usage(prov, resp)
+        assert usage.total_tokens == 150     # fallback: prompt + completion
+
+    def test_calls_compute_cost(self):
+        prov = MagicMock(spec=GeminiProvider)
+        prov._compute_cost = MagicMock(return_value=0.0042)
+        resp = _fake_response(_fake_usage_md(prompt=1000, candidates=500, cached=100))
+        usage = GeminiProvider._extract_gemini_usage(prov, resp)
+        prov._compute_cost.assert_called_once()
+        assert usage.cost_estimate == 0.0042
+
+    def test_cost_calc_exception_does_not_propagate(self):
+        # Cost calc nunca pode quebrar a request — falha em DEBUG, devolve 0.
+        prov = MagicMock(spec=GeminiProvider)
+        prov._compute_cost = MagicMock(side_effect=RuntimeError("catalog miss"))
+        resp = _fake_response(_fake_usage_md(prompt=10, candidates=5))
+        usage = GeminiProvider._extract_gemini_usage(prov, resp)
+        assert usage.cost_estimate == 0.0    # default, sem propagar
+        assert usage.prompt_tokens == 10     # tokens ainda capturados
+
+
+# -------- _aggregate_usage --------------------------------------------------
+
+class TestAggregateUsage:
+    def test_sums_all_fields(self):
+        a = ModelUsage(
+            prompt_tokens=100, completion_tokens=50, cached_tokens=10,
+            total_tokens=150, request_time=1.0, cost_estimate=0.001,
+        )
+        b = ModelUsage(
+            prompt_tokens=200, completion_tokens=80, cached_tokens=20,
+            total_tokens=280, request_time=2.5, cost_estimate=0.002,
+        )
+        c = GeminiProvider._aggregate_usage(a, b)
+        assert c.prompt_tokens == 300
+        assert c.completion_tokens == 130
+        assert c.cached_tokens == 30
+        assert c.total_tokens == 430
+        assert c.request_time == 3.5
+        assert c.cost_estimate == pytest.approx(0.003)
+
+    def test_aggregate_with_empty_usage_is_idempotent(self):
+        empty = ModelUsage()
+        other = ModelUsage(
+            prompt_tokens=10, completion_tokens=5, cost_estimate=0.001,
+        )
+        # Empty + outro = outro
+        result = GeminiProvider._aggregate_usage(empty, other)
+        assert result.prompt_tokens == 10
+        assert result.cost_estimate == pytest.approx(0.001)
+
+    def test_aggregate_handles_none_cost(self):
+        # Em alguns providers cost_estimate pode vir como None.
+        a = ModelUsage(prompt_tokens=10, cost_estimate=None)
+        b = ModelUsage(prompt_tokens=20, cost_estimate=0.002)
+        c = GeminiProvider._aggregate_usage(a, b)
+        assert c.prompt_tokens == 30
+        assert c.cost_estimate == pytest.approx(0.002)
+
+
+# -------- chat_with_tools chama _record_usage --------------------------------
+
+@pytest.mark.asyncio
+class TestChatWithToolsPersists:
+    async def test_records_usage_on_success(self):
+        """Sucesso path: deve chamar _record_usage com session_id + usage agregado."""
+        prov = MagicMock(spec=GeminiProvider)
+        prov.provider_id = "gemini"
+        prov.model_name = "gemini-3.1-pro-preview"
+        # _gemini_chat_with_tools devolve 3-tuple agora (text, results, usage).
+        agg = ModelUsage(prompt_tokens=500, completion_tokens=200,
+                         cached_tokens=50, total_tokens=700,
+                         cost_estimate=0.003)
+        prov._gemini_chat_with_tools = AsyncMock(
+            return_value=("hi", [], agg),
+        )
+        prov._extract_system = MagicMock(return_value="system")
+        prov._messages_to_gemini_user_input = MagicMock(return_value="hello")
+        prov.create_chat_session = AsyncMock(return_value=MagicMock())
+        prov._chat_sessions = {}
+        prov._record_usage = AsyncMock()
+        prov._record_failed_usage = AsyncMock()
+
+        text, results, usage = await GeminiProvider.chat_with_tools(
+            prov, messages=[], tools=[], system_instruction="sys",
+            session_id="sess-42",
+        )
+
+        assert text == "hi"
+        prov._record_usage.assert_awaited_once()
+        kwargs = prov._record_usage.call_args.kwargs
+        assert kwargs["session_id"] == "sess-42"
+        assert kwargs["usage"] is agg
+        assert kwargs["success"] is True
+        # error path NÃO foi tocado
+        prov._record_failed_usage.assert_not_awaited()
+
+    async def test_records_failed_usage_on_exception(self):
+        """Erro path: _gemini_chat_with_tools lança → record_failed_usage + raise."""
+        from deile.core.models.errors import ProviderInvocationError
+
+        prov = MagicMock(spec=GeminiProvider)
+        prov.provider_id = "gemini"
+        prov.model_name = "gemini-3.1-pro-preview"
+        prov._gemini_chat_with_tools = AsyncMock(
+            side_effect=RuntimeError("API down"),
+        )
+        prov._extract_system = MagicMock(return_value="system")
+        prov._messages_to_gemini_user_input = MagicMock(return_value="hello")
+        prov.create_chat_session = AsyncMock(return_value=MagicMock())
+        prov._chat_sessions = {}
+        prov._record_usage = AsyncMock()
+        prov._record_failed_usage = AsyncMock()
+
+        with patch("deile.core.models.gemini_provider.make_gemini_envelope") \
+                as mk_env:
+            mk_env.return_value = MagicMock()
+            with pytest.raises(ProviderInvocationError):
+                await GeminiProvider.chat_with_tools(
+                    prov, messages=[], tools=[], system_instruction="sys",
+                    session_id="sess-99",
+                )
+
+        prov._record_failed_usage.assert_awaited_once()
+        kwargs = prov._record_failed_usage.call_args.kwargs
+        assert kwargs["session_id"] == "sess-99"
+        prov._record_usage.assert_not_awaited()
+
+
+# -------- generate() chama _record_usage no sucesso ------------------------
+
+@pytest.mark.asyncio
+class TestGenerateRecords:
+    async def test_record_called_with_response_usage(self):
+        # Stub mínimo do response retornado por _generate_with_new_sdk
+        usage = ModelUsage(prompt_tokens=120, completion_tokens=60,
+                           cached_tokens=10, total_tokens=180,
+                           cost_estimate=0.0015)
+        response = SimpleNamespace(usage=usage, content="ok")
+        prov = MagicMock(spec=GeminiProvider)
+        prov.provider_id = "gemini"
+        prov.model_name = "gemini-3.1-pro-preview"
+        prov._compose_system_instruction = MagicMock(return_value="sys")
+        prov._process_messages_for_gemini = MagicMock(return_value=[])
+        prov._create_generation_config = MagicMock(return_value={})
+        prov._generate_with_new_sdk = AsyncMock(return_value=response)
+        prov.debug_logger = MagicMock(request_count=0)
+        prov._record_usage = AsyncMock()
+        prov._last_request_time = 0.0
+
+        with patch("deile.core.models.gemini_provider.is_debug_enabled",
+                   return_value=False):
+            result = await GeminiProvider.generate(
+                prov, messages=[], system_instruction="x", session_id="s1",
+            )
+
+        assert result is response
+        prov._record_usage.assert_awaited_once()
+        kwargs = prov._record_usage.call_args.kwargs
+        assert kwargs["session_id"] == "s1"
+        assert kwargs["usage"] is usage
+        assert kwargs["success"] is True

--- a/deile/tests/core/models/test_gemini_provider_usage.py
+++ b/deile/tests/core/models/test_gemini_provider_usage.py
@@ -19,7 +19,6 @@ import pytest
 from deile.core.models.base import ModelUsage
 from deile.core.models.gemini_provider import GeminiProvider
 
-
 # -------- helpers de fixture -------------------------------------------------
 
 def _fake_usage_md(prompt=0, candidates=0, total=0, cached=0):

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -1,0 +1,610 @@
+"""Unit tests for the panel data providers + alert engine.
+
+Covers ``infra/k8s/_panel_data.py`` (Cache TTL, parsers, providers) and
+the alert engine + activity adapter that live in ``infra/k8s/_panel.py``.
+The infra scripts live outside the ``deile`` package, so the path is
+inserted on sys.path for the import (same pattern as ``test_worker_resume``).
+
+Os providers de cluster são exercitados com kubectl mockado via
+``subprocess.run`` patch — nenhum teste toca o cluster real ou faz call
+de rede. O CostsProvider usa um SQLite temporário.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel_data as pd  # noqa: E402
+import _panel as panel  # noqa: E402
+
+
+# ===== Cache TTL ============================================================
+
+class TestCache:
+    def test_first_call_invokes_fetcher(self):
+        calls: List[int] = []
+        cache = pd.Cache(ttl_s=10.0, fetcher=lambda: calls.append(1) or "ok",
+                         fallback="-")
+        assert cache.get() == "ok"
+        assert calls == [1]
+
+    def test_second_call_within_ttl_uses_cache(self):
+        calls: List[int] = []
+        cache = pd.Cache(ttl_s=10.0, fetcher=lambda: calls.append(1) or "ok",
+                         fallback="-")
+        cache.get()
+        cache.get()
+        cache.get()
+        assert calls == [1]
+
+    def test_force_bypasses_ttl(self):
+        calls: List[int] = []
+        cache = pd.Cache(ttl_s=10.0, fetcher=lambda: calls.append(1) or "ok",
+                         fallback="-")
+        cache.get()
+        cache.get(force=True)
+        assert calls == [1, 1]
+
+    def test_error_keeps_last_value_and_records_error(self):
+        attempts = {"n": 0}
+
+        def fetcher() -> str:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return "good"
+            raise RuntimeError("boom")
+
+        cache = pd.Cache(ttl_s=0.0, fetcher=fetcher, fallback="fallback")
+        assert cache.get() == "good"
+        # Segunda chamada (TTL=0) refaz e falha — mantém o último valor bom.
+        assert cache.get() == "good"
+        assert cache.last_error is not None
+        assert "boom" in cache.last_error
+
+    def test_error_before_any_good_value_returns_fallback(self):
+        def boom() -> str:
+            raise RuntimeError("never returns")
+
+        cache = pd.Cache(ttl_s=10.0, fetcher=boom, fallback="DEFAULT")
+        assert cache.get() == "DEFAULT"
+
+
+# ===== _fmt_age =============================================================
+
+class TestFmtAge:
+    @pytest.mark.parametrize("secs,expected", [
+        (None, "—"),
+        (-5, "0s"),
+        (0, "0s"),
+        (45, "45s"),
+        (60, "1m"),
+        (119, "1m"),
+        (3600, "1h"),
+        (3660, "1h01m"),
+        (86400, "1d"),
+        (90000, "1d"),
+    ])
+    def test_humanizes(self, secs, expected):
+        assert pd._fmt_age(secs) == expected
+
+
+# ===== _parse_k8s_ts / _parse_log_line ======================================
+
+class TestK8sTs:
+    def test_parses_rfc3339_z(self):
+        ts = pd._parse_k8s_ts("2026-05-23T14:21:56Z")
+        assert ts is not None
+        assert ts.year == 2026 and ts.tzinfo is not None
+
+    def test_parses_rfc3339_offset(self):
+        ts = pd._parse_k8s_ts("2026-05-23T11:22:03.124543858-03:00")
+        assert ts is not None
+
+    def test_none_on_garbage(self):
+        assert pd._parse_k8s_ts("not a ts") is None
+        assert pd._parse_k8s_ts(None) is None
+
+
+class TestParseLogLine:
+    def test_extracts_ts_and_body(self):
+        raw = ("2026-05-23T14:21:56.123-03:00 2026-05-23 17:21:56,123 INFO "
+               "deile.foo something happened")
+        ll = pd._parse_log_line(raw)
+        assert ll is not None
+        assert ll.ts.year == 2026
+        assert "deile.foo something happened" in ll.body
+
+    def test_returns_none_when_no_ts(self):
+        assert pd._parse_log_line("no timestamp here") is None
+
+
+# ===== _classify_pipeline_line =============================================
+
+class TestPipelineClassifier:
+    def _line(self, body: str) -> pd.LogLine:
+        return pd.LogLine(ts=datetime(2026, 5, 23, 14, 0, tzinfo=timezone.utc),
+                          body=body)
+
+    def test_mention_issue(self):
+        ev = pd._classify_pipeline_line(self._line(
+            "deile.orchestration.pipeline.stages mention group issue:278: "
+            "triggers=['assignee']"
+        ))
+        assert ev is not None
+        assert ev.action == "mention"
+        assert ev.target == "#278"
+        assert "assignee" in ev.detail
+
+    def test_mention_pr(self):
+        ev = pd._classify_pipeline_line(self._line(
+            "stages mention group pr:291: triggers=['reviewer']"
+        ))
+        assert ev is not None and ev.target == "PR291"
+
+    def test_dispatch_starting(self):
+        ev = pd._classify_pipeline_line(self._line(
+            "INFO deile.infrastructure.deile_worker_client worker dispatch starting"
+        ))
+        assert ev is not None and ev.action == "dispatch"
+        assert "starting" in ev.detail
+
+    def test_http_post(self):
+        ev = pd._classify_pipeline_line(self._line(
+            'httpx HTTP Request: POST http://x/v1/dispatch "HTTP/1.1 200 OK"'
+        ))
+        assert ev is not None and ev.action == "http"
+        assert "200" in ev.detail
+
+    def test_startup(self):
+        ev = pd._classify_pipeline_line(self._line(
+            "INFO deile.pipeline.runner starting pipeline monitor (repo=...)"
+        ))
+        assert ev is not None and ev.action == "startup"
+
+    def test_unrelated_returns_none(self):
+        assert pd._classify_pipeline_line(self._line(
+            "completely unrelated log line about something else"
+        )) is None
+
+
+# ===== _derive_workflow =====================================================
+
+class TestDeriveWorkflow:
+    def test_empty(self):
+        assert pd._derive_workflow([]) == ""
+
+    def test_picks_workflow_label(self):
+        assert pd._derive_workflow(["bug", "~workflow:em_implementacao"]) \
+            == "em_implementacao"
+
+    def test_bloqueada_wins_over_other_workflow_label(self):
+        # Estado terminal: o pipeline a respeita mesmo quando outra label
+        # de fase ainda está presente. Sem essa precedência, a UI mostraria
+        # o estado anterior em vez do bloqueio.
+        assert pd._derive_workflow([
+            "~workflow:em_implementacao", "~workflow:bloqueada",
+        ]) == "bloqueada"
+        assert pd._derive_workflow([
+            "~workflow:bloqueada", "~workflow:em_implementacao",
+        ]) == "bloqueada"
+
+    def test_non_workflow_labels_ignored(self):
+        assert pd._derive_workflow(["help wanted", "P0"]) == ""
+
+
+# ===== PodsProvider =========================================================
+
+class TestPodsProvider:
+    def _payload(self) -> Dict[str, Any]:
+        return {
+            "items": [
+                {
+                    "metadata": {
+                        "name": "deile-worker-abc",
+                        "labels": {"app": "deile-worker", "role": "deile"},
+                    },
+                    "status": {
+                        "phase": "Running",
+                        "startTime": "2026-05-23T14:00:00Z",
+                        "containerStatuses": [
+                            {"ready": True, "restartCount": 0,
+                             "state": {"running": {}}},
+                        ],
+                    },
+                    "spec": {"nodeName": "test-node"},
+                },
+                {
+                    "metadata": {
+                        "name": "deilebot-xyz",
+                        "labels": {"app": "deilebot"},
+                    },
+                    "status": {
+                        "phase": "Pending",
+                        "containerStatuses": [],
+                    },
+                    "spec": {},
+                },
+                {
+                    "metadata": {
+                        "name": "unknown-app",
+                        "labels": {"app": "something-else"},
+                    },
+                    "status": {"phase": "Running",
+                               "containerStatuses": [{"ready": True,
+                                                       "restartCount": 5}]},
+                    "spec": {},
+                },
+            ],
+        }
+
+    def _provider_with_payload(self, payload: Dict[str, Any]) -> pd.PodsProvider:
+        # TTL alto: o primeiro `get()` dentro do `with patch` cacheia, e
+        # as chamadas subsequentes (no corpo do teste) servem do cache —
+        # mesmo se o patch já saiu de escopo.
+        prov = pd.PodsProvider(ttl_s=600.0)
+        prov._kubectl = "kubectl"
+        with patch.object(pd, "_capture_json", return_value=payload):
+            prov.get(force=True)
+        return prov
+
+    def test_no_kubectl_returns_fallback(self):
+        prov = pd.PodsProvider(ttl_s=10.0)
+        prov._kubectl = None
+        # Cache fallback é []; nenhum erro propagado pra UI.
+        assert prov.get() == []
+        assert prov.last_error is not None
+
+    def test_parses_pods_with_roles(self):
+        prov = self._provider_with_payload(self._payload())
+        rows = prov.get()
+        names = [r.name for r in rows]
+        assert "deile-worker-abc" in names
+        assert "deilebot-xyz" in names
+        roles = {r.name: r.role for r in rows}
+        assert roles["deile-worker-abc"] == "worker"
+        assert roles["deilebot-xyz"] == "bot"
+        assert roles["unknown-app"] == "other"
+
+    def test_ordering_pipeline_first_then_worker(self):
+        payload = self._payload()
+        payload["items"].append({
+            "metadata": {"name": "deile-pipeline-zzz",
+                         "labels": {"app": "deile-pipeline"}},
+            "status": {"phase": "Running",
+                       "startTime": "2026-05-23T14:00:00Z",
+                       "containerStatuses": [{"ready": True,
+                                              "restartCount": 0}]},
+            "spec": {},
+        })
+        prov = self._provider_with_payload(payload)
+        rows = prov.get()
+        assert rows[0].role == "pipeline"
+        assert rows[1].role == "worker"
+
+    def test_aggregates_restart_count_across_containers(self):
+        prov = self._provider_with_payload(self._payload())
+        rows = {r.name: r for r in prov.get()}
+        assert rows["unknown-app"].restarts == 5
+        assert rows["deile-worker-abc"].restarts == 0
+
+    def test_kubectl_failure_falls_back(self):
+        prov = pd.PodsProvider(ttl_s=0.0)
+        prov._kubectl = "kubectl"
+        with patch.object(pd, "_capture_json", return_value=None):
+            assert prov.get() == []
+        assert prov.last_error is not None
+
+
+# ===== WorkerProvider (busy detection) =====================================
+
+class TestWorkerProvider:
+    def _build(self) -> pd.WorkerProvider:
+        prov = pd.WorkerProvider(ttl_s=0.0)
+        prov._kubectl = "kubectl"
+        return prov
+
+    def _recent_log(self, *bodies: str) -> str:
+        # Format `kubectl logs --timestamps`: <iso>\t<body>
+        # Use timestamps "agora" para o cálculo busy/idle bater.
+        now = datetime.now(timezone.utc)
+        out = []
+        for i, body in enumerate(bodies):
+            ts = (now - timedelta(seconds=i * 2))
+            out.append(ts.strftime("%Y-%m-%dT%H:%M:%S.000000000+00:00")
+                       + f" {body}")
+        return "\n".join(out)
+
+    def test_idle_when_only_health_in_window(self):
+        prov = self._build()
+        text = self._recent_log(
+            'aiohttp.access "GET /v1/health HTTP/1.1" 200 237',
+            'aiohttp.access "GET /v1/health HTTP/1.1" 200 237',
+        )
+        names_text = "worker-1"
+
+        def fake_capture(cmd, timeout):
+            if "jsonpath" in cmd[-1]:
+                return names_text
+            return text
+
+        with patch.object(pd, "_capture_text", side_effect=fake_capture):
+            states = prov.get(force=True)
+        assert "worker-1" in states
+        assert states["worker-1"].busy is False
+
+    def test_busy_when_dispatch_within_90s(self):
+        prov = self._build()
+        text = self._recent_log(
+            'aiohttp.access "POST /v1/dispatch HTTP/1.1" 200 237',
+        )
+        names_text = "worker-2"
+
+        def fake_capture(cmd, timeout):
+            if "jsonpath" in cmd[-1]:
+                return names_text
+            return text
+
+        with patch.object(pd, "_capture_text", side_effect=fake_capture):
+            states = prov.get(force=True)
+        assert states["worker-2"].busy is True
+
+    def test_idle_when_dispatch_older_than_90s(self):
+        prov = self._build()
+        # Linha com timestamp "antigo" — 5 min atrás
+        old_ts = (datetime.now(timezone.utc) - timedelta(minutes=5))
+        old_str = (old_ts.strftime("%Y-%m-%dT%H:%M:%S.000000000+00:00")
+                   + ' POST /v1/dispatch HTTP/1.1 200')
+        names_text = "worker-3"
+
+        def fake_capture(cmd, timeout):
+            if "jsonpath" in cmd[-1]:
+                return names_text
+            return old_str
+
+        with patch.object(pd, "_capture_text", side_effect=fake_capture):
+            states = prov.get(force=True)
+        assert states["worker-3"].busy is False
+
+
+# ===== GitHubProvider =======================================================
+
+class TestGitHubProvider:
+    def _items(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "number": 296,
+                "title": "[FEATURE] foo",
+                "state": "open",
+                "labels": [{"name": "feature"},
+                           {"name": "~workflow:em_implementacao"}],
+                "assignees": [{"login": "deile-one"}],
+                "updated_at": "2026-05-23T12:00:00Z",
+                "html_url": "https://github.com/x/y/issues/296",
+            },
+            {
+                "number": 283,
+                "title": "[FEATURE] bar",
+                "state": "open",
+                "labels": [{"name": "~workflow:em_implementacao"},
+                           {"name": "~workflow:bloqueada"}],
+                "assignees": [{"login": "elimarcavalli"}],
+                "updated_at": "2026-05-22T20:00:00Z",
+                "html_url": "https://github.com/x/y/issues/283",
+            },
+            {
+                "number": 291,
+                "title": "PR demo",
+                "state": "open",
+                "labels": [{"name": "~review:em_andamento"}],
+                "assignees": [{"login": "deile-one"}],
+                "pull_request": {"url": "..."},
+                "updated_at": "2026-05-23T11:36:53Z",
+                "html_url": "https://github.com/x/y/pull/291",
+            },
+        ]
+
+    def test_separates_issues_from_prs(self):
+        prov = pd.GitHubProvider(ttl_s=0.0)
+        prov._gh = "gh"
+        with patch.object(pd, "_capture_json", return_value=self._items()):
+            snap = prov.get(force=True)
+        assert len(snap.issues) == 2
+        assert len(snap.prs) == 1
+        assert snap.prs[0].number == 291
+
+    def test_bloqueada_takes_priority(self):
+        prov = pd.GitHubProvider(ttl_s=0.0)
+        prov._gh = "gh"
+        with patch.object(pd, "_capture_json", return_value=self._items()):
+            snap = prov.get(force=True)
+        by_n = {it.number: it for it in snap.issues}
+        assert by_n[283].workflow == "bloqueada"
+        assert by_n[283].blocked is True
+
+    def test_state_counts(self):
+        prov = pd.GitHubProvider(ttl_s=0.0)
+        prov._gh = "gh"
+        with patch.object(pd, "_capture_json", return_value=self._items()):
+            snap = prov.get(force=True)
+        assert snap.issue_states.get("em_implementacao") == 1
+        assert snap.issue_states.get("bloqueada") == 1
+        assert snap.pr_states.get("em_andamento") == 1
+
+    def test_no_gh_fallback(self):
+        prov = pd.GitHubProvider(ttl_s=10.0)
+        prov._gh = None
+        snap = prov.get()
+        assert snap.issues == [] and snap.prs == []
+
+
+# ===== CostsProvider ========================================================
+
+class TestCostsProvider:
+    def _populated_db(self, tmp_path: Path) -> Path:
+        db = tmp_path / "usage.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("""
+            CREATE TABLE usage_records (
+              id INTEGER PRIMARY KEY,
+              timestamp REAL NOT NULL,
+              provider_id TEXT NOT NULL,
+              model_id TEXT NOT NULL,
+              tier TEXT NOT NULL,
+              session_id TEXT NOT NULL,
+              prompt_tokens INTEGER, completion_tokens INTEGER,
+              cached_tokens INTEGER, total_tokens INTEGER,
+              cost_usd REAL, latency_ms INTEGER,
+              success INTEGER, error_type TEXT
+            )
+        """)
+        now = time.time()
+        rows = [
+            (now - 30, "anthropic", "claude", "premium", "s1",
+             100, 50, 0, 150, 0.10, 1000, 1, None),
+            (now - 60, "anthropic", "claude", "premium", "s1",
+             200, 80, 0, 280, 0.15, 1000, 1, None),
+            (now - 1800, "openai", "gpt-4", "premium", "s2",
+             100, 50, 0, 150, 0.05, 800, 1, None),
+            (now - 90000, "deepseek", "ds", "basic", "s3",  # >24h ago: filtrado
+             50, 20, 0, 70, 0.99, 500, 1, None),
+        ]
+        conn.executemany(
+            "INSERT INTO usage_records VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            rows,
+        )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_missing_db_returns_empty_snapshot(self, tmp_path):
+        prov = pd.CostsProvider(db_path=tmp_path / "nope.db", ttl_s=0.0)
+        snap = prov.get()
+        assert snap.records_24h == 0
+        assert snap.total_24h == 0.0
+        assert prov.last_error is None  # fallback gracioso, sem erro
+
+    def test_aggregates_within_24h(self, tmp_path):
+        db = self._populated_db(tmp_path)
+        prov = pd.CostsProvider(db_path=db, ttl_s=0.0)
+        snap = prov.get(force=True)
+        assert snap.records_24h == 3   # 4ª linha tem >24h, fica fora
+        assert snap.total_24h == pytest.approx(0.30, abs=0.001)
+        assert snap.by_provider_24h["anthropic"] == pytest.approx(0.25, abs=0.001)
+        assert snap.by_provider_24h["openai"] == pytest.approx(0.05, abs=0.001)
+        assert "deepseek" not in snap.by_provider_24h
+
+    def test_1h_window_subset(self, tmp_path):
+        db = self._populated_db(tmp_path)
+        prov = pd.CostsProvider(db_path=db, ttl_s=0.0)
+        snap = prov.get(force=True)
+        # As 3 linhas dentro de 1h (30s, 60s e 30min): 0.10 + 0.15 + 0.05.
+        # A linha de >24h não entra (já validado no test_aggregates_within_24h).
+        assert snap.total_1h == pytest.approx(0.30, abs=0.001)
+
+    def test_top_sessions(self, tmp_path):
+        db = self._populated_db(tmp_path)
+        prov = pd.CostsProvider(db_path=db, ttl_s=0.0)
+        snap = prov.get(force=True)
+        sids = [s[0] for s in snap.top_sessions_24h]
+        assert sids[0] == "s1"     # mais caro
+
+
+# ===== Alerts engine ========================================================
+
+class TestAlerts:
+    def _data_with(self, pods=None, pipeline=None, issues=None,
+                   errors=None) -> Any:
+        d = MagicMock()
+        d.pods.get.return_value = pods or []
+        ps = MagicMock()
+        if pipeline is not None:
+            for k, v in pipeline.items():
+                setattr(ps, k, v)
+        else:
+            ps.last_action_age_s = None
+        d.pipeline.get.return_value = ps
+        snap = MagicMock()
+        snap.issues = issues or []
+        d.github.get.return_value = snap
+        d.errors.return_value = errors or []
+        return d
+
+    def test_no_alerts_when_clean(self):
+        d = self._data_with(pods=[], pipeline={"last_action_age_s": 10})
+        assert panel._alerts_from_data(d) == []
+
+    def test_pod_restart_crit_above_3(self):
+        pod = MagicMock()
+        pod.name, pod.restarts, pod.age_s = "x", 4, 3600
+        d = self._data_with(pods=[pod],
+                            pipeline={"last_action_age_s": 10})
+        alerts = panel._alerts_from_data(d)
+        assert any(a.severity == "crit" for a in alerts)
+
+    def test_pod_restart_warn_below_30min(self):
+        pod = MagicMock()
+        pod.name, pod.restarts, pod.age_s = "x", 1, 600
+        d = self._data_with(pods=[pod],
+                            pipeline={"last_action_age_s": 10})
+        alerts = panel._alerts_from_data(d)
+        assert any(a.severity == "warn" for a in alerts)
+
+    def test_pipeline_stale_warns(self):
+        d = self._data_with(pipeline={"last_action_age_s": 600})
+        alerts = panel._alerts_from_data(d)
+        assert any("travado" in a.msg.lower() or "sem ação" in a.msg for a in alerts)
+
+    def test_blocked_issues_warn(self):
+        it = MagicMock()
+        it.number, it.blocked, it.workflow = 283, True, "bloqueada"
+        d = self._data_with(pipeline={"last_action_age_s": 10}, issues=[it])
+        alerts = panel._alerts_from_data(d)
+        assert any("bloqueada" in a.msg for a in alerts)
+
+    def test_demo_mode_returns_synthetic(self):
+        # Sem cluster, devolve os mocks de _panel_demo.ALERTS.
+        alerts = panel._alerts_from_data(None)
+        assert alerts  # não vazio
+
+
+# ===== _pod_rows adapter ====================================================
+
+class TestPodRowsAdapter:
+    def test_demo_mode_uses_demo_pods(self):
+        rows = panel._pod_rows(None)
+        assert rows
+        assert any(r.role == "worker" for r in rows)
+
+    def test_with_data_passes_through(self):
+        d = MagicMock()
+        pod = MagicMock()
+        pod.name, pod.role, pod.status, pod.ready, pod.restarts = (
+            "p1", "worker", "Running", True, 0,
+        )
+        pod.age_s, pod.started_at, pod.node = 3600, None, "n1"
+        d.pods.get.return_value = [pod]
+        ws = MagicMock()
+        ws.busy = True
+        ws.last_activity_s = 5
+        ws.last_substantive_body = "some text"
+        d.workers.get.return_value = {"p1": ws}
+        ps = MagicMock()
+        ps.last_action_age_s = None
+        ps.last_action_summary = ""
+        d.pipeline.get.return_value = ps
+        rows = panel._pod_rows(d)
+        assert rows[0].busy is True
+        assert rows[0].icon == "⚡"

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -27,9 +27,8 @@ for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
     if str(_p) not in sys.path:
         sys.path.insert(0, str(_p))
 
-import _panel_data as pd  # noqa: E402
 import _panel as panel  # noqa: E402
-
+import _panel_data as pd  # noqa: E402
 
 # ===== Cache TTL ============================================================
 
@@ -708,6 +707,37 @@ class TestSetPreferredModel:
         assert ok is False
         assert "forbidden" in msg
 
+    @pytest.mark.parametrize("bad_slug", [
+        "evil\nDEILE_OTHER=injected",   # newline → outra env via shell
+        "x=y",                          # '=' não é permitido (corromperia argv)
+        "with space",                   # espaço não permitido
+        "ctrl\x01char",                 # caractere de controle
+        "ctrl\x00null",                 # NUL
+        "",                             # vazio
+        "/leading-slash",               # primeiro char inválido
+        "a" * 200,                      # comprimento > 128
+    ])
+    def test_rejects_malicious_slugs_without_calling_kubectl(self, bad_slug,
+                                                              monkeypatch):
+        """B2: slugs com caracteres perigosos são recusados ANTES de
+        chegar ao kubectl (subprocess.run nunca deve ser chamado)."""
+        monkeypatch.setattr(pd, "kubectl_bin", lambda: "kubectl")
+        with patch("subprocess.run") as run:
+            ok, msg = pd.set_preferred_model("deile-worker", bad_slug)
+        assert ok is False
+        assert "slug" in msg.lower()
+        run.assert_not_called()
+
+    def test_accepts_typical_anthropic_slug(self, monkeypatch):
+        """Sanity: o slug canônico não pode regredir junto com a validação."""
+        monkeypatch.setattr(pd, "kubectl_bin", lambda: "kubectl")
+        mock_proc = MagicMock(returncode=0, stdout="ok\n", stderr="")
+        with patch("subprocess.run", return_value=mock_proc):
+            ok, _ = pd.set_preferred_model(
+                "deile-worker", "anthropic:claude-opus-4-7",
+            )
+        assert ok is True
+
 
 class TestPodRowsAdapter:
     def test_demo_mode_uses_demo_pods(self):
@@ -735,3 +765,17 @@ class TestPodRowsAdapter:
         rows = panel._pod_rows(d)
         assert rows[0].busy is True
         assert rows[0].icon == "⚡"
+
+    def test_cluster_up_but_no_pods_returns_empty(self):
+        """n4: cobrir o caminho 'cluster respondeu, mas namespace está
+        vazio' — antes da gente assumir, pods.get() pode devolver lista
+        vazia (namespace recém-criado, scale 0 etc) sem erro."""
+        d = MagicMock()
+        d.pods.get.return_value = []
+        d.workers.get.return_value = {}
+        ps = MagicMock()
+        ps.last_action_age_s = None
+        ps.last_action_summary = ""
+        d.pipeline.get.return_value = ps
+        rows = panel._pod_rows(d)
+        assert rows == []

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -582,6 +582,133 @@ class TestAlerts:
 
 # ===== _pod_rows adapter ====================================================
 
+class TestModelsProvider:
+    def _yaml(self, tmp_path: Path) -> Path:
+        path = tmp_path / "model_providers.yaml"
+        path.write_text(
+            "version: 1\n"
+            "models:\n"
+            "  - provider_id: anthropic\n"
+            "    model_id: claude-opus-4-7\n"
+            "    display_name: Claude Opus 4.7\n"
+            "    tier: tier_1\n"
+            "    label: flagship\n"
+            "    pricing:\n"
+            "      input_per_1m_usd: 5.0\n"
+            "      output_per_1m_usd: 25.0\n"
+            "  - provider_id: openai\n"
+            "    model_id: gpt-5.4\n"
+            "    display_name: GPT-5.4\n"
+            "    tier: tier_2\n"
+            "    label: balanced\n"
+            "    pricing:\n"
+            "      input_per_1m_usd: 2.5\n"
+            "      output_per_1m_usd: 15.0\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_parses_models_from_yaml(self, tmp_path):
+        prov = pd.ModelsProvider(yaml_path=self._yaml(tmp_path), ttl_s=0.0)
+        models = prov.get(force=True)
+        assert len(models) == 2
+        slugs = [m.slug for m in models]
+        assert "anthropic:claude-opus-4-7" in slugs
+        assert "openai:gpt-5.4" in slugs
+
+    def test_pricing_extracted(self, tmp_path):
+        prov = pd.ModelsProvider(yaml_path=self._yaml(tmp_path), ttl_s=0.0)
+        models = {m.slug: m for m in prov.get(force=True)}
+        assert models["anthropic:claude-opus-4-7"].input_cost_per_1m == 5.0
+        assert models["openai:gpt-5.4"].output_cost_per_1m == 15.0
+
+    def test_missing_yaml_falls_back_empty(self, tmp_path):
+        prov = pd.ModelsProvider(yaml_path=tmp_path / "nope.yaml", ttl_s=0.0)
+        assert prov.get() == []
+        assert prov.last_error is not None
+
+
+class TestCurrentModelProvider:
+    def test_extracts_from_deployment_json(self):
+        sample = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {"name": "OTHER", "value": "x"},
+                                    {"name": "DEILE_PREFERRED_MODEL",
+                                     "value": "anthropic:claude-opus-4-7"},
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+        assert pd.CurrentModelProvider._extract(sample) \
+            == "anthropic:claude-opus-4-7"
+
+    def test_missing_env_returns_none(self):
+        sample = {"spec": {"template": {"spec": {
+            "containers": [{"env": [{"name": "OTHER", "value": "x"}]}],
+        }}}}
+        assert pd.CurrentModelProvider._extract(sample) is None
+
+    def test_no_containers_returns_none(self):
+        assert pd.CurrentModelProvider._extract(
+            {"spec": {"template": {"spec": {"containers": []}}}}
+        ) is None
+
+    def test_fetch_uses_kubectl_per_deployment(self):
+        prov = pd.CurrentModelProvider(
+            deployments=("deile-worker", "deile-pipeline"), ttl_s=0.0,
+        )
+        prov._kubectl = "kubectl"
+        payloads = {
+            "deile-worker": {"spec": {"template": {"spec": {"containers": [
+                {"env": [{"name": "DEILE_PREFERRED_MODEL",
+                          "value": "anthropic:claude-sonnet-4-6"}]},
+            ]}}}},
+            "deile-pipeline": None,
+        }
+
+        def fake_capture(cmd, timeout=None):
+            # cmd = [kubectl, -n, deile, get, deployment/<name>, -o, json]
+            dep_arg = cmd[4].split("/", 1)[1]
+            return payloads[dep_arg]
+
+        with patch.object(pd, "_capture_json", side_effect=fake_capture):
+            result = prov.get(force=True)
+        assert result["deile-worker"] == "anthropic:claude-sonnet-4-6"
+        assert result["deile-pipeline"] is None
+
+
+class TestSetPreferredModel:
+    def test_no_kubectl_returns_false(self, monkeypatch):
+        monkeypatch.setattr(pd, "kubectl_bin", lambda: None)
+        ok, msg = pd.set_preferred_model("deile-worker",
+                                         "anthropic:claude-opus-4-7")
+        assert ok is False
+        assert "kubectl" in msg
+
+    def test_success_returns_true(self, monkeypatch):
+        monkeypatch.setattr(pd, "kubectl_bin", lambda: "kubectl")
+        mock_proc = MagicMock(returncode=0, stdout="ok\n", stderr="")
+        with patch("subprocess.run", return_value=mock_proc):
+            ok, _ = pd.set_preferred_model("deile-worker", "x:y")
+        assert ok is True
+
+    def test_failure_propagates_stderr(self, monkeypatch):
+        monkeypatch.setattr(pd, "kubectl_bin", lambda: "kubectl")
+        mock_proc = MagicMock(returncode=1, stdout="", stderr="forbidden\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            ok, msg = pd.set_preferred_model("deile-worker", "x:y")
+        assert ok is False
+        assert "forbidden" in msg
+
+
 class TestPodRowsAdapter:
     def test_demo_mode_uses_demo_pods(self):
         rows = panel._pod_rows(None)

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -40,12 +40,27 @@ class TestCache:
         assert cache.get() == "ok"
         assert calls == [1]
 
-    def test_second_call_within_ttl_uses_cache(self):
+    def test_second_call_never_refetches_via_get(self):
+        # Contrato novo: get() NUNCA bloqueia depois do primeiro fetch —
+        # devolve sempre o cached. O refresh fica por conta do
+        # BackgroundRefresher chamando `maybe_refresh()`.
         calls: List[int] = []
         cache = pd.Cache(ttl_s=10.0, fetcher=lambda: calls.append(1) or "ok",
                          fallback="-")
         cache.get()
         cache.get()
+        cache.get()
+        assert calls == [1]
+
+    def test_get_returns_cached_even_when_stale(self):
+        # Mesmo com TTL=0, get() devolve o cache existente. Sem essa
+        # garantia, render no thread principal podia disparar fetch
+        # sincrono e congelar a UI.
+        calls: List[int] = []
+        cache = pd.Cache(ttl_s=0.0, fetcher=lambda: calls.append(1) or "ok",
+                         fallback="-")
+        cache.get()                # primeiro fetch (cold start)
+        cache.get()                # cache stale, mas NÃO refaz
         cache.get()
         assert calls == [1]
 
@@ -56,6 +71,37 @@ class TestCache:
         cache.get()
         cache.get(force=True)
         assert calls == [1, 1]
+
+    def test_maybe_refresh_respects_ttl(self):
+        # `maybe_refresh` faz fetch só se TTL venceu — é o que o
+        # BackgroundRefresher chama em loop.
+        calls: List[int] = []
+        cache = pd.Cache(ttl_s=10.0, fetcher=lambda: calls.append(1) or "ok",
+                         fallback="-")
+        cache.get()                              # 1º fetch (cold)
+        assert cache.maybe_refresh() is False    # TTL ainda fresco
+        assert calls == [1]
+
+    def test_maybe_refresh_fetches_when_stale(self):
+        calls: List[int] = []
+        cache = pd.Cache(ttl_s=0.0, fetcher=lambda: calls.append(1) or "ok",
+                         fallback="-")
+        cache.get()                              # 1º fetch (cold)
+        assert cache.maybe_refresh() is True     # TTL=0 → sempre stale
+        assert calls == [1, 1]
+
+    def test_invalidate_marks_stale_without_dropping_value(self):
+        # `invalidate` (usado pelo hotkey [r]) marca como vencido mas
+        # devolve o valor antigo via get() — o BackgroundRefresher
+        # repõe no próximo tick sem segurar a UI.
+        cache = pd.Cache(ttl_s=10.0, fetcher=lambda: "fresh",
+                         fallback="-")
+        cache.get()
+        cache.invalidate()
+        # get() ainda devolve "fresh", sem chamar fetcher de novo.
+        assert cache.get() == "fresh"
+        # maybe_refresh agora rebusca.
+        assert cache.maybe_refresh() is True
 
     def test_error_keeps_last_value_and_records_error(self):
         attempts = {"n": 0}
@@ -68,8 +114,10 @@ class TestCache:
 
         cache = pd.Cache(ttl_s=0.0, fetcher=fetcher, fallback="fallback")
         assert cache.get() == "good"
-        # Segunda chamada (TTL=0) refaz e falha — mantém o último valor bom.
-        assert cache.get() == "good"
+        # `get()` não refaz fetch (contrato novo); precisamos do
+        # `maybe_refresh` para vir o erro.
+        assert cache.maybe_refresh() is True
+        assert cache.get() == "good"             # mantém último valor bom
         assert cache.last_error is not None
         assert "boom" in cache.last_error
 
@@ -259,9 +307,12 @@ class TestPodsProvider:
             prov.get(force=True)
         return prov
 
-    def test_no_kubectl_returns_fallback(self):
+    def test_no_kubectl_returns_fallback(self, monkeypatch):
+        # `kubectl_bin()` é chamado tanto no __init__ quanto no
+        # `_resolve_kubectl` (lazy fallback adicionado no branch
+        # a68ace9). Monkeypatch garante que nenhum dos dois encontra.
+        monkeypatch.setattr(pd, "kubectl_bin", lambda: None)
         prov = pd.PodsProvider(ttl_s=10.0)
-        prov._kubectl = None
         # Cache fallback é []; nenhum erro propagado pra UI.
         assert prov.get() == []
         assert prov.last_error is not None

--- a/deile/tests/test_gemini_function_calling.py
+++ b/deile/tests/test_gemini_function_calling.py
@@ -264,7 +264,7 @@ class TestChatWithToolsLoop:
     ) -> None:
         chat = _FakeChat([_make_response(_make_text_part("hi"))])
 
-        text, results = await provider._gemini_chat_with_tools(chat, "ping")
+        text, results, _usage = await provider._gemini_chat_with_tools(chat, "ping")
 
         assert text == "hi"
         assert results == []
@@ -294,7 +294,7 @@ class TestChatWithToolsLoop:
             ]
         )
 
-        text, results = await provider._gemini_chat_with_tools(
+        text, results, _usage = await provider._gemini_chat_with_tools(
             chat, "list files", working_directory="/work"
         )
 
@@ -333,7 +333,7 @@ class TestChatWithToolsLoop:
             ]
         )
 
-        text, results = await provider._gemini_chat_with_tools(chat, "run my script")
+        text, results, _usage = await provider._gemini_chat_with_tools(chat, "run my script")
 
         assert "Sorry" in text
         assert len(results) == 1
@@ -368,7 +368,7 @@ class TestChatWithToolsLoop:
             for i in range(20)
         ])
 
-        text, results = await provider._gemini_chat_with_tools(
+        text, results, _usage = await provider._gemini_chat_with_tools(
             chat, "loop please", max_iterations=3
         )
 
@@ -407,7 +407,7 @@ class TestChatWithToolsLoop:
             ]
         )
 
-        text, results = await provider._gemini_chat_with_tools(chat, "two cmds")
+        text, results, _usage = await provider._gemini_chat_with_tools(chat, "two cmds")
 
         assert text == "Done."
         assert len(results) == 2

--- a/deile/tests/test_gemini_provider_unified.py
+++ b/deile/tests/test_gemini_provider_unified.py
@@ -109,7 +109,7 @@ async def test_generate_stream_yields_unified_events(provider):
 async def test_unified_chat_with_tools_returns_triple(provider):
     """Unified chat_with_tools must return (str, list, ModelUsage)."""
     provider.create_chat_session = AsyncMock(return_value=MagicMock())
-    provider._gemini_chat_with_tools = AsyncMock(return_value=("answer", []))
+    provider._gemini_chat_with_tools = AsyncMock(return_value=("answer", [], __import__('deile.core.models.base', fromlist=['ModelUsage']).ModelUsage()))
 
     text, tool_results, usage = await provider.chat_with_tools(
         messages=[ModelMessage(role="user", content="hello")],
@@ -126,7 +126,7 @@ async def test_unified_chat_with_tools_returns_triple(provider):
 @pytest.mark.asyncio
 async def test_unified_chat_with_tools_text_passes_through(provider):
     provider.create_chat_session = AsyncMock(return_value=MagicMock())
-    provider._gemini_chat_with_tools = AsyncMock(return_value=("Paris is the capital", []))
+    provider._gemini_chat_with_tools = AsyncMock(return_value=("Paris is the capital", [], __import__('deile.core.models.base', fromlist=['ModelUsage']).ModelUsage()))
 
     text, _, _ = await provider.chat_with_tools(
         messages=[ModelMessage(role="user", content="Capital of France?")],

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -276,44 +276,445 @@ em loop:
 python3 infra/k8s/deploy.py k8s panel
 ```
 
-O painel é uma TUI navegável (`rich.Live`) que cruza o estado do cluster com
-a fonte de verdade do pipeline (GitHub issues + PRs) e o uso do
-`UsageRepository`. **Não muta nada** — é só observação.
+O painel é uma TUI navegável (`rich.Live`) que cruza o estado do cluster
+(pods, deployments, restarts) com a fonte de verdade do pipeline (GitHub
+issues + PRs) e o uso (`~/.deile/db/usage.db`). **Não muta nada** — é só
+observação, exceto onde explicitamente acionado (`[a]ções` e `[m]odel`,
+ambos com confirmação para destrutivos).
 
-**Hotkeys globais** (qualquer view):
+Composição (módulos em `infra/k8s/`):
+
+- `_panel_data.py` — cache TTL + 7 providers (Pods, Pipeline, Worker,
+  GitHub, Costs, Models, CurrentModel). Fonte única de verdade dos números.
+- `_panel_demo.py` — mocks usados quando o cluster está fora ou o `kubectl`
+  não está no PATH (modo demo: a UI ainda abre).
+- `_panel.py` — `KeyReader` (termios cbreak / `msvcrt`), view contract,
+  alerts engine, 9 views, loop principal `PanelApp`.
+
+Zero dependência nova: `rich` já está em `pyproject.toml`.
+
+#### 4.3.1 Visão geral — o dashboard
+
+A primeira tela que aparece. Refresh padrão **3s**.
+
+```text
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ DEILE Stack  ·  Dashboard  ·  2026-05-23 13:28:18  ·  refresh 3.0s                                         ┃
+┃ cluster: rancher-desktop (k3s)   namespace: deile   image: deile-stack:local                               ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+╭─ PODS ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│        pod                           status     age      r   last-activi…   doing now                      │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  ●     deile-pipeline-676866dcdf-…   Running    2h06m    0   12m ago        worker dispatch completed      │
+│  ●     deile-worker-6486989bbb-45…   Running    2h23m    0   3s ago         idle                           │
+│  ●     deile-worker-6486989bbb-lr…   Running    2h22m    0   12m ago        2026-05-23 16:15:57,852 INFO…  │
+│  ●     deilebot-75b5dc48d4-k88v7     Running    2h23m    0   —              —                              │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ PIPELINE ──────────────────────────────────────────╮╭─ ALERTS ────────────────────────────────────────────╮
+│ running for 2h06m   ·  last action 12m ago          ││ ⚠ pipeline sem ação há 12m — pode estar travado     │
+│ summary: worker dispatch completed                  ││ ⚠ 1 issue(s) com ~workflow:bloqueada: #283          │
+│ dispatches/24h: 3  mentions/24h: 3                  ││                                                     │
+│ Issues open: 2  bloqueada:1  sem_workflow:1         ││                                                     │
+│ PRs open:    2  sem_review:2                        ││                                                     │
+╰─────────────────────────────────────────────────────╯╰─────────────────────────────────────────────────────╯
+╭─ ACTIVITY (últimos 10) ────────────────────────────────────────────────────────────────────────────────────╮
+│  13:15:57        pipeline          dispatch                            worker dispatch completed           │
+│  13:15:57        pipeline          http                                POST /v1/dispatch → 200             │
+│  13:04:58        pipeline          dispatch                            worker dispatch starting            │
+│  13:04:58        pipeline          mention              PR295          triggers=reviewer                   │
+│  11:56:26        pipeline          mention              #278           triggers=assignee                   │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ TOKENS & CUSTOS ───────────────────────────────────╮╭─ ÚLTIMAS DECISÕES ──────────────────────────────────╮
+│ anthropic $0.32   openai $0.04                      ││ —  worker dispatch completed                        │
+│ total 24h: $0.36   records: 196  ·  1h: $0.12       ││ —  worker dispatch starting                         │
+│                                                     ││ PR295  triggers=reviewer                            │
+╰─────────────────────────────────────────────────────╯╰─────────────────────────────────────────────────────╯
+  [1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  [5]Tokens  [n]otifier  [a]ctions  [m]odel
+```
+
+Cada bloco vem de um provider diferente:
+
+| bloco | provider | TTL |
+|---|---|---|
+| PODS | `PodsProvider` + `WorkerProvider` + `PipelineProvider` | 3s + 5s + 5s |
+| PIPELINE | `PipelineProvider` + `GitHubProvider` | 5s + 10s |
+| ALERTS | regras locais em `_alerts_from_data` | — (recomputado a cada render) |
+| ACTIVITY | `PipelineProvider.events` | 5s |
+| TOKENS & CUSTOS | `CostsProvider` (SQLite local) | 60s |
+| ÚLTIMAS DECISÕES | últimos 3 eventos `mention`/`dispatch`/`stages` | 5s |
+
+#### 4.3.2 Hotkeys globais
+
+Valem em **qualquer view**. As que a view específica respondem antes vão na
+descrição dela.
 
 | tecla | ação |
 |---|---|
-| `1-5, a, m, n` | drill em sub-view |
-| `esc` | volta à view anterior |
+| `1`–`5`, `a`, `m`, `n` | drill em sub-view (a partir do dashboard) |
+| `↑` / `↓` ou `j` / `k` | navega em listas (picker, issues/PRs, modelos) |
+| `enter` | seleciona o item destacado |
+| `esc` | volta à view anterior (ou ao dashboard) |
 | `q` | sai do painel |
-| `p` | pause / resume refresh automático |
-| `+` / `-` | acelera / desacelera o refresh (×0.25 a ×4) |
-| `r` | força refresh imediato (invalida caches) |
-| `s` | snapshot da tela em `~/.deile/snapshots/` |
-| `?` | mostra a tela de ajuda |
+| `p` | pause / resume do refresh automático |
+| `+` / `-` | acelera / desacelera o refresh (×0.25 → ×4) |
+| `r` | força refresh imediato e **invalida os caches** de todos os providers |
+| `s` | snapshot da tela atual em `~/.deile/snapshots/panel-YYYYMMDD-HHMMSS.txt` |
+| `?` | tela de ajuda |
 
-**Views**:
+#### 4.3.3 Pod picker → Pod watch (`[1]`)
 
-| `[N]` | view | refresh | o que mostra |
-|---|---|---|---|
-| `[1]` | Pod picker → Pod watch | 3s / 1s | lista de pods navegável (↑/↓, enter); pod-watch abre kubectl logs -f embedded com filtro de health-checks |
-| `[2]` | Pipeline timeline | 5s | events classificados (mention/dispatch/http/startup) + stats (gap p95/max, ticks/h, failures) + histograma 24h |
-| `[3]` | Issues & PRs | 10s | tabela viva GitHub × labels do pipeline (filtros `a/i/p/b/m`, enter copia URL pro clipboard) |
-| `[5]` | Tokens & Custos | 60s | `~/.deile/db/usage.db` por provider (24h/1h, %, top 5 sessions) |
-| `[n]` | Notifier echo | 5s | últimos eventos `deilebot.audit` (outbound_sent/failed) |
-| `[a]` | Ações | 1s | `status` / `restart` / `build` / `up` / `stop` / `start` / `test` / `DOWN` (com confirmação) acionáveis sem sair do painel |
-| `[?]` | Help | — | resumo dos hotkeys |
+`[1]` abre o picker. **`↑`/`↓`** navega, **`enter`** entra no pod selecionado.
 
-**Alertas automáticos** acendem no dashboard quando:
-- algum pod reiniciou ≥3× (crítico) ou ≥1× nos últimos 30min (warning);
-- o pipeline está sem ação há >5min (provável travamento);
-- existe issue com `~workflow:bloqueada`;
-- existe issue com `~workflow:aguardando_stakeholder` (esperando você);
-- algum provider está reportando erro.
+```text
+╭─ escolha um pod para assistir ─────────────────────────────────────────────────────────────────────────────╮
+│             pod                           role         status       age      doing now                     │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  ▶     ●    deile-pipeline-676866dcdf-…   pipeline     Running      2h06m    worker dispatch completed     │
+│        ●    deile-worker-6486989bbb-45…   worker       Running      2h23m    idle                          │
+│        ●    deile-worker-6486989bbb-lr…   worker       Running      2h22m    2026-05-23 16:15:57,852 INFO  │
+│        ●    deilebot-75b5dc48d4-k88v7     bot          Running      2h23m    —                             │
+│        ●    deile-shell-7bcbb8c79f-t6p…   shell        Running      2h23m    —                             │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [↑/↓] navega   [enter] entra   [esc] volta   [q] sai
+```
 
-**Modo demo**: quando `kubectl` não está disponível ou o cluster está fora,
-o painel cai em mocks (mostra dados sintéticos) — a UI ainda abre.
+Depois do `enter` abre o **Pod Watch** (refresh **1s**): header com info do
+pod + log live seguindo `kubectl logs -f`.
+
+```text
+╭─ POD ────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ name: deile-worker-6486989bbb-45nb5   role: worker   status: Running                                                 │
+│ uptime: 2h23m   restarts: 0   ready: yes   node: lima-rancher-desktop                                                │
+│ worker: idle   last activity: 5s ago                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ LIVE LOG  ·  FOLLOW ON  ·  health ESCONDIDOS  ·  40 health filtrados  ·  deile-worker-6486989bbb-45nb5 ─────────────╮
+│ (sem linhas significativas — aguardando atividade real)                                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [f] follow on/off   [h] mostrar/esconder health   [c] clear log   [esc] volta   [q] sai
+```
+
+Hotkeys da view:
+
+| tecla | ação |
+|---|---|
+| `f` | pause / resume o follow (sem perder o buffer) |
+| `h` | mostra / esconde linhas `GET /v1/health` (default: esconde — workers ociosos lotam o painel) |
+| `c` | limpa o buffer de log |
+
+O título do painel sempre informa o estado (`FOLLOW ON`/`PAUSED`,
+`health ESCONDIDOS`/`VISÍVEIS`, **N health filtrados** quando algo foi
+oculto). Buffer rolling de 400 linhas. SIGTERM no kubectl ao sair (2s →
+SIGKILL como garantia).
+
+#### 4.3.4 Pipeline timeline (`[2]`)
+
+Refresh **5s**. Eventos classificados a partir de
+`kubectl logs deploy/deile-pipeline --tail=200` — mention, dispatch, http,
+startup, stages.
+
+```text
+╭─ STATS ─────────────────────────────────────────────╮╭─ HISTOGRAMA 24h ────────────────────────────────────╮
+│ events:    13                                       ││ events 24h (1 col = 1h, mais recente à direita):    │
+│ ticks/1h:  4                                        ││                      ▂█▄                            │
+│ running:   2h06m                                    ││ ├──────────────────────┤                            │
+│ last age:  12m                                      ││ -24h                now                             │
+│ gap p95:   38m                                      ││                                                     │
+│ gap max:   1h08m                                    ││                                                     │
+│ failures:  0                                        ││                                                     │
+╰─────────────────────────────────────────────────────╯╰─────────────────────────────────────────────────────╯
+╭─ EVENTS (mais recentes em cima) ───────────────────────────────────────────────────────────────────────────╮
+│  time                action                target             detail                                       │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  13:15:57            dispatch                                 worker dispatch completed                    │
+│  13:15:57            http                                     POST /v1/dispatch → 200                      │
+│  13:04:58            dispatch                                 worker dispatch starting                     │
+│  13:04:58            mention               PR295              triggers=reviewer                            │
+│  11:56:26            mention               #278               triggers=assignee                            │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [esc] volta   [r] força refresh   [q] sai
+```
+
+- **STATS**: `gap p95`/`max` são o tempo entre eventos consecutivos
+  (proxy de ociosidade). `failures` conta POST `/v1/dispatch` com retorno
+  5xx na janela.
+- **HISTOGRAMA 24h**: 24 colunas (1 por hora), densidade renderizada com
+  blocos `▁▂▃▄▅▆▇█`, peak normalizado. Vazio? `--tail=200` só pegou as
+  últimas N entradas (em workload moderado cobre ~5h, não 24h).
+- **EVENTS**: últimos 30 eventos classificados.
+
+#### 4.3.5 Issues & PRs (`[3]`)
+
+Refresh **10s** — `gh` API custa rate-limit. Cruz cluster ↔ GitHub,
+respeitando precedência de label (`bloqueada` vence sobre fase).
+
+```text
+╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ filtro: todos    issues: 2    PRs: 2                                                                                           │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ ISSUES ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│        #        workflow                 review           updated      assignees            title                              │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  ▶     283      bloqueada                —                11h17m       elimarcavalli        [FEATURE] Suíte de testes…         │
+│        257      —                        —                17h57m       —                    [INTENT] Decomposição autônoma…   │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ PRS ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│        #        workflow                 review           updated      assignees            title                              │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│        295      —                        —                12m          elimarcavalli        feat: decomposição autônoma…      │
+│        294      —                        —                17m          —                    feat(panel): live TUI monitoring… │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [a] all   [i] só issues   [p] só PRs   [b] só bloqueadas   [m] minhas   [↑/↓] navega   [enter] abrir URL   [esc] volta
+```
+
+Hotkeys da view:
+
+| tecla | ação |
+|---|---|
+| `a` / `i` / `p` / `b` / `m` | filtros: all / só issues / só PRs / só bloqueadas / minhas (assignee = `$GH_USER` ou `elimarcavalli`) |
+| `enter` | copia URL pro clipboard (best-effort: `pbcopy` / `xclip` / `wl-copy`) |
+
+`workflow` aparece em **vermelho-bold** quando a issue/PR está bloqueada;
+ciano para o estado normal de pipeline.
+
+#### 4.3.6 Tokens & Custos (`[5]`)
+
+Refresh **60s** — SQLite local é barato mas re-abrir a cada 2s é
+desperdício. Lê `~/.deile/db/usage.db` (`UsageRepository`).
+
+```text
+╭────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ records 24h: 196   ·   total: $0.36   ·   1h: $0.12                                                        │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ POR PROVIDER ─────────────────────────────────────────────────────────────────────────────────────────────╮
+│  provider                                             24h                       1h                      %  │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  anthropic                                         $0.323                   $0.104                  89.5%  │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ TOP 5 SESSIONS (24h) ─────────────────────────────────────────────────────────────────────────────────────╮
+│  session_id                                                                                          cost  │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  default                                                                                           $0.361  │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [r] força refresh   [esc] volta   [q] sai
+```
+
+> **Sem dados?** O DB só recebe registros quando o agente roda **localmente**
+> (no host). Os pods em K8s gravam no PVC do worker — o painel ainda não
+> tem acesso a esse PVC. Trabalho futuro: endpoint `/admin/usage` no
+> `worker_server.py` (opção pareada à do model switcher).
+
+#### 4.3.7 Notifier echo (`[n]`)
+
+Refresh **5s**. Parsea `kubectl logs deploy/deilebot --tail=500` filtrando
+linhas JSON do logger `deilebot.audit`. Captura tanto `outbound_sent`
+quanto `outbound_failed`.
+
+```text
+╭─ AUDIT EVENTS ─────────────────────────────────────────────────────────────────────────────────────────────╮
+│  ts                      event                    status       detail                                      │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  -05-23 14:26:38,490     outbound_failed          FAIL         op=channel.post, reason=denied              │
+│  -05-23 14:36:54,033     outbound_failed          FAIL         op=channel.post, reason=denied              │
+│  -05-23 16:04:58,997     outbound_failed          FAIL         op=channel.post, reason=denied              │
+│  -05-23 16:23:27,192     outbound_sent            OK           op=dm.send, user_id=1475913578648436909,    │
+│                                                                message_id=15077810                         │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [r] força refresh   [esc] volta   [q] sai
+```
+
+Status verde (`OK`) quando o evento contém `sent`/`received`, vermelho
+(`FAIL`) quando contém `failed`, cinza (`—`) para outros.
+
+#### 4.3.8 Ações (`[a]`)
+
+Refresh **1s** (pra mostrar o output streaming). Lista os verbos do
+`deploy.py` acionáveis sem sair do painel.
+
+```text
+╭─ AÇÕES ────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│         ação                  comando                                                                      │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  1      status                /Users/elimar.cavalli/dev/github/elimarcavalli/deile/infra/k8s/deploy.py     │
+│                               k8s status                                                                   │
+│  2      restart               k8s restart --yes                                                            │
+│  3      build (no restart)    k8s build --yes                                                              │
+│  4      build + restart       build --restart --yes                                                        │
+│  5      up (provisiona)       k8s up --yes                                                                 │
+│  6      stop (scale 0)        k8s stop --yes                                                               │
+│  7      start (scale 1)       k8s start --yes                                                              │
+│  8      test (Job one-shot)   k8s test --yes                                                               │
+│  9      DOWN (apaga ns)       k8s down --yes        ← destrutivo, pede confirmação [y/n]                   │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ OUTPUT ───────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ (rode uma ação para ver o output aqui)                                                                     │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [1-9] dispara   [c] cancelar   [esc] volta   [q] sai
+```
+
+- `[1]`–`[9]` dispara a ação correspondente (subprocess streaming em
+  thread daemon, buffer rolling de 500 linhas).
+- `[9] DOWN` é **destrutiva** — overlay de confirmação `[y/n]` antes de
+  rodar.
+- `[c]` cancela a ação em curso (SIGTERM → SIGKILL após 2s).
+- Borda do painel OUTPUT: **amarelo** = running, **verde** = exit 0,
+  **vermelho** = exit ≠ 0.
+- Sair da view (`[esc]`) mata o runner pendente.
+
+#### 4.3.9 Trocar modelo em runtime (`[m]`)
+
+Refresh **5s**. Lista o catálogo de modelos lido do
+`deile/config/model_providers.yaml` e mostra o que está efetivamente em uso
+em cada Deployment. **`enter`** abre overlay de confirmação; **`y`**
+aplica via `kubectl set env`, o que dispara rollout (zero-downtime no
+worker com `RollingUpdate maxSurge:1/maxUnavailable:0`; rápido restart no
+pipeline que é `Recreate`).
+
+```text
+╭─ TARGET ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ target: deile-worker                                                                                                           │
+│ DEILE_PREFERRED_MODEL atual:                                                                                                   │
+│   · deile-worker: anthropic:claude-sonnet-4-6                                                                                  │
+│   · deile-pipeline: (não setado — usa defaults do settings)                                                                    │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ MODELOS DISPONÍVEIS ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│         slug                                     display                          tier        label        $/1M in   $/1M out  │
+│  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  │
+│  ▶      anthropic:claude-opus-4-7                Claude Opus 4.7                  tier_1      flagship       $5.00     $25.00  │
+│         anthropic:claude-sonnet-4-6  ●           Claude Sonnet 4.6                tier_2      balanced       $3.00     $15.00  │
+│         anthropic:claude-haiku-4-5               Claude Haiku 4.5                 tier_3      fast           $1.00      $5.00  │
+│         openai:gpt-5.4                           GPT-5.4                          tier_2      balanced       $2.50     $15.00  │
+│         openai:gpt-5.4-mini                      GPT-5.4 Mini                     tier_3      fast           $0.75      $4.50  │
+│         gemini:gemini-3.1-pro-preview            Gemini 3.1 Pro Preview           tier_1      flagship       $2.00     $12.00  │
+│         gemini:gemini-3-flash-preview            Gemini 3 Flash Preview           tier_2      balanced       $0.50      $3.00  │
+│         gemini:gemini-3.1-flash-lite-preview     Gemini 3.1 Flash-Lite Preview    tier_3      fast           $0.25      $1.50  │
+│         deepseek:deepseek-v4-pro                 DeepSeek V4 Pro                  tier_1      flagship-…     $1.74      $3.48  │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+  [↑/↓] navega   [w] target=worker   [p] target=pipeline   [b] both   [enter] aplicar   [esc] volta   [q] sai
+```
+
+A bolinha verde **`●`** ao lado de um slug indica que ele é o valor
+**efetivamente em uso** num dos targets atuais (cross-reference com
+`CurrentModelProvider`).
+
+Hotkeys da view:
+
+| tecla | ação |
+|---|---|
+| `w` / `p` / `b` | troca o alvo: só worker (default) / só pipeline / both |
+| `enter` | overlay de confirmação para aplicar o slug destacado |
+| `y` / `n` | confirma / cancela (no overlay) |
+
+> **Implementação atual = opção A** (env var + rollout). Opções pareadas
+> que ficaram anotadas como evolução futura:
+> - **B** — endpoint `/admin/set_model` no `worker_server.py` (swap
+>   in-process instantâneo, sem rollout);
+> - **C** — `ConfigMap` + hot-reload via `watchdog` (declarativo,
+>   K8s-native, depende do hot-reload cobrir `model_providers`).
+
+#### 4.3.10 Ajuda (`[?]`)
+
+Resumo dos hotkeys globais. Útil pra lembrar dos atalhos sem sair do
+painel.
+
+```text
+╭─ Hotkeys globais ────────────────────────────────────────────────────────────────────────────────╮
+│   1-5, a, m, n               drill em sub-view (no dashboard)                                    │
+│   ↑/↓ ou j/k                 navega em listas (picker, issues/PRs, modelos)                      │
+│   enter                      seleciona o item destacado                                          │
+│   esc                        volta à view anterior (ou ao dashboard)                             │
+│   q                          sai do painel                                                       │
+│   p                          pause / resume refresh automático                                   │
+│   + / -                      acelera / desacelera o refresh (×0.25 a ×4)                         │
+│   r                          força refresh imediato (invalida caches)                            │
+│   s                          snapshot: salva a tela atual em ~/.deile/snapshots/                 │
+│   ?                          esta tela                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### 4.3.11 Alertas — regras
+
+O painel ALERTS no dashboard cruza limiares contra o estado atual:
+
+| ícone | severidade | condição |
+|---|---|---|
+| ⛔ | **crit** | pod com `restarts ≥ 3` |
+| ⚠ | warn | pod com `restarts ≥ 1` há menos de 30min |
+| ⚠ | warn | pipeline sem ação há **>5min** (possível travamento) |
+| ⚠ | warn | issue(s) com `~workflow:bloqueada` (lista até 3 números) |
+| 🙋 | warn | issue(s) com `~workflow:aguardando_stakeholder` (esperando você) |
+| ⚠ | warn | algum provider retornou erro no último fetch |
+
+Borda do painel ALERTS muda conforme a pior severidade: **vermelha** se há
+crítico, **amarela** se há warn, **verde** se está limpo. Limite visual de
+6 alertas — o resto vira `… (+N mais)`.
+
+#### 4.3.12 Modo demo
+
+Quando `kubectl` não está disponível **ou** o cluster está fora, o painel
+não trava: cai em mocks de `_panel_demo.py` (pods sintéticos, eventos
+fictícios, 1 alerta de exemplo, custo de teste). A UI ainda abre — útil
+para hackear/testar a TUI offline (em viagem, num CI, etc).
+
+A detecção é silenciosa: a tentativa de instanciar `PanelData.default()`
+captura qualquer falha do primeiro `pods.get()` e seta `data = None`.
+
+#### 4.3.13 Arquitetura interna (para estender)
+
+Adicionar uma view nova:
+
+1. Crie uma classe que herda de `View` em `_panel.py`:
+   ```python
+   class MyView(View):
+       name = "my-view"
+       title = "Minha View"
+       refresh_s = 5.0
+       HOTKEYS = "[esc] volta   [q] sai"
+
+       def __init__(self, data=None):
+           self.data = data
+
+       def render(self, app):
+           # devolve qualquer RenderableType do rich
+           return Panel(Text("oi"), title="MEU PAINEL",
+                        border_style="green")
+
+       def handle_key(self, key, app):
+           # hotkeys próprios (globais já foram tratados antes)
+           return ActionResult()
+   ```
+2. Registre em `_build_views(data)`:
+   ```python
+   "my-view": MyView(data=data),
+   ```
+3. Adicione hotkey de navegação no `DashboardView.HOTKEYS` e no
+   `DashboardView.handle_key` (ou navegue a partir de outra view).
+4. Se a view precisa de **dados novos**, escreva um provider em
+   `_panel_data.py` (use `Cache` para TTL automático), adicione ao
+   `PanelData` dataclass e ao `errors()` / `force_refresh_all()`.
+
+Padrões do contract:
+
+- `render()` é puro — apenas snapshot do estado atual; nunca faz I/O em
+  primeira pessoa, consulta os providers (que são cacheados).
+- `handle_key()` retorna um `ActionResult`: `.nav(target)`, `.back()`,
+  `.refresh()`, `.quit()` ou `ActionResult()` (no-op).
+- `on_mount(app)` / `on_unmount(app)` são chamados quando a view entra /
+  sai da pilha — use pra iniciar/parar streamers (ver `PodWatchView`).
+- Cadência (`refresh_s`) é por view. O multiplicador global (`+`/`-`)
+  divide a cadência efetiva.
+
+#### 4.3.14 Troubleshooting
+
+| sintoma | causa provável | solução |
+|---|---|---|
+| `painel exige terminal interativo (sem TTY)` | rodou via pipe / CI | rode num terminal real, ou use o snapshot (`-s`) depois pra capturar |
+| painel abre **em modo demo** mesmo com cluster no ar | `kubectl` não está no `PATH` | use a versão do Rancher Desktop: `export PATH="$HOME/.rd/bin:$PATH"` |
+| `provider github: ...` no ALERTS | `gh` ausente ou não autenticado | `gh auth login` ou aceite que esse painel fique vazio |
+| `provider costs: ...` ou painel TOKENS vazio | DB `~/.deile/db/usage.db` ainda não existe | rode o agente localmente uma vez (`python3 deile.py`) ou ignore — não bloqueia o resto |
+| issues bloqueadas que não deviam estar | a label `~workflow:bloqueada` vence sobre a fase no derive — verifique no GitHub | edite as labels via REST (ver seção "Label edits" no `CLAUDE.md`) |
+| `[m]` mostra `(não setado)` no pipeline | é o estado correto se o manifest do pipeline não define `DEILE_PREFERRED_MODEL` | aplique normalmente — o `set env` cria a entrada |
+| painel trava ao apertar `c` em Ações com runner em curso | é a parada (SIGTERM → SIGKILL 2s); aguarde | até 2s; se persistir, `Ctrl-C` no terminal mata o painel inteiro |
+| logs do pod-watch só mostram `health` em loop | filtro `[h]` está em "VISÍVEIS" | aperte `h` para esconder; o título mostra `N health filtrados` |
 
 ### 4.4 Diagnóstico rápido
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -267,7 +267,55 @@ kubectl delete pvc deile-shell-home -n deile
 > **Nota:** O PVC sobrevive a `kubectl rollout restart` mas NÃO a
 > `bash infra/k8s/run.sh down` (que deleta o namespace inteiro).
 
-### 4.3 Diagnóstico rápido
+### 4.3 Painel TUI ao vivo (`deploy.py k8s panel`)
+
+Para acompanhar a stack em tempo real, sem ficar abrindo `kubectl get`/`logs`
+em loop:
+
+```bash
+python3 infra/k8s/deploy.py k8s panel
+```
+
+O painel é uma TUI navegável (`rich.Live`) que cruza o estado do cluster com
+a fonte de verdade do pipeline (GitHub issues + PRs) e o uso do
+`UsageRepository`. **Não muta nada** — é só observação.
+
+**Hotkeys globais** (qualquer view):
+
+| tecla | ação |
+|---|---|
+| `1-5, a, m, n` | drill em sub-view |
+| `esc` | volta à view anterior |
+| `q` | sai do painel |
+| `p` | pause / resume refresh automático |
+| `+` / `-` | acelera / desacelera o refresh (×0.25 a ×4) |
+| `r` | força refresh imediato (invalida caches) |
+| `s` | snapshot da tela em `~/.deile/snapshots/` |
+| `?` | mostra a tela de ajuda |
+
+**Views**:
+
+| `[N]` | view | refresh | o que mostra |
+|---|---|---|---|
+| `[1]` | Pod picker → Pod watch | 3s / 1s | lista de pods navegável (↑/↓, enter); pod-watch abre kubectl logs -f embedded com filtro de health-checks |
+| `[2]` | Pipeline timeline | 5s | events classificados (mention/dispatch/http/startup) + stats (gap p95/max, ticks/h, failures) + histograma 24h |
+| `[3]` | Issues & PRs | 10s | tabela viva GitHub × labels do pipeline (filtros `a/i/p/b/m`, enter copia URL pro clipboard) |
+| `[5]` | Tokens & Custos | 60s | `~/.deile/db/usage.db` por provider (24h/1h, %, top 5 sessions) |
+| `[n]` | Notifier echo | 5s | últimos eventos `deilebot.audit` (outbound_sent/failed) |
+| `[a]` | Ações | 1s | `status` / `restart` / `build` / `up` / `stop` / `start` / `test` / `DOWN` (com confirmação) acionáveis sem sair do painel |
+| `[?]` | Help | — | resumo dos hotkeys |
+
+**Alertas automáticos** acendem no dashboard quando:
+- algum pod reiniciou ≥3× (crítico) ou ≥1× nos últimos 30min (warning);
+- o pipeline está sem ação há >5min (provável travamento);
+- existe issue com `~workflow:bloqueada`;
+- existe issue com `~workflow:aguardando_stakeholder` (esperando você);
+- algum provider está reportando erro.
+
+**Modo demo**: quando `kubectl` não está disponível ou o cluster está fora,
+o painel cai em mocks (mostra dados sintéticos) — a UI ainda abre.
+
+### 4.4 Diagnóstico rápido
 
 ```bash
 # tudo no namespace
@@ -285,7 +333,7 @@ kubectl -n deile exec deploy/deilebot -- \
   python3 -c "import sqlite3; print(sorted(r[0] for r in sqlite3.connect('/home/deile/data/deilebot.sqlite').execute('SELECT name FROM sqlite_master WHERE type=\"table\"')))"
 ```
 
-### 4.4 Health checks de isolamento
+### 4.5 Health checks de isolamento
 
 São esses os experimentos que provam que o container está fechado.
 Reaproveite a qualquer hora:

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -295,7 +295,8 @@ Zero dependência nova: `rich` já está em `pyproject.toml`.
 
 #### 4.3.1 Visão geral — o dashboard
 
-A primeira tela que aparece. Refresh padrão **3s**.
+A primeira tela que aparece. Refresh visual **1s** (cada bloco refresca
+conforme TTL do seu provider — ver tabela abaixo).
 
 ```text
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -332,16 +333,35 @@ A primeira tela que aparece. Refresh padrão **3s**.
   [1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  [5]Tokens  [n]otifier  [a]ctions  [m]odel
 ```
 
-Cada bloco vem de um provider diferente:
+**Visual vs fetch — desacoplados.** A view re-renderiza em cadência
+**de 1s** (`refresh_s`) — render é ~3ms, custo desprezível. O fetch
+real (subprocess kubectl/gh, query SQLite) acontece no
+`BackgroundRefresher` (thread daemon) e respeita o TTL próprio de cada
+provider. O thread principal **nunca bloqueia**: `provider.get()`
+devolve o cache (mesmo velho) e o refresher repõe no próximo tick.
 
-| bloco | provider | TTL |
+Cada bloco do dashboard vem de um provider diferente:
+
+| bloco | provider | TTL do provider |
 |---|---|---|
-| PODS | `PodsProvider` + `WorkerProvider` + `PipelineProvider` | 3s + 5s + 5s |
-| PIPELINE | `PipelineProvider` + `GitHubProvider` | 5s + 10s |
+| PODS | `PodsProvider` + `WorkerProvider` + `PipelineProvider` | 1s + 2s + 2s |
+| PIPELINE | `PipelineProvider` + `GitHubProvider` | 2s + 10s |
 | ALERTS | regras locais em `_alerts_from_data` | — (recomputado a cada render) |
-| ACTIVITY | `PipelineProvider.events` | 5s |
-| TOKENS & CUSTOS | `CostsProvider` (SQLite local) | 60s |
-| ÚLTIMAS DECISÕES | últimos 3 eventos `mention`/`dispatch`/`stages` | 5s |
+| ACTIVITY | `PipelineProvider.events` | 2s |
+| TOKENS & CUSTOS | `CostsProvider` (SQLite local) | 30s |
+| ÚLTIMAS DECISÕES | últimos 3 eventos `mention`/`dispatch`/`stages` | 2s |
+
+TTLs escolhidos por origem da fonte:
+
+| fonte | TTL | racional |
+|---|---|---|
+| `kubectl get pods` (local k3s) | 1s | <50ms por chamada, sem custo |
+| `kubectl logs --tail=200` (pipeline/audit) | 2s | ~200ms por chamada |
+| `kubectl logs` por worker (N pods) | 2s | rodam em paralelo no pool |
+| `kubectl get deploy/<dep> -o json` (current model) | 3s | 1 chamada por deploy |
+| `gh api --paginate /repos/.../issues` | 10s | rate-limit (5000/h auth = 1.4/s) — 10s = 360/h, folga confortável |
+| SQLite `usage.db` (costs) | 30s | local, mas poll mais frequente é só barulho |
+| `model_providers.yaml` | 300s | catálogo estático |
 
 #### 4.3.2 Hotkeys globais
 
@@ -408,7 +428,8 @@ SIGKILL como garantia).
 
 #### 4.3.4 Pipeline timeline (`[2]`)
 
-Refresh **5s**. Eventos classificados a partir de
+Refresh visual **1s** (fetch real do `PipelineProvider` a cada **2s**).
+Eventos classificados a partir de
 `kubectl logs deploy/deile-pipeline --tail=200` — mention, dispatch, http,
 startup, stages.
 
@@ -444,7 +465,8 @@ startup, stages.
 
 #### 4.3.5 Issues & PRs (`[3]`)
 
-Refresh **10s** — `gh` API custa rate-limit. Cruz cluster ↔ GitHub,
+Refresh visual **1s** (fetch real do `GitHubProvider` a cada **10s** —
+`gh` API custa rate-limit). Cruz cluster ↔ GitHub,
 respeitando precedência de label (`bloqueada` vence sobre fase).
 
 ```text
@@ -478,8 +500,9 @@ ciano para o estado normal de pipeline.
 
 #### 4.3.6 Tokens & Custos (`[5]`)
 
-Refresh **60s** — SQLite local é barato mas re-abrir a cada 2s é
-desperdício. Lê `~/.deile/db/usage.db` (`UsageRepository`).
+Refresh visual **1s** (fetch real do `CostsProvider` a cada **30s** —
+SQLite local é barato mas poll muito frequente é só barulho). Lê
+`~/.deile/db/usage.db` (`UsageRepository`).
 
 ```text
 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
@@ -505,7 +528,8 @@ desperdício. Lê `~/.deile/db/usage.db` (`UsageRepository`).
 
 #### 4.3.7 Notifier echo (`[n]`)
 
-Refresh **5s**. Parsea `kubectl logs deploy/deilebot --tail=500` filtrando
+Refresh visual **1s** (fetch real do `BotAuditProvider` a cada **2s**).
+Parsea `kubectl logs deploy/deilebot --tail=500` filtrando
 linhas JSON do logger `deilebot.audit`. Captura tanto `outbound_sent`
 quanto `outbound_failed`.
 
@@ -562,7 +586,9 @@ Refresh **1s** (pra mostrar o output streaming). Lista os verbos do
 
 #### 4.3.9 Trocar modelo em runtime (`[m]`)
 
-Refresh **5s**. Lista o catálogo de modelos lido do
+Refresh visual **1s** (fetch real do `CurrentModelProvider` a cada
+**3s**, catálogo `ModelsProvider` a cada **300s** — YAML estático).
+Lista o catálogo de modelos lido do
 `deile/config/model_providers.yaml` e mostra o que está efetivamente em uso
 em cada Deployment. **`enter`** abre overlay de confirmação; **`y`**
 aplica via `kubectl set env`, o que dispara rollout (zero-downtime no

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -54,7 +54,7 @@ import _panel_demo as demo  # noqa: E402
 # sys.path setup feito por `deploy.py` (que insere `infra/k8s/` no path
 # antes de importar `_panel`). Não trocar para `from infra.k8s. ...` sem
 # revisar como o orquestrador invoca o painel.
-from _panel_data import PanelData, _fmt_age, kubectl_bin  # noqa: F401
+from _panel_data import BackgroundRefresher, PanelData, _fmt_age, kubectl_bin  # noqa: F401
 from _panel_data import set_preferred_model as pd_set_preferred_model
 from rich import box
 from rich.align import Align
@@ -481,7 +481,7 @@ class DashboardView(View):
 
     name = "dashboard"
     title = "Dashboard"
-    refresh_s = 3.0
+    refresh_s = 1.0    # render é ~3ms; conteúdo refresca conforme TTL do provider
 
     HOTKEYS = (
         "[1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  "
@@ -783,7 +783,7 @@ class PodPickerView(View):
 
     name = "pod-picker"
     title = "Selecionar pod"
-    refresh_s = 3.0
+    refresh_s = 1.0
 
     HOTKEYS = "[↑/↓] navega   [enter] entra   [esc] volta   [q] sai"
 
@@ -999,7 +999,7 @@ class PipelineTimelineView(View):
 
     name = "pipeline-timeline"
     title = "Pipeline Timeline"
-    refresh_s = 5.0
+    refresh_s = 1.0
 
     HOTKEYS = "[esc] volta   [r] força refresh   [q] sai"
 
@@ -1139,7 +1139,7 @@ class IssuesPRsView(View):
 
     name = "issues-prs"
     title = "Issues & PRs"
-    refresh_s = 10.0
+    refresh_s = 1.0
 
     HOTKEYS = ("[a] all   [i] só issues   [p] só PRs   [b] só bloqueadas   "
                "[m] minhas   [↑/↓] navega   [enter] abrir URL   [esc] volta")
@@ -1304,7 +1304,7 @@ class TokensView(View):
 
     name = "tokens"
     title = "Tokens & Custos"
-    refresh_s = 60.0
+    refresh_s = 1.0
 
     HOTKEYS = "[r] força refresh   [esc] volta   [q] sai"
 
@@ -1396,11 +1396,17 @@ _AUDIT_LOG_RE = re.compile(r'"logger":\s*"deilebot\.audit"')
 
 
 class NotifierEchoView(View):
-    """Últimas mensagens de I/O do bot (audit log)."""
+    """Últimas mensagens de I/O do bot (audit log).
+
+    Os dados vêm do `BotAuditProvider` (cacheado, refrescado em
+    background pelo `BackgroundRefresher`). O render nunca chama
+    subprocess — antes da Fase 11 ele fazia `kubectl logs` direto a
+    cada 5s e congelava a UI.
+    """
 
     name = "notifier-echo"
     title = "Notifier Echo"
-    refresh_s = 5.0
+    refresh_s = 1.0
 
     HOTKEYS = "[r] força refresh   [esc] volta   [q] sai"
 
@@ -1450,6 +1456,11 @@ class NotifierEchoView(View):
             return None
 
     def render(self, app: "PanelApp") -> RenderableType:
+        # Usa o NotifierProvider via _fetch_lines (cache + parse JSON
+        # robusto). Antes desta resolução de merge, render lia direto
+        # de `data.audit` (BotAuditProvider, parser estrito) que foi
+        # substituído pelo NotifierProvider (linhas cruas + parser
+        # JSON-first com fallback regex).
         events = self._fetch_lines()
         if not events:
             body: RenderableType = Text(
@@ -1768,7 +1779,7 @@ class ModelSwitcherView(View):
 
     name = "model-switcher"
     title = "Trocar modelo (runtime)"
-    refresh_s = 5.0
+    refresh_s = 1.0
 
     HOTKEYS = ("[↑/↓] navega   [w] target=worker   [p] target=pipeline   "
                "[b] both   [enter] aplicar   [esc] volta   [q] sai")
@@ -2221,6 +2232,20 @@ class PanelApp:
                 "(stdin e stdout precisam ser TTY).[/yellow]"
             )
             return 1
+        # BackgroundRefresher mantém os caches frescos fora do thread
+        # principal — sem isso, `render()` que cair num provider com TTL
+        # vencido bloqueia a UI por segundos (kubectl/gh).
+        refresher = (BackgroundRefresher(self.data)
+                     if self.data is not None else None)
+        if refresher is not None:
+            refresher.start()
+        try:
+            return self._run_loop(refresher)
+        finally:
+            if refresher is not None:
+                refresher.stop()
+
+    def _run_loop(self, refresher: Optional["BackgroundRefresher"]) -> int:
         with KeyReader() as keys, Live(
             self.current_view.render(self),
             console=self.console,

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -96,7 +96,14 @@ else:
     class KeyReader:
         """Lê uma tecla em cbreak mode, sem ecoar e sem bloquear.
 
-        Decodifica ESC sozinho (vs prefix de seta) com timeout de 50ms — o
+        Usa ``os.read`` no FD bruto em vez de ``sys.stdin.read`` para
+        bypassar o BufferedReader interno do TextIOWrapper — sem isso, o
+        ``\\x1b`` da seta era puxado para o buffer e o ``select.select``
+        seguinte (testando só o FD raw) retornava vazio, fazendo o reader
+        confundir uma seta CSI com ESC sozinho. Resultado prático antes do
+        fix: setas ↑/↓ não funcionavam.
+
+        Decodifica ESC sozinho (vs prefix CSI) com timeout de 50ms — o
         suficiente para distinguir num terminal local sem deixar o usuário
         sentir lag.
         """
@@ -120,24 +127,28 @@ else:
         def read(self, timeout: float = 0.0) -> Optional[str]:
             if self._fd is None:
                 return None
-            if not select.select([sys.stdin], [], [], timeout)[0]:
+            if not select.select([self._fd], [], [], timeout)[0]:
                 return None
-            ch = sys.stdin.read(1)
-            if ch != "\x1b":
-                return ch
+            b = os.read(self._fd, 1)
+            if not b:
+                return None
+            if b != b"\x1b":
+                return b.decode("utf-8", errors="ignore") or None
             # ESC sozinho ou prefix CSI?
-            if not select.select([sys.stdin], [], [], 0.05)[0]:
+            if not select.select([self._fd], [], [], 0.05)[0]:
                 return "ESC"
-            seq = sys.stdin.read(1)
-            if seq != "[":
+            seq = os.read(self._fd, 1)
+            if seq != b"[":
                 return "ESC"
-            buf: List[str] = []
-            while select.select([sys.stdin], [], [], 0.05)[0]:
-                c = sys.stdin.read(1)
-                buf.append(c)
-                if c.isalpha() or c == "~":
+            buf: List[bytes] = []
+            while select.select([self._fd], [], [], 0.05)[0]:
+                c = os.read(self._fd, 1)
+                if not c:
                     break
-            code = "".join(buf)
+                buf.append(c)
+                if c.isalpha() or c == b"~":
+                    break
+            code = b"".join(buf).decode("utf-8", errors="ignore")
             return _ARROW.get(code, f"CSI:{code}")
 
 
@@ -1796,14 +1807,16 @@ class HelpView(View):
         tbl.add_column("tecla", style="bold cyan", width=18)
         tbl.add_column("ação")
         rows = [
-            ("1-5, a, m",   "drill em sub-view (no dashboard)"),
-            ("esc",         "volta à view anterior (ou ao dashboard)"),
-            ("q",           "sai do painel"),
-            ("p",           "pause / resume refresh automático"),
-            ("+ / -",       "acelera / desacelera o refresh (×0.5 a ×4)"),
-            ("r",           "força um refresh imediato"),
-            ("s",           "snapshot: salva a tela atual em .deile/snapshots/"),
-            ("?",           "esta tela"),
+            ("1-5, a, m, n",  "drill em sub-view (no dashboard)"),
+            ("↑/↓ ou j/k",    "navega em listas (picker, issues/PRs, modelos)"),
+            ("enter",         "seleciona o item destacado"),
+            ("esc",           "volta à view anterior (ou ao dashboard)"),
+            ("q",             "sai do painel"),
+            ("p",             "pause / resume refresh automático"),
+            ("+ / -",         "acelera / desacelera o refresh (×0.25 a ×4)"),
+            ("r",             "força refresh imediato (invalida caches)"),
+            ("s",             "snapshot: salva a tela atual em ~/.deile/snapshots/"),
+            ("?",             "esta tela"),
         ]
         for k, v in rows:
             tbl.add_row(k, v)
@@ -1951,26 +1964,35 @@ class PanelApp:
             self.current_view.render(self),
             console=self.console,
             screen=True,
-            refresh_per_second=10,
+            refresh_per_second=30,
             transient=False,
         ) as live:
             self._last_render = time.monotonic()
             while self.running:
-                key = keys.read(timeout=0.1)
+                # `timeout=0.05` mantém o loop responsivo (até 50ms para
+                # detectar tecla nova) sem ficar acordando inutilmente.
+                key = keys.read(timeout=0.05)
+                consumed = False
                 if key:
-                    if not self._handle_global(key):
+                    if self._handle_global(key):
+                        consumed = True
+                    else:
                         result = self.current_view.handle_key(key, self)
                         self._apply(result)
+                        # NOOP = tecla ignorada pela view; não força render.
+                        if result.kind != Action.NOOP:
+                            consumed = True
                 if not self.running:
                     break
-                if (not self.paused) and (
-                    time.monotonic() - self._last_render
-                    >= self.current_refresh_s
-                ):
-                    live.update(self.current_view.render(self))
-                    self._last_render = time.monotonic()
-                elif self._last_render == 0.0:
-                    # Force-refresh pedido via [r].
+                # Render imediato quando: (a) tecla mudou o estado,
+                # (b) hotkey [r] zerou `_last_render`, ou (c) o
+                # `refresh_s` da view vigente venceu.
+                now = time.monotonic()
+                cadence_due = (
+                    not self.paused
+                    and (now - self._last_render) >= self.current_refresh_s
+                )
+                if consumed or self._last_render == 0.0 or cadence_due:
                     live.update(self.current_view.render(self))
                     self._last_render = time.monotonic()
         return 0

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -49,6 +49,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Deque, Dict, List, Optional
 
+import _panel_demo as demo  # noqa: E402
+# Imports `_panel_data` e `_panel_demo` são unqualified — dependem do
+# sys.path setup feito por `deploy.py` (que insere `infra/k8s/` no path
+# antes de importar `_panel`). Não trocar para `from infra.k8s. ...` sem
+# revisar como o orquestrador invoca o painel.
+from _panel_data import PanelData, _fmt_age, kubectl_bin  # noqa: F401
+from _panel_data import set_preferred_model as pd_set_preferred_model
 from rich import box
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
@@ -57,14 +64,6 @@ from rich.live import Live
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
-
-# Imports `_panel_data` e `_panel_demo` são unqualified — dependem do
-# sys.path setup feito por `deploy.py` (que insere `infra/k8s/` no path
-# antes de importar `_panel`). Não trocar para `from infra.k8s. ...` sem
-# revisar como o orquestrador invoca o painel.
-from _panel_data import PanelData, _fmt_age, kubectl_bin  # noqa: F401
-from _panel_data import set_preferred_model as pd_set_preferred_model
-import _panel_demo as demo  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -1510,8 +1509,7 @@ def _audit_panel_action(spec: "_ActionSpec", *, result: str,
     isolado) — mas registra warning no logger local."""
     try:
         from deile.security.audit_logger import (  # noqa: PLC0415
-            AuditEvent, AuditEventType, SeverityLevel, get_audit_logger,
-        )
+            AuditEventType, SeverityLevel, get_audit_logger)
     except Exception as exc:  # noqa: BLE001
         logger.warning("audit logger indisponível para ação do painel: %s", exc)
         return

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -1,18 +1,30 @@
 """TUI ao vivo de monitoramento da stack DEILE no Kubernetes.
 
 Painel full-screen com `rich.Live` que cruza o estado do cluster (pods,
-deployments, métricas) com o estado da fonte de verdade do pipeline
-(issues + PRs no GitHub) e do trabalho LLM (logs, progress.md, custos).
+deployments) com a fonte de verdade do pipeline (issues + PRs no
+GitHub) e do uso (UsageRepository).
 
-Esqueleto (Fase 1): layout completo do dashboard + key handler navegável
-+ stub das sub-views. Dados ainda são mock — as Fases 2+ ligam providers
-reais (kubectl, gh, sqlite de usage).
+Composição em três módulos (todos em `infra/k8s/`):
+- `_panel_data.py` — Cache TTL + providers (Pods, Pipeline, Worker,
+  GitHub, Costs). Fonte única de verdade dos números.
+- `_panel_demo.py` — mocks usados quando o cluster está fora ou o
+  kubectl não está instalado (modo demo: UI ainda abre).
+- `_panel.py` (este arquivo) — KeyReader (termios cbreak / msvcrt),
+  view contract (`View`/`ActionResult`/`PanelApp`), alerts engine,
+  adapters de rendering e o registry/loop principal.
 
 Uso:
-    python3 infra/k8s/deploy.py panel        # entra no painel
-    [1-5] drill em sub-view   [esc] back   [q] quit
-    [p] pause refresh         [+/-] velocidade   [r] force refresh
-    [s] snapshot              [?] ajuda
+    python3 infra/k8s/deploy.py k8s panel     # entra no painel
+
+Hotkeys globais (qualquer view):
+    [1-5, a, m, n]  drill em sub-view (do dashboard)
+    [esc]           volta à view anterior
+    [q]             sai do painel
+    [p]             pause / resume refresh automático
+    [+] / [-]       acelera / desacelera o refresh (×0.25 a ×4)
+    [r]             força refresh imediato (invalida caches dos providers)
+    [s]             snapshot da tela em ~/.deile/snapshots/
+    [?]             tela de ajuda
 """
 
 from __future__ import annotations

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -29,15 +29,25 @@ Hotkeys globais (qualquer view):
 
 from __future__ import annotations
 
+import atexit
+import json
+import logging
 import os
+import re
 import select
+import shutil
+import signal
+import subprocess
 import sys
+import threading
 import time
 from abc import ABC, abstractmethod
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Deque, Dict, List, Optional
 
 from rich import box
 from rich.align import Align
@@ -48,17 +58,31 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+# Imports `_panel_data` e `_panel_demo` são unqualified — dependem do
+# sys.path setup feito por `deploy.py` (que insere `infra/k8s/` no path
+# antes de importar `_panel`). Não trocar para `from infra.k8s. ...` sem
+# revisar como o orquestrador invoca o painel.
 from _panel_data import PanelData, _fmt_age, kubectl_bin  # noqa: F401
 from _panel_data import set_preferred_model as pd_set_preferred_model
-import _panel_demo as demo
-import collections
-import re
-import shutil
-import subprocess
-import threading
-from pathlib import Path
+import _panel_demo as demo  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 _HEALTH_LINE_RE = re.compile(r"GET /v1/health")
+
+# Mapa estável (módulo-level) para encurtar nomes de workflow no header —
+# montar a cada chamada em hot-path era desperdício.
+_SHORT_LABELS = {
+    "em_refinamento": "refine",
+    "em_arquitetura": "arq",
+    "em_implementacao": "impl",
+    "em_pr": "pr",
+    "aguardando_stakeholder": "aguard",
+}
+
+# Quantidade máxima de snapshots a manter em ~/.deile/snapshots/ — os
+# mais antigos são apagados para o diretório não crescer indefinidamente.
+_SNAPSHOT_RETAIN = 50
 
 
 # ===== key reader ===========================================================
@@ -106,23 +130,66 @@ else:
         Decodifica ESC sozinho (vs prefix CSI) com timeout de 50ms — o
         suficiente para distinguir num terminal local sem deixar o usuário
         sentir lag.
+
+        Restaura termios em qualquer caminho de saída (context-manager,
+        atexit, SIGTERM/SIGHUP/SIGQUIT) — sem isso, um kill -TERM no painel
+        deixa o shell do operador em cbreak mode.
         """
+
+        _SIGNALS = (signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT)
 
         def __init__(self):
             self._fd: Optional[int] = (
                 sys.stdin.fileno() if sys.stdin.isatty() else None
             )
             self._old = None
+            self._restored = False
+            self._prev_handlers: Dict[int, Any] = {}
 
         def __enter__(self):
             if self._fd is not None:
                 self._old = termios.tcgetattr(self._fd)
                 tty.setcbreak(self._fd)
+                self._restored = False
+                atexit.register(self._restore)
+                for sig in self._SIGNALS:
+                    try:
+                        self._prev_handlers[sig] = signal.signal(
+                            sig, self._signal_handler,
+                        )
+                    except (OSError, ValueError):
+                        # Em threads não-main signal.signal levanta; ignorar.
+                        pass
             return self
 
         def __exit__(self, *exc):
+            self._restore()
+
+        def _restore(self) -> None:
+            if self._restored:
+                return
+            self._restored = True
             if self._fd is not None and self._old is not None:
-                termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old)
+                try:
+                    termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old)
+                except (OSError, termios.error):
+                    pass
+            for sig, prev in self._prev_handlers.items():
+                try:
+                    signal.signal(sig, prev)
+                except (OSError, ValueError):
+                    pass
+            self._prev_handlers.clear()
+
+        def _signal_handler(self, signum, frame):
+            # Restaura o terminal e re-dispara o sinal com o handler default
+            # — o processo sai com o status canônico do sinal.
+            self._restore()
+            try:
+                signal.signal(signum, signal.SIG_DFL)
+            except (OSError, ValueError):
+                pass
+            os.kill(os.getpid(), signum)
 
         def read(self, timeout: float = 0.0) -> Optional[str]:
             if self._fd is None:
@@ -385,7 +452,16 @@ def _head_panel(view_title: str, app: "PanelApp") -> Panel:
         "image: deile-stack:local",
         style="dim",
     )
-    return Panel(Group(head, sub), border_style="cyan", box=box.HEAVY)
+    pieces: List[RenderableType] = [head, sub]
+    # Toasts efêmeros (snapshot salvo, etc) aparecem como linha extra
+    # discreta no head — não quebram o layout das views.
+    toasts = app.active_toasts()
+    if toasts:
+        toast_line = Text()
+        for icon, msg in toasts[-2:]:
+            toast_line.append(f"{icon} {msg}  ", style="bold yellow")
+        pieces.append(toast_line)
+    return Panel(Group(*pieces), border_style="cyan", box=box.HEAVY)
 
 
 def _footer_panel(hotkeys: str) -> Panel:
@@ -631,15 +707,11 @@ def _compact_state_counts(counts: Dict[str, int]) -> str:
     """Formata `{nova:2, em_impl:3}` em string compacta `nova:2  impl:3`."""
     if not counts:
         return "—"
-    # Aliases pra encurtar nomes longos no header.
-    short = {"em_refinamento": "refine", "em_arquitetura": "arq",
-             "em_implementacao": "impl", "em_pr": "pr",
-             "aguardando_stakeholder": "aguard"}
     bits = []
     for k, v in counts.items():
         if v == 0:
             continue
-        bits.append(f"{short.get(k, k)}:{v}")
+        bits.append(f"{_SHORT_LABELS.get(k, k)}:{v}")
     return "  ".join(bits) if bits else "—"
 
 
@@ -648,15 +720,16 @@ class _LogStreamer:
 
     Pensado para ser dono curto-prazo: criado pelo `PodWatchView.on_mount`
     e parado no `on_unmount`. O processo `kubectl` recebe SIGTERM; após
-    2s sem morrer, SIGKILL. A thread de leitura é daemon — segura contra
-    vazamento se o app fechar antes do `stop`.
+    500ms sem morrer, SIGKILL (também não-bloqueante). A thread de
+    leitura é daemon — segura contra vazamento se o app fechar antes do
+    `stop`.
     """
 
     def __init__(self, kubectl: str, ns: str, pod: str,
                  tail: int = 50, maxlen: int = 300):
         self._cmd = [kubectl, "-n", ns, "logs", pod, "-f",
                      f"--tail={tail}", "--timestamps"]
-        self.buf: "collections.deque[str]" = collections.deque(maxlen=maxlen)
+        self.buf: Deque[str] = deque(maxlen=maxlen)
         self._proc: Optional[subprocess.Popen] = None
         self._thread: Optional[threading.Thread] = None
         self._stop = threading.Event()
@@ -679,6 +752,8 @@ class _LogStreamer:
         if self._proc is None or self._proc.stdout is None:
             return
         for line in self._proc.stdout:
+            # Checa stop ANTES de processar — evita lag de 1 linha após
+            # stop() e diminui o tempo até o break em buffers cheios.
             if self._stop.is_set():
                 break
             self.buf.append(line.rstrip())
@@ -688,9 +763,13 @@ class _LogStreamer:
         if self._proc is not None:
             try:
                 self._proc.terminate()
-                self._proc.wait(timeout=2.0)
+                self._proc.wait(timeout=0.5)
             except subprocess.TimeoutExpired:
-                self._proc.kill()
+                try:
+                    self._proc.kill()
+                    self._proc.wait(timeout=0.5)
+                except (subprocess.TimeoutExpired, OSError):
+                    pass
             except OSError:
                 pass
             self._proc = None
@@ -795,6 +874,14 @@ class PodWatchView(View):
         self.hide_health: bool = True
 
     def on_mount(self, app: "PanelApp") -> None:
+        # PodWatchView é singleton no registry — re-mount com pod diferente
+        # precisa zerar TODO o estado, senão preferências (follow, hide_health)
+        # vazam entre pods, confundindo o operador.
+        self.following = True
+        self.hide_health = True
+        if self.streamer is not None:
+            self.streamer.stop()
+            self.streamer = None
         # Payload da navegação vem em `app.last_payload` (setado pelo PanelApp).
         payload = getattr(app, "last_payload", {}) or {}
         self.pod_name = payload.get("pod_name", "")
@@ -1062,7 +1149,27 @@ class IssuesPRsView(View):
         self.data = data
         self.filter: str = "all"
         self.cursor: int = 0
-        self.my_login: str = os.environ.get("GH_USER", "elimarcavalli")
+        # Sem nome hardcoded: tenta env GH_USER → `gh api user` → vazio.
+        self.my_login: str = self._resolve_login()
+
+    @staticmethod
+    def _resolve_login() -> str:
+        env = os.environ.get("GH_USER")
+        if env:
+            return env
+        gh = shutil.which("gh")
+        if gh is None:
+            return ""
+        try:
+            out = subprocess.run(
+                [gh, "api", "user", "-q", ".login"],
+                capture_output=True, text=True, timeout=3.0,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return ""
+        if out.returncode == 0:
+            return out.stdout.strip()
+        return ""
 
     def _rows(self):
         if self.data is None:
@@ -1172,7 +1279,8 @@ class IssuesPRsView(View):
 def _copy_to_clipboard(text: str) -> bool:
     """Tenta colar `text` no clipboard via pbcopy/xclip/wl-copy.
 
-    Sem erro se nenhum bin disponível — é só um nice-to-have.
+    Sem erro fatal se nenhum bin disponível — é só um nice-to-have —
+    mas registra warning para o operador entender por que copy não fez nada.
     """
     for cmd in (["pbcopy"], ["xclip", "-selection", "clipboard"], ["wl-copy"]):
         if shutil.which(cmd[0]):
@@ -1181,6 +1289,9 @@ def _copy_to_clipboard(text: str) -> bool:
                 return True
             except (OSError, subprocess.SubprocessError):
                 continue
+    logger.warning(
+        "_copy_to_clipboard: nenhum bin (pbcopy/xclip/wl-copy) encontrado",
+    )
     return False
 
 
@@ -1279,8 +1390,10 @@ class TokensView(View):
 
 # ----- Notifier echo --------------------------------------------------------
 
-_AUDIT_LOG_RE = re.compile(r'\{"ts":\s*"[^"]+",\s*"level":\s*"\w+",'
-                           r'\s*"logger":\s*"deilebot\.audit"')
+# Fallback regex caso a linha não seja JSON pura — checagem barata
+# antes de tentar `json.loads`. JSON-first é mais robusto que regex
+# (cobre serializadores que reordenam chaves, espaços etc).
+_AUDIT_LOG_RE = re.compile(r'"logger":\s*"deilebot\.audit"')
 
 
 class NotifierEchoView(View):
@@ -1292,37 +1405,50 @@ class NotifierEchoView(View):
 
     HOTKEYS = "[r] força refresh   [esc] volta   [q] sai"
 
-    BOT_DEPLOY = "deilebot"
-    TAIL = 500
-
     def __init__(self, data: Optional[PanelData] = None):
         self.data = data
 
     def _fetch_lines(self) -> List[Dict[str, Any]]:
-        kubectl = kubectl_bin()
-        if kubectl is None:
+        # Lê do NotifierProvider (cache TTL 5s) — antes fazia kubectl direto
+        # por render, gerando 12 chamadas/min.
+        if self.data is None or self.data.notifier is None:
             return []
-        try:
-            out = subprocess.run(
-                [kubectl, "-n", "deile", "logs",
-                 f"deploy/{self.BOT_DEPLOY}", f"--tail={self.TAIL}"],
-                capture_output=True, text=True, timeout=5,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            return []
-        if out.returncode != 0:
-            return []
+        raw_lines = self.data.notifier.get()
         events: List[Dict[str, Any]] = []
-        import json as _json
-        for line in out.stdout.splitlines():
-            if not _AUDIT_LOG_RE.search(line):
-                continue
-            try:
-                ev = _json.loads(line)
-            except _json.JSONDecodeError:
-                continue
-            events.append(ev)
+        for line in raw_lines:
+            ev = self._parse_line(line)
+            if ev is not None:
+                events.append(ev)
         return events
+
+    @staticmethod
+    def _parse_line(line: str) -> Optional[Dict[str, Any]]:
+        """Tenta JSON primeiro (estrutura do audit do bot); fallback ao regex.
+
+        Estruturas diferentes de log (com `{...}` wrappados em prefixos do
+        runtime do bot) caem no regex match + json no payload."""
+        line = line.strip()
+        if not line:
+            return None
+        # JSON puro
+        if line.startswith("{"):
+            try:
+                obj = json.loads(line)
+                if isinstance(obj, dict) and obj.get("logger") == "deilebot.audit":
+                    return obj
+            except json.JSONDecodeError:
+                pass
+        # Fallback: regex casa qualquer linha contendo logger=deilebot.audit
+        # e tenta extrair o último JSON da linha.
+        if not _AUDIT_LOG_RE.search(line):
+            return None
+        brace = line.find("{")
+        if brace < 0:
+            return None
+        try:
+            return json.loads(line[brace:])
+        except json.JSONDecodeError:
+            return None
 
     def render(self, app: "PanelApp") -> RenderableType:
         events = self._fetch_lines()
@@ -1369,6 +1495,46 @@ class _ActionSpec:
     label: str
     cmd: List[str]
     destructive: bool = False
+    # Verbo "mutador" = modifica estado do cluster (build/up/restart/stop/
+    # start/test/down). Read-only (`status`) tem mutates=False e roda sem
+    # confirmação. Todos os mutadores exigem [y/N] mesmo quando não
+    # destrutivos — README anuncia "não muta nada do estado existente".
+    mutates: bool = False
+
+
+def _audit_panel_action(spec: "_ActionSpec", *, result: str,
+                        detail: str = "") -> None:
+    """Emite AuditEvent(TOOL_EXECUTION) para uma ação do painel.
+
+    Falha silenciosa se o pacote `deile` não estiver importável (rodando
+    isolado) — mas registra warning no logger local."""
+    try:
+        from deile.security.audit_logger import (  # noqa: PLC0415
+            AuditEvent, AuditEventType, SeverityLevel, get_audit_logger,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("audit logger indisponível para ação do painel: %s", exc)
+        return
+    severity = (SeverityLevel.WARNING if spec.destructive
+                else SeverityLevel.INFO)
+    try:
+        get_audit_logger().log_event(
+            event_type=AuditEventType.TOOL_EXECUTION,
+            severity=severity,
+            actor="panel:actions",
+            resource=f"deploy.py:{spec.label}",
+            action="dispatch",
+            result=result,
+            details={
+                "label": spec.label,
+                "cmd": spec.cmd,
+                "destructive": spec.destructive,
+                "mutates": spec.mutates,
+                "detail": detail[:200],
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("falha emitindo AuditEvent para ação: %s", exc)
 
 
 class _ActionRunner:
@@ -1381,7 +1547,7 @@ class _ActionRunner:
 
     def __init__(self, cmd: List[str], maxlen: int = 500):
         self.cmd = cmd
-        self.buf: "collections.deque[str]" = collections.deque(maxlen=maxlen)
+        self.buf: Deque[str] = deque(maxlen=maxlen)
         self._proc: Optional[subprocess.Popen] = None
         self._thread: Optional[threading.Thread] = None
         self.returncode: Optional[int] = None
@@ -1404,6 +1570,8 @@ class _ActionRunner:
         if self._proc is None or self._proc.stdout is None:
             return
         for line in self._proc.stdout:
+            # Checa stop ANTES de processar cada linha — sem isso o stop
+            # só toma efeito após o próximo flush do stdout do subprocess.
             if self._stop.is_set():
                 break
             self.buf.append(line.rstrip())
@@ -1416,9 +1584,13 @@ class _ActionRunner:
         if self._proc is not None and self._proc.poll() is None:
             try:
                 self._proc.terminate()
-                self._proc.wait(timeout=2.0)
+                self._proc.wait(timeout=0.5)
             except subprocess.TimeoutExpired:
-                self._proc.kill()
+                try:
+                    self._proc.kill()
+                    self._proc.wait(timeout=0.5)
+                except (subprocess.TimeoutExpired, OSError):
+                    pass
             except OSError:
                 pass
 
@@ -1453,14 +1625,14 @@ class ActionsView(View):
         # é nossa, na view, antes de chamar.
         return [
             _ActionSpec("status",            [py, deploy, "k8s", "status"]),
-            _ActionSpec("restart",           [py, deploy, "k8s", "restart", "--yes"]),
-            _ActionSpec("build (no restart)",[py, deploy, "k8s", "build", "--yes"]),
-            _ActionSpec("build + restart",   [py, deploy, "k8s", "build", "--restart", "--yes"]),
-            _ActionSpec("up (provisiona)",   [py, deploy, "k8s", "up", "--yes"]),
-            _ActionSpec("stop (scale 0)",    [py, deploy, "k8s", "stop", "--yes"], destructive=False),
-            _ActionSpec("start (scale 1)",   [py, deploy, "k8s", "start", "--yes"]),
-            _ActionSpec("test (Job one-shot)",[py, deploy, "k8s", "test", "--yes"]),
-            _ActionSpec("DOWN (apaga ns)",   [py, deploy, "k8s", "down", "--yes"], destructive=True),
+            _ActionSpec("restart",           [py, deploy, "k8s", "restart", "--yes"], mutates=True),
+            _ActionSpec("build (no restart)",[py, deploy, "k8s", "build", "--yes"], mutates=True),
+            _ActionSpec("build + restart",   [py, deploy, "k8s", "build", "--restart", "--yes"], mutates=True),
+            _ActionSpec("up (provisiona)",   [py, deploy, "k8s", "up", "--yes"], mutates=True),
+            _ActionSpec("stop (scale 0)",    [py, deploy, "k8s", "stop", "--yes"], mutates=True),
+            _ActionSpec("start (scale 1)",   [py, deploy, "k8s", "start", "--yes"], mutates=True),
+            _ActionSpec("test (Job one-shot)",[py, deploy, "k8s", "test", "--yes"], mutates=True),
+            _ActionSpec("DOWN (apaga ns)",   [py, deploy, "k8s", "down", "--yes"], destructive=True, mutates=True),
         ]
 
     def render(self, app: "PanelApp") -> RenderableType:
@@ -1475,17 +1647,21 @@ class ActionsView(View):
             menu.add_row(str(i), label, " ".join(a.cmd[-3:]))
         # confirmação?
         if self.confirm_for is not None:
+            is_destructive = self.confirm_for.destructive
+            tag = "DESTRUTIVA" if is_destructive else "mutadora"
+            heading_style = "bold red" if is_destructive else "bold yellow"
+            border = "red" if is_destructive else "yellow"
             confirm_body = Group(
-                Text(f"Vai rodar a ação DESTRUTIVA: {self.confirm_for.label}",
-                     style="bold red"),
+                Text(f"Vai rodar a ação {tag}: {self.confirm_for.label}",
+                     style=heading_style),
                 Text(" ".join(self.confirm_for.cmd), style="dim"),
                 Text(),
-                Text("Aperte [y] para confirmar, [n] para cancelar.",
-                     style="bold yellow"),
+                Text("Confirma?  [y/N]", style="bold yellow"),
             )
             confirm_panel: Optional[RenderableType] = Panel(
-                confirm_body, title="[bold red]CONFIRMAÇÃO[/bold red]",
-                title_align="left", border_style="red",
+                confirm_body,
+                title=f"[{heading_style}]CONFIRMAÇÃO[/{heading_style}]",
+                title_align="left", border_style=border,
             )
         else:
             confirm_panel = None
@@ -1531,10 +1707,14 @@ class ActionsView(View):
                 self._dispatch(self.confirm_for)
                 self.confirm_for = None
                 return ActionResult.refresh()
-            if key == "n":
-                self.confirm_for = None
-                return ActionResult.refresh()
-            return ActionResult()
+            # Default-deny: qualquer tecla que não seja 'y' (incluindo
+            # 'n' e Enter) cancela. Mantém prompt no estilo `[y/N]`.
+            _audit_panel_action(
+                self.confirm_for, result="denied",
+                detail="operador cancelou na confirmação",
+            )
+            self.confirm_for = None
+            return ActionResult.refresh()
         if key == "c" and self.runner is not None and self.runner.running:
             self.runner.stop()
             return ActionResult.refresh()
@@ -1543,7 +1723,11 @@ class ActionsView(View):
             actions = self._actions()
             if 0 <= idx < len(actions):
                 spec = actions[idx]
-                if spec.destructive:
+                # Toda ação mutadora (mutates=True) — destrutiva ou não —
+                # precisa de confirmação explícita do operador. README anuncia
+                # "não muta nada do estado existente" sem opt-in; o gate é o
+                # `[y/N]`. `status` (não-mutador) roda direto.
+                if spec.mutates:
                     self.confirm_for = spec
                 else:
                     self._dispatch(spec)
@@ -1552,7 +1736,15 @@ class ActionsView(View):
 
     def _dispatch(self, spec: _ActionSpec) -> None:
         if self.runner is not None and self.runner.running:
+            _audit_panel_action(
+                spec, result="denied",
+                detail="já tem ação rodando — ignorado",
+            )
             return                # já tem ação rodando, ignora
+        # Audit ANTES de iniciar — registra a intenção mesmo que o
+        # subprocess falhe ao ligar.
+        _audit_panel_action(spec, result="allowed",
+                            detail="iniciando subprocess")
         self.runner = _ActionRunner(spec.cmd)
         self.last_action = spec.label
         self.runner.start()
@@ -1751,18 +1943,52 @@ class ModelSwitcherView(View):
         deployments = (("deile-worker",) if self.target == "worker"
                        else ("deile-pipeline",) if self.target == "pipeline"
                        else ("deile-worker", "deile-pipeline"))
-        results = []
+        # Para rollback em "both": captura o slug ATUAL de cada deployment
+        # ANTES de tentar trocar. Se o segundo falhar depois do primeiro
+        # ter sucesso, tentamos reverter o primeiro ao valor capturado.
+        prev_slugs: Dict[str, Optional[str]] = {}
+        if len(deployments) > 1:
+            try:
+                current_snap = self.data.current_model.get()
+            except Exception:  # noqa: BLE001
+                current_snap = {}
+            for dep in deployments:
+                prev_slugs[dep] = current_snap.get(dep)
+
+        results: List[tuple] = []
+        rolled_back: List[str] = []
         for dep in deployments:
             ok, msg = pd_set_preferred_model(dep, slug)
             results.append((dep, ok, msg))
-        all_ok = all(ok for _, ok, _ in results)
+            if not ok and len(deployments) > 1 and any(
+                ok_prev for _, ok_prev, _ in results[:-1]
+            ):
+                # Tenta reverter os deployments já alterados (best-effort).
+                for prev_dep, prev_ok, _ in results[:-1]:
+                    if not prev_ok:
+                        continue
+                    prev = prev_slugs.get(prev_dep)
+                    if not prev:
+                        # Sem slug anterior conhecido: não consegue reverter
+                        # (era default-do-settings). Registra no alerta final.
+                        rolled_back.append(f"{prev_dep}:sem-prev")
+                        continue
+                    rb_ok, _ = pd_set_preferred_model(prev_dep, prev)
+                    rolled_back.append(
+                        f"{prev_dep}:{'rb-ok' if rb_ok else 'rb-fail'}"
+                    )
+                break  # não tenta o resto da lista após falha+rollback
+        all_ok = all(ok for _, ok, _ in results) and len(results) == len(deployments)
         # Força provider a re-ler o valor atual no próximo render.
-        self.data.current_model._cache._fetched_at = 0.0  # noqa: SLF001
+        self.data.current_model._cache.invalidate()  # noqa: SLF001
         self.last_ok = all_ok
-        self.last_msg = " | ".join(
-            f"{dep}: {'OK' if ok else 'FAIL'} ({msg[:40]})"
-            for dep, ok, msg in results
+        msg = " | ".join(
+            f"{dep}: {'OK' if ok else 'FAIL'} ({m[:40]})"
+            for dep, ok, m in results
         )
+        if rolled_back:
+            msg += f"  | rollback: {', '.join(rolled_back)}"
+        self.last_msg = msg
 
 
 class StubView(View):
@@ -1840,6 +2066,10 @@ class _Settings:
     paused: bool = False
     refresh_mult: float = 1.0    # 0.25, 0.5, 1.0, 2.0, 4.0
     snapshots_dir: Optional[str] = None
+    # Fila simples de alertas para feedback do usuário (snapshot salvo,
+    # clipboard indisponível, etc). Cada item: (icon, msg, expires_at).
+    # Mostrado no header e expira após 5s. Não persiste entre runs.
+    toasts: List[tuple] = field(default_factory=list)
 
 
 class PanelApp:
@@ -1903,7 +2133,6 @@ class PanelApp:
     # --- snapshots ---
 
     def _snapshot(self) -> Optional[str]:
-        from pathlib import Path
         out_dir = Path(
             self.settings.snapshots_dir
             or os.path.expanduser("~/.deile/snapshots")
@@ -1913,7 +2142,39 @@ class PanelApp:
         capture = Console(record=True, width=self.console.size.width)
         capture.print(self.current_view.render(self))
         path.write_text(capture.export_text(), encoding="utf-8")
+        self._purge_old_snapshots(out_dir)
         return str(path)
+
+    @staticmethod
+    def _purge_old_snapshots(out_dir: Path) -> None:
+        """Mantém só os `_SNAPSHOT_RETAIN` mais recentes (por mtime).
+
+        Sem política, ~/.deile/snapshots/ cresce indefinidamente."""
+        try:
+            files = sorted(
+                (p for p in out_dir.glob("panel-*.txt") if p.is_file()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except OSError:
+            return
+        for old in files[_SNAPSHOT_RETAIN:]:
+            try:
+                old.unlink()
+            except OSError:
+                pass
+
+    def push_toast(self, icon: str, msg: str, ttl_s: float = 5.0) -> None:
+        """Adiciona um toast efêmero (mostrado no header até expirar)."""
+        self.settings.toasts.append((icon, msg, time.monotonic() + ttl_s))
+
+    def active_toasts(self) -> List[tuple]:
+        """Retorna toasts não-expirados (ícone, mensagem). Limpa expirados."""
+        now = time.monotonic()
+        self.settings.toasts = [
+            t for t in self.settings.toasts if t[2] > now
+        ]
+        return [(i, m) for i, m, _ in self.settings.toasts]
 
     # --- key dispatch ---
 
@@ -1943,21 +2204,23 @@ class PanelApp:
                 self.data.force_refresh_all()
             return True
         if key == "s":
-            path = self._snapshot()
+            try:
+                path = self._snapshot()
+            except OSError as exc:
+                self.push_toast("⚠", f"snapshot falhou: {exc}", ttl_s=6.0)
+                return True
             if path:
-                # NOTE: não printa aqui (quebraria a TUI); a próxima
-                # render mostra no head. Fase 3 vai pôr um toast.
-                self.settings.snapshots_dir = self.settings.snapshots_dir
+                self.push_toast("💾", f"snapshot salvo: {path}", ttl_s=6.0)
             return True
         return False
 
     # --- main loop ---
 
     def run(self) -> int:
-        if not sys.stdin.isatty():
+        if not sys.stdin.isatty() or not sys.stdout.isatty():
             self.console.print(
                 "[yellow]painel exige terminal interativo "
-                "(sem TTY).[/yellow]"
+                "(stdin e stdout precisam ser TTY).[/yellow]"
             )
             return 1
         with KeyReader() as keys, Live(
@@ -2042,7 +2305,13 @@ def run_panel() -> int:
         # Toque inicial pra detectar fonte morta cedo (sem custo perceptível —
         # o provider mais pesado é o gh, mas cai em fallback se falhar).
         data.pods.get()
-    except Exception:
+    except Exception:  # noqa: BLE001
+        # Sem log, falhas de bootstrap (kubectl absent, gh com auth ruim,
+        # PyYAML missing etc.) cairiam silenciosamente em modo demo,
+        # confundindo o operador que vê dados sintéticos sem saber por quê.
+        logger.warning(
+            "falha bootstrap providers, caindo em modo demo", exc_info=True,
+        )
         data = None
 
     app = PanelApp(_build_views(data), data=data)

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -35,8 +35,14 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from _panel_data import PanelData, _fmt_age  # noqa: F401 (re-export)
+from _panel_data import PanelData, _fmt_age, kubectl_bin  # noqa: F401
 import _panel_demo as demo
+import collections
+import re
+import subprocess
+import threading
+
+_HEALTH_LINE_RE = re.compile(r"GET /v1/health")
 
 
 # ===== key reader ===========================================================
@@ -578,7 +584,7 @@ class DashboardView(View):
 
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
         nav = {
-            "1": "pod-watch",
+            "1": "pod-picker",
             "2": "pipeline-timeline",
             "3": "issues-prs",
             "4": "logs-split",
@@ -607,6 +613,271 @@ def _compact_state_counts(counts: Dict[str, int]) -> str:
             continue
         bits.append(f"{short.get(k, k)}:{v}")
     return "  ".join(bits) if bits else "—"
+
+
+class _LogStreamer:
+    """Background `kubectl logs -f` que enche uma deque rolling.
+
+    Pensado para ser dono curto-prazo: criado pelo `PodWatchView.on_mount`
+    e parado no `on_unmount`. O processo `kubectl` recebe SIGTERM; após
+    2s sem morrer, SIGKILL. A thread de leitura é daemon — segura contra
+    vazamento se o app fechar antes do `stop`.
+    """
+
+    def __init__(self, kubectl: str, ns: str, pod: str,
+                 tail: int = 50, maxlen: int = 300):
+        self._cmd = [kubectl, "-n", ns, "logs", pod, "-f",
+                     f"--tail={tail}", "--timestamps"]
+        self.buf: "collections.deque[str]" = collections.deque(maxlen=maxlen)
+        self._proc: Optional[subprocess.Popen] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        if self._proc is not None:
+            return
+        try:
+            self._proc = subprocess.Popen(
+                self._cmd, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, text=True, bufsize=1,
+            )
+        except OSError as exc:
+            self.buf.append(f"[ERRO] não consegui rodar kubectl: {exc}")
+            return
+        self._thread = threading.Thread(target=self._reader, daemon=True)
+        self._thread.start()
+
+    def _reader(self) -> None:
+        if self._proc is None or self._proc.stdout is None:
+            return
+        for line in self._proc.stdout:
+            if self._stop.is_set():
+                break
+            self.buf.append(line.rstrip())
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._proc is not None:
+            try:
+                self._proc.terminate()
+                self._proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+            except OSError:
+                pass
+            self._proc = None
+        self._thread = None
+
+    def snapshot(self, n: int = 30) -> List[str]:
+        return list(self.buf)[-n:]
+
+
+class PodPickerView(View):
+    """Lista pods selecionável com setas / Enter abre o PodWatch."""
+
+    name = "pod-picker"
+    title = "Selecionar pod"
+    refresh_s = 3.0
+
+    HOTKEYS = "[↑/↓] navega   [enter] entra   [esc] volta   [q] sai"
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+        self.cursor = 0
+
+    def _rows(self) -> List[PodRow]:
+        return _pod_rows(self.data)
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        rows = self._rows()
+        if rows:
+            self.cursor = max(0, min(self.cursor, len(rows) - 1))
+        tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+        tbl.add_column(" ", width=2)
+        tbl.add_column(" ", width=2)
+        tbl.add_column("pod", style="bold")
+        tbl.add_column("role", width=10)
+        tbl.add_column("status", width=10)
+        tbl.add_column("age", width=6)
+        tbl.add_column("doing now")
+        for i, p in enumerate(rows):
+            marker = "▶" if i == self.cursor else " "
+            row_style = "bold cyan on grey15" if i == self.cursor else ""
+            tbl.add_row(
+                Text(marker, style="bold cyan"),
+                Text(p.icon, style="bold yellow" if p.busy else "green"),
+                Text(p.name, style=row_style),
+                p.role,
+                p.status,
+                p.age,
+                Text(p.doing_now, style="dim"),
+            )
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(tbl, title="[bold]escolha um pod para assistir[/bold]",
+                         title_align="left", border_style="cyan"),
+                   name="body"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        rows = self._rows()
+        n = len(rows)
+        if n == 0:
+            return ActionResult()
+        if key in ("UP", "k"):
+            self.cursor = (self.cursor - 1) % n
+            return ActionResult.refresh()
+        if key in ("DOWN", "j"):
+            self.cursor = (self.cursor + 1) % n
+            return ActionResult.refresh()
+        if key in ("\r", "\n"):
+            pod = rows[self.cursor]
+            return ActionResult.nav("pod-watch", pod_name=pod.name,
+                                    pod_role=pod.role)
+        return ActionResult()
+
+
+class PodWatchView(View):
+    """Drill-in num pod: header + log live via kubectl logs -f.
+
+    Fase 4 entrega o log streaming e o cabeçalho com o estado atual do
+    pod (via PodsProvider) + busy/idle do worker (via WorkerProvider).
+    Resources (cpu/mem via metrics-server) e o `.deile-progress.md`
+    ficam para refinamento em fase posterior — exigem `kubectl top` /
+    `kubectl exec` extras que valem encapsular como sub-providers.
+    """
+
+    name = "pod-watch"
+    title = "Pod Watch"
+    refresh_s = 1.0
+
+    HOTKEYS = ("[f] follow on/off   [h] mostrar/esconder health   "
+               "[c] clear log   [esc] volta   [q] sai")
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+        self.pod_name: str = ""
+        self.pod_role: str = ""
+        self.streamer: Optional[_LogStreamer] = None
+        self.following: bool = True
+        # Health-checks lotam o buffer em workers ociosos; por default escondemos.
+        self.hide_health: bool = True
+
+    def on_mount(self, app: "PanelApp") -> None:
+        # Payload da navegação vem em `app.last_payload` (setado pelo PanelApp).
+        payload = getattr(app, "last_payload", {}) or {}
+        self.pod_name = payload.get("pod_name", "")
+        self.pod_role = payload.get("pod_role", "")
+        kubectl = kubectl_bin()
+        if not self.pod_name or kubectl is None:
+            return
+        self.streamer = _LogStreamer(kubectl, "deile", self.pod_name,
+                                     tail=40, maxlen=400)
+        self.streamer.start()
+
+    def on_unmount(self, app: "PanelApp") -> None:
+        if self.streamer is not None:
+            self.streamer.stop()
+            self.streamer = None
+
+    def _header_body(self) -> RenderableType:
+        if self.data is None:
+            return Text("(modo demo — sem dados reais do pod)", style="dim yellow")
+        pod = next((p for p in self.data.pods.get() if p.name == self.pod_name), None)
+        if pod is None:
+            return Text(f"pod `{self.pod_name}` não encontrado.", style="red")
+        wstate = self.data.workers.get().get(self.pod_name) \
+            if self.pod_role == "worker" else None
+        lines = [
+            Text.assemble(
+                ("name: ", "dim"), (pod.name, "bold"),
+                ("   role: ", "dim"), (pod.role, "bold cyan"),
+                ("   status: ", "dim"),
+                (pod.status, "green" if pod.status == "Running" else "red"),
+            ),
+            Text.assemble(
+                ("uptime: ", "dim"), (_fmt_age(pod.age_s), "bold"),
+                ("   restarts: ", "dim"),
+                (str(pod.restarts),
+                 "bold red" if pod.restarts > 0 else "bold green"),
+                ("   ready: ", "dim"),
+                ("yes" if pod.ready else "NO",
+                 "bold green" if pod.ready else "bold red"),
+                ("   node: ", "dim"), (pod.node or "?", "dim"),
+            ),
+        ]
+        if wstate is not None:
+            lines.append(Text.assemble(
+                ("worker: ", "dim"),
+                ("BUSY" if wstate.busy else "idle",
+                 "bold yellow" if wstate.busy else "dim"),
+                ("   last activity: ", "dim"),
+                (_fmt_age(wstate.last_activity_s) + " ago"
+                 if wstate.last_activity_s is not None else "—", "bold"),
+            ))
+        return Group(*lines)
+
+    def _log_panel(self) -> Panel:
+        hidden = 0
+        if self.streamer is None:
+            body: RenderableType = Text("(streamer não iniciado)", style="dim")
+        else:
+            raw = self.streamer.snapshot(n=200)
+            if self.hide_health:
+                before = len(raw)
+                raw = [ln for ln in raw if not _HEALTH_LINE_RE.search(ln)]
+                hidden = before - len(raw)
+            raw = raw[-30:]
+            if not raw:
+                body = Text(
+                    "(sem linhas significativas — aguardando atividade real)"
+                    if self.hide_health
+                    else "(sem linhas no buffer ainda — aguardando log)",
+                    style="dim",
+                )
+            else:
+                body = Text("\n".join(raw), no_wrap=False)
+        follow_label = "FOLLOW ON" if self.following else "PAUSED"
+        health_label = ("health ESCONDIDOS" if self.hide_health
+                        else "health VISÍVEIS")
+        hidden_label = f"  ·  {hidden} health filtrados" if hidden else ""
+        title = (f"[bold]LIVE LOG[/bold]  ·  {follow_label}  ·  "
+                 f"{health_label}{hidden_label}  ·  {self.pod_name}")
+        return Panel(body, title=title, title_align="left",
+                     border_style="green" if self.following else "yellow")
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(self._header_body(),
+                         title="[bold]POD[/bold]", title_align="left",
+                         border_style="cyan"),
+                   name="info", size=6),
+            Layout(self._log_panel(), name="log"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        if key == "f":
+            self.following = not self.following
+            if self.following and self.streamer is None:
+                self.on_mount(app)
+            elif not self.following and self.streamer is not None:
+                self.streamer.stop()
+                self.streamer = None
+            return ActionResult.refresh()
+        if key == "c" and self.streamer is not None:
+            self.streamer.buf.clear()
+            return ActionResult.refresh()
+        if key == "h":
+            self.hide_health = not self.hide_health
+            return ActionResult.refresh()
+        return ActionResult()
 
 
 class StubView(View):
@@ -700,6 +971,7 @@ class PanelApp:
         self.console = Console()
         self.settings = _Settings()
         self.data = data
+        self.last_payload: Dict[str, Any] = {}
         self._last_render = 0.0
 
     # --- propriedades de conveniência expostas às views ---
@@ -727,6 +999,7 @@ class PanelApp:
         if view is None:
             return
         self.current_view.on_unmount(self)
+        self.last_payload = payload
         self.stack.append(view)
         view.on_mount(self)
 
@@ -846,11 +1119,8 @@ def _build_views(data: Optional[PanelData] = None) -> Dict[str, View]:
     return {
         "dashboard": DashboardView(data=data),
         "help": HelpView(),
-        "pod-watch": StubView(
-            "pod-watch", "Pod Watch", "Fase 4",
-            "Drill-in num pod (worker/pipeline/bot): "
-            "phase atual, progress.md, log live, recent tasks.",
-        ),
+        "pod-picker": PodPickerView(data=data),
+        "pod-watch": PodWatchView(data=data),
         "pipeline-timeline": StubView(
             "pipeline-timeline", "Pipeline Timeline", "Fase 5",
             "Últimos N ticks com duração + actions. "

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -24,7 +24,7 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from rich import box
 from rich.align import Align
@@ -34,6 +34,9 @@ from rich.live import Live
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
+
+from _panel_data import PanelData, _fmt_age  # noqa: F401 (re-export)
+import _panel_demo as demo
 
 
 # ===== key reader ===========================================================
@@ -170,15 +173,108 @@ class View(ABC):
         return ActionResult()
 
 
-# ===== mock data (Fase 1) ===================================================
+# ===== alerts engine ========================================================
 #
-# Substituído pela camada `_panel_data.py` na Fase 2. Mantido aqui para o
-# esqueleto rodar standalone sem cluster.
+# Regras simples, todas baseadas em snapshots dos providers. Cada regra
+# retorna 0 ou 1 alerta — agregamos antes de renderizar. Mantemos no nível
+# de módulo pra Fase 7 testar isoladamente sem montar a UI.
 
 @dataclass
-class _PodRow:
+class Alert:
+    severity: str  # 'warn' | 'crit'
+    icon: str
+    msg: str
+
+
+def _alerts_from_data(data: Optional[PanelData]) -> List[Alert]:
+    """Avalia thresholds contra o estado atual dos providers.
+
+    Em modo demo (data is None), devolve o alerta sintético — para o
+    operador ver como o painel se comporta com algo aceso.
+    """
+    if data is None:
+        return [Alert("warn", icon, msg) for icon, msg in demo.ALERTS]
+
+    out: List[Alert] = []
+    # Pods restarting recentemente.
+    for p in data.pods.get():
+        if p.restarts >= 3:
+            out.append(Alert(
+                "crit", "⛔",
+                f"{p.name} reiniciou {p.restarts} vez(es) — investigar",
+            ))
+        elif p.restarts >= 1 and p.age_s < 1800:
+            out.append(Alert(
+                "warn", "⚠",
+                f"{p.name} reiniciou {p.restarts}× nos últimos 30min",
+            ))
+    # Pipeline ocioso por muito tempo (talvez tick travado).
+    ps = data.pipeline.get()
+    if ps.last_action_age_s is not None and ps.last_action_age_s > 300:
+        out.append(Alert(
+            "warn", "⚠",
+            f"pipeline sem ação há {_fmt_age(ps.last_action_age_s)} — "
+            "pode estar travado",
+        ))
+    # Issues bloqueadas em aberto.
+    snap = data.github.get()
+    blocked = [it for it in snap.issues if it.blocked]
+    if blocked:
+        nums = ", ".join(f"#{it.number}" for it in blocked[:3])
+        more = f" (+{len(blocked) - 3})" if len(blocked) > 3 else ""
+        out.append(Alert(
+            "warn", "⚠",
+            f"{len(blocked)} issue(s) com ~workflow:bloqueada: {nums}{more}",
+        ))
+    # Aguardando stakeholder (humano).
+    awaiting = [it for it in snap.issues
+                if it.workflow == "aguardando_stakeholder"]
+    if awaiting:
+        nums = ", ".join(f"#{it.number}" for it in awaiting[:3])
+        out.append(Alert(
+            "warn", "🙋",
+            f"{len(awaiting)} issue(s) aguardando você: {nums}",
+        ))
+    # Provider errors.
+    for name, err in data.errors():
+        out.append(Alert("warn", "⚠", f"provider {name}: {err.split(':', 1)[0]}"))
+    return out
+
+
+# ===== activity feed ========================================================
+
+@dataclass
+class ActivityRow:
+    hhmmss: str
+    actor: str
+    action: str
+    target: str
+    detail: str
+
+
+def _activity_from_data(data: Optional[PanelData], limit: int = 8) -> List[ActivityRow]:
+    if data is None:
+        return [ActivityRow(*row) for row in demo.ACTIVITY[:limit]]
+    rows: List[ActivityRow] = []
+    ps = data.pipeline.get()
+    for ev in reversed(ps.events[-limit:]):
+        rows.append(ActivityRow(
+            hhmmss=ev.hhmmss,
+            actor=ev.actor,
+            action=ev.action,
+            target=ev.target,
+            detail=ev.detail,
+        ))
+    return rows
+
+
+# ===== pod adapter para a tabela ============================================
+
+@dataclass
+class PodRow:
     icon: str
     name: str
+    role: str
     status: str
     age: str
     restarts: str
@@ -187,54 +283,50 @@ class _PodRow:
     busy: bool = False
 
 
-_MOCK_PODS: List[_PodRow] = [
-    _PodRow("●", "deile-pipeline-7f8d", "Running", "17m", "0",
-            "23s ago", "tick #287, idle"),
-    _PodRow("●", "deile-worker-abc-1", "Running", "2h", "0",
-            "4m ago", "idle"),
-    _PodRow("⚡", "deile-worker-abc-2", "Running", "2h", "0",
-            "0s ago", "IMPL #296 [t+240s]", busy=True),
-    _PodRow("●", "deilebot-xyz", "Running", "5h", "0",
-            "1m ago", "0 inflight DMs"),
-    _PodRow("●", "deile-shell-def0", "Running", "5h", "0",
-            "—", "idle"),
-]
+def _pod_rows(data: Optional[PanelData]) -> List[PodRow]:
+    """Converte o estado dos providers em linhas da tabela de pods."""
+    if data is None:
+        return [
+            PodRow(p.icon, p.name, p.role, p.status, p.age, p.restarts,
+                   p.last_activity, p.doing_now, p.busy)
+            for p in demo.PODS
+        ]
+    workers = data.workers.get()
+    ps = data.pipeline.get()
+    rows: List[PodRow] = []
+    for p in data.pods.get():
+        # Last-activity humano por role.
+        if p.role == "worker":
+            ws = workers.get(p.name)
+            last = _fmt_age(ws.last_activity_s) + " ago" if ws else "—"
+            doing = ws.last_substantive_body[:32] if ws and ws.last_substantive_body \
+                else ("ocupado" if ws and ws.busy else "idle")
+            busy = bool(ws and ws.busy)
+            icon = "⚡" if busy else "●"
+        elif p.role == "pipeline":
+            last = (_fmt_age(ps.last_action_age_s) + " ago"
+                    if ps.last_action_age_s is not None else "—")
+            doing = ps.last_action_summary[:48] or "idle"
+            busy = (ps.last_action_age_s is not None
+                    and ps.last_action_age_s < 60)
+            icon = "⚡" if busy else "●"
+        else:
+            last = "—"
+            doing = "—"
+            busy = False
+            icon = "●"
 
-_MOCK_PIPELINE = {
-    "tick_n": 287,
-    "tick_age_s": 23,
-    "issues_open": 12,
-    "issue_states": {"nova": 2, "em_refinamento": 1, "revisada": 0,
-                     "em_impl": 3, "bloqueada": 1, "outros": 5},
-    "prs_open": 4,
-    "pr_states": {"pendente": 1, "em_andamento": 1, "concluida": 0,
-                  "outros": 2},
-    "last_decisions": [
-        ("#296", "claim+dispatch implement"),
-        ("#294", "refine round 2 (em_refinamento)"),
-        ("#281", "blocked (escalou TIMEOUT 2×)"),
-    ],
-}
+        ready_label = p.status
+        if p.status == "Running" and not p.ready:
+            ready_label = "NotReady"
 
-_MOCK_ACTIVITY: List[Tuple[str, str, str, str, str]] = [
-    ("14:51:48", "worker-2", "start  implement", "#296", "attempt 2  budget 0s"),
-    ("14:51:30", "pipeline", "claim", "#294", "batch:7a2c → analyst"),
-    ("14:50:55", "worker-1", "done   review", "#293", "veredito APROVADO"),
-    ("14:50:30", "pipeline", "merge", "PR#293", "commit 6bba656 (green suite)"),
-    ("14:49:12", "notifier", "→discord", "", "PR #293 merged"),
-    ("14:48:30", "pipeline", "resume", "#281", "attempt 3/5  backoff 4×"),
-    ("14:47:30", "pipeline", "classify", "PR#293", "→ ~review:pendente"),
-    ("14:46:08", "worker-1", "start  review", "PR#293", "budget 0s"),
-]
-
-_MOCK_ALERTS: List[Tuple[str, str]] = [
-    ("⚠", "#281 attempt 3/5 — próximo loop com mesmo erro vai bloquear"),
-]
-
-_MOCK_TOKENS = {
-    "providers": [("anthropic", 9.43), ("openai", 1.12), ("deepseek", 0.85)],
-    "total": 11.40,
-}
+        rows.append(PodRow(
+            icon=icon, name=p.name, role=p.role,
+            status=ready_label, age=_fmt_age(p.age_s),
+            restarts=str(p.restarts), last_activity=last,
+            doing_now=doing, busy=busy,
+        ))
+    return rows
 
 
 # ===== renderers reaproveitáveis ============================================
@@ -271,7 +363,13 @@ def _footer_panel(hotkeys: str) -> Panel:
 # ===== views ================================================================
 
 class DashboardView(View):
-    """Tela-mãe: pods + pipeline + activity + alerts + tokens."""
+    """Tela-mãe: pods + pipeline + activity + alerts + tokens.
+
+    Quando `data` é None roda em modo demo (mocks); caso contrário lê
+    dos providers do `_panel_data`. Cada `_*_panel` é resiliente — se um
+    provider falhar, o painel correspondente desenha o último valor bom
+    e o erro vai pro feed de alertas via `_alerts_from_data`.
+    """
 
     name = "dashboard"
     title = "Dashboard"
@@ -281,6 +379,9 @@ class DashboardView(View):
         "[1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  "
         "[5]Tokens  [a]ctions  [m]odel  [?]help  [q]uit"
     )
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
 
     def render(self, app: "PanelApp") -> RenderableType:
         layout = Layout()
@@ -305,6 +406,7 @@ class DashboardView(View):
     # --- panels ---
 
     def _pods_panel(self) -> Panel:
+        rows = _pod_rows(self.data)
         tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
         tbl.add_column(" ", width=2, no_wrap=True)
         tbl.add_column("pod", style="bold")
@@ -312,14 +414,15 @@ class DashboardView(View):
         tbl.add_column("age", width=5)
         tbl.add_column("r", width=2, justify="right")
         tbl.add_column("last-activity", width=12)
-        tbl.add_column("doing now")
-        for p in _MOCK_PODS:
+        tbl.add_column("doing now", no_wrap=False)
+        for p in rows:
             icon_style = "bold yellow" if p.busy else "green"
             doing_style = "bold yellow" if p.busy else "dim"
+            status_style = "green" if p.status == "Running" else "red"
             tbl.add_row(
                 Text(p.icon, style=icon_style),
                 p.name,
-                Text(p.status, style="green"),
+                Text(p.status, style=status_style),
                 p.age,
                 p.restarts,
                 Text(p.last_activity, style="dim"),
@@ -329,85 +432,146 @@ class DashboardView(View):
                      title_align="left", border_style="cyan")
 
     def _pipeline_panel(self) -> Panel:
-        states = _MOCK_PIPELINE["issue_states"]
-        pr_states = _MOCK_PIPELINE["pr_states"]
+        if self.data is None:
+            running = demo.PIPELINE["running_for_human"]
+            last_age = demo.PIPELINE["last_action_age_human"]
+            summary = demo.PIPELINE["last_action_summary"]
+            dispatches = demo.PIPELINE["dispatches_24h"]
+            mentions = demo.PIPELINE["mentions_24h"]
+            issue_states = demo.ISSUE_STATES
+            pr_states = demo.PR_STATES
+            issues_n = sum(issue_states.values())
+            prs_n = sum(pr_states.values())
+        else:
+            ps = self.data.pipeline.get()
+            running = _fmt_age(ps.running_for_s)
+            last_age = (_fmt_age(ps.last_action_age_s) + " ago"
+                        if ps.last_action_age_s is not None else "—")
+            summary = ps.last_action_summary
+            dispatches = ps.dispatches_24h
+            mentions = ps.mentions_24h
+            snap = self.data.github.get()
+            issue_states = snap.issue_states
+            pr_states = snap.pr_states
+            issues_n = len(snap.issues)
+            prs_n = len(snap.prs)
         lines = [
             Text.assemble(
-                ("tick #", "dim"),
-                (str(_MOCK_PIPELINE["tick_n"]), "bold cyan"),
-                ("  ·  ", "dim"),
-                (f"{_MOCK_PIPELINE['tick_age_s']}s ago", "dim"),
+                ("running for ", "dim"),
+                (running, "bold cyan"),
+                ("   ·  last action ", "dim"),
+                (last_age, "bold cyan"),
             ),
             Text.assemble(
-                (f"Issues abertas: {_MOCK_PIPELINE['issues_open']}",
-                 "bold"),
-                ("  ", ""),
-                (f"nova:{states['nova']}  refine:{states['em_refinamento']}  "
-                 f"revisada:{states['revisada']}  "
-                 f"impl:{states['em_impl']}  block:{states['bloqueada']}",
-                 "dim"),
+                ("summary: ", "dim"),
+                (summary[:60], "italic"),
             ),
             Text.assemble(
-                (f"PRs abertos:    {_MOCK_PIPELINE['prs_open']}", "bold"),
-                ("  ", ""),
-                (f"pendente:{pr_states['pendente']}  "
-                 f"em_andamento:{pr_states['em_andamento']}  "
-                 f"concluida:{pr_states['concluida']}", "dim"),
+                (f"dispatches/24h: {dispatches}  ", "dim"),
+                (f"mentions/24h: {mentions}", "dim"),
+            ),
+            Text.assemble(
+                (f"Issues open: {issues_n}  ", "bold"),
+                (_compact_state_counts(issue_states), "dim"),
+            ),
+            Text.assemble(
+                (f"PRs open:    {prs_n}  ", "bold"),
+                (_compact_state_counts(pr_states), "dim"),
             ),
         ]
         return Panel(Group(*lines), title="[bold]PIPELINE[/bold]",
                      title_align="left", border_style="magenta")
 
     def _activity_panel(self) -> Panel:
-        tbl = Table(box=box.SIMPLE, expand=True, show_header=False,
-                    pad_edge=False)
-        tbl.add_column(width=8, style="dim")
-        tbl.add_column(width=10, style="bold cyan")
-        tbl.add_column(width=18)
-        tbl.add_column(width=8, style="yellow")
-        tbl.add_column()
-        for ts, actor, action, target, detail in _MOCK_ACTIVITY:
-            tbl.add_row(ts, actor, action, target, Text(detail, style="dim"))
-        return Panel(tbl, title="[bold]ACTIVITY[/bold] (últimos 10)",
+        rows = _activity_from_data(self.data, limit=10)
+        if not rows:
+            body: RenderableType = Text(
+                "· sem atividade recente registrada", style="dim"
+            )
+        else:
+            tbl = Table(box=box.SIMPLE, expand=True, show_header=False,
+                        pad_edge=False)
+            tbl.add_column(width=8, style="dim")
+            tbl.add_column(width=10, style="bold cyan")
+            tbl.add_column(width=12)
+            tbl.add_column(width=8, style="yellow")
+            tbl.add_column()
+            for r in rows:
+                tbl.add_row(r.hhmmss, r.actor, r.action, r.target,
+                            Text(r.detail, style="dim"))
+            body = tbl
+        return Panel(body, title="[bold]ACTIVITY[/bold] (últimos 10)",
                      title_align="left", border_style="green")
 
     def _alerts_panel(self) -> Panel:
-        if not _MOCK_ALERTS:
-            body: RenderableType = Text("· sem alertas críticos", style="dim")
+        alerts = _alerts_from_data(self.data)
+        if not alerts:
+            body: RenderableType = Text(
+                "· sem alertas críticos", style="dim green",
+            )
         else:
-            lines = [
-                Text.assemble((f"{icon} ", "bold yellow"), msg)
-                for icon, msg in _MOCK_ALERTS
-            ]
+            lines = []
+            for a in alerts[:6]:
+                style = "bold red" if a.severity == "crit" else "bold yellow"
+                lines.append(Text.assemble((f"{a.icon} ", style), a.msg))
+            if len(alerts) > 6:
+                lines.append(Text(f"… (+{len(alerts) - 6} mais)", style="dim"))
             body = Group(*lines)
+        border = ("red" if any(a.severity == "crit" for a in alerts)
+                  else "yellow" if alerts else "green")
         return Panel(body, title="[bold]ALERTS[/bold]",
-                     title_align="left", border_style="yellow")
+                     title_align="left", border_style=border)
 
     def _tokens_panel(self) -> Panel:
-        bits: List[Text] = []
-        for prov, cost in _MOCK_TOKENS["providers"]:
-            bits.append(Text.assemble(
-                (f"{prov} ", "dim"),
-                (f"${cost:.2f}", "bold green"),
-            ))
-        line = Text("   ").join(bits)
-        total = Text.assemble(
+        if self.data is None:
+            providers = list(demo.TOKENS["providers"])
+            total = float(demo.TOKENS["total_24h"])
+            extra = f"records: {demo.TOKENS['records_24h']}  "  \
+                    f"·  1h: ${demo.TOKENS['total_1h']:.2f}"
+        else:
+            c = self.data.costs.get()
+            providers = sorted(c.by_provider_24h.items(),
+                               key=lambda kv: -kv[1])
+            total = c.total_24h
+            extra = (f"records: {c.records_24h}  ·  "
+                     f"1h: ${c.total_1h:.2f}")
+        if providers:
+            bits: List[Text] = []
+            for prov, cost in providers:
+                bits.append(Text.assemble(
+                    (f"{prov} ", "dim"),
+                    (f"${cost:.2f}", "bold green"),
+                ))
+            line = Text("   ").join(bits)
+        else:
+            line = Text("· sem registros de uso", style="dim")
+        total_line = Text.assemble(
             ("total 24h: ", "dim"),
-            (f"${_MOCK_TOKENS['total']:.2f}", "bold green"),
+            (f"${total:.2f}", "bold green"),
+            ("   ", ""),
+            (extra, "dim"),
         )
-        return Panel(Group(line, total), title="[bold]TOKENS (24h)[/bold]",
+        return Panel(Group(line, total_line),
+                     title="[bold]TOKENS & CUSTOS[/bold]",
                      title_align="left", border_style="green")
 
     def _decisions_panel(self) -> Panel:
-        lines = [
-            Text.assemble(
-                (f"{ref}  ", "bold cyan"),
-                (desc, "dim"),
-            )
-            for ref, desc in _MOCK_PIPELINE["last_decisions"]
-        ]
-        return Panel(Group(*lines),
-                     title="[bold]ÚLTIMAS DECISÕES[/bold]",
+        if self.data is None:
+            items = list(demo.DECISIONS)
+        else:
+            ps = self.data.pipeline.get()
+            items = [(ev.target or "—", ev.detail)
+                     for ev in reversed(ps.events[-5:])
+                     if ev.action in {"mention", "stages", "dispatch"}][:3]
+        if not items:
+            body: RenderableType = Text("· sem decisões recentes", style="dim")
+        else:
+            lines = [
+                Text.assemble((f"{ref}  ", "bold cyan"), (desc[:50], "dim"))
+                for ref, desc in items
+            ]
+            body = Group(*lines)
+        return Panel(body, title="[bold]ÚLTIMAS DECISÕES[/bold]",
                      title_align="left", border_style="blue")
 
     # --- key ---
@@ -427,6 +591,22 @@ class DashboardView(View):
         if key == "?":
             return ActionResult.nav("help")
         return ActionResult()
+
+
+def _compact_state_counts(counts: Dict[str, int]) -> str:
+    """Formata `{nova:2, em_impl:3}` em string compacta `nova:2  impl:3`."""
+    if not counts:
+        return "—"
+    # Aliases pra encurtar nomes longos no header.
+    short = {"em_refinamento": "refine", "em_arquitetura": "arq",
+             "em_implementacao": "impl", "em_pr": "pr",
+             "aguardando_stakeholder": "aguard"}
+    bits = []
+    for k, v in counts.items():
+        if v == 0:
+            continue
+        bits.append(f"{short.get(k, k)}:{v}")
+    return "  ".join(bits) if bits else "—"
 
 
 class StubView(View):
@@ -512,12 +692,14 @@ class PanelApp:
     a cadência efetiva.
     """
 
-    def __init__(self, views: Dict[str, View], root: str = "dashboard"):
+    def __init__(self, views: Dict[str, View], root: str = "dashboard",
+                 data: Optional[PanelData] = None):
         self.views = views
         self.stack: List[View] = [views[root]]
         self.running = True
         self.console = Console()
         self.settings = _Settings()
+        self.data = data
         self._last_render = 0.0
 
     # --- propriedades de conveniência expostas às views ---
@@ -597,6 +779,8 @@ class PanelApp:
             return True
         if key == "r":
             self._last_render = 0.0       # força próximo tick a renderizar
+            if self.data is not None:
+                self.data.force_refresh_all()
             return True
         if key == "s":
             path = self._snapshot()
@@ -657,10 +841,10 @@ class PanelApp:
 
 # ===== entry point ==========================================================
 
-def _build_views() -> Dict[str, View]:
+def _build_views(data: Optional[PanelData] = None) -> Dict[str, View]:
     """Registry das views. Próximas fases trocam os stubs por views reais."""
     return {
-        "dashboard": DashboardView(),
+        "dashboard": DashboardView(data=data),
         "help": HelpView(),
         "pod-watch": StubView(
             "pod-watch", "Pod Watch", "Fase 4",
@@ -700,8 +884,20 @@ def _build_views() -> Dict[str, View]:
 
 
 def run_panel() -> int:
-    """Entry point chamado pelo `deploy.py panel`."""
-    app = PanelApp(_build_views())
+    """Entry point chamado pelo `deploy.py panel`.
+
+    Tenta levantar os providers reais (kubectl/gh/SQLite). Se `kubectl`
+    não existe, cai em modo demo (mocks) com aviso — UI ainda abre.
+    """
+    try:
+        data: Optional[PanelData] = PanelData.default()
+        # Toque inicial pra detectar fonte morta cedo (sem custo perceptível —
+        # o provider mais pesado é o gh, mas cai em fallback se falhar).
+        data.pods.get()
+    except Exception:
+        data = None
+
+    app = PanelApp(_build_views(data), data=data)
     try:
         return app.run()
     except KeyboardInterrupt:

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -140,6 +140,10 @@ else:
         deixa o shell do operador em cbreak mode.
         """
 
+        # SIGINT é omitido propositalmente: o cbreak mode preserva `isig`
+        # (Ctrl-C continua disparando SIGINT pelo terminal), e o KeyboardInterrupt
+        # resultante já é capturado por `run_panel()` no entry point — não
+        # precisamos do handler customizado pra restaurar termios nesse caminho.
         _SIGNALS = (signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT)
 
         def __init__(self):
@@ -1525,6 +1529,20 @@ class _ActionSpec:
     # confirmação. Todos os mutadores exigem [y/N] mesmo quando não
     # destrutivos — README anuncia "não muta nada do estado existente".
     mutates: bool = False
+    # Verbo curto pra emitir como `action` no AuditEvent — ergonômico pra
+    # filtragem no log (e.g., `action=k8s_restart`). Derivado por padrão
+    # da segunda palavra do `cmd` (e.g., `[..., "k8s", "restart", ...]`).
+    audit_action: Optional[str] = None
+
+    def resolved_audit_action(self) -> str:
+        if self.audit_action:
+            return self.audit_action
+        # cmd costuma ser [py, deploy, "k8s", "<verb>", ...] — pega o verb.
+        try:
+            k8s_idx = self.cmd.index("k8s")
+            return f"k8s_{self.cmd[k8s_idx + 1]}"
+        except (ValueError, IndexError):
+            return "dispatch"
 
 
 def _audit_panel_action(spec: "_ActionSpec", *, result: str,
@@ -1547,7 +1565,7 @@ def _audit_panel_action(spec: "_ActionSpec", *, result: str,
             severity=severity,
             actor="panel:actions",
             resource=f"deploy.py:{spec.label}",
-            action="dispatch",
+            action=spec.resolved_audit_action(),
             result=result,
             details={
                 "label": spec.label,
@@ -1993,7 +2011,9 @@ class ModelSwitcherView(View):
         for dep in deployments:
             ok, msg = pd_set_preferred_model(dep, slug)
             results.append((dep, ok, msg))
-            if not ok and len(deployments) > 1 and any(
+            # `len(deployments) > 1` é implícito: para `len == 1`,
+            # `results[:-1]` é sempre vazio, logo `any(...)` é False.
+            if not ok and any(
                 ok_prev for _, ok_prev, _ in results[:-1]
             ):
                 # Tenta reverter os deployments já alterados (best-effort).
@@ -2006,9 +2026,15 @@ class ModelSwitcherView(View):
                         # (era default-do-settings). Registra no alerta final.
                         rolled_back.append(f"{prev_dep}:sem-prev")
                         continue
-                    rb_ok, _ = pd_set_preferred_model(prev_dep, prev)
+                    rb_ok, rb_msg = pd_set_preferred_model(prev_dep, prev)
+                    status = "rb-ok" if rb_ok else "rb-fail"
+                    # Inclui prefixo curto do output (até 30 chars) — útil
+                    # pra distinguir "kubectl ausente" de "permission denied"
+                    # sem precisar abrir o audit log.
+                    snippet = (rb_msg or "").strip()[:30]
                     rolled_back.append(
-                        f"{prev_dep}:{'rb-ok' if rb_ok else 'rb-fail'}"
+                        f"{prev_dep}:{status}"
+                        + (f" ({snippet})" if snippet else "")
                     )
                 break  # não tenta o resto da lista após falha+rollback
         all_ok = all(ok for _, ok, _ in results) and len(results) == len(deployments)
@@ -2198,15 +2224,33 @@ class PanelApp:
                 pass
 
     def push_toast(self, icon: str, msg: str, ttl_s: float = 5.0) -> None:
-        """Adiciona um toast efêmero (mostrado no header até expirar)."""
-        self.settings.toasts.append((icon, msg, time.monotonic() + ttl_s))
+        """Adiciona um toast efêmero (mostrado no header até expirar).
+
+        Dedup: se já existe toast com a mesma `msg`, apenas renova o
+        timestamp em vez de empilhar — evita que apertar [s] N vezes
+        acumule N toasts idênticos.
+        """
+        expires_at = time.monotonic() + ttl_s
+        for i, (existing_icon, existing_msg, _) in enumerate(
+            self.settings.toasts,
+        ):
+            if existing_msg == msg:
+                self.settings.toasts[i] = (existing_icon, existing_msg,
+                                           expires_at)
+                return
+        self.settings.toasts.append((icon, msg, expires_at))
 
     def active_toasts(self) -> List[tuple]:
-        """Retorna toasts não-expirados (ícone, mensagem). Limpa expirados."""
+        """Retorna toasts não-expirados (ícone, mensagem). Limpa expirados.
+
+        Fast-path: se nenhum toast expirou, devolve a projeção direta sem
+        reconstruir a lista interna (chamado em ~30fps pelo renderer).
+        """
+        toasts = self.settings.toasts
         now = time.monotonic()
-        self.settings.toasts = [
-            t for t in self.settings.toasts if t[2] > now
-        ]
+        if all(t[2] > now for t in toasts):
+            return [(i, m) for i, m, _ in toasts]
+        self.settings.toasts = [t for t in toasts if t[2] > now]
         return [(i, m) for i, m, _ in self.settings.toasts]
 
     # --- key dispatch ---

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -54,7 +54,12 @@ import _panel_demo as demo  # noqa: E402
 # sys.path setup feito por `deploy.py` (que insere `infra/k8s/` no path
 # antes de importar `_panel`). Não trocar para `from infra.k8s. ...` sem
 # revisar como o orquestrador invoca o painel.
-from _panel_data import BackgroundRefresher, PanelData, _fmt_age, kubectl_bin  # noqa: F401
+from _panel_data import (  # noqa: F401
+    BackgroundRefresher, PanelData, _fmt_age, kubectl_bin,
+)
+from _panel_data import (
+    _audit_security_policy_change as pd_audit_security_policy_change,
+)
 from _panel_data import set_preferred_model as pd_set_preferred_model
 from rich import box
 from rich.align import Align
@@ -183,6 +188,16 @@ else:
         def _signal_handler(self, signum, frame):
             # Restaura o terminal e re-dispara o sinal com o handler default
             # — o processo sai com o status canônico do sinal.
+            #
+            # Trade-off: `termios.tcsetattr` e `signal.signal` não são
+            # estritamente async-signal-safe pela POSIX, mas no CPython
+            # típico (signal handlers executados entre instruções de
+            # bytecode pelo eval loop, fora de syscalls bloqueantes) o
+            # padrão é seguro o suficiente para um cleanup TUI best-effort.
+            # A alternativa pure-safe (set flag + checar no loop principal)
+            # exigiria um caminho de wakeup confiável a partir do
+            # `select.select` em `KeyReader.read`, o que não é uma melhoria
+            # proporcional ao risco aqui.
             self._restore()
             try:
                 signal.signal(signum, signal.SIG_DFL)
@@ -1781,7 +1796,7 @@ class ModelSwitcherView(View):
     title = "Trocar modelo (runtime)"
     refresh_s = 1.0
 
-    HOTKEYS = ("[↑/↓] navega   [w] target=worker   [p] target=pipeline   "
+    HOTKEYS = ("[↑/↓] navega   [w] target=worker   [l] target=pipeline   "
                "[b] both   [enter] aplicar   [esc] volta   [q] sai")
 
     def __init__(self, data: Optional[PanelData] = None):
@@ -1907,23 +1922,30 @@ class ModelSwitcherView(View):
         return layout
 
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
-        # Resolver confirmação primeiro: na pendência, só [y]/[n] valem.
+        # Resolver confirmação primeiro: na pendência, default-deny (só [y]
+        # aplica; qualquer outra tecla cancela e emite audit). Casa o
+        # padrão de ActionsView e evita confirmação ficar pendurada.
         if self.confirm_for is not None:
+            slug = self.confirm_for
             if key == "y":
-                self._apply(self.confirm_for)
+                self._apply(slug)
                 self.confirm_for = None
                 return ActionResult.refresh()
-            if key == "n":
-                self.confirm_for = None
-                self.last_msg = "cancelado pelo operador"
-                self.last_ok = False
-                return ActionResult.refresh()
-            return ActionResult()
-        # Troca de target.
+            reason = ("operador cancelou na confirmação" if key == "n"
+                      else f"tecla inesperada na confirmação: {key!r}")
+            pd_audit_security_policy_change(
+                self.target, slug, result="cancelled", detail=reason,
+            )
+            self.confirm_for = None
+            self.last_msg = "cancelado pelo operador"
+            self.last_ok = False
+            return ActionResult.refresh()
+        # Troca de target. Note: 'p' é shadowed pelo pause/resume global —
+        # usamos 'l' (pipe-L-ine) para o target pipeline.
         if key == "w":
             self.target = "worker"
             return ActionResult.refresh()
-        if key == "p":
+        if key == "l":
             self.target = "pipeline"
             return ActionResult.refresh()
         if key == "b":
@@ -1955,10 +1977,12 @@ class ModelSwitcherView(View):
         # Para rollback em "both": captura o slug ATUAL de cada deployment
         # ANTES de tentar trocar. Se o segundo falhar depois do primeiro
         # ter sucesso, tentamos reverter o primeiro ao valor capturado.
+        # `force=True` evita usar um snapshot do cache (até 5s de idade) —
+        # o estado real do cluster pode ter mudado desde a última leitura.
         prev_slugs: Dict[str, Optional[str]] = {}
         if len(deployments) > 1:
             try:
-                current_snap = self.data.current_model.get()
+                current_snap = self.data.current_model.get(force=True)
             except Exception:  # noqa: BLE001
                 current_snap = {}
             for dep in deployments:

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -54,12 +54,10 @@ import _panel_demo as demo  # noqa: E402
 # sys.path setup feito por `deploy.py` (que insere `infra/k8s/` no path
 # antes de importar `_panel`). Não trocar para `from infra.k8s. ...` sem
 # revisar como o orquestrador invoca o painel.
-from _panel_data import (  # noqa: F401
-    BackgroundRefresher, PanelData, _fmt_age, kubectl_bin,
-)
-from _panel_data import (
-    _audit_security_policy_change as pd_audit_security_policy_change,
-)
+from _panel_data import BackgroundRefresher, PanelData  # noqa: F401
+from _panel_data import \
+    _audit_security_policy_change as pd_audit_security_policy_change
+from _panel_data import _fmt_age, kubectl_bin  # noqa: F401
 from _panel_data import set_preferred_model as pd_set_preferred_model
 from rich import box
 from rich.align import Align

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -1,0 +1,708 @@
+"""TUI ao vivo de monitoramento da stack DEILE no Kubernetes.
+
+Painel full-screen com `rich.Live` que cruza o estado do cluster (pods,
+deployments, métricas) com o estado da fonte de verdade do pipeline
+(issues + PRs no GitHub) e do trabalho LLM (logs, progress.md, custos).
+
+Esqueleto (Fase 1): layout completo do dashboard + key handler navegável
++ stub das sub-views. Dados ainda são mock — as Fases 2+ ligam providers
+reais (kubectl, gh, sqlite de usage).
+
+Uso:
+    python3 infra/k8s/deploy.py panel        # entra no painel
+    [1-5] drill em sub-view   [esc] back   [q] quit
+    [p] pause refresh         [+/-] velocidade   [r] force refresh
+    [s] snapshot              [?] ajuda
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import sys
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+from rich import box
+from rich.align import Align
+from rich.console import Console, Group, RenderableType
+from rich.layout import Layout
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+
+# ===== key reader ===========================================================
+
+if os.name == "nt":  # pragma: no cover - Windows fallback
+    import msvcrt
+
+    class KeyReader:  # type: ignore[no-redef]
+        """Variant Windows usando msvcrt.kbhit/getch."""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def read(self, timeout: float = 0.0) -> Optional[str]:
+            end = time.monotonic() + max(timeout, 0)
+            while True:
+                if msvcrt.kbhit():
+                    ch = msvcrt.getch()
+                    try:
+                        return ch.decode("utf-8")
+                    except UnicodeDecodeError:
+                        return None
+                if time.monotonic() >= end:
+                    return None
+                time.sleep(0.01)
+else:
+    import termios
+    import tty
+
+    _ARROW = {"A": "UP", "B": "DOWN", "C": "RIGHT", "D": "LEFT"}
+
+    class KeyReader:
+        """Lê uma tecla em cbreak mode, sem ecoar e sem bloquear.
+
+        Decodifica ESC sozinho (vs prefix de seta) com timeout de 50ms — o
+        suficiente para distinguir num terminal local sem deixar o usuário
+        sentir lag.
+        """
+
+        def __init__(self):
+            self._fd: Optional[int] = (
+                sys.stdin.fileno() if sys.stdin.isatty() else None
+            )
+            self._old = None
+
+        def __enter__(self):
+            if self._fd is not None:
+                self._old = termios.tcgetattr(self._fd)
+                tty.setcbreak(self._fd)
+            return self
+
+        def __exit__(self, *exc):
+            if self._fd is not None and self._old is not None:
+                termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old)
+
+        def read(self, timeout: float = 0.0) -> Optional[str]:
+            if self._fd is None:
+                return None
+            if not select.select([sys.stdin], [], [], timeout)[0]:
+                return None
+            ch = sys.stdin.read(1)
+            if ch != "\x1b":
+                return ch
+            # ESC sozinho ou prefix CSI?
+            if not select.select([sys.stdin], [], [], 0.05)[0]:
+                return "ESC"
+            seq = sys.stdin.read(1)
+            if seq != "[":
+                return "ESC"
+            buf: List[str] = []
+            while select.select([sys.stdin], [], [], 0.05)[0]:
+                c = sys.stdin.read(1)
+                buf.append(c)
+                if c.isalpha() or c == "~":
+                    break
+            code = "".join(buf)
+            return _ARROW.get(code, f"CSI:{code}")
+
+
+# ===== view contract ========================================================
+
+class Action(Enum):
+    NOOP = "noop"
+    BACK = "back"
+    QUIT = "quit"
+    NAV = "nav"
+    REFRESH = "refresh"
+
+
+@dataclass
+class ActionResult:
+    kind: Action = Action.NOOP
+    target: Optional[str] = None
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def quit(cls) -> "ActionResult":
+        return cls(kind=Action.QUIT)
+
+    @classmethod
+    def back(cls) -> "ActionResult":
+        return cls(kind=Action.BACK)
+
+    @classmethod
+    def nav(cls, target: str, **payload: Any) -> "ActionResult":
+        return cls(kind=Action.NAV, target=target, payload=payload)
+
+    @classmethod
+    def refresh(cls) -> "ActionResult":
+        return cls(kind=Action.REFRESH)
+
+
+class View(ABC):
+    """Sub-tela do painel: renderiza e responde a teclas.
+
+    Sub-classes podem mudar `refresh_s` para uma cadência diferente
+    (1s no pod-watch, 5s no timeline, 10s no GitHub etc).
+    """
+
+    name: str = "?"
+    title: str = ""
+    refresh_s: float = 3.0
+
+    def on_mount(self, app: "PanelApp") -> None: ...
+    def on_unmount(self, app: "PanelApp") -> None: ...
+
+    @abstractmethod
+    def render(self, app: "PanelApp") -> RenderableType: ...
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        return ActionResult()
+
+
+# ===== mock data (Fase 1) ===================================================
+#
+# Substituído pela camada `_panel_data.py` na Fase 2. Mantido aqui para o
+# esqueleto rodar standalone sem cluster.
+
+@dataclass
+class _PodRow:
+    icon: str
+    name: str
+    status: str
+    age: str
+    restarts: str
+    last_activity: str
+    doing_now: str
+    busy: bool = False
+
+
+_MOCK_PODS: List[_PodRow] = [
+    _PodRow("●", "deile-pipeline-7f8d", "Running", "17m", "0",
+            "23s ago", "tick #287, idle"),
+    _PodRow("●", "deile-worker-abc-1", "Running", "2h", "0",
+            "4m ago", "idle"),
+    _PodRow("⚡", "deile-worker-abc-2", "Running", "2h", "0",
+            "0s ago", "IMPL #296 [t+240s]", busy=True),
+    _PodRow("●", "deilebot-xyz", "Running", "5h", "0",
+            "1m ago", "0 inflight DMs"),
+    _PodRow("●", "deile-shell-def0", "Running", "5h", "0",
+            "—", "idle"),
+]
+
+_MOCK_PIPELINE = {
+    "tick_n": 287,
+    "tick_age_s": 23,
+    "issues_open": 12,
+    "issue_states": {"nova": 2, "em_refinamento": 1, "revisada": 0,
+                     "em_impl": 3, "bloqueada": 1, "outros": 5},
+    "prs_open": 4,
+    "pr_states": {"pendente": 1, "em_andamento": 1, "concluida": 0,
+                  "outros": 2},
+    "last_decisions": [
+        ("#296", "claim+dispatch implement"),
+        ("#294", "refine round 2 (em_refinamento)"),
+        ("#281", "blocked (escalou TIMEOUT 2×)"),
+    ],
+}
+
+_MOCK_ACTIVITY: List[Tuple[str, str, str, str, str]] = [
+    ("14:51:48", "worker-2", "start  implement", "#296", "attempt 2  budget 0s"),
+    ("14:51:30", "pipeline", "claim", "#294", "batch:7a2c → analyst"),
+    ("14:50:55", "worker-1", "done   review", "#293", "veredito APROVADO"),
+    ("14:50:30", "pipeline", "merge", "PR#293", "commit 6bba656 (green suite)"),
+    ("14:49:12", "notifier", "→discord", "", "PR #293 merged"),
+    ("14:48:30", "pipeline", "resume", "#281", "attempt 3/5  backoff 4×"),
+    ("14:47:30", "pipeline", "classify", "PR#293", "→ ~review:pendente"),
+    ("14:46:08", "worker-1", "start  review", "PR#293", "budget 0s"),
+]
+
+_MOCK_ALERTS: List[Tuple[str, str]] = [
+    ("⚠", "#281 attempt 3/5 — próximo loop com mesmo erro vai bloquear"),
+]
+
+_MOCK_TOKENS = {
+    "providers": [("anthropic", 9.43), ("openai", 1.12), ("deepseek", 0.85)],
+    "total": 11.40,
+}
+
+
+# ===== renderers reaproveitáveis ============================================
+#
+# Mantidos no nível de módulo para que as views da Fase 3+ reusem o mesmo
+# estilo visual sem duplicar código.
+
+def _head_panel(view_title: str, app: "PanelApp") -> Panel:
+    """Cabeçalho com cluster + namespace + image + relógio + cadência."""
+    paused = " ⏸ pausado" if app.paused else ""
+    speed = "" if app.refresh_mult == 1.0 else f" ×{app.refresh_mult:g}"
+    clock = time.strftime("%Y-%m-%d %H:%M:%S")
+    head = Text()
+    head.append("DEILE Stack", style="bold cyan")
+    head.append("  ·  ")
+    head.append(view_title, style="bold")
+    head.append("  ·  ")
+    head.append(clock, style="dim")
+    head.append(f"  ·  refresh {app.current_refresh_s:.1f}s{speed}{paused}",
+                style="dim yellow" if app.paused else "dim")
+    sub = Text(
+        "cluster: rancher-desktop (k3s)   namespace: deile   "
+        "image: deile-stack:local",
+        style="dim",
+    )
+    return Panel(Group(head, sub), border_style="cyan", box=box.HEAVY)
+
+
+def _footer_panel(hotkeys: str) -> Panel:
+    """Rodapé com a linha de hotkeys da view ativa."""
+    return Panel(Text(hotkeys, style="dim"), border_style="dim", box=box.SIMPLE)
+
+
+# ===== views ================================================================
+
+class DashboardView(View):
+    """Tela-mãe: pods + pipeline + activity + alerts + tokens."""
+
+    name = "dashboard"
+    title = "Dashboard"
+    refresh_s = 3.0
+
+    HOTKEYS = (
+        "[1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  "
+        "[5]Tokens  [a]ctions  [m]odel  [?]help  [q]uit"
+    )
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(self._pods_panel(), name="pods", size=10),
+            Layout(name="middle", size=8),
+            Layout(self._activity_panel(), name="activity"),
+            Layout(name="bottom", size=5),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        layout["middle"].split_row(
+            Layout(self._pipeline_panel()),
+            Layout(self._alerts_panel()),
+        )
+        layout["bottom"].split_row(
+            Layout(self._tokens_panel()),
+            Layout(self._decisions_panel()),
+        )
+        return layout
+
+    # --- panels ---
+
+    def _pods_panel(self) -> Panel:
+        tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+        tbl.add_column(" ", width=2, no_wrap=True)
+        tbl.add_column("pod", style="bold")
+        tbl.add_column("status", width=8)
+        tbl.add_column("age", width=5)
+        tbl.add_column("r", width=2, justify="right")
+        tbl.add_column("last-activity", width=12)
+        tbl.add_column("doing now")
+        for p in _MOCK_PODS:
+            icon_style = "bold yellow" if p.busy else "green"
+            doing_style = "bold yellow" if p.busy else "dim"
+            tbl.add_row(
+                Text(p.icon, style=icon_style),
+                p.name,
+                Text(p.status, style="green"),
+                p.age,
+                p.restarts,
+                Text(p.last_activity, style="dim"),
+                Text(p.doing_now, style=doing_style),
+            )
+        return Panel(tbl, title="[bold]PODS[/bold]",
+                     title_align="left", border_style="cyan")
+
+    def _pipeline_panel(self) -> Panel:
+        states = _MOCK_PIPELINE["issue_states"]
+        pr_states = _MOCK_PIPELINE["pr_states"]
+        lines = [
+            Text.assemble(
+                ("tick #", "dim"),
+                (str(_MOCK_PIPELINE["tick_n"]), "bold cyan"),
+                ("  ·  ", "dim"),
+                (f"{_MOCK_PIPELINE['tick_age_s']}s ago", "dim"),
+            ),
+            Text.assemble(
+                (f"Issues abertas: {_MOCK_PIPELINE['issues_open']}",
+                 "bold"),
+                ("  ", ""),
+                (f"nova:{states['nova']}  refine:{states['em_refinamento']}  "
+                 f"revisada:{states['revisada']}  "
+                 f"impl:{states['em_impl']}  block:{states['bloqueada']}",
+                 "dim"),
+            ),
+            Text.assemble(
+                (f"PRs abertos:    {_MOCK_PIPELINE['prs_open']}", "bold"),
+                ("  ", ""),
+                (f"pendente:{pr_states['pendente']}  "
+                 f"em_andamento:{pr_states['em_andamento']}  "
+                 f"concluida:{pr_states['concluida']}", "dim"),
+            ),
+        ]
+        return Panel(Group(*lines), title="[bold]PIPELINE[/bold]",
+                     title_align="left", border_style="magenta")
+
+    def _activity_panel(self) -> Panel:
+        tbl = Table(box=box.SIMPLE, expand=True, show_header=False,
+                    pad_edge=False)
+        tbl.add_column(width=8, style="dim")
+        tbl.add_column(width=10, style="bold cyan")
+        tbl.add_column(width=18)
+        tbl.add_column(width=8, style="yellow")
+        tbl.add_column()
+        for ts, actor, action, target, detail in _MOCK_ACTIVITY:
+            tbl.add_row(ts, actor, action, target, Text(detail, style="dim"))
+        return Panel(tbl, title="[bold]ACTIVITY[/bold] (últimos 10)",
+                     title_align="left", border_style="green")
+
+    def _alerts_panel(self) -> Panel:
+        if not _MOCK_ALERTS:
+            body: RenderableType = Text("· sem alertas críticos", style="dim")
+        else:
+            lines = [
+                Text.assemble((f"{icon} ", "bold yellow"), msg)
+                for icon, msg in _MOCK_ALERTS
+            ]
+            body = Group(*lines)
+        return Panel(body, title="[bold]ALERTS[/bold]",
+                     title_align="left", border_style="yellow")
+
+    def _tokens_panel(self) -> Panel:
+        bits: List[Text] = []
+        for prov, cost in _MOCK_TOKENS["providers"]:
+            bits.append(Text.assemble(
+                (f"{prov} ", "dim"),
+                (f"${cost:.2f}", "bold green"),
+            ))
+        line = Text("   ").join(bits)
+        total = Text.assemble(
+            ("total 24h: ", "dim"),
+            (f"${_MOCK_TOKENS['total']:.2f}", "bold green"),
+        )
+        return Panel(Group(line, total), title="[bold]TOKENS (24h)[/bold]",
+                     title_align="left", border_style="green")
+
+    def _decisions_panel(self) -> Panel:
+        lines = [
+            Text.assemble(
+                (f"{ref}  ", "bold cyan"),
+                (desc, "dim"),
+            )
+            for ref, desc in _MOCK_PIPELINE["last_decisions"]
+        ]
+        return Panel(Group(*lines),
+                     title="[bold]ÚLTIMAS DECISÕES[/bold]",
+                     title_align="left", border_style="blue")
+
+    # --- key ---
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        nav = {
+            "1": "pod-watch",
+            "2": "pipeline-timeline",
+            "3": "issues-prs",
+            "4": "logs-split",
+            "5": "tokens",
+            "a": "actions",
+            "m": "model-switcher",
+        }
+        if key in nav:
+            return ActionResult.nav(nav[key])
+        if key == "?":
+            return ActionResult.nav("help")
+        return ActionResult()
+
+
+class StubView(View):
+    """Sub-view placeholder enquanto a Fase correspondente não foi feita."""
+
+    HOTKEYS = "[esc] back   [q] quit"
+
+    def __init__(self, name: str, title: str, fase: str, what: str):
+        self.name = name
+        self.title = title
+        self.fase = fase
+        self.what = what
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        body = Group(
+            Align.center(Text(self.title, style="bold cyan"), vertical="middle"),
+            Text(),
+            Align.center(Text(f"Em construção — {self.fase}", style="yellow")),
+            Text(),
+            Align.center(Text(self.what, style="dim")),
+            Text(),
+            Align.center(Text("[esc] volta ao dashboard", style="dim")),
+        )
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(body, border_style="dim"), name="body"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+
+class HelpView(View):
+    name = "help"
+    title = "Ajuda"
+    refresh_s = 60.0
+
+    HOTKEYS = "[esc] back   [q] quit"
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        tbl = Table(box=box.SIMPLE_HEAD, expand=True, show_header=False)
+        tbl.add_column("tecla", style="bold cyan", width=18)
+        tbl.add_column("ação")
+        rows = [
+            ("1-5, a, m",   "drill em sub-view (no dashboard)"),
+            ("esc",         "volta à view anterior (ou ao dashboard)"),
+            ("q",           "sai do painel"),
+            ("p",           "pause / resume refresh automático"),
+            ("+ / -",       "acelera / desacelera o refresh (×0.5 a ×4)"),
+            ("r",           "força um refresh imediato"),
+            ("s",           "snapshot: salva a tela atual em .deile/snapshots/"),
+            ("?",           "esta tela"),
+        ]
+        for k, v in rows:
+            tbl.add_row(k, v)
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(tbl, title="[bold]Hotkeys globais[/bold]",
+                         title_align="left", border_style="cyan"),
+                   name="body"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+
+# ===== main app =============================================================
+
+@dataclass
+class _Settings:
+    """Estado mutável compartilhado entre views e key handler."""
+
+    paused: bool = False
+    refresh_mult: float = 1.0    # 0.25, 0.5, 1.0, 2.0, 4.0
+    snapshots_dir: Optional[str] = None
+
+
+class PanelApp:
+    """Loop principal: rich.Live + key handler + view stack.
+
+    O stack é uma pilha de views; navegação empilha e ESC desempilha.
+    Cada view declara `refresh_s` que combinada com `refresh_mult` define
+    a cadência efetiva.
+    """
+
+    def __init__(self, views: Dict[str, View], root: str = "dashboard"):
+        self.views = views
+        self.stack: List[View] = [views[root]]
+        self.running = True
+        self.console = Console()
+        self.settings = _Settings()
+        self._last_render = 0.0
+
+    # --- propriedades de conveniência expostas às views ---
+
+    @property
+    def paused(self) -> bool:
+        return self.settings.paused
+
+    @property
+    def refresh_mult(self) -> float:
+        return self.settings.refresh_mult
+
+    @property
+    def current_view(self) -> View:
+        return self.stack[-1]
+
+    @property
+    def current_refresh_s(self) -> float:
+        return self.current_view.refresh_s / max(self.refresh_mult, 0.01)
+
+    # --- navegação ---
+
+    def push(self, name: str, **payload: Any) -> None:
+        view = self.views.get(name)
+        if view is None:
+            return
+        self.current_view.on_unmount(self)
+        self.stack.append(view)
+        view.on_mount(self)
+
+    def pop(self) -> None:
+        if len(self.stack) <= 1:
+            return
+        self.current_view.on_unmount(self)
+        self.stack.pop()
+        self.current_view.on_mount(self)
+
+    def quit(self) -> None:
+        self.running = False
+
+    # --- snapshots ---
+
+    def _snapshot(self) -> Optional[str]:
+        from pathlib import Path
+        out_dir = Path(
+            self.settings.snapshots_dir
+            or os.path.expanduser("~/.deile/snapshots")
+        )
+        out_dir.mkdir(parents=True, exist_ok=True)
+        path = out_dir / f"panel-{time.strftime('%Y%m%d-%H%M%S')}.txt"
+        capture = Console(record=True, width=self.console.size.width)
+        capture.print(self.current_view.render(self))
+        path.write_text(capture.export_text(), encoding="utf-8")
+        return str(path)
+
+    # --- key dispatch ---
+
+    def _handle_global(self, key: str) -> bool:
+        """Hotkeys globais que TODA view respeita.
+
+        Retorna True quando consumiu a tecla — a view não vê o key.
+        """
+        if key == "q":
+            self.quit()
+            return True
+        if key == "ESC":
+            self.pop()
+            return True
+        if key == "p":
+            self.settings.paused = not self.settings.paused
+            return True
+        if key == "+":
+            self.settings.refresh_mult = min(self.settings.refresh_mult * 2, 4.0)
+            return True
+        if key == "-":
+            self.settings.refresh_mult = max(self.settings.refresh_mult / 2, 0.25)
+            return True
+        if key == "r":
+            self._last_render = 0.0       # força próximo tick a renderizar
+            return True
+        if key == "s":
+            path = self._snapshot()
+            if path:
+                # NOTE: não printa aqui (quebraria a TUI); a próxima
+                # render mostra no head. Fase 3 vai pôr um toast.
+                self.settings.snapshots_dir = self.settings.snapshots_dir
+            return True
+        return False
+
+    # --- main loop ---
+
+    def run(self) -> int:
+        if not sys.stdin.isatty():
+            self.console.print(
+                "[yellow]painel exige terminal interativo "
+                "(sem TTY).[/yellow]"
+            )
+            return 1
+        with KeyReader() as keys, Live(
+            self.current_view.render(self),
+            console=self.console,
+            screen=True,
+            refresh_per_second=10,
+            transient=False,
+        ) as live:
+            self._last_render = time.monotonic()
+            while self.running:
+                key = keys.read(timeout=0.1)
+                if key:
+                    if not self._handle_global(key):
+                        result = self.current_view.handle_key(key, self)
+                        self._apply(result)
+                if not self.running:
+                    break
+                if (not self.paused) and (
+                    time.monotonic() - self._last_render
+                    >= self.current_refresh_s
+                ):
+                    live.update(self.current_view.render(self))
+                    self._last_render = time.monotonic()
+                elif self._last_render == 0.0:
+                    # Force-refresh pedido via [r].
+                    live.update(self.current_view.render(self))
+                    self._last_render = time.monotonic()
+        return 0
+
+    def _apply(self, result: ActionResult) -> None:
+        if result.kind == Action.QUIT:
+            self.quit()
+        elif result.kind == Action.BACK:
+            self.pop()
+        elif result.kind == Action.NAV and result.target:
+            self.push(result.target, **result.payload)
+        elif result.kind == Action.REFRESH:
+            self._last_render = 0.0
+
+
+# ===== entry point ==========================================================
+
+def _build_views() -> Dict[str, View]:
+    """Registry das views. Próximas fases trocam os stubs por views reais."""
+    return {
+        "dashboard": DashboardView(),
+        "help": HelpView(),
+        "pod-watch": StubView(
+            "pod-watch", "Pod Watch", "Fase 4",
+            "Drill-in num pod (worker/pipeline/bot): "
+            "phase atual, progress.md, log live, recent tasks.",
+        ),
+        "pipeline-timeline": StubView(
+            "pipeline-timeline", "Pipeline Timeline", "Fase 5",
+            "Últimos N ticks com duração + actions. "
+            "Stats (P95/P99) e histograma 24h.",
+        ),
+        "issues-prs": StubView(
+            "issues-prs", "Issues & PRs", "Fase 5",
+            "Tabela cruzada cluster ↔ GitHub: estado, tempo no estado, "
+            "assignee, próxima ação esperada.",
+        ),
+        "logs-split": StubView(
+            "logs-split", "Logs Split", "Fase 4",
+            "Pipeline + Worker-1 + Worker-2 lado a lado, follow real.",
+        ),
+        "tokens": StubView(
+            "tokens", "Tokens & Custos", "Fase 6",
+            "Gasto 24h por provider e por task type. "
+            "Top 5 issues mais caras.",
+        ),
+        "actions": StubView(
+            "actions", "Ações", "Fase 6",
+            "Build / restart / up / down / test acionáveis sem sair "
+            "do painel.",
+        ),
+        "model-switcher": StubView(
+            "model-switcher", "Trocar modelo", "Fase 9",
+            "Lista modelos disponíveis e modelo em uso por pod. "
+            "Troca em runtime sem rebuild.",
+        ),
+    }
+
+
+def run_panel() -> int:
+    """Entry point chamado pelo `deploy.py panel`."""
+    app = PanelApp(_build_views())
+    try:
+        return app.run()
+    except KeyboardInterrupt:
+        return 130

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -49,6 +49,7 @@ from rich.table import Table
 from rich.text import Text
 
 from _panel_data import PanelData, _fmt_age, kubectl_bin  # noqa: F401
+from _panel_data import set_preferred_model as pd_set_preferred_model
 import _panel_demo as demo
 import collections
 import re
@@ -1551,6 +1552,208 @@ class ActionsView(View):
             self.runner.stop()
 
 
+class ModelSwitcherView(View):
+    """Troca o `DEILE_PREFERRED_MODEL` do worker (e/ou pipeline) em runtime.
+
+    Implementação **opção A** (env var + rollout): `kubectl set env` muda
+    a spec do Deployment e dispara rollout. No worker (RollingUpdate
+    maxSurge:1/maxUnavailable:0) o swap é zero-downtime. Tarefas in-flight
+    rodam até o fim antes do pod morrer.
+
+    Opções B (endpoint /admin/set_model no worker, swap instantâneo) e C
+    (ConfigMap + hot-reload via watchdog) ficam como evolução futura —
+    exigem código no worker_server e no settings/watchdog respectivamente.
+    """
+
+    name = "model-switcher"
+    title = "Trocar modelo (runtime)"
+    refresh_s = 5.0
+
+    HOTKEYS = ("[↑/↓] navega   [w] target=worker   [p] target=pipeline   "
+               "[b] both   [enter] aplicar   [esc] volta   [q] sai")
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+        self.cursor: int = 0
+        self.target: str = "worker"  # 'worker' | 'pipeline' | 'both'
+        # Estado da última troca (mostrado no painel até a próxima).
+        self.last_msg: str = ""
+        self.last_ok: Optional[bool] = None
+        self.confirm_for: Optional[str] = None  # slug em confirmação
+
+    def _models(self):
+        if self.data is None:
+            return []
+        return self.data.models.get()
+
+    def _current(self) -> Dict[str, Optional[str]]:
+        if self.data is None:
+            return {}
+        return self.data.current_model.get()
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        models = self._models()
+        current = self._current()
+
+        # Header com targets + valor atual
+        target_pretty = {"worker": "deile-worker",
+                         "pipeline": "deile-pipeline",
+                         "both": "deile-worker + deile-pipeline"}[self.target]
+        head_lines = [
+            Text.assemble(
+                ("target: ", "dim"),
+                (target_pretty, "bold yellow"),
+            ),
+            Text.assemble(
+                ("DEILE_PREFERRED_MODEL atual:", "dim"),
+            ),
+        ]
+        for dep, val in current.items():
+            head_lines.append(Text.assemble(
+                ("  · ", "dim"),
+                (f"{dep}: ", "bold"),
+                (val or "(não setado — usa defaults do settings)",
+                 "cyan" if val else "dim yellow"),
+            ))
+        header_panel = Panel(Group(*head_lines),
+                             title="[bold]TARGET[/bold]",
+                             title_align="left", border_style="yellow")
+
+        # Tabela de modelos
+        if not models:
+            body: RenderableType = Text(
+                "(sem modelos no catálogo — checar model_providers.yaml)",
+                style="dim")
+            list_panel = Panel(body, title="[bold]MODELOS[/bold]",
+                               title_align="left", border_style="dim")
+        else:
+            self.cursor = max(0, min(self.cursor, len(models) - 1))
+            tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+            tbl.add_column(" ", width=2)
+            tbl.add_column("slug", style="bold")
+            tbl.add_column("display", style="cyan")
+            tbl.add_column("tier", width=8)
+            tbl.add_column("label", width=10)
+            tbl.add_column("$/1M in", justify="right", style="green")
+            tbl.add_column("$/1M out", justify="right", style="green")
+            current_vals = set(v for v in current.values() if v)
+            for i, m in enumerate(models):
+                marker = "▶" if i == self.cursor else " "
+                is_active = m.slug in current_vals
+                slug_text = Text(
+                    m.slug,
+                    style="bold yellow" if is_active else "bold",
+                )
+                if is_active:
+                    slug_text.append("  ●", style="bold green")
+                tbl.add_row(
+                    Text(marker, style="bold cyan"),
+                    slug_text,
+                    m.display_name,
+                    m.tier,
+                    m.label,
+                    f"${m.input_cost_per_1m:.2f}",
+                    f"${m.output_cost_per_1m:.2f}",
+                )
+            list_panel = Panel(tbl, title="[bold]MODELOS DISPONÍVEIS[/bold]",
+                               title_align="left", border_style="cyan")
+
+        # Painel de status / confirmação
+        if self.confirm_for is not None:
+            confirm_panel: Optional[RenderableType] = Panel(
+                Group(
+                    Text(f"Aplicar {self.confirm_for} em {target_pretty}?",
+                         style="bold yellow"),
+                    Text("`kubectl set env` dispara rollout automático "
+                         "(zero-downtime no worker).", style="dim"),
+                    Text(),
+                    Text("[y] confirmar    [n] cancelar", style="bold cyan"),
+                ),
+                title="[bold yellow]CONFIRMAÇÃO[/bold yellow]",
+                title_align="left", border_style="yellow",
+            )
+        elif self.last_msg:
+            border = "green" if self.last_ok else "red"
+            confirm_panel = Panel(
+                Text(self.last_msg, style="bold green" if self.last_ok
+                     else "bold red"),
+                title="[bold]ÚLTIMA AÇÃO[/bold]",
+                title_align="left", border_style=border,
+            )
+        else:
+            confirm_panel = None
+
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(header_panel, name="targets", size=8),
+            Layout(list_panel, name="list"),
+            *([Layout(confirm_panel, name="confirm", size=7)]
+              if confirm_panel is not None else []),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        # Resolver confirmação primeiro: na pendência, só [y]/[n] valem.
+        if self.confirm_for is not None:
+            if key == "y":
+                self._apply(self.confirm_for)
+                self.confirm_for = None
+                return ActionResult.refresh()
+            if key == "n":
+                self.confirm_for = None
+                self.last_msg = "cancelado pelo operador"
+                self.last_ok = False
+                return ActionResult.refresh()
+            return ActionResult()
+        # Troca de target.
+        if key == "w":
+            self.target = "worker"
+            return ActionResult.refresh()
+        if key == "p":
+            self.target = "pipeline"
+            return ActionResult.refresh()
+        if key == "b":
+            self.target = "both"
+            return ActionResult.refresh()
+        models = self._models()
+        n = len(models)
+        if n == 0:
+            return ActionResult()
+        if key in ("UP", "k"):
+            self.cursor = (self.cursor - 1) % n
+            return ActionResult.refresh()
+        if key in ("DOWN", "j"):
+            self.cursor = (self.cursor + 1) % n
+            return ActionResult.refresh()
+        if key in ("\r", "\n"):
+            self.confirm_for = models[self.cursor].slug
+            return ActionResult.refresh()
+        return ActionResult()
+
+    def _apply(self, slug: str) -> None:
+        if self.data is None:
+            self.last_msg = "modo demo — nenhuma ação aplicada"
+            self.last_ok = False
+            return
+        deployments = (("deile-worker",) if self.target == "worker"
+                       else ("deile-pipeline",) if self.target == "pipeline"
+                       else ("deile-worker", "deile-pipeline"))
+        results = []
+        for dep in deployments:
+            ok, msg = pd_set_preferred_model(dep, slug)
+            results.append((dep, ok, msg))
+        all_ok = all(ok for _, ok, _ in results)
+        # Força provider a re-ler o valor atual no próximo render.
+        self.data.current_model._cache._fetched_at = 0.0  # noqa: SLF001
+        self.last_ok = all_ok
+        self.last_msg = " | ".join(
+            f"{dep}: {'OK' if ok else 'FAIL'} ({msg[:40]})"
+            for dep, ok, msg in results
+        )
+
+
 class StubView(View):
     """Sub-view placeholder enquanto a Fase correspondente não foi feita."""
 
@@ -1802,11 +2005,7 @@ def _build_views(data: Optional[PanelData] = None) -> Dict[str, View]:
         "tokens": TokensView(data=data),
         "actions": ActionsView(data=data),
         "notifier-echo": NotifierEchoView(data=data),
-        "model-switcher": StubView(
-            "model-switcher", "Trocar modelo", "Fase 9",
-            "Lista modelos disponíveis e modelo em uso por pod. "
-            "Troca em runtime sem rebuild.",
-        ),
+        "model-switcher": ModelSwitcherView(data=data),
     }
 
 

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -23,6 +23,7 @@ import sys
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -39,6 +40,7 @@ from _panel_data import PanelData, _fmt_age, kubectl_bin  # noqa: F401
 import _panel_demo as demo
 import collections
 import re
+import shutil
 import subprocess
 import threading
 
@@ -880,6 +882,282 @@ class PodWatchView(View):
         return ActionResult()
 
 
+class PipelineTimelineView(View):
+    """Timeline de eventos do pipeline + stats + histograma 24h."""
+
+    name = "pipeline-timeline"
+    title = "Pipeline Timeline"
+    refresh_s = 5.0
+
+    HOTKEYS = "[esc] volta   [r] força refresh   [q] sai"
+
+    HIST_BUCKETS = 24      # 24 buckets de 1h cada
+    _SPARK = " ▁▂▃▄▅▆▇█"
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+
+    def _events(self):
+        if self.data is None:
+            return []
+        return self.data.pipeline.get().events
+
+    def _stats(self) -> Dict[str, Any]:
+        evs = self._events()
+        if not evs:
+            return {"count": 0, "p95": None, "max": None, "avg": None,
+                    "ticks_h": 0, "failures_h": 0,
+                    "running_for": None, "last_age": None}
+        # "Gap" entre eventos consecutivos como proxy de inatividade do pipeline.
+        gaps: List[float] = []
+        for i in range(1, len(evs)):
+            delta = (evs[i].ts - evs[i - 1].ts).total_seconds()
+            if delta >= 0:
+                gaps.append(delta)
+        ps = self.data.pipeline.get() if self.data else None
+        return {
+            "count": len(evs),
+            "p95": _percentile(gaps, 0.95) if gaps else None,
+            "max": max(gaps) if gaps else None,
+            "avg": sum(gaps) / len(gaps) if gaps else None,
+            "ticks_h": sum(1 for e in evs
+                           if (datetime.now(timezone.utc) - e.ts).total_seconds() < 3600),
+            "failures_h": sum(1 for e in evs
+                              if e.action == "http"
+                              and "→ 5" in (e.detail or "")),
+            "running_for": ps.running_for_s if ps else None,
+            "last_age": ps.last_action_age_s if ps else None,
+        }
+
+    def _histogram(self) -> str:
+        """24 colunas (1 por hora) — densidade de events em cada hora."""
+        now = datetime.now(timezone.utc)
+        buckets = [0] * self.HIST_BUCKETS
+        for e in self._events():
+            age_h = (now - e.ts).total_seconds() / 3600
+            if 0 <= age_h < self.HIST_BUCKETS:
+                buckets[self.HIST_BUCKETS - 1 - int(age_h)] += 1
+        if not any(buckets):
+            return " " * self.HIST_BUCKETS
+        peak = max(buckets)
+        return "".join(self._SPARK[min(len(self._SPARK) - 1,
+                                       int(v / peak * (len(self._SPARK) - 1)))]
+                       for v in buckets)
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        events = list(reversed(self._events()))  # mais recentes em cima
+        stats = self._stats()
+        # Tabela de eventos
+        if events:
+            tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+            tbl.add_column("time", width=8, style="dim")
+            tbl.add_column("action", width=10, style="bold cyan")
+            tbl.add_column("target", width=8, style="yellow")
+            tbl.add_column("detail")
+            for e in events[:30]:
+                tbl.add_row(e.hhmmss, e.action, e.target,
+                            Text(e.detail[:80], style="dim"))
+            events_body: RenderableType = tbl
+        else:
+            events_body = Text(
+                "(sem eventos — pipeline não logou nada nas últimas 200 linhas, "
+                "ou está em modo demo)", style="dim")
+        # Stats panel
+        stats_lines = [
+            Text.assemble(("events:    ", "dim"),
+                          (str(stats["count"]), "bold")),
+            Text.assemble(("ticks/1h:  ", "dim"),
+                          (str(stats["ticks_h"]), "bold")),
+            Text.assemble(("running:   ", "dim"),
+                          (_fmt_age(stats["running_for"]) if stats["running_for"]
+                           else "—", "bold")),
+            Text.assemble(("last age:  ", "dim"),
+                          (_fmt_age(stats["last_age"]) if stats["last_age"]
+                           else "—", "bold")),
+            Text.assemble(("gap p95:   ", "dim"),
+                          (_fmt_age(stats["p95"]) if stats["p95"]
+                           else "—", "bold")),
+            Text.assemble(("gap max:   ", "dim"),
+                          (_fmt_age(stats["max"]) if stats["max"]
+                           else "—", "bold")),
+            Text.assemble(("failures:  ", "dim"),
+                          (str(stats["failures_h"]),
+                           "bold red" if stats["failures_h"] else "bold green")),
+        ]
+        hist = self._histogram()
+        hist_panel = Group(
+            Text("events 24h (1 col = 1h, mais recente à direita):", style="dim"),
+            Text(hist, style="bold cyan"),
+            Text(("├" + "─" * (self.HIST_BUCKETS - 2) + "┤"), style="dim"),
+            Text(f"{'-24h':<{self.HIST_BUCKETS - 4}}now", style="dim"),
+        )
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(name="middle", size=10),
+            Layout(Panel(events_body,
+                         title="[bold]EVENTS (mais recentes em cima)[/bold]",
+                         title_align="left", border_style="green"),
+                   name="events"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        layout["middle"].split_row(
+            Layout(Panel(Group(*stats_lines),
+                         title="[bold]STATS[/bold]", title_align="left",
+                         border_style="magenta")),
+            Layout(Panel(hist_panel,
+                         title="[bold]HISTOGRAMA 24h[/bold]",
+                         title_align="left", border_style="blue")),
+        )
+        return layout
+
+
+def _percentile(values: List[float], p: float) -> Optional[float]:
+    """Percentil simples (interpolação linear); None se vazio."""
+    if not values:
+        return None
+    s = sorted(values)
+    k = (len(s) - 1) * p
+    f, c = int(k), min(int(k) + 1, len(s) - 1)
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+class IssuesPRsView(View):
+    """Tabela de issues e PRs com labels cruzadas + filtros."""
+
+    name = "issues-prs"
+    title = "Issues & PRs"
+    refresh_s = 10.0
+
+    HOTKEYS = ("[a] all   [i] só issues   [p] só PRs   [b] só bloqueadas   "
+               "[m] minhas   [↑/↓] navega   [enter] abrir URL   [esc] volta")
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+        self.filter: str = "all"
+        self.cursor: int = 0
+        self.my_login: str = os.environ.get("GH_USER", "elimarcavalli")
+
+    def _rows(self):
+        if self.data is None:
+            return [], []
+        snap = self.data.github.get()
+        issues, prs = snap.issues, snap.prs
+        if self.filter == "i":
+            prs = []
+        elif self.filter == "p":
+            issues = []
+        elif self.filter == "b":
+            issues = [it for it in issues if it.blocked]
+            prs = [pr for pr in prs if pr.blocked]
+        elif self.filter == "m":
+            issues = [it for it in issues if self.my_login in it.assignees]
+            prs = [pr for pr in prs if self.my_login in pr.assignees]
+        return issues, prs
+
+    def _flat(self):
+        issues, prs = self._rows()
+        return list(issues) + list(prs)
+
+    def _build_table(self, items, label: str) -> Panel:
+        if not items:
+            return Panel(Text(f"· nada em {label}", style="dim"),
+                         title=f"[bold]{label.upper()}[/bold]",
+                         title_align="left", border_style="dim")
+        tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+        tbl.add_column(" ", width=2)
+        tbl.add_column("#", width=6)
+        tbl.add_column("workflow", width=22)
+        tbl.add_column("review", width=14)
+        tbl.add_column("updated", width=10)
+        tbl.add_column("assignees", width=18)
+        tbl.add_column("title")
+        now = datetime.now(timezone.utc)
+        flat = self._flat()
+        for it in items:
+            global_idx = flat.index(it)
+            marker = "▶" if global_idx == self.cursor else " "
+            wf_style = "bold red" if it.blocked else "cyan"
+            age_s = ((now - it.updated_at).total_seconds()
+                     if it.updated_at else None)
+            tbl.add_row(
+                Text(marker, style="bold cyan"),
+                str(it.number),
+                Text(it.workflow or "—", style=wf_style),
+                Text(it.review or "—", style="magenta" if it.review else "dim"),
+                _fmt_age(age_s),
+                ", ".join(it.assignees) or "—",
+                Text(it.title[:60], style="dim"),
+            )
+        return Panel(tbl, title=f"[bold]{label.upper()}[/bold]",
+                     title_align="left", border_style="cyan")
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        issues, prs = self._rows()
+        flat = list(issues) + list(prs)
+        if flat:
+            self.cursor = max(0, min(self.cursor, len(flat) - 1))
+        filter_label = {
+            "all": "todos", "i": "só issues", "p": "só PRs",
+            "b": "só bloqueadas", "m": f"minhas (@{self.my_login})",
+        }[self.filter]
+        filter_panel = Panel(
+            Text.assemble(
+                ("filtro: ", "dim"), (filter_label, "bold yellow"),
+                ("    issues: ", "dim"), (str(len(issues)), "bold"),
+                ("    PRs: ", "dim"), (str(len(prs)), "bold"),
+            ),
+            border_style="dim",
+        )
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(filter_panel, name="filter", size=3),
+            Layout(self._build_table(issues, "Issues"), name="issues"),
+            Layout(self._build_table(prs, "PRs"), name="prs"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        flat = self._flat()
+        if key in ("a", "i", "p", "b", "m"):
+            self.filter = key
+            self.cursor = 0
+            return ActionResult.refresh()
+        n = len(flat)
+        if n == 0:
+            return ActionResult()
+        if key in ("UP", "k"):
+            self.cursor = (self.cursor - 1) % n
+            return ActionResult.refresh()
+        if key in ("DOWN", "j"):
+            self.cursor = (self.cursor + 1) % n
+            return ActionResult.refresh()
+        if key in ("\r", "\n"):
+            url = flat[self.cursor].url
+            _copy_to_clipboard(url)
+            # Não temos toast ainda — devolve refresh para a próxima render
+            # surgir com indicador. (Fase 6: ActionsOverlay com toast queue.)
+            return ActionResult.refresh()
+        return ActionResult()
+
+
+def _copy_to_clipboard(text: str) -> bool:
+    """Tenta colar `text` no clipboard via pbcopy/xclip/wl-copy.
+
+    Sem erro se nenhum bin disponível — é só um nice-to-have.
+    """
+    for cmd in (["pbcopy"], ["xclip", "-selection", "clipboard"], ["wl-copy"]):
+        if shutil.which(cmd[0]):
+            try:
+                subprocess.run(cmd, input=text, text=True, check=True, timeout=2)
+                return True
+            except (OSError, subprocess.SubprocessError):
+                continue
+    return False
+
+
 class StubView(View):
     """Sub-view placeholder enquanto a Fase correspondente não foi feita."""
 
@@ -1121,16 +1399,8 @@ def _build_views(data: Optional[PanelData] = None) -> Dict[str, View]:
         "help": HelpView(),
         "pod-picker": PodPickerView(data=data),
         "pod-watch": PodWatchView(data=data),
-        "pipeline-timeline": StubView(
-            "pipeline-timeline", "Pipeline Timeline", "Fase 5",
-            "Últimos N ticks com duração + actions. "
-            "Stats (P95/P99) e histograma 24h.",
-        ),
-        "issues-prs": StubView(
-            "issues-prs", "Issues & PRs", "Fase 5",
-            "Tabela cruzada cluster ↔ GitHub: estado, tempo no estado, "
-            "assignee, próxima ação esperada.",
-        ),
+        "pipeline-timeline": PipelineTimelineView(data=data),
+        "issues-prs": IssuesPRsView(data=data),
         "logs-split": StubView(
             "logs-split", "Logs Split", "Fase 4",
             "Pipeline + Worker-1 + Worker-2 lado a lado, follow real.",

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -43,6 +43,7 @@ import re
 import shutil
 import subprocess
 import threading
+from pathlib import Path
 
 _HEALTH_LINE_RE = re.compile(r"GET /v1/health")
 
@@ -385,7 +386,7 @@ class DashboardView(View):
 
     HOTKEYS = (
         "[1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  "
-        "[5]Tokens  [a]ctions  [m]odel  [?]help  [q]uit"
+        "[5]Tokens  [n]otifier  [a]ctions  [m]odel  [?]help  [q]uit"
     )
 
     def __init__(self, data: Optional[PanelData] = None):
@@ -591,6 +592,7 @@ class DashboardView(View):
             "3": "issues-prs",
             "4": "logs-split",
             "5": "tokens",
+            "n": "notifier-echo",
             "a": "actions",
             "m": "model-switcher",
         }
@@ -1158,6 +1160,385 @@ def _copy_to_clipboard(text: str) -> bool:
     return False
 
 
+class TokensView(View):
+    """Detalhe de custos via UsageRepository.
+
+    Mostra breakdown por provider (1h / 24h), records e top 5 sessions.
+    A view tem TTL alto (60s) — o SQLite é local mas re-abrir a cada
+    poucos segundos é desperdício.
+    """
+
+    name = "tokens"
+    title = "Tokens & Custos"
+    refresh_s = 60.0
+
+    HOTKEYS = "[r] força refresh   [esc] volta   [q] sai"
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        if self.data is None:
+            body: RenderableType = Text(
+                "(modo demo — sem UsageRepository real)", style="dim yellow")
+            return self._wrap(app, body)
+        c = self.data.costs.get()
+        if c.records_24h == 0:
+            body = Text(
+                "Sem registros de uso nas últimas 24h.\n\n"
+                "O UsageRepository fica em ~/.deile/db/usage.db e só recebe\n"
+                "dados quando você roda o agente localmente. Os pods em K8s\n"
+                "usam o PVC do worker — para o painel ver, monte o PVC ou\n"
+                "implemente o endpoint /admin/usage (Fase 9).",
+                style="dim",
+            )
+            return self._wrap(app, body)
+        # Tabela por provider
+        tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+        tbl.add_column("provider", style="bold cyan")
+        tbl.add_column("24h", justify="right", style="bold green")
+        tbl.add_column("1h", justify="right", style="green")
+        tbl.add_column("%", justify="right", style="dim")
+        for prov in sorted(c.by_provider_24h.keys(),
+                           key=lambda k: -c.by_provider_24h[k]):
+            cost_24 = c.by_provider_24h[prov]
+            cost_1 = c.by_provider_1h.get(prov, 0.0)
+            pct = (cost_24 / c.total_24h * 100) if c.total_24h else 0
+            tbl.add_row(prov, f"${cost_24:.3f}", f"${cost_1:.3f}",
+                        f"{pct:5.1f}%")
+        tbl.add_row(
+            Text("TOTAL", style="bold"),
+            Text(f"${c.total_24h:.3f}", style="bold green"),
+            Text(f"${c.total_1h:.3f}", style="bold green"),
+            "—",
+        )
+        # Top sessions
+        if c.top_sessions_24h:
+            sess_tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+            sess_tbl.add_column("session_id", style="dim")
+            sess_tbl.add_column("cost", justify="right", style="bold green")
+            for sid, cost in c.top_sessions_24h:
+                sess_tbl.add_row(sid[:40], f"${cost:.3f}")
+        else:
+            sess_tbl = Text("· sem sessions registradas", style="dim")
+        meta = Text.assemble(
+            ("records 24h: ", "dim"),
+            (f"{c.records_24h}", "bold"),
+            ("   ·   total: ", "dim"),
+            (f"${c.total_24h:.2f}", "bold green"),
+            ("   ·   1h: ", "dim"),
+            (f"${c.total_1h:.2f}", "bold green"),
+        )
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(meta, border_style="dim"), name="meta", size=3),
+            Layout(Panel(tbl, title="[bold]POR PROVIDER[/bold]",
+                         title_align="left", border_style="green"),
+                   name="prov"),
+            Layout(Panel(sess_tbl, title="[bold]TOP 5 SESSIONS (24h)[/bold]",
+                         title_align="left", border_style="blue"),
+                   name="sess", size=10),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+    def _wrap(self, app: "PanelApp", body: RenderableType) -> RenderableType:
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(body, border_style="dim"), name="body"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+
+# ----- Notifier echo --------------------------------------------------------
+
+_AUDIT_LOG_RE = re.compile(r'\{"ts":\s*"[^"]+",\s*"level":\s*"\w+",'
+                           r'\s*"logger":\s*"deilebot\.audit"')
+
+
+class NotifierEchoView(View):
+    """Últimas mensagens de I/O do bot (audit log)."""
+
+    name = "notifier-echo"
+    title = "Notifier Echo"
+    refresh_s = 5.0
+
+    HOTKEYS = "[r] força refresh   [esc] volta   [q] sai"
+
+    BOT_DEPLOY = "deilebot"
+    TAIL = 500
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+
+    def _fetch_lines(self) -> List[Dict[str, Any]]:
+        kubectl = kubectl_bin()
+        if kubectl is None:
+            return []
+        try:
+            out = subprocess.run(
+                [kubectl, "-n", "deile", "logs",
+                 f"deploy/{self.BOT_DEPLOY}", f"--tail={self.TAIL}"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return []
+        if out.returncode != 0:
+            return []
+        events: List[Dict[str, Any]] = []
+        import json as _json
+        for line in out.stdout.splitlines():
+            if not _AUDIT_LOG_RE.search(line):
+                continue
+            try:
+                ev = _json.loads(line)
+            except _json.JSONDecodeError:
+                continue
+            events.append(ev)
+        return events
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        events = self._fetch_lines()
+        if not events:
+            body: RenderableType = Text(
+                "Nenhum evento `deilebot.audit` recente.\n\n"
+                "Quando o bot recebe ou envia mensagens, este painel mostra\n"
+                "evento + payload (op, reason, channel, etc).",
+                style="dim",
+            )
+        else:
+            tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+            tbl.add_column("ts", width=20, style="dim")
+            tbl.add_column("event", width=22, style="bold")
+            tbl.add_column("status", width=10)
+            tbl.add_column("detail")
+            for ev in events[-20:]:
+                ts = (ev.get("ts", "") or "")[-19:]
+                name = ev.get("event") or ev.get("message", "")
+                ok = "OK" if "sent" in name or "received" in name else \
+                     "FAIL" if "failed" in name else "—"
+                ok_style = "green" if ok == "OK" else \
+                           "red" if ok == "FAIL" else "dim"
+                payload = ev.get("payload") or {}
+                detail = ", ".join(f"{k}={v}" for k, v in payload.items())
+                tbl.add_row(ts, name, Text(ok, style=f"bold {ok_style}"),
+                            Text(detail[:60], style="dim"))
+            body = tbl
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(body, title="[bold]AUDIT EVENTS[/bold]",
+                         title_align="left", border_style="cyan"),
+                   name="body"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+
+# ----- Actions overlay ------------------------------------------------------
+
+@dataclass
+class _ActionSpec:
+    label: str
+    cmd: List[str]
+    destructive: bool = False
+
+
+class _ActionRunner:
+    """Wrap de subprocess streaming pra ActionsView.
+
+    Diferente do _LogStreamer (que vive enquanto a view existe), este é
+    one-shot: roda o comando, encerra, deixa o output no buffer pra
+    consulta. Cancelável com .stop().
+    """
+
+    def __init__(self, cmd: List[str], maxlen: int = 500):
+        self.cmd = cmd
+        self.buf: "collections.deque[str]" = collections.deque(maxlen=maxlen)
+        self._proc: Optional[subprocess.Popen] = None
+        self._thread: Optional[threading.Thread] = None
+        self.returncode: Optional[int] = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        try:
+            self._proc = subprocess.Popen(
+                self.cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True, bufsize=1,
+            )
+        except OSError as exc:
+            self.buf.append(f"[ERRO] {exc}")
+            self.returncode = -1
+            return
+        self._thread = threading.Thread(target=self._reader, daemon=True)
+        self._thread.start()
+
+    def _reader(self) -> None:
+        if self._proc is None or self._proc.stdout is None:
+            return
+        for line in self._proc.stdout:
+            if self._stop.is_set():
+                break
+            self.buf.append(line.rstrip())
+        self._proc.wait()
+        self.returncode = self._proc.returncode
+        self.buf.append(f"--- exit {self.returncode} ---")
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._proc is not None and self._proc.poll() is None:
+            try:
+                self._proc.terminate()
+                self._proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+            except OSError:
+                pass
+
+    @property
+    def running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+
+class ActionsView(View):
+    """Lista de verbos do deploy.py acionáveis a partir do painel."""
+
+    name = "actions"
+    title = "Ações"
+    refresh_s = 1.0
+
+    HOTKEYS = "[1-9] dispara   [c] cancelar   [esc] volta   [q] sai"
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+        self.runner: Optional[_ActionRunner] = None
+        self.last_action: str = ""
+        self.confirm_for: Optional[_ActionSpec] = None
+
+    @staticmethod
+    def _actions() -> List[_ActionSpec]:
+        # `python3 infra/k8s/deploy.py` resolvido em runtime — o painel vive
+        # dentro do mesmo repo.
+        repo_root = str(Path(__file__).resolve().parent.parent.parent)
+        py = sys.executable
+        deploy = f"{repo_root}/infra/k8s/deploy.py"
+        # `--yes` pula confirmação interna do deploy.py — a confirmação aqui
+        # é nossa, na view, antes de chamar.
+        return [
+            _ActionSpec("status",            [py, deploy, "k8s", "status"]),
+            _ActionSpec("restart",           [py, deploy, "k8s", "restart", "--yes"]),
+            _ActionSpec("build (no restart)",[py, deploy, "k8s", "build", "--yes"]),
+            _ActionSpec("build + restart",   [py, deploy, "k8s", "build", "--restart", "--yes"]),
+            _ActionSpec("up (provisiona)",   [py, deploy, "k8s", "up", "--yes"]),
+            _ActionSpec("stop (scale 0)",    [py, deploy, "k8s", "stop", "--yes"], destructive=False),
+            _ActionSpec("start (scale 1)",   [py, deploy, "k8s", "start", "--yes"]),
+            _ActionSpec("test (Job one-shot)",[py, deploy, "k8s", "test", "--yes"]),
+            _ActionSpec("DOWN (apaga ns)",   [py, deploy, "k8s", "down", "--yes"], destructive=True),
+        ]
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        actions = self._actions()
+        # menu
+        menu = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+        menu.add_column(" ", width=3)
+        menu.add_column("ação", style="bold")
+        menu.add_column("comando", style="dim")
+        for i, a in enumerate(actions, 1):
+            label = Text(a.label, style="bold red" if a.destructive else "bold")
+            menu.add_row(str(i), label, " ".join(a.cmd[-3:]))
+        # confirmação?
+        if self.confirm_for is not None:
+            confirm_body = Group(
+                Text(f"Vai rodar a ação DESTRUTIVA: {self.confirm_for.label}",
+                     style="bold red"),
+                Text(" ".join(self.confirm_for.cmd), style="dim"),
+                Text(),
+                Text("Aperte [y] para confirmar, [n] para cancelar.",
+                     style="bold yellow"),
+            )
+            confirm_panel: Optional[RenderableType] = Panel(
+                confirm_body, title="[bold red]CONFIRMAÇÃO[/bold red]",
+                title_align="left", border_style="red",
+            )
+        else:
+            confirm_panel = None
+        # output do runner
+        if self.runner is not None:
+            lines = list(self.runner.buf)[-25:]
+            running_label = ("RUNNING" if self.runner.running
+                             else f"DONE (exit {self.runner.returncode})")
+            color = ("yellow" if self.runner.running
+                     else "green" if self.runner.returncode == 0
+                     else "red")
+            output_body: RenderableType = (
+                Text("\n".join(lines), no_wrap=False) if lines
+                else Text("(aguardando output)", style="dim")
+            )
+            output_panel = Panel(
+                output_body,
+                title=f"[bold]OUTPUT[/bold] · {self.last_action} · {running_label}",
+                title_align="left", border_style=color,
+            )
+        else:
+            output_panel = Panel(
+                Text("(rode uma ação para ver o output aqui)", style="dim"),
+                title="[bold]OUTPUT[/bold]", title_align="left",
+                border_style="dim",
+            )
+        layout = Layout()
+        layout.split_column(
+            Layout(_head_panel(self.title, app), name="head", size=4),
+            Layout(Panel(menu, title="[bold]AÇÕES[/bold]",
+                         title_align="left", border_style="cyan"),
+                   name="menu", size=14),
+            *([Layout(confirm_panel, name="confirm", size=6)]
+              if confirm_panel is not None else []),
+            Layout(output_panel, name="output"),
+            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+        )
+        return layout
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        if self.confirm_for is not None:
+            if key == "y":
+                self._dispatch(self.confirm_for)
+                self.confirm_for = None
+                return ActionResult.refresh()
+            if key == "n":
+                self.confirm_for = None
+                return ActionResult.refresh()
+            return ActionResult()
+        if key == "c" and self.runner is not None and self.runner.running:
+            self.runner.stop()
+            return ActionResult.refresh()
+        if key.isdigit():
+            idx = int(key) - 1
+            actions = self._actions()
+            if 0 <= idx < len(actions):
+                spec = actions[idx]
+                if spec.destructive:
+                    self.confirm_for = spec
+                else:
+                    self._dispatch(spec)
+                return ActionResult.refresh()
+        return ActionResult()
+
+    def _dispatch(self, spec: _ActionSpec) -> None:
+        if self.runner is not None and self.runner.running:
+            return                # já tem ação rodando, ignora
+        self.runner = _ActionRunner(spec.cmd)
+        self.last_action = spec.label
+        self.runner.start()
+
+    def on_unmount(self, app: "PanelApp") -> None:
+        # Mata runner pendente quando o usuário sai da view (ESC).
+        if self.runner is not None and self.runner.running:
+            self.runner.stop()
+
+
 class StubView(View):
     """Sub-view placeholder enquanto a Fase correspondente não foi feita."""
 
@@ -1402,19 +1783,13 @@ def _build_views(data: Optional[PanelData] = None) -> Dict[str, View]:
         "pipeline-timeline": PipelineTimelineView(data=data),
         "issues-prs": IssuesPRsView(data=data),
         "logs-split": StubView(
-            "logs-split", "Logs Split", "Fase 4",
-            "Pipeline + Worker-1 + Worker-2 lado a lado, follow real.",
+            "logs-split", "Logs Split", "Pós-MVP",
+            "Pipeline + Worker-1 + Worker-2 lado a lado, follow real. "
+            "Pode ser composto a partir do _LogStreamer.",
         ),
-        "tokens": StubView(
-            "tokens", "Tokens & Custos", "Fase 6",
-            "Gasto 24h por provider e por task type. "
-            "Top 5 issues mais caras.",
-        ),
-        "actions": StubView(
-            "actions", "Ações", "Fase 6",
-            "Build / restart / up / down / test acionáveis sem sair "
-            "do painel.",
-        ),
+        "tokens": TokensView(data=data),
+        "actions": ActionsView(data=data),
+        "notifier-echo": NotifierEchoView(data=data),
         "model-switcher": StubView(
             "model-switcher", "Trocar modelo", "Fase 9",
             "Lista modelos disponíveis e modelo em uso por pod. "

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -737,6 +737,143 @@ class CostsProvider:
         return snap
 
 
+# ===== Model providers ======================================================
+
+@dataclass
+class ModelInfo:
+    provider_id: str
+    model_id: str
+    display_name: str
+    tier: str
+    label: str
+    input_cost_per_1m: float
+    output_cost_per_1m: float
+
+    @property
+    def slug(self) -> str:
+        return f"{self.provider_id}:{self.model_id}"
+
+
+_MODELS_YAML_DEFAULT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "deile" / "config" / "model_providers.yaml"
+)
+
+
+class ModelsProvider:
+    """Catálogo de modelos disponíveis lido do `model_providers.yaml`.
+
+    Lê uma vez (TTL 5min) — o catálogo é estático na vasta maioria do
+    tempo; refresh é só pra cobrir o caso de edição em vivo do YAML.
+    """
+
+    def __init__(self, yaml_path: Path = _MODELS_YAML_DEFAULT,
+                 ttl_s: float = 300.0):
+        self._path = yaml_path
+        self._cache: Cache[List[ModelInfo]] = Cache(
+            ttl_s, self._fetch, fallback=[],
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> List[ModelInfo]:
+        return self._cache.get(force)
+
+    def _fetch(self) -> List[ModelInfo]:
+        try:
+            import yaml as _yaml  # lazy
+        except ImportError as exc:
+            raise RuntimeError(f"PyYAML ausente: {exc}") from exc
+        if not self._path.is_file():
+            raise RuntimeError(f"model_providers.yaml não encontrado em {self._path}")
+        data = _yaml.safe_load(self._path.read_text(encoding="utf-8")) or {}
+        models = data.get("models") or []
+        out: List[ModelInfo] = []
+        for m in models:
+            p = (m.get("pricing") or {})
+            out.append(ModelInfo(
+                provider_id=str(m.get("provider_id", "?")),
+                model_id=str(m.get("model_id", "?")),
+                display_name=str(m.get("display_name", m.get("model_id", "?"))),
+                tier=str(m.get("tier", "—")),
+                label=str(m.get("label", "—")),
+                input_cost_per_1m=float(p.get("input_per_1m_usd", 0.0)),
+                output_cost_per_1m=float(p.get("output_per_1m_usd", 0.0)),
+            ))
+        return out
+
+
+class CurrentModelProvider:
+    """Lê o `DEILE_PREFERRED_MODEL` setado no Deployment do worker (e/ou
+    pipeline) — o valor que efetivamente roda agora nos pods."""
+
+    DEFAULT_DEPLOYMENTS = ("deile-worker", "deile-pipeline")
+
+    def __init__(self, deployments=DEFAULT_DEPLOYMENTS, ttl_s: float = 5.0):
+        self._kubectl = kubectl_bin()
+        self._deployments = tuple(deployments)
+        self._cache: Cache[Dict[str, Optional[str]]] = Cache(
+            ttl_s, self._fetch, fallback={d: None for d in deployments},
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> Dict[str, Optional[str]]:
+        return self._cache.get(force)
+
+    def _fetch(self) -> Dict[str, Optional[str]]:
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        out: Dict[str, Optional[str]] = {}
+        for dep in self._deployments:
+            data = _capture_json(
+                [self._kubectl, "-n", NS, "get",
+                 f"deployment/{dep}", "-o", "json"],
+                timeout=4.0,
+            )
+            out[dep] = self._extract(data) if data else None
+        return out
+
+    @staticmethod
+    def _extract(data: Dict[str, Any]) -> Optional[str]:
+        containers = (data.get("spec", {}).get("template", {})
+                      .get("spec", {}).get("containers", []) or [])
+        if not containers:
+            return None
+        for env in (containers[0].get("env") or []):
+            if env.get("name") == "DEILE_PREFERRED_MODEL":
+                return env.get("value")
+        return None
+
+
+def set_preferred_model(deployment: str, slug: str,
+                        timeout: float = 15.0) -> tuple:
+    """Aplica `DEILE_PREFERRED_MODEL=<slug>` no Deployment.
+
+    `kubectl set env` modifica a spec do Deployment, o que dispara
+    rollout automático (com a strategy do manifest — `RollingUpdate`
+    para o worker e `Recreate` para o pipeline). Retorna `(ok, msg)`.
+    """
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", NS, "set", "env", f"deploy/{deployment}",
+             f"DEILE_PREFERRED_MODEL={slug}"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+    return True, (proc.stdout or "rollout disparado").strip()
+
+
 # ===== Aggregate hub ========================================================
 
 @dataclass
@@ -747,6 +884,8 @@ class PanelData:
     workers: WorkerProvider
     github: GitHubProvider
     costs: CostsProvider
+    models: ModelsProvider
+    current_model: CurrentModelProvider
 
     @classmethod
     def default(cls, repo: str = REPO_DEFAULT) -> "PanelData":
@@ -756,12 +895,14 @@ class PanelData:
             workers=WorkerProvider(),
             github=GitHubProvider(repo=repo),
             costs=CostsProvider(),
+            models=ModelsProvider(),
+            current_model=CurrentModelProvider(),
         )
 
     def force_refresh_all(self) -> None:
         """Usado pelo hotkey [r]: invalida todos os caches no próximo `get`."""
         for p in (self.pods, self.pipeline, self.workers,
-                  self.github, self.costs):
+                  self.github, self.costs, self.models, self.current_model):
             p._cache._fetched_at = 0.0  # noqa: SLF001 (intentional internal)
 
     def errors(self) -> List[tuple]:
@@ -773,6 +914,8 @@ class PanelData:
             ("workers", self.workers),
             ("github", self.github),
             ("costs", self.costs),
+            ("models", self.models),
+            ("current_model", self.current_model),
         ):
             if p.last_error:
                 out.append((name, p.last_error))

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -1,0 +1,779 @@
+"""Data providers do painel TUI — kubectl, gh, SQLite — com cache TTL.
+
+Cada provider expõe um `get()` que devolve um dataclass tipado e fica
+silenciosamente vazio quando a fonte está indisponível (cluster down, gh
+sem auth, DB ausente). A camada de view (`_panel.py`) lê dos `get()` sem
+saber se veio do cluster ou do fallback.
+
+Cache: cada provider tem `Cache[T]` com TTL próprio (3-60s). `get(force=True)`
+re-busca; chamadas posteriores dentro do TTL retornam o valor cacheado.
+Não usa threads — a leitura é lazy, o custo de cada `kubectl/gh/sqlite` é
+absorvido pelo loop principal do `PanelApp` que renderiza em cadência
+calma (3s default).
+
+Fontes:
+- pods + recursos:  `kubectl -n deile get pods -o json`
+- pipeline:         `kubectl logs deploy/deile-pipeline --tail=200 --timestamps`
+- worker (por pod): `kubectl logs <pod> --tail=200 --timestamps`
+- issues + PRs:     `gh api /repos/<repo>/issues?state=open`
+- custos:           `~/.deile/db/usage.db` (UsageRepository)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
+
+T = TypeVar("T")
+
+NS = "deile"
+REPO_DEFAULT = "elimarcavalli/deile"
+USAGE_DB = Path.home() / ".deile" / "db" / "usage.db"
+
+
+# ===== cache ================================================================
+
+@dataclass
+class Cache(Generic[T]):
+    """Cache TTL ao redor de um fetcher.
+
+    Em caso de erro, mantém o último valor bom; se nunca houve valor bom,
+    devolve o `fallback`. Guarda a última exceção em `last_error` para a
+    view exibir um indicador discreto.
+    """
+
+    ttl_s: float
+    fetcher: Callable[[], T]
+    fallback: T
+    _value: Optional[T] = field(default=None, init=False, repr=False)
+    _fetched_at: float = field(default=0.0, init=False, repr=False)
+    _last_error: Optional[str] = field(default=None, init=False, repr=False)
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._last_error
+
+    @property
+    def age_s(self) -> float:
+        return time.monotonic() - self._fetched_at if self._fetched_at else 0.0
+
+    def get(self, force: bool = False) -> T:
+        now = time.monotonic()
+        fresh_enough = (
+            self._value is not None
+            and (now - self._fetched_at) < self.ttl_s
+        )
+        if fresh_enough and not force:
+            return self._value  # type: ignore[return-value]
+        try:
+            new = self.fetcher()
+            self._value = new
+            self._fetched_at = now
+            self._last_error = None
+            return new
+        except Exception as exc:  # noqa: BLE001 (defensive — render must never crash)
+            self._last_error = f"{type(exc).__name__}: {exc}"
+            if self._value is None:
+                return self.fallback
+            return self._value
+
+
+# ===== subprocess helpers ===================================================
+
+def _resolve(tool: str) -> Optional[str]:
+    """Acha um binário no PATH ou no diretório do Rancher Desktop."""
+    found = shutil.which(tool)
+    if found:
+        return found
+    rd = Path.home() / ".rd" / "bin" / tool
+    return str(rd) if rd.is_file() else None
+
+
+def kubectl_bin() -> Optional[str]:
+    return _resolve("kubectl")
+
+
+def gh_bin() -> Optional[str]:
+    return shutil.which("gh")
+
+
+def _capture_json(cmd: List[str], timeout: float = 5.0) -> Optional[Any]:
+    try:
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0 or not out.stdout.strip():
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _capture_text(cmd: List[str], timeout: float = 5.0) -> Optional[str]:
+    try:
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout
+
+
+# ===== time helpers =========================================================
+
+_UTC = timezone.utc
+
+
+def _parse_k8s_ts(s: Optional[str]) -> Optional[datetime]:
+    """Decoder leniente para timestamps do Kubernetes (RFC3339)."""
+    if not s:
+        return None
+    s = s.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+_LOG_TS_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+[+\-Z][\d:]*)\s+(.*)$")
+
+
+def _parse_log_line(line: str) -> Optional["LogLine"]:
+    """Extrai timestamp + corpo de uma linha de `kubectl logs --timestamps`."""
+    m = _LOG_TS_RE.match(line)
+    if not m:
+        return None
+    ts = _parse_k8s_ts(m.group(1))
+    if ts is None:
+        return None
+    return LogLine(ts=ts, body=m.group(2))
+
+
+def _fmt_age(seconds: Optional[float]) -> str:
+    """Idade humanamente legível: 3s, 47s, 2m, 1h12m, 3d."""
+    if seconds is None:
+        return "—"
+    s = int(seconds)
+    if s < 0:
+        s = 0
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m"
+    if s < 86400:
+        return f"{s // 3600}h{(s % 3600) // 60:02d}m" if s % 3600 else f"{s // 3600}h"
+    return f"{s // 86400}d"
+
+
+# ===== Pods provider ========================================================
+
+@dataclass
+class PodInfo:
+    name: str
+    role: str            # 'pipeline' | 'worker' | 'bot' | 'shell' | 'other'
+    status: str          # 'Running' | 'Pending' | etc
+    ready: bool
+    restarts: int
+    age_s: float
+    started_at: Optional[datetime]
+    node: str = ""
+
+
+_ROLE_BY_APP = {
+    "deile-pipeline": "pipeline",
+    "deile-worker":   "worker",
+    "deilebot":       "bot",
+    "deile-shell":    "shell",
+}
+
+
+class PodsProvider:
+    """Lista os pods do namespace `deile` em forma tipada."""
+
+    def __init__(self, ttl_s: float = 3.0):
+        self._kubectl = kubectl_bin()
+        self._cache: Cache[List[PodInfo]] = Cache(ttl_s, self._fetch, fallback=[])
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> List[PodInfo]:
+        return self._cache.get(force)
+
+    def _fetch(self) -> List[PodInfo]:
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        data = _capture_json(
+            [self._kubectl, "-n", NS, "get", "pods", "-o", "json"],
+            timeout=4.0,
+        )
+        if data is None:
+            raise RuntimeError("kubectl get pods falhou")
+        rows: List[PodInfo] = []
+        now = datetime.now(_UTC)
+        for item in data.get("items", []):
+            meta = item.get("metadata", {})
+            labels = meta.get("labels", {})
+            app = labels.get("app", "")
+            role = _ROLE_BY_APP.get(app, "other")
+            status = item.get("status", {})
+            phase = status.get("phase", "Unknown")
+            container_statuses = status.get("containerStatuses", []) or []
+            ready = all(cs.get("ready", False) for cs in container_statuses) \
+                if container_statuses else False
+            restarts = sum(cs.get("restartCount", 0) for cs in container_statuses)
+            started_at = _parse_k8s_ts(status.get("startTime"))
+            age_s = (now - started_at).total_seconds() if started_at else 0.0
+            rows.append(PodInfo(
+                name=meta.get("name", "?"),
+                role=role,
+                status=phase,
+                ready=ready,
+                restarts=restarts,
+                age_s=age_s,
+                started_at=started_at,
+                node=item.get("spec", {}).get("nodeName", ""),
+            ))
+        # Ordem estável: pipeline > worker > bot > shell > outros, por nome.
+        order = {"pipeline": 0, "worker": 1, "bot": 2, "shell": 3, "other": 4}
+        rows.sort(key=lambda p: (order.get(p.role, 9), p.name))
+        return rows
+
+
+# ===== Log line + pipeline/worker activity =================================
+
+@dataclass
+class LogLine:
+    ts: datetime
+    body: str
+
+
+@dataclass
+class ActivityEvent:
+    ts: datetime
+    actor: str          # 'pipeline' | 'worker-<short>' | 'bot' | 'notifier'
+    action: str         # 'dispatch' | 'mention' | 'http' | 'startup' | 'other'
+    target: str         # '#296' | 'PR#291' | ''
+    detail: str         # texto livre curto
+
+    @property
+    def hhmmss(self) -> str:
+        return self.ts.astimezone().strftime("%H:%M:%S")
+
+
+_DISPATCH_START_RE = re.compile(r"worker dispatch starting", re.IGNORECASE)
+_DISPATCH_DONE_RE = re.compile(r"worker dispatch completed", re.IGNORECASE)
+_HTTP_POST_RE = re.compile(
+    r'HTTP Request: POST .*?/v1/dispatch.*?"HTTP/[\d.]+ (\d+)', re.IGNORECASE
+)
+_MENTION_RE = re.compile(
+    r"mention group (issue|pr):(\d+): triggers=\[(.*?)\]", re.IGNORECASE
+)
+_STAGES_RE = re.compile(
+    r"deile\.orchestration\.pipeline\.stages\s+(.*)$", re.IGNORECASE
+)
+_STARTUP_RE = re.compile(r"starting pipeline monitor", re.IGNORECASE)
+
+
+def _classify_pipeline_line(ll: LogLine) -> Optional[ActivityEvent]:
+    """Reduz uma linha bruta a um ActivityEvent semântico, se reconhecida."""
+    body = ll.body
+    m = _MENTION_RE.search(body)
+    if m:
+        kind = m.group(1).lower()
+        num = m.group(2)
+        triggers = m.group(3).replace("'", "").replace('"', "")
+        target = f"{'PR' if kind == 'pr' else '#'}{num}"
+        return ActivityEvent(
+            ts=ll.ts, actor="pipeline", action="mention",
+            target=target, detail=f"triggers={triggers}",
+        )
+    if _DISPATCH_START_RE.search(body):
+        return ActivityEvent(
+            ts=ll.ts, actor="pipeline", action="dispatch", target="",
+            detail="worker dispatch starting",
+        )
+    if _DISPATCH_DONE_RE.search(body):
+        return ActivityEvent(
+            ts=ll.ts, actor="pipeline", action="dispatch", target="",
+            detail="worker dispatch completed",
+        )
+    m = _HTTP_POST_RE.search(body)
+    if m:
+        return ActivityEvent(
+            ts=ll.ts, actor="pipeline", action="http", target="",
+            detail=f"POST /v1/dispatch → {m.group(1)}",
+        )
+    if _STARTUP_RE.search(body):
+        return ActivityEvent(
+            ts=ll.ts, actor="pipeline", action="startup", target="",
+            detail="pipeline monitor started",
+        )
+    m = _STAGES_RE.search(body)
+    if m:
+        # Linhas do stages.py mais raras (claim/refine/block) caem aqui em forma genérica.
+        return ActivityEvent(
+            ts=ll.ts, actor="pipeline", action="stages",
+            target="", detail=m.group(1).strip(),
+        )
+    return None
+
+
+@dataclass
+class PipelineState:
+    """Estado deduzido do log do `deile-pipeline`."""
+    running_since: Optional[datetime] = None
+    last_action_ts: Optional[datetime] = None
+    last_action_summary: str = "—"
+    last_dispatch_ts: Optional[datetime] = None
+    dispatches_24h: int = 0
+    mentions_24h: int = 0
+    events: List[ActivityEvent] = field(default_factory=list)
+    raw_lines: int = 0
+
+    @property
+    def running_for_s(self) -> Optional[float]:
+        if self.running_since is None:
+            return None
+        return (datetime.now(_UTC) - self.running_since).total_seconds()
+
+    @property
+    def last_action_age_s(self) -> Optional[float]:
+        if self.last_action_ts is None:
+            return None
+        return (datetime.now(_UTC) - self.last_action_ts).total_seconds()
+
+
+class PipelineProvider:
+    """Lê os últimos N segundos de log do deile-pipeline e classifica."""
+
+    DEPLOY = "deile-pipeline"
+    TAIL_LINES = 200
+
+    def __init__(self, ttl_s: float = 5.0):
+        self._kubectl = kubectl_bin()
+        self._cache: Cache[PipelineState] = Cache(
+            ttl_s, self._fetch, fallback=PipelineState(),
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> PipelineState:
+        return self._cache.get(force)
+
+    def _fetch(self) -> PipelineState:
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        text = _capture_text(
+            [self._kubectl, "-n", NS, "logs",
+             f"deploy/{self.DEPLOY}",
+             f"--tail={self.TAIL_LINES}", "--timestamps"],
+            timeout=5.0,
+        )
+        if text is None:
+            raise RuntimeError(f"kubectl logs {self.DEPLOY} falhou")
+        return self._parse(text)
+
+    def _parse(self, text: str) -> PipelineState:
+        state = PipelineState()
+        now = datetime.now(_UTC)
+        cutoff_24h = now - timedelta(hours=24)
+        for raw in text.splitlines():
+            state.raw_lines += 1
+            ll = _parse_log_line(raw)
+            if ll is None:
+                continue
+            ev = _classify_pipeline_line(ll)
+            if ev is None:
+                continue
+            if ev.action == "startup":
+                state.running_since = ev.ts
+            if ev.action == "dispatch" and "starting" in ev.detail:
+                state.last_dispatch_ts = ev.ts
+                if ev.ts >= cutoff_24h:
+                    state.dispatches_24h += 1
+            if ev.action == "mention" and ev.ts >= cutoff_24h:
+                state.mentions_24h += 1
+            state.last_action_ts = ev.ts
+            state.last_action_summary = self._summary(ev)
+            state.events.append(ev)
+        # Mantém só os 60 mais recentes — o feed da UI nunca precisa de mais.
+        state.events = state.events[-60:]
+        return state
+
+    @staticmethod
+    def _summary(ev: ActivityEvent) -> str:
+        if ev.action == "mention":
+            return f"mention {ev.target}: {ev.detail}"
+        if ev.action == "dispatch":
+            return ev.detail
+        if ev.action == "http":
+            return f"dispatch {ev.detail}"
+        if ev.action == "stages":
+            return ev.detail[:80]
+        return ev.detail[:80]
+
+
+# ===== Worker activity ======================================================
+
+@dataclass
+class WorkerState:
+    """Estado deduzido do log de um pod worker."""
+    pod_name: str
+    busy: bool = False
+    last_dispatch_ts: Optional[datetime] = None
+    last_health_ts: Optional[datetime] = None
+    last_substantive_body: str = ""
+
+    @property
+    def last_activity_s(self) -> Optional[float]:
+        ts = self.last_substantive_ts
+        if ts is None:
+            ts = self.last_health_ts
+        if ts is None:
+            return None
+        return (datetime.now(_UTC) - ts).total_seconds()
+
+    @property
+    def last_substantive_ts(self) -> Optional[datetime]:
+        return self.last_dispatch_ts
+
+
+_WORKER_HEALTH_RE = re.compile(r"GET /v1/health", re.IGNORECASE)
+_WORKER_DISPATCH_RE = re.compile(r"POST /v1/dispatch", re.IGNORECASE)
+_WORKER_BUSY_WINDOW_S = 90  # se houve POST /v1/dispatch nos últimos 90s, está busy
+
+
+class WorkerProvider:
+    """Por pod worker, deduz busy/idle do log."""
+
+    LABEL_SELECTOR = "app=deile-worker"
+    TAIL_LINES = 200
+
+    def __init__(self, ttl_s: float = 5.0):
+        self._kubectl = kubectl_bin()
+        self._cache: Cache[Dict[str, WorkerState]] = Cache(
+            ttl_s, self._fetch, fallback={},
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> Dict[str, WorkerState]:
+        return self._cache.get(force)
+
+    def _fetch(self) -> Dict[str, WorkerState]:
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        names_raw = _capture_text(
+            [self._kubectl, "-n", NS, "get", "pods",
+             "-l", self.LABEL_SELECTOR,
+             "-o", "jsonpath={.items[*].metadata.name}"],
+            timeout=4.0,
+        )
+        if names_raw is None:
+            raise RuntimeError("kubectl get worker pods falhou")
+        pod_names = [n for n in names_raw.split() if n]
+        states: Dict[str, WorkerState] = {}
+        for name in pod_names:
+            text = _capture_text(
+                [self._kubectl, "-n", NS, "logs", name,
+                 f"--tail={self.TAIL_LINES}", "--timestamps"],
+                timeout=4.0,
+            ) or ""
+            states[name] = self._parse(name, text)
+        return states
+
+    def _parse(self, pod_name: str, text: str) -> WorkerState:
+        state = WorkerState(pod_name=pod_name)
+        now = datetime.now(_UTC)
+        for raw in text.splitlines():
+            ll = _parse_log_line(raw)
+            if ll is None:
+                continue
+            if _WORKER_HEALTH_RE.search(ll.body):
+                state.last_health_ts = ll.ts
+                continue
+            if _WORKER_DISPATCH_RE.search(ll.body):
+                state.last_dispatch_ts = ll.ts
+                state.last_substantive_body = ll.body[:100]
+                continue
+            # Qualquer outra linha "não-health" também conta como atividade real.
+            state.last_substantive_body = ll.body[:100]
+            if state.last_dispatch_ts is None or ll.ts > state.last_dispatch_ts:
+                state.last_dispatch_ts = ll.ts
+        if state.last_dispatch_ts is not None:
+            since = (now - state.last_dispatch_ts).total_seconds()
+            state.busy = since < _WORKER_BUSY_WINDOW_S
+        return state
+
+
+# ===== GitHub provider ======================================================
+
+@dataclass
+class GitHubIssue:
+    number: int
+    title: str
+    is_pr: bool
+    state: str           # 'open' | 'closed'
+    labels: List[str]
+    assignees: List[str]
+    updated_at: Optional[datetime]
+    url: str
+    # Estado derivado das labels do pipeline
+    workflow: str = ""   # ex: 'em_implementacao'
+    review: str = ""     # ex: 'pendente'
+    blocked: bool = False
+    refining: bool = False
+
+
+@dataclass
+class GitHubSnapshot:
+    issues: List[GitHubIssue] = field(default_factory=list)
+    prs: List[GitHubIssue] = field(default_factory=list)
+
+    @property
+    def issue_states(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for it in self.issues:
+            key = it.workflow or "sem_workflow"
+            counts[key] = counts.get(key, 0) + 1
+        return counts
+
+    @property
+    def pr_states(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for pr in self.prs:
+            key = pr.review or "sem_review"
+            counts[key] = counts.get(key, 0) + 1
+        return counts
+
+
+_WORKFLOW_PREFIX = "~workflow:"
+_REVIEW_PREFIX = "~review:"
+_BLOCKED_LABEL = "~workflow:bloqueada"
+
+
+def _derive_workflow(labels: List[str]) -> str:
+    """Estado workflow efetivo. `bloqueada` vence — é terminal e o pipeline
+    a respeita mesmo quando outra label de fase ainda está presente."""
+    workflow_labels = [lbl[len(_WORKFLOW_PREFIX):]
+                       for lbl in labels if lbl.startswith(_WORKFLOW_PREFIX)]
+    if not workflow_labels:
+        return ""
+    if "bloqueada" in workflow_labels:
+        return "bloqueada"
+    return workflow_labels[0]
+
+
+def _derive_review(labels: List[str]) -> str:
+    for lbl in labels:
+        if lbl.startswith(_REVIEW_PREFIX):
+            return lbl[len(_REVIEW_PREFIX):]
+    return ""
+
+
+class GitHubProvider:
+    """Lista issues e PRs abertos via `gh api`."""
+
+    PER_PAGE = 100
+
+    def __init__(self, repo: str = REPO_DEFAULT, ttl_s: float = 10.0):
+        self._gh = gh_bin()
+        self._repo = repo
+        self._cache: Cache[GitHubSnapshot] = Cache(
+            ttl_s, self._fetch, fallback=GitHubSnapshot(),
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> GitHubSnapshot:
+        return self._cache.get(force)
+
+    def _fetch(self) -> GitHubSnapshot:
+        if self._gh is None:
+            raise RuntimeError("gh não encontrado")
+        # /issues retorna issues + PRs no mesmo array; PR tem chave 'pull_request'.
+        data = _capture_json(
+            [self._gh, "api", "--paginate",
+             f"/repos/{self._repo}/issues?state=open&per_page={self.PER_PAGE}"],
+            timeout=15.0,
+        )
+        if data is None:
+            raise RuntimeError("gh api issues falhou")
+        snap = GitHubSnapshot()
+        # `--paginate` pode retornar lista única ou várias páginas concatenadas
+        # (lista de listas) dependendo do gh — normaliza.
+        items: List[Dict[str, Any]] = []
+        if isinstance(data, list):
+            for chunk in data:
+                if isinstance(chunk, list):
+                    items.extend(chunk)
+                else:
+                    items.append(chunk)
+        for it in items:
+            labels = [lbl.get("name", "") for lbl in it.get("labels", []) or []]
+            assignees = [a.get("login", "")
+                         for a in it.get("assignees", []) or []]
+            obj = GitHubIssue(
+                number=int(it.get("number", 0)),
+                title=it.get("title", ""),
+                is_pr=("pull_request" in it),
+                state=it.get("state", "open"),
+                labels=labels,
+                assignees=assignees,
+                updated_at=_parse_k8s_ts(it.get("updated_at")),
+                url=it.get("html_url", ""),
+                workflow=_derive_workflow(labels),
+                review=_derive_review(labels),
+                blocked=_BLOCKED_LABEL in labels,
+                refining=any(lbl == "refinar" for lbl in labels),
+            )
+            if obj.is_pr:
+                snap.prs.append(obj)
+            else:
+                snap.issues.append(obj)
+        snap.issues.sort(key=lambda x: x.number, reverse=True)
+        snap.prs.sort(key=lambda x: x.number, reverse=True)
+        return snap
+
+
+# ===== Costs (UsageRepository) ==============================================
+
+@dataclass
+class CostsSnapshot:
+    by_provider_24h: Dict[str, float] = field(default_factory=dict)
+    by_provider_1h: Dict[str, float] = field(default_factory=dict)
+    total_24h: float = 0.0
+    total_1h: float = 0.0
+    records_24h: int = 0
+    top_sessions_24h: List[tuple] = field(default_factory=list)  # (session_id, cost)
+
+
+class CostsProvider:
+    """Agrega custos do `~/.deile/db/usage.db`.
+
+    Fallback gracioso quando o DB ainda não existe (DEILE nunca rodou
+    localmente nem montou o PVC do worker no host).
+    """
+
+    def __init__(self, db_path: Path = USAGE_DB, ttl_s: float = 60.0):
+        self._db_path = db_path
+        self._cache: Cache[CostsSnapshot] = Cache(
+            ttl_s, self._fetch, fallback=CostsSnapshot(),
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> CostsSnapshot:
+        return self._cache.get(force)
+
+    def _fetch(self) -> CostsSnapshot:
+        if not self._db_path.is_file():
+            return CostsSnapshot()
+        snap = CostsSnapshot()
+        now = time.time()
+        since_24h = now - 86400
+        since_1h = now - 3600
+        try:
+            conn = sqlite3.connect(
+                f"file:{self._db_path}?mode=ro", uri=True, timeout=2.0,
+            )
+        except sqlite3.OperationalError:
+            return snap
+        try:
+            cur = conn.cursor()
+            for prov, cost in cur.execute(
+                "SELECT provider_id, COALESCE(SUM(cost_usd),0) "
+                "FROM usage_records WHERE timestamp>=? GROUP BY provider_id",
+                (since_24h,),
+            ):
+                snap.by_provider_24h[prov] = float(cost)
+                snap.total_24h += float(cost)
+            for prov, cost in cur.execute(
+                "SELECT provider_id, COALESCE(SUM(cost_usd),0) "
+                "FROM usage_records WHERE timestamp>=? GROUP BY provider_id",
+                (since_1h,),
+            ):
+                snap.by_provider_1h[prov] = float(cost)
+                snap.total_1h += float(cost)
+            count_row = cur.execute(
+                "SELECT COUNT(*) FROM usage_records WHERE timestamp>=?",
+                (since_24h,),
+            ).fetchone()
+            snap.records_24h = int(count_row[0]) if count_row else 0
+            snap.top_sessions_24h = [
+                (sid, float(cost))
+                for sid, cost in cur.execute(
+                    "SELECT session_id, SUM(cost_usd) AS c "
+                    "FROM usage_records WHERE timestamp>=? "
+                    "GROUP BY session_id ORDER BY c DESC LIMIT 5",
+                    (since_24h,),
+                )
+            ]
+        finally:
+            conn.close()
+        return snap
+
+
+# ===== Aggregate hub ========================================================
+
+@dataclass
+class PanelData:
+    """Conjunto de providers consumidos pela UI."""
+    pods: PodsProvider
+    pipeline: PipelineProvider
+    workers: WorkerProvider
+    github: GitHubProvider
+    costs: CostsProvider
+
+    @classmethod
+    def default(cls, repo: str = REPO_DEFAULT) -> "PanelData":
+        return cls(
+            pods=PodsProvider(),
+            pipeline=PipelineProvider(),
+            workers=WorkerProvider(),
+            github=GitHubProvider(repo=repo),
+            costs=CostsProvider(),
+        )
+
+    def force_refresh_all(self) -> None:
+        """Usado pelo hotkey [r]: invalida todos os caches no próximo `get`."""
+        for p in (self.pods, self.pipeline, self.workers,
+                  self.github, self.costs):
+            p._cache._fetched_at = 0.0  # noqa: SLF001 (intentional internal)
+
+    def errors(self) -> List[tuple]:
+        """Lista provider name + último erro, pra UI mostrar discretamente."""
+        out: List[tuple] = []
+        for name, p in (
+            ("pods", self.pods),
+            ("pipeline", self.pipeline),
+            ("workers", self.workers),
+            ("github", self.github),
+            ("costs", self.costs),
+        ):
+            if p.last_error:
+                out.append((name, p.last_error))
+        return out

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -22,20 +22,59 @@ Fontes:
 from __future__ import annotations
 
 import json
+import logging
 import re
 import shutil
 import sqlite3
 import subprocess
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from functools import cached_property
 from pathlib import Path
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
 
 T = TypeVar("T")
 
+logger = logging.getLogger(__name__)
+
 NS = "deile"
-REPO_DEFAULT = "elimarcavalli/deile"
+# Tamanho máximo de log (bytes) que parsers carregam em memória — protege
+# contra pods com saídas multi-MB. Aplicado antes de `splitlines()`.
+MAX_LOG_BYTES = 256_000
+# Slug seguro para kubectl set env: alfanum + [._:/-], 1-128 chars, sem
+# espaços, sem controle, sem '=' nem '\n'. Rejeita injeção em argv.
+_MODEL_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,127}$")
+
+
+def _detect_default_repo() -> str:
+    """Tenta derivar `owner/repo` de `git remote get-url origin`.
+
+    Fallback para `elimarcavalli/deile` se git ausente, sem origin, ou
+    formato não reconhecido. Roda uma única vez no import — silencioso.
+    """
+    fallback = "elimarcavalli/deile"
+    git = shutil.which("git")
+    if git is None:
+        return fallback
+    try:
+        out = subprocess.run(
+            [git, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=2.0,
+            cwd=str(Path(__file__).resolve().parent.parent.parent),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return fallback
+    if out.returncode != 0:
+        return fallback
+    url = out.stdout.strip()
+    # github.com[:/]owner/repo(.git)?  — cobre https e ssh.
+    m = re.search(r"github\.com[:/]([^/]+/[^/.]+?)(?:\.git)?/?$", url)
+    return m.group(1) if m else fallback
+
+
+REPO_DEFAULT = _detect_default_repo()
 USAGE_DB = Path.home() / ".deile" / "db" / "usage.db"
 
 
@@ -56,6 +95,9 @@ class Cache(Generic[T]):
     _value: Optional[T] = field(default=None, init=False, repr=False)
     _fetched_at: float = field(default=0.0, init=False, repr=False)
     _last_error: Optional[str] = field(default=None, init=False, repr=False)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False,
+    )
 
     @property
     def last_error(self) -> Optional[str]:
@@ -64,6 +106,15 @@ class Cache(Generic[T]):
     @property
     def age_s(self) -> float:
         return time.monotonic() - self._fetched_at if self._fetched_at else 0.0
+
+    def invalidate(self) -> None:
+        """Força o próximo `get()` a refazer o fetch.
+
+        Substitui o acesso direto a `_fetched_at = 0.0` (que tinha race
+        entre threads e ignorava o lock interno).
+        """
+        with self._lock:
+            self._fetched_at = 0.0
 
     def get(self, force: bool = False) -> T:
         now = time.monotonic()
@@ -75,15 +126,23 @@ class Cache(Generic[T]):
             return self._value  # type: ignore[return-value]
         try:
             new = self.fetcher()
-            self._value = new
-            self._fetched_at = now
-            self._last_error = None
-            return new
         except Exception as exc:  # noqa: BLE001 (defensive — render must never crash)
-            self._last_error = f"{type(exc).__name__}: {exc}"
+            # Falhas crônicas devem ficar visíveis nos logs do operador (debug
+            # apenas — alarmar a cada tick poluiria; last_error já é exibido
+            # discretamente na UI).
+            logger.debug(
+                "Cache.get fetcher failed: %s", exc, exc_info=True,
+            )
+            with self._lock:
+                self._last_error = f"{type(exc).__name__}: {exc}"
             if self._value is None:
                 return self.fallback
             return self._value
+        with self._lock:
+            self._value = new
+            self._fetched_at = now
+            self._last_error = None
+        return new
 
 
 # ===== subprocess helpers ===================================================
@@ -214,7 +273,15 @@ class PodsProvider:
     def get(self, force: bool = False) -> List[PodInfo]:
         return self._cache.get(force)
 
+    def _resolve_kubectl(self) -> Optional[str]:
+        """Re-resolve kubectl lazy — operador pode tê-lo instalado depois
+        do painel ter sido aberto."""
+        if self._kubectl is None:
+            self._kubectl = kubectl_bin()
+        return self._kubectl
+
     def _fetch(self) -> List[PodInfo]:
+        self._resolve_kubectl()
         if self._kubectl is None:
             raise RuntimeError("kubectl não encontrado")
         data = _capture_json(
@@ -377,7 +444,13 @@ class PipelineProvider:
     def get(self, force: bool = False) -> PipelineState:
         return self._cache.get(force)
 
+    def _resolve_kubectl(self) -> Optional[str]:
+        if self._kubectl is None:
+            self._kubectl = kubectl_bin()
+        return self._kubectl
+
     def _fetch(self) -> PipelineState:
+        self._resolve_kubectl()
         if self._kubectl is None:
             raise RuntimeError("kubectl não encontrado")
         text = _capture_text(
@@ -394,6 +467,10 @@ class PipelineProvider:
         state = PipelineState()
         now = datetime.now(_UTC)
         cutoff_24h = now - timedelta(hours=24)
+        # Cap defensivo: pods com saída multi-MB não devem virar strings de
+        # MB em memória. Mantemos o final do log (mais recente).
+        if len(text) > MAX_LOG_BYTES:
+            text = text[-MAX_LOG_BYTES:]
         for raw in text.splitlines():
             state.raw_lines += 1
             ll = _parse_log_line(raw)
@@ -438,21 +515,18 @@ class WorkerState:
     pod_name: str
     busy: bool = False
     last_dispatch_ts: Optional[datetime] = None
+    last_substantive_ts: Optional[datetime] = None
     last_health_ts: Optional[datetime] = None
     last_substantive_body: str = ""
 
     @property
     def last_activity_s(self) -> Optional[float]:
-        ts = self.last_substantive_ts
+        ts = self.last_substantive_ts or self.last_dispatch_ts
         if ts is None:
             ts = self.last_health_ts
         if ts is None:
             return None
         return (datetime.now(_UTC) - ts).total_seconds()
-
-    @property
-    def last_substantive_ts(self) -> Optional[datetime]:
-        return self.last_dispatch_ts
 
 
 _WORKER_HEALTH_RE = re.compile(r"GET /v1/health", re.IGNORECASE)
@@ -479,7 +553,13 @@ class WorkerProvider:
     def get(self, force: bool = False) -> Dict[str, WorkerState]:
         return self._cache.get(force)
 
+    def _resolve_kubectl(self) -> Optional[str]:
+        if self._kubectl is None:
+            self._kubectl = kubectl_bin()
+        return self._kubectl
+
     def _fetch(self) -> Dict[str, WorkerState]:
+        self._resolve_kubectl()
         if self._kubectl is None:
             raise RuntimeError("kubectl não encontrado")
         names_raw = _capture_text(
@@ -504,6 +584,9 @@ class WorkerProvider:
     def _parse(self, pod_name: str, text: str) -> WorkerState:
         state = WorkerState(pod_name=pod_name)
         now = datetime.now(_UTC)
+        # Cap defensivo contra logs muito grandes.
+        if len(text) > MAX_LOG_BYTES:
+            text = text[-MAX_LOG_BYTES:]
         for raw in text.splitlines():
             ll = _parse_log_line(raw)
             if ll is None:
@@ -512,13 +595,19 @@ class WorkerProvider:
                 state.last_health_ts = ll.ts
                 continue
             if _WORKER_DISPATCH_RE.search(ll.body):
+                # `last_dispatch_ts` é a fonte de verdade do busy-window —
+                # restrita a "POST /v1/dispatch" para casar com a constante
+                # `_WORKER_BUSY_WINDOW_S` ("nos últimos 90s teve dispatch").
                 state.last_dispatch_ts = ll.ts
+                state.last_substantive_ts = ll.ts
                 state.last_substantive_body = ll.body[:100]
                 continue
-            # Qualquer outra linha "não-health" também conta como atividade real.
+            # Qualquer outra linha "não-health" conta como atividade real
+            # (substantiva) mas NÃO sobe busy — só dispatch real faz isso.
             state.last_substantive_body = ll.body[:100]
-            if state.last_dispatch_ts is None or ll.ts > state.last_dispatch_ts:
-                state.last_dispatch_ts = ll.ts
+            if (state.last_substantive_ts is None
+                    or ll.ts > state.last_substantive_ts):
+                state.last_substantive_ts = ll.ts
         if state.last_dispatch_ts is not None:
             since = (now - state.last_dispatch_ts).total_seconds()
             state.busy = since < _WORKER_BUSY_WINDOW_S
@@ -549,7 +638,7 @@ class GitHubSnapshot:
     issues: List[GitHubIssue] = field(default_factory=list)
     prs: List[GitHubIssue] = field(default_factory=list)
 
-    @property
+    @cached_property
     def issue_states(self) -> Dict[str, int]:
         counts: Dict[str, int] = {}
         for it in self.issues:
@@ -557,7 +646,7 @@ class GitHubSnapshot:
             counts[key] = counts.get(key, 0) + 1
         return counts
 
-    @property
+    @cached_property
     def pr_states(self) -> Dict[str, int]:
         counts: Dict[str, int] = {}
         for pr in self.prs:
@@ -613,6 +702,10 @@ class GitHubProvider:
         if self._gh is None:
             raise RuntimeError("gh não encontrado")
         # /issues retorna issues + PRs no mesmo array; PR tem chave 'pull_request'.
+        # `--paginate` percorre tudo; o único limite é o timeout de 15s
+        # abaixo — repositórios com milhares de issues abertas atingem o
+        # timeout antes do limite de páginas. Adicionar `--slurp --jq`
+        # com cap explícito é evolução futura caso o teto fique pequeno.
         data = _capture_json(
             [self._gh, "api", "--paginate",
              f"/repos/{self._repo}/issues?state=open&per_page={self.PER_PAGE}"],
@@ -825,7 +918,13 @@ class CurrentModelProvider:
     def get(self, force: bool = False) -> Dict[str, Optional[str]]:
         return self._cache.get(force)
 
+    def _resolve_kubectl(self) -> Optional[str]:
+        if self._kubectl is None:
+            self._kubectl = kubectl_bin()
+        return self._kubectl
+
     def _fetch(self) -> Dict[str, Optional[str]]:
+        self._resolve_kubectl()
         if self._kubectl is None:
             raise RuntimeError("kubectl não encontrado")
         out: Dict[str, Optional[str]] = {}
@@ -850,6 +949,38 @@ class CurrentModelProvider:
         return None
 
 
+def _audit_security_policy_change(
+    deployment: str, slug: str, *, result: str, detail: str,
+) -> None:
+    """Emite AuditEvent(SECURITY_POLICY_CHANGED) para a troca de modelo.
+
+    Silencioso se o pacote deile não estiver importável (e.g., rodando
+    o painel em isolamento sem o módulo principal no sys.path). A falha
+    de log NUNCA bloqueia a ação — mas a falha de validação sim.
+    """
+    try:
+        from deile.security.audit_logger import (  # noqa: PLC0415
+            AuditEvent, AuditEventType, SeverityLevel, get_audit_logger,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "audit logger indisponível para set_preferred_model: %s", exc,
+        )
+        return
+    try:
+        get_audit_logger().log_event(
+            event_type=AuditEventType.SECURITY_POLICY_CHANGED,
+            severity=SeverityLevel.WARNING,
+            actor="panel:set_preferred_model",
+            resource=f"deployment:{NS}/{deployment}:DEILE_PREFERRED_MODEL",
+            action="kubectl_set_env",
+            result=result,
+            details={"slug": slug, "detail": detail[:200]},
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("falha emitindo AuditEvent: %s", exc)
+
+
 def set_preferred_model(deployment: str, slug: str,
                         timeout: float = 15.0) -> tuple:
     """Aplica `DEILE_PREFERRED_MODEL=<slug>` no Deployment.
@@ -857,10 +988,29 @@ def set_preferred_model(deployment: str, slug: str,
     `kubectl set env` modifica a spec do Deployment, o que dispara
     rollout automático (com a strategy do manifest — `RollingUpdate`
     para o worker e `Recreate` para o pipeline). Retorna `(ok, msg)`.
+
+    Slug é validado contra `_MODEL_SLUG_RE` antes de virar argv — rejeita
+    quebras de linha, `=`, NUL, controle e espaços que permitiriam
+    injeção em argumentos do kubectl. Toda chamada (allowed/denied/falha)
+    emite `AuditEvent(SECURITY_POLICY_CHANGED)`.
     """
+    if not isinstance(slug, str) or not _MODEL_SLUG_RE.match(slug):
+        _audit_security_policy_change(
+            deployment, slug if isinstance(slug, str) else repr(slug),
+            result="denied", detail="slug inválido",
+        )
+        return False, "slug inválido — recusado por validação"
     kubectl = kubectl_bin()
     if kubectl is None:
+        _audit_security_policy_change(
+            deployment, slug, result="failed", detail="kubectl não encontrado",
+        )
         return False, "kubectl não encontrado"
+    # Audit ANTES de executar — registra a intenção, ainda que o
+    # subprocess depois falhe ou trave.
+    _audit_security_policy_change(
+        deployment, slug, result="allowed", detail="executando kubectl set env",
+    )
     try:
         proc = subprocess.run(
             [kubectl, "-n", NS, "set", "env", f"deploy/{deployment}",
@@ -868,10 +1018,67 @@ def set_preferred_model(deployment: str, slug: str,
             capture_output=True, text=True, timeout=timeout,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
+        _audit_security_policy_change(
+            deployment, slug, result="failed", detail=f"subprocess: {exc}",
+        )
         return False, f"falha ao executar kubectl: {exc}"
     if proc.returncode != 0:
-        return False, (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
-    return True, (proc.stdout or "rollout disparado").strip()
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        _audit_security_policy_change(
+            deployment, slug, result="failed",
+            detail=f"rc={proc.returncode} {err}",
+        )
+        return False, err
+    msg = (proc.stdout or "rollout disparado").strip()
+    _audit_security_policy_change(
+        deployment, slug, result="completed", detail=msg,
+    )
+    return True, msg
+
+
+# ===== Notifier (bot audit log) =============================================
+
+class NotifierProvider:
+    """Tail dos audit events do `deilebot` via kubectl logs.
+
+    Sai como `List[str]` (linhas cruas) — a view filtra/parsea. Cache TTL
+    5s evita o `kubectl logs deploy/deilebot --tail=500` por render (a
+    NotifierEchoView refresha em 5s; era 12 chamadas/min sem cache).
+    """
+
+    BOT_DEPLOY = "deilebot"
+    TAIL = 500
+
+    def __init__(self, ttl_s: float = 5.0):
+        self._kubectl = kubectl_bin()
+        self._cache: Cache[List[str]] = Cache(ttl_s, self._fetch, fallback=[])
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> List[str]:
+        return self._cache.get(force)
+
+    def _resolve_kubectl(self) -> Optional[str]:
+        if self._kubectl is None:
+            self._kubectl = kubectl_bin()
+        return self._kubectl
+
+    def _fetch(self) -> List[str]:
+        self._resolve_kubectl()
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        text = _capture_text(
+            [self._kubectl, "-n", NS, "logs",
+             f"deploy/{self.BOT_DEPLOY}", f"--tail={self.TAIL}"],
+            timeout=5.0,
+        )
+        if text is None:
+            raise RuntimeError("kubectl logs deilebot falhou")
+        if len(text) > MAX_LOG_BYTES:
+            text = text[-MAX_LOG_BYTES:]
+        return text.splitlines()
 
 
 # ===== Aggregate hub ========================================================
@@ -886,6 +1093,7 @@ class PanelData:
     costs: CostsProvider
     models: ModelsProvider
     current_model: CurrentModelProvider
+    notifier: NotifierProvider
 
     @classmethod
     def default(cls, repo: str = REPO_DEFAULT) -> "PanelData":
@@ -897,13 +1105,15 @@ class PanelData:
             costs=CostsProvider(),
             models=ModelsProvider(),
             current_model=CurrentModelProvider(),
+            notifier=NotifierProvider(),
         )
 
     def force_refresh_all(self) -> None:
         """Usado pelo hotkey [r]: invalida todos os caches no próximo `get`."""
         for p in (self.pods, self.pipeline, self.workers,
-                  self.github, self.costs, self.models, self.current_model):
-            p._cache._fetched_at = 0.0  # noqa: SLF001 (intentional internal)
+                  self.github, self.costs, self.models, self.current_model,
+                  self.notifier):
+            p._cache.invalidate()  # noqa: SLF001 (público no Cache; provider ainda é pacote)
 
     def errors(self) -> List[tuple]:
         """Lista provider name + último erro, pra UI mostrar discretamente."""
@@ -916,6 +1126,7 @@ class PanelData:
             ("costs", self.costs),
             ("models", self.models),
             ("current_model", self.current_model),
+            ("notifier", self.notifier),
         ):
             if p.last_error:
                 out.append((name, p.last_error))

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -259,6 +259,21 @@ def _parse_log_line(line: str) -> Optional["LogLine"]:
     return LogLine(ts=ts, body=m.group(2))
 
 
+class _KubectlProviderMixin:
+    """Reusa o padrão `_kubectl + _resolve_kubectl()` entre os providers.
+
+    Operador pode ter instalado kubectl depois do painel abrir — toda
+    chamada de fetch tenta re-resolver se a referência local ainda é None.
+    """
+
+    _kubectl: Optional[str]
+
+    def _resolve_kubectl(self) -> Optional[str]:
+        if self._kubectl is None:
+            self._kubectl = kubectl_bin()
+        return self._kubectl
+
+
 def _fmt_age(seconds: Optional[float]) -> str:
     """Idade humanamente legível: 3s, 47s, 2m, 1h12m, 3d."""
     if seconds is None:
@@ -297,7 +312,7 @@ _ROLE_BY_APP = {
 }
 
 
-class PodsProvider:
+class PodsProvider(_KubectlProviderMixin):
     """Lista os pods do namespace `deile` em forma tipada."""
 
     def __init__(self, ttl_s: float = 1.0):
@@ -311,13 +326,6 @@ class PodsProvider:
 
     def get(self, force: bool = False) -> List[PodInfo]:
         return self._cache.get(force)
-
-    def _resolve_kubectl(self) -> Optional[str]:
-        """Re-resolve kubectl lazy — operador pode tê-lo instalado depois
-        do painel ter sido aberto."""
-        if self._kubectl is None:
-            self._kubectl = kubectl_bin()
-        return self._kubectl
 
     def _fetch(self) -> List[PodInfo]:
         self._resolve_kubectl()
@@ -464,7 +472,7 @@ class PipelineState:
         return (datetime.now(_UTC) - self.last_action_ts).total_seconds()
 
 
-class PipelineProvider:
+class PipelineProvider(_KubectlProviderMixin):
     """Lê os últimos N segundos de log do deile-pipeline e classifica."""
 
     DEPLOY = "deile-pipeline"
@@ -483,11 +491,6 @@ class PipelineProvider:
 
     def get(self, force: bool = False) -> PipelineState:
         return self._cache.get(force)
-
-    def _resolve_kubectl(self) -> Optional[str]:
-        if self._kubectl is None:
-            self._kubectl = kubectl_bin()
-        return self._kubectl
 
     def _fetch(self) -> PipelineState:
         self._resolve_kubectl()
@@ -574,7 +577,7 @@ _WORKER_DISPATCH_RE = re.compile(r"POST /v1/dispatch", re.IGNORECASE)
 _WORKER_BUSY_WINDOW_S = 90  # se houve POST /v1/dispatch nos últimos 90s, está busy
 
 
-class WorkerProvider:
+class WorkerProvider(_KubectlProviderMixin):
     """Por pod worker, deduz busy/idle do log."""
 
     LABEL_SELECTOR = "app=deile-worker"
@@ -593,11 +596,6 @@ class WorkerProvider:
 
     def get(self, force: bool = False) -> Dict[str, WorkerState]:
         return self._cache.get(force)
-
-    def _resolve_kubectl(self) -> Optional[str]:
-        if self._kubectl is None:
-            self._kubectl = kubectl_bin()
-        return self._kubectl
 
     def _fetch(self) -> Dict[str, WorkerState]:
         self._resolve_kubectl()
@@ -942,7 +940,7 @@ class ModelsProvider:
         return out
 
 
-class CurrentModelProvider:
+class CurrentModelProvider(_KubectlProviderMixin):
     """Lê o `DEILE_PREFERRED_MODEL` setado no Deployment do worker (e/ou
     pipeline) — o valor que efetivamente roda agora nos pods."""
 
@@ -962,11 +960,6 @@ class CurrentModelProvider:
 
     def get(self, force: bool = False) -> Dict[str, Optional[str]]:
         return self._cache.get(force)
-
-    def _resolve_kubectl(self) -> Optional[str]:
-        if self._kubectl is None:
-            self._kubectl = kubectl_bin()
-        return self._kubectl
 
     def _fetch(self) -> Dict[str, Optional[str]]:
         self._resolve_kubectl()
@@ -1044,10 +1037,13 @@ def set_preferred_model(deployment: str, slug: str,
     injeção em argumentos do kubectl. Toda chamada (allowed/denied/falha)
     emite `AuditEvent(SECURITY_POLICY_CHANGED)`.
     """
+    # Normaliza valores não-string pra um repr seguro antes de logar — evita
+    # crashes no audit quando o caller passa algo bizarro (None, dict, etc).
+    safe_dep = deployment if isinstance(deployment, str) else repr(deployment)
+    safe_slug = slug if isinstance(slug, str) else repr(slug)
     if deployment not in _ALLOWED_DEPLOYMENTS:
         _audit_security_policy_change(
-            deployment if isinstance(deployment, str) else repr(deployment),
-            slug if isinstance(slug, str) else repr(slug),
+            safe_dep, safe_slug,
             result="denied", detail="deployment fora da whitelist",
         )
         allowed = ", ".join(sorted(_ALLOWED_DEPLOYMENTS))
@@ -1057,7 +1053,7 @@ def set_preferred_model(deployment: str, slug: str,
         )
     if not isinstance(slug, str) or not _MODEL_SLUG_RE.match(slug):
         _audit_security_policy_change(
-            deployment, slug if isinstance(slug, str) else repr(slug),
+            deployment, safe_slug,
             result="denied", detail="slug inválido",
         )
         return False, "slug inválido — recusado por validação"
@@ -1099,7 +1095,7 @@ def set_preferred_model(deployment: str, slug: str,
 
 # ===== Notifier (bot audit log) =============================================
 
-class NotifierProvider:
+class NotifierProvider(_KubectlProviderMixin):
     """Tail dos audit events do `deilebot` via kubectl logs.
 
     Sai como `List[str]` (linhas cruas) — a view filtra/parsea. Cache TTL
@@ -1120,11 +1116,6 @@ class NotifierProvider:
 
     def get(self, force: bool = False) -> List[str]:
         return self._cache.get(force)
-
-    def _resolve_kubectl(self) -> Optional[str]:
-        if self._kubectl is None:
-            self._kubectl = kubectl_bin()
-        return self._kubectl
 
     def _fetch(self) -> List[str]:
         self._resolve_kubectl()

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -960,8 +960,7 @@ def _audit_security_policy_change(
     """
     try:
         from deile.security.audit_logger import (  # noqa: PLC0415
-            AuditEvent, AuditEventType, SeverityLevel, get_audit_logger,
-        )
+            AuditEventType, SeverityLevel, get_audit_logger)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "audit logger indisponível para set_preferred_model: %s", exc,

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -47,6 +47,10 @@ MAX_LOG_BYTES = 256_000
 # Slug seguro para kubectl set env: alfanum + [._:/-], 1-128 chars, sem
 # espaços, sem controle, sem '=' nem '\n'. Rejeita injeção em argv.
 _MODEL_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,127}$")
+# Deployments cuja env DEILE_PREFERRED_MODEL é modificável pelo painel.
+# Argumento `deployment` de `set_preferred_model` vai direto em argv —
+# whitelist impede qualquer outro alvo (acidental ou malicioso).
+_ALLOWED_DEPLOYMENTS = frozenset({"deile-worker", "deile-pipeline"})
 
 
 def _detect_default_repo() -> str:
@@ -1007,10 +1011,16 @@ def _audit_security_policy_change(
             "audit logger indisponível para set_preferred_model: %s", exc,
         )
         return
+    # INFO para fluxos não-anômalos (allowed/completed/cancelled); WARNING
+    # para falhas ou recusas — evita que toda troca bem-sucedida (ou um
+    # cancelamento legítimo do operador) vire WARNING no log.
+    severity = (SeverityLevel.INFO
+                if result in ("allowed", "completed", "cancelled")
+                else SeverityLevel.WARNING)
     try:
         get_audit_logger().log_event(
             event_type=AuditEventType.SECURITY_POLICY_CHANGED,
-            severity=SeverityLevel.WARNING,
+            severity=severity,
             actor="panel:set_preferred_model",
             resource=f"deployment:{NS}/{deployment}:DEILE_PREFERRED_MODEL",
             action="kubectl_set_env",
@@ -1034,6 +1044,17 @@ def set_preferred_model(deployment: str, slug: str,
     injeção em argumentos do kubectl. Toda chamada (allowed/denied/falha)
     emite `AuditEvent(SECURITY_POLICY_CHANGED)`.
     """
+    if deployment not in _ALLOWED_DEPLOYMENTS:
+        _audit_security_policy_change(
+            deployment if isinstance(deployment, str) else repr(deployment),
+            slug if isinstance(slug, str) else repr(slug),
+            result="denied", detail="deployment fora da whitelist",
+        )
+        allowed = ", ".join(sorted(_ALLOWED_DEPLOYMENTS))
+        return False, (
+            f"deployment '{deployment}' não permitido — "
+            f"esperado um de: {allowed}"
+        )
     if not isinstance(slug, str) or not _MODEL_SLUG_RE.match(slug):
         _audit_security_policy_change(
             deployment, slug if isinstance(slug, str) else repr(slug),

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -29,6 +29,7 @@ import sqlite3
 import subprocess
 import threading
 import time
+from concurrent import futures
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
@@ -87,6 +88,19 @@ class Cache(Generic[T]):
     Em caso de erro, mantém o último valor bom; se nunca houve valor bom,
     devolve o `fallback`. Guarda a última exceção em `last_error` para a
     view exibir um indicador discreto.
+
+    Contrato de blocking:
+    - ``get()`` **nunca bloqueia** depois do primeiro fetch — retorna o
+      valor cacheado mesmo que esteja velho.
+    - ``maybe_refresh()`` é o que o ``BackgroundRefresher`` chama em loop
+      para manter o cache fresco (faz fetch só se TTL venceu).
+    - ``get(force=True)`` continua síncrono — usado pelo hotkey [r] para
+      cold-start no primeiro render.
+
+    Antes desta separação, o render no thread principal eventualmente
+    caía no ramo de fetch quando o TTL vencia, e qualquer subprocess
+    kubectl/gh segurava a UI por segundos. Agora todo I/O pesado vive em
+    ``BackgroundRefresher``.
     """
 
     ttl_s: float
@@ -117,32 +131,52 @@ class Cache(Generic[T]):
             self._fetched_at = 0.0
 
     def get(self, force: bool = False) -> T:
-        now = time.monotonic()
-        fresh_enough = (
-            self._value is not None
-            and (now - self._fetched_at) < self.ttl_s
-        )
-        if fresh_enough and not force:
-            return self._value  # type: ignore[return-value]
-        try:
-            new = self.fetcher()
-        except Exception as exc:  # noqa: BLE001 (defensive — render must never crash)
-            # Falhas crônicas devem ficar visíveis nos logs do operador (debug
-            # apenas — alarmar a cada tick poluiria; last_error já é exibido
-            # discretamente na UI).
-            logger.debug(
-                "Cache.get fetcher failed: %s", exc, exc_info=True,
-            )
-            with self._lock:
-                self._last_error = f"{type(exc).__name__}: {exc}"
-            if self._value is None:
-                return self.fallback
+        """Devolve o valor cacheado, sem bloquear (a menos que `force`).
+
+        - Há valor + ``force=False``: retorna instantâneo, **mesmo se
+          velho**. O ``BackgroundRefresher`` cuida do refresh.
+        - Sem valor (cold start): faz fetch síncrono uma vez, para a
+          primeira render ter algo.
+        - ``force=True``: faz fetch síncrono (usado pelos testes e por
+          comportamento legado).
+        """
+        if self._value is not None and not force:
             return self._value
+        return self._refresh()
+
+    def maybe_refresh(self) -> bool:
+        """Refaz o fetch se o TTL venceu. Para uso do BackgroundRefresher.
+
+        Retorna ``True`` se realmente fez fetch novo.
+        """
+        if (self._value is not None
+                and (time.monotonic() - self._fetched_at) < self.ttl_s):
+            return False
+        self._refresh()
+        return True
+
+    def _refresh(self) -> T:
+        # Combinação dos dois lados do merge: lock thread-safe + logger
+        # debug em falha (vindo do branch remoto a68ace9), mas com o
+        # caminho "não bloqueia depois do primeiro fetch" do lado novo
+        # (theirs / BackgroundRefresher). `invalidate()` já vive acima e
+        # apenas zera `_fetched_at` — o `get()` passa a tratar isso como
+        # "cold start" e refaz fetch único na próxima chamada.
         with self._lock:
-            self._value = new
-            self._fetched_at = now
-            self._last_error = None
-        return new
+            try:
+                new = self.fetcher()
+                self._value = new
+                self._fetched_at = time.monotonic()
+                self._last_error = None
+                return new
+            except Exception as exc:  # noqa: BLE001 (defensive — render must never crash)
+                logger.debug(
+                    "Cache.refresh fetcher failed: %s", exc, exc_info=True,
+                )
+                self._last_error = f"{type(exc).__name__}: {exc}"
+                if self._value is None:
+                    return self.fallback
+                return self._value
 
 
 # ===== subprocess helpers ===================================================
@@ -262,7 +296,8 @@ _ROLE_BY_APP = {
 class PodsProvider:
     """Lista os pods do namespace `deile` em forma tipada."""
 
-    def __init__(self, ttl_s: float = 3.0):
+    def __init__(self, ttl_s: float = 1.0):
+        # 1s: `kubectl get pods` local <50ms, sem custo perceptível.
         self._kubectl = kubectl_bin()
         self._cache: Cache[List[PodInfo]] = Cache(ttl_s, self._fetch, fallback=[])
 
@@ -431,7 +466,8 @@ class PipelineProvider:
     DEPLOY = "deile-pipeline"
     TAIL_LINES = 200
 
-    def __init__(self, ttl_s: float = 5.0):
+    def __init__(self, ttl_s: float = 2.0):
+        # 2s: `kubectl logs --tail=200` ~200ms; balanceado entre vivo e custo.
         self._kubectl = kubectl_bin()
         self._cache: Cache[PipelineState] = Cache(
             ttl_s, self._fetch, fallback=PipelineState(),
@@ -540,7 +576,8 @@ class WorkerProvider:
     LABEL_SELECTOR = "app=deile-worker"
     TAIL_LINES = 200
 
-    def __init__(self, ttl_s: float = 5.0):
+    def __init__(self, ttl_s: float = 2.0):
+        # 2s: N `kubectl logs` (1 por worker) — só roda em background.
         self._kubectl = kubectl_bin()
         self._cache: Cache[Dict[str, WorkerState]] = Cache(
             ttl_s, self._fetch, fallback={},
@@ -685,6 +722,8 @@ class GitHubProvider:
     PER_PAGE = 100
 
     def __init__(self, repo: str = REPO_DEFAULT, ttl_s: float = 10.0):
+        # 10s: `gh api --paginate` custa rate-limit (5000/h auth = 1.4/s);
+        # 10s = 360/h, folga confortável.
         self._gh = gh_bin()
         self._repo = repo
         self._cache: Cache[GitHubSnapshot] = Cache(
@@ -769,7 +808,8 @@ class CostsProvider:
     localmente nem montou o PVC do worker no host).
     """
 
-    def __init__(self, db_path: Path = USAGE_DB, ttl_s: float = 60.0):
+    def __init__(self, db_path: Path = USAGE_DB, ttl_s: float = 30.0):
+        # 30s: SQLite local; mais frequente é só polling barulhento.
         self._db_path = db_path
         self._cache: Cache[CostsSnapshot] = Cache(
             ttl_s, self._fetch, fallback=CostsSnapshot(),
@@ -904,7 +944,8 @@ class CurrentModelProvider:
 
     DEFAULT_DEPLOYMENTS = ("deile-worker", "deile-pipeline")
 
-    def __init__(self, deployments=DEFAULT_DEPLOYMENTS, ttl_s: float = 5.0):
+    def __init__(self, deployments=DEFAULT_DEPLOYMENTS, ttl_s: float = 3.0):
+        # 3s: 1 `kubectl get -o json` por deployment (~100ms cada).
         self._kubectl = kubectl_bin()
         self._deployments = tuple(deployments)
         self._cache: Cache[Dict[str, Optional[str]]] = Cache(
@@ -1107,26 +1148,98 @@ class PanelData:
             notifier=NotifierProvider(),
         )
 
+    def _all_providers(self) -> tuple:
+        """Ordem usada por `force_refresh_all` e `errors`."""
+        return (self.pods, self.pipeline, self.workers, self.github,
+                self.costs, self.models, self.current_model, self.notifier)
+
     def force_refresh_all(self) -> None:
-        """Usado pelo hotkey [r]: invalida todos os caches no próximo `get`."""
-        for p in (self.pods, self.pipeline, self.workers,
-                  self.github, self.costs, self.models, self.current_model,
-                  self.notifier):
-            p._cache.invalidate()  # noqa: SLF001 (público no Cache; provider ainda é pacote)
+        """Hotkey [r]: marca todos os caches como vencidos sem bloquear.
+
+        O ``BackgroundRefresher`` pega no próximo tick (≤0.5s) e refaz.
+        Enquanto isso, ``get()`` continua devolvendo o valor velho — a UI
+        nunca trava.
+        """
+        for p in self._all_providers():
+            p._cache.invalidate()  # noqa: SLF001 (intentional internal)
 
     def errors(self) -> List[tuple]:
         """Lista provider name + último erro, pra UI mostrar discretamente."""
+        names = ("pods", "pipeline", "workers", "github", "costs",
+                 "models", "current_model", "notifier")
         out: List[tuple] = []
-        for name, p in (
-            ("pods", self.pods),
-            ("pipeline", self.pipeline),
-            ("workers", self.workers),
-            ("github", self.github),
-            ("costs", self.costs),
-            ("models", self.models),
-            ("current_model", self.current_model),
-            ("notifier", self.notifier),
-        ):
+        for name, p in zip(names, self._all_providers()):
             if p.last_error:
                 out.append((name, p.last_error))
         return out
+
+
+# ===== BackgroundRefresher ==================================================
+
+class BackgroundRefresher:
+    """Thread daemon que mantém os caches de ``PanelData`` frescos sem
+    bloquear o thread principal.
+
+    Roda ``maybe_refresh`` de cada provider em paralelo via thread pool
+    (até 8 ao mesmo tempo, pra um refresh único do gh API não atrasar o
+    do kubectl que é mais rápido). Cada provider tem seu próprio TTL —
+    o refresher não dispara fetch antes da hora.
+
+    Pensado para iniciar via ``with``/``start()`` no ``PanelApp.run`` e
+    parar no ``__exit__``/``stop()``. Daemon=True: morre junto com o
+    processo se algo der errado.
+    """
+
+    DEFAULT_TICK_S = 0.5  # frequência de checagem; fetch real respeita TTL
+
+    def __init__(self, data: PanelData, tick_s: float = DEFAULT_TICK_S):
+        self._data = data
+        self._tick_s = tick_s
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # Pool dimensionado para acomodar todos os providers em paralelo
+        # (8 hoje), assim um fetch lento não bloqueia os rápidos.
+        self._pool = futures.ThreadPoolExecutor(
+            max_workers=8, thread_name_prefix="panel-bg",
+        )
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True, name="panel-refresher",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+        # `cancel_futures=True` evita esperar fetches já enfileirados.
+        self._pool.shutdown(wait=False, cancel_futures=True)
+
+    def __enter__(self) -> "BackgroundRefresher":
+        self.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.stop()
+
+    def _loop(self) -> None:
+        # `maybe_refresh` vive no Cache, não no Provider; cada provider
+        # expõe o cache em `._cache` por convenção.
+        providers = self._data._all_providers()  # noqa: SLF001
+        while not self._stop.is_set():
+            futs = [self._pool.submit(p._cache.maybe_refresh)  # noqa: SLF001
+                    for p in providers]
+            # Aguarda concluir (ou stop ser sinalizado) — sem bloquear
+            # eternamente caso um fetcher pendure.
+            for f in futs:
+                if self._stop.is_set():
+                    break
+                try:
+                    f.result(timeout=20.0)
+                except Exception:  # noqa: BLE001 (defensive — never crash)
+                    pass
+            self._stop.wait(timeout=self._tick_s)

--- a/infra/k8s/_panel_demo.py
+++ b/infra/k8s/_panel_demo.py
@@ -1,0 +1,79 @@
+"""Dados-fantasma para o painel rodar em modo demo (sem cluster).
+
+Usado quando `kubectl` não está disponível ou o cluster está fora — a UI
+ainda abre e mostra o esqueleto preenchido, em vez de bater contra uma
+fonte morta a cada refresh.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+
+@dataclass
+class DemoPodRow:
+    icon: str
+    name: str
+    role: str
+    status: str
+    age: str
+    restarts: str
+    last_activity: str
+    doing_now: str
+    busy: bool = False
+
+
+PODS: List[DemoPodRow] = [
+    DemoPodRow("●", "deile-pipeline-7f8d", "pipeline", "Running", "17m", "0",
+               "23s ago", "monitor rodando, ocioso"),
+    DemoPodRow("●", "deile-worker-abc-1", "worker",   "Running", "2h",  "0",
+               "4m ago",  "idle"),
+    DemoPodRow("⚡", "deile-worker-abc-2", "worker",   "Running", "2h",  "0",
+               "0s ago",  "IMPL #296 [t+240s]", busy=True),
+    DemoPodRow("●", "deilebot-xyz",       "bot",      "Running", "5h",  "0",
+               "1m ago",  "0 inflight DMs"),
+    DemoPodRow("●", "deile-shell-def0",   "shell",    "Running", "5h",  "0",
+               "—",       "idle"),
+]
+
+PIPELINE: Dict[str, object] = {
+    "running_for_human": "1h7m",
+    "last_action_age_human": "23s ago",
+    "last_action_summary": "mention PR291: triggers=reviewer",
+    "dispatches_24h": 14,
+    "mentions_24h": 5,
+}
+
+ISSUE_STATES = {"nova": 2, "em_refinamento": 1, "em_arquitetura": 1,
+                "em_implementacao": 3, "em_pr": 0, "bloqueada": 1,
+                "aguardando_stakeholder": 0}
+PR_STATES = {"pendente": 1, "em_andamento": 1, "concluida": 0}
+
+ACTIVITY: List[Tuple[str, str, str, str, str]] = [
+    ("14:51:48", "worker-2", "start  implement", "#296",   "attempt 2  budget 0s"),
+    ("14:51:30", "pipeline", "claim",            "#294",   "batch:7a2c → analyst"),
+    ("14:50:55", "worker-1", "done   review",    "#293",   "veredito APROVADO"),
+    ("14:50:30", "pipeline", "merge",            "PR#293", "commit 6bba656 (green suite)"),
+    ("14:49:12", "notifier", "→discord",         "",       "PR #293 merged"),
+    ("14:48:30", "pipeline", "resume",           "#281",   "attempt 3/5  backoff 4×"),
+    ("14:47:30", "pipeline", "classify",         "PR#293", "→ ~review:pendente"),
+    ("14:46:08", "worker-1", "start  review",    "PR#293", "budget 0s"),
+]
+
+ALERTS: List[Tuple[str, str]] = [
+    ("⚠", "#281 attempt 3/5 — próximo loop com mesmo erro vai bloquear"),
+]
+
+TOKENS = {
+    "providers": [("anthropic", 9.43), ("openai", 1.12), ("deepseek", 0.85)],
+    "total_24h": 11.40,
+    "total_1h": 1.32,
+    "records_24h": 187,
+}
+
+DECISIONS: List[Tuple[str, str]] = [
+    ("#296",   "claim+dispatch implement"),
+    ("#294",   "refine round 2 (em_refinamento)"),
+    ("#281",   "blocked (escalou TIMEOUT 2×)"),
+]

--- a/infra/k8s/deploy.py
+++ b/infra/k8s/deploy.py
@@ -470,6 +470,22 @@ def k8s_logs(args: dict) -> int:
 
 # ===== k8s: test (Job one-shot) ==============================================
 
+def k8s_panel(args: dict) -> int:
+    """Sobe o painel TUI ao vivo de monitoramento da stack."""
+    kubectl = _kubectl()
+    if kubectl is None or not cluster_reachable():
+        ui.err("cluster Kubernetes inacessível.")
+        ui.info("Rode `deploy.py k8s up` para subir a stack antes do painel.")
+        return 1
+    if not namespace_exists():
+        ui.warn(f"namespace `{NS}` ausente — a stack não está no ar.")
+        ui.info("Rode `deploy.py k8s up` primeiro.")
+        return 1
+    # `panel` é inspeção pura (não muta nada); sem `announce_plan`.
+    from _panel import run_panel  # import tardio: rich só é carregado se usado
+    return run_panel()
+
+
 def k8s_test(args: dict) -> int:
     kubectl = _kubectl()
     if kubectl is None or not cluster_reachable():
@@ -681,7 +697,7 @@ _K8S = {
     "up": k8s_up, "down": k8s_down, "start": k8s_start, "stop": k8s_stop,
     "restart": k8s_restart, "status": k8s_status, "logs": k8s_logs,
     "build": k8s_build, "test": k8s_test, "clone": k8s_clone,
-    "doctor": cmd_doctor,
+    "panel": k8s_panel, "doctor": cmd_doctor,
 }
 _LOCAL = {
     "start": local_start, "stop": local_stop, "restart": local_restart,
@@ -691,6 +707,7 @@ _LOCAL = {
 # (ação, descrição) — usado no help E no menu interativo. `clone` fica fora do
 # menu por exigir um argumento <owner/repo>.
 _K8S_ACTIONS = [
+    ("panel", "painel TUI ao vivo (pods + pipeline + GitHub + custos)"),
     ("status", "ver pods, deployments e services"),
     ("up", "provisionar / atualizar a stack (idempotente)"),
     ("build", "rebuildar a imagem (--restart religa os pods)"),

--- a/infra/k8s/worker_server.py
+++ b/infra/k8s/worker_server.py
@@ -46,14 +46,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-# aiohttp comes from the deilebot extra (already in the image).
-from aiohttp import web
-
 # Resume-mode helpers (issue #254). Sibling module under infra/k8s — the worker
 # runs with this directory on sys.path (set by the entrypoint / Dockerfile), so
 # a plain import resolves it. Done as a module so the git/fingerprint/journal
 # logic is unit-testable without aiohttp.
 import _worker_resume as resume
+# aiohttp comes from the deilebot extra (already in the image).
+from aiohttp import web
 
 logger = logging.getLogger("deile.worker_server")
 logging.basicConfig(


### PR DESCRIPTION
## Descrição

Transforma o `deploy.py` num **painel TUI ao vivo** que monitora a stack DEILE em tempo real, cruzando estado do cluster Kubernetes com a fonte de verdade do pipeline (GitHub issues+PRs) e do uso (UsageRepository). Adicionado verbo `python3 infra/k8s/deploy.py k8s panel` — sem mutar nada do estado existente.

Pedido humano: navegável (não fecha após escolher), drill-in por pod, histórico de ações, refresh contínuo, e troca de modelo do pod em runtime.

Implementado em 10 commits, um por fase, todos verdes na suíte completa.

## Tipo de Mudança

- [x] **Nova funcionalidade** — adiciona uma capacidade que não existia

## Composição (3 módulos novos em `infra/k8s/`)

| arquivo | papel |
|---|---|
| `_panel_data.py` | Cache TTL + 7 providers (Pods, Pipeline, Worker, GitHub, Costs, Models, CurrentModel) + `set_preferred_model` |
| `_panel_demo.py` | Mocks usados quando cluster está fora (UI ainda abre em modo demo) |
| `_panel.py` | KeyReader (termios cbreak / msvcrt), view contract, alerts engine, 9 views, loop principal `PanelApp` |

## Views

| `[N]` | view | refresh | o que mostra |
|---|---|---|---|
| `[1]` | Pod picker → Pod watch | 3s / 1s | lista pods navegável (↑/↓, enter); watch streama `kubectl logs -f` com filtro de health |
| `[2]` | Pipeline timeline | 5s | events classificados (mention/dispatch/http/startup) + stats (gap p95/max, ticks/h, failures) + histograma 24h |
| `[3]` | Issues & PRs | 10s | tabela viva GitHub × labels (filtros `a/i/p/b/m`, enter copia URL) |
| `[5]` | Tokens & Custos | 60s | `UsageRepository` por provider (24h/1h, %, top 5 sessions) |
| `[n]` | Notifier echo | 5s | últimos eventos `deilebot.audit` (outbound_sent/failed) |
| `[a]` | Ações | 1s | `status` / `restart` / `build` / `up` / `stop` / `start` / `test` / `DOWN` (com confirmação) acionáveis sem sair do painel |
| `[m]` | Trocar modelo | 5s | troca `DEILE_PREFERRED_MODEL` em runtime via `kubectl set env` (zero-downtime no worker) |
| `[?]` | Help | — | resumo dos hotkeys |

## Alertas automáticos no dashboard

- pod restart ≥3× (crit) ou ≥1× nos últimos 30min (warn)
- pipeline sem ação >5min
- issues `~workflow:bloqueada`
- issues `~workflow:aguardando_stakeholder`
- provider com erro

## Como foi testado

- Suíte completa verde: **3435 passed, 19 skipped, 0 failed** (52s).
- Validado contra cluster real durante o desenvolvimento: pods detectados corretamente, events classificados, alertas pegaram #283 bloqueada + pipeline ocioso, tokens mostraram breakdown anthropic/openai, modelo atual detectado (`anthropic:claude-sonnet-4-6`).
- 64 testes unitários novos em `deile/tests/infra/test_panel_data.py` (mockam kubectl/gh/SQLite, sem chamada real).

```
python3 -m pytest deile/tests/ --ignore=deile/tests/might -q
# 3435 passed, 19 skipped in ~52s
```

## Checklist

- [x] O código segue as diretrizes de estilo do projeto (`ruff check`, `isort`)
- [x] Revisei meu próprio código antes de abrir o PR
- [x] Adicionei ou atualizei testes que cobrem as mudanças (64 novos)
- [x] Todos os testes passam (`pytest`)
- [ ] A cobertura não caiu abaixo de 80% — cobertura global está em **79%** (o painel é UI/I/O com kubectl, parte difícil de cobrir; os providers e parsers têm cobertura alta). Pré-PR estava em 79%; este PR mantém o mesmo número.
- [x] Atualizei a documentação afetada (README seção 4.3 + docstrings)
- [x] Nenhum novo warning foi introduzido

## Issues Relacionadas

Atende a um pedido direto do operador — sem issue formal aberta. Sugere fechar como melhoria da experiência de operação do pipeline.

## Trabalho futuro (anotado, fora deste PR)

- **Opção B** do model switcher: endpoint `/admin/set_model` no `worker_server.py` para swap instantâneo (sem rollout).
- **Logs split view** (`[4]`): pipeline + workers lado a lado, follow real. Pode ser composta a partir do `_LogStreamer` existente.
- **`.deile-progress.md`** no Pod Watch: requer `kubectl exec cat` da issue corrente (deduzida dos logs).
- **Métricas de CPU/mem**: hoje só `kubectl top` — adicionar provider que consulta metrics-server.
