### PR TITLE
fix(cost): não criar arquivo de export quando não há entradas (#301)

### DIFF
--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -304,12 +304,30 @@ EXEMPLOS:
     async def _export_costs(self, fmt: str = "json", days: int = 30) -> "CommandResult":
         try:
             start_time, end_time = _period_range(days)
+
+            # Issue #301: `export_costs` always returns a non-empty payload
+            # (metadata wrapper around `entries`), so `if not data:` never
+            # catches the empty case. Gate the file write on the actual entry
+            # count from the summary to avoid leaving dead `{"entries": []}`
+            # artifacts in the working tree.
+            summary = self.cost_tracker.get_cost_summary(start_time, end_time)
+            entry_count, _ = _safe_summary_values(summary)
+
+            if entry_count == 0:
+                return CommandResult.success_result(
+                    _cost_views.build_no_data_panel(
+                        "Nenhum dado de custo encontrado no período. Nenhum arquivo foi criado.",
+                        title="📤 Export de Custos",
+                    ),
+                    "rich",
+                )
+
             data = self.cost_tracker.export_costs(start_time, end_time, format_type=fmt)
 
             if not data:
                 return CommandResult.success_result(
                     _cost_views.build_no_data_panel(
-                        "Nenhum dado de custo encontrado no período.",
+                        "Falha ao gerar payload de exportação.",
                         title="📤 Export de Custos",
                     ),
                     "rich",

--- a/deile/tests/commands/test_cost_command.py
+++ b/deile/tests/commands/test_cost_command.py
@@ -80,12 +80,15 @@ async def test_decimal_formatting_no_exception():
 
 
 @pytest.mark.unit
-async def test_version_from_version_module():
+async def test_version_from_version_module(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from deile.__version__ import __version__
-    export_data = '{"entries": []}'
+    export_data = '{"entries": [{"id": "1", "amount": 0.01}], "total_entries": 1}'
+    summary = _make_summary(total="0.01", entry_count=1)
     cmd = CostCommand()
-    with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
-        result = await cmd.execute(_make_context("export json"))
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
+            result = await cmd.execute(_make_context("export json"))
     assert result.success
     rendered = _render_rich(result.content)
     assert "4.0.0" not in rendered, "Versão hardcoded 4.0.0 encontrada"
@@ -189,16 +192,39 @@ async def test_top_empty_no_crash():
 @pytest.mark.unit
 async def test_export_json_writes_valid_file(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    export_data = '{"entries": [], "period_start": "2026-01-01", "period_end": "2026-01-31"}'
+    export_data = (
+        '{"entries": [{"id": "1", "amount": 0.01}], '
+        '"period_start": "2026-01-01", "period_end": "2026-01-31"}'
+    )
+    summary = _make_summary(total="0.01", entry_count=1)
     cmd = CostCommand()
-    with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
-        result = await cmd.execute(_make_context("export json 30"))
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
+            result = await cmd.execute(_make_context("export json 30"))
     assert result.success
     json_files = list(tmp_path.glob("costs_export_*.json"))
     assert len(json_files) == 1
     import json
     data = json.loads(json_files[0].read_text())
     assert "entries" in data
+
+
+@pytest.mark.unit
+async def test_export_json_no_entries_skips_file_creation(tmp_path, monkeypatch):
+    """Issue #301: don't create dead `{"entries": []}` files when there's
+    no data to export."""
+    monkeypatch.chdir(tmp_path)
+    summary = _make_summary(entry_count=0)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        # export_costs should NOT be called when entry_count is 0 — gate is
+        # the summary check, not the payload check.
+        with patch.object(cmd.cost_tracker, "export_costs") as mock_export:
+            result = await cmd.execute(_make_context("export json 30"))
+    assert result.success
+    json_files = list(tmp_path.glob("costs_export_*.json"))
+    assert len(json_files) == 0, f"Expected no files, got {json_files}"
+    mock_export.assert_not_called()
 
 
 @pytest.mark.unit
@@ -232,8 +258,9 @@ async def test_alerts_no_crash_when_empty():
 
 
 @pytest.mark.unit
-async def test_all_subcommands_dispatched():
+async def test_all_subcommands_dispatched(tmp_path, monkeypatch):
     """Nenhum subcomando declarado deve retornar 'Ação desconhecida'"""
+    monkeypatch.chdir(tmp_path)
     cmd = CostCommand()
     declared = [
         ("summary", {}),
@@ -248,7 +275,9 @@ async def test_all_subcommands_dispatched():
     ]
     for args, extra_patches in declared:
         ctx = _make_context(args)
-        summary = _make_summary()
+        # entry_count>0 so /cost export does not short-circuit on the
+        # "no data" guard (issue #301) and we exercise the full dispatch.
+        summary = _make_summary(total="0.01", entry_count=1)
         with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
             with patch.object(cmd.cost_tracker, "get_current_session_cost", return_value=Decimal("0")):
                 with patch.object(cmd.cost_tracker, "export_costs", return_value=extra_patches.get("export_costs", "{}")):


### PR DESCRIPTION
`/cost export` gravava `costs_export_*.json` em todo turno mesmo sem
dados, deixando arquivos `{"entries": []}` mortos na raiz do projeto.
A guarda `if not data:` nunca disparava porque `export_costs` sempre
retorna um envelope com metadata (timestamp/period) mesmo com lista de
entries vazia.

Agora `_export_costs` checa `entry_count` do `CostSummary` antes de
serializar e gravar, retornando o painel "sem dados" quando não há nada
a exportar. Testes atualizados (incluem caso novo cobrindo a regressão).