### PR TITLE
fix(cost): skip writing costs_export_*.json when there are no entries (#301)

### DIFF
--- a/deile/commands/builtin/cost_command.py
+++ b/deile/commands/builtin/cost_command.py
@@ -304,6 +304,25 @@ EXEMPLOS:
     async def _export_costs(self, fmt: str = "json", days: int = 30) -> "CommandResult":
         try:
             start_time, end_time = _period_range(days)
+
+            # Issue #301: cost_tracker.export_costs sempre devolve payload envelopado
+            # (JSON com cabeçalho + entries=[] ou CSV só-header), então ``if not data:``
+            # escapa o caso vazio e gera arquivos mortos ``costs_export_*.json`` no
+            # diretório de execução. Checar entry_count via summary antes do export é
+            # idiomatico com ``_show_top``/``_show_categories`` e garante zero escritas
+            # quando não há entradas no período.
+            summary = self.cost_tracker.get_cost_summary(start_time, end_time)
+            entry_count, _ = _safe_summary_values(summary)
+
+            if entry_count == 0:
+                return CommandResult.success_result(
+                    _cost_views.build_no_data_panel(
+                        "Nenhum dado de custo encontrado no período.",
+                        title="📤 Export de Custos",
+                    ),
+                    "rich",
+                )
+
             data = self.cost_tracker.export_costs(start_time, end_time, format_type=fmt)
 
             if not data:

--- a/deile/tests/commands/test_cost_command.py
+++ b/deile/tests/commands/test_cost_command.py
@@ -80,12 +80,21 @@ async def test_decimal_formatting_no_exception():
 
 
 @pytest.mark.unit
-async def test_version_from_version_module():
+async def test_version_from_version_module(tmp_path, monkeypatch):
+    """Caminho de sucesso do export deve renderizar a versão de ``__version__``.
+
+    Exige ``entry_count>0`` para chegar ao success-panel (issue #301).
+    ``monkeypatch.chdir(tmp_path)`` evita poluir a raiz do repositório com o
+    arquivo escrito pelo path feliz.
+    """
     from deile.__version__ import __version__
-    export_data = '{"entries": []}'
+    monkeypatch.chdir(tmp_path)
+    export_data = '{"entries": [{"id": 1, "amount": 1.0}]}'
+    summary = _make_summary(total="1.0", entry_count=1)
     cmd = CostCommand()
-    with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
-        result = await cmd.execute(_make_context("export json"))
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
+            result = await cmd.execute(_make_context("export json"))
     assert result.success
     rendered = _render_rich(result.content)
     assert "4.0.0" not in rendered, "Versão hardcoded 4.0.0 encontrada"
@@ -189,16 +198,55 @@ async def test_top_empty_no_crash():
 @pytest.mark.unit
 async def test_export_json_writes_valid_file(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    export_data = '{"entries": [], "period_start": "2026-01-01", "period_end": "2026-01-31"}'
+    export_data = '{"entries": [{"id": 1}], "period_start": "2026-01-01", "period_end": "2026-01-31"}'
+    summary = _make_summary(total="1.0", entry_count=1)
     cmd = CostCommand()
-    with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
-        result = await cmd.execute(_make_context("export json 30"))
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        with patch.object(cmd.cost_tracker, "export_costs", return_value=export_data):
+            result = await cmd.execute(_make_context("export json 30"))
     assert result.success
     json_files = list(tmp_path.glob("costs_export_*.json"))
     assert len(json_files) == 1
     import json
     data = json.loads(json_files[0].read_text())
     assert "entries" in data
+
+
+@pytest.mark.unit
+async def test_export_no_data_does_not_write_file(tmp_path, monkeypatch):
+    """Regressão #301: /cost export NÃO deve criar arquivo quando entry_count==0.
+
+    Antes do fix, ``_export_costs`` validava ``if not data:``; mas ``export_costs``
+    sempre retorna JSON não-vazio (mesmo com ``entries=[]``), o que escapava o guard
+    e gerava arquivos mortos ``costs_export_*.json`` no diretório de execução.
+    """
+    monkeypatch.chdir(tmp_path)
+    empty_export = '{"export_timestamp": "2026-05-25T00:00:00", "total_entries": 0, "entries": []}'
+    empty_summary = _make_summary(total="0", entry_count=0)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=empty_summary):
+        with patch.object(cmd.cost_tracker, "export_costs", return_value=empty_export):
+            result = await cmd.execute(_make_context("export json 30"))
+    assert result.success
+    leaked = list(tmp_path.glob("costs_export_*.json"))
+    assert leaked == [], f"Arquivo morto vazado: {leaked}"
+    rendered = _render_rich(result.content) if result.content else ""
+    assert "Nenhum dado" in rendered or "nenhum dado" in rendered.lower()
+
+
+@pytest.mark.unit
+async def test_export_csv_no_data_does_not_write_file(tmp_path, monkeypatch):
+    """Regressão #301: o guard precisa cobrir CSV também (não só JSON)."""
+    monkeypatch.chdir(tmp_path)
+    csv_header_only = "id,datetime,category,subcategory,amount,currency,description,session_id\r\n"
+    empty_summary = _make_summary(total="0", entry_count=0)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=empty_summary):
+        with patch.object(cmd.cost_tracker, "export_costs", return_value=csv_header_only):
+            result = await cmd.execute(_make_context("export csv 30"))
+    assert result.success
+    leaked = list(tmp_path.glob("costs_export_*.csv"))
+    assert leaked == [], f"Arquivo morto vazado: {leaked}"
 
 
 @pytest.mark.unit
@@ -232,8 +280,15 @@ async def test_alerts_no_crash_when_empty():
 
 
 @pytest.mark.unit
-async def test_all_subcommands_dispatched():
-    """Nenhum subcomando declarado deve retornar 'Ação desconhecida'"""
+async def test_all_subcommands_dispatched(tmp_path, monkeypatch):
+    """Nenhum subcomando declarado deve retornar 'Ação desconhecida'.
+
+    ``monkeypatch.chdir(tmp_path)`` é defensivo: mesmo com o fix da issue #301
+    ('export json' cai em no-data branch porque ``_make_summary()`` tem
+    ``entry_count=0``), qualquer regressão futura que reabra a escrita não
+    polui a raiz do repositório.
+    """
+    monkeypatch.chdir(tmp_path)
     cmd = CostCommand()
     declared = [
         ("summary", {}),

--- a/deile/tests/commands/test_cost_command.py
+++ b/deile/tests/commands/test_cost_command.py
@@ -250,6 +250,49 @@ async def test_export_csv_no_data_does_not_write_file(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+async def test_export_csv_writes_valid_file_when_data_exists(tmp_path, monkeypatch):
+    """Simetria do happy path: CSV com dados deve produzir arquivo .csv válido.
+
+    Cobre o caminho de sucesso de ``/cost export csv`` que não tinha cobertura
+    direta — só JSON tinha (``test_export_json_writes_valid_file``).
+    """
+    monkeypatch.chdir(tmp_path)
+    csv_data = (
+        "id,datetime,category,subcategory,amount,currency,description,session_id\r\n"
+        "1,2026-01-01T00:00:00,api_calls,gpt4,0.5,USD,call,sess1\r\n"
+    )
+    summary = _make_summary(total="0.5", entry_count=1)
+    cmd = CostCommand()
+    with patch.object(cmd.cost_tracker, "get_cost_summary", return_value=summary):
+        with patch.object(cmd.cost_tracker, "export_costs", return_value=csv_data):
+            result = await cmd.execute(_make_context("export csv 30"))
+    assert result.success
+    csv_files = list(tmp_path.glob("costs_export_*.csv"))
+    assert len(csv_files) == 1
+    written = csv_files[0].read_text()
+    assert "api_calls" in written and "0.5" in written
+
+
+@pytest.mark.unit
+async def test_export_summary_query_failure_does_not_write_file(tmp_path, monkeypatch):
+    """Defesa extra (#301): se ``get_cost_summary`` levantar, o comando deve
+    falhar limpo sem escrever arquivo na pasta atual. Cobre o ``except Exception``
+    do ``_export_costs`` no caminho onde o ``summary`` é consultado primeiro.
+    """
+    monkeypatch.chdir(tmp_path)
+    cmd = CostCommand()
+    with patch.object(
+        cmd.cost_tracker,
+        "get_cost_summary",
+        side_effect=RuntimeError("simulação de falha no DB"),
+    ):
+        result = await cmd.execute(_make_context("export json 30"))
+    assert not result.success
+    leaked = list(tmp_path.glob("costs_export_*"))
+    assert leaked == [], f"Falha no DB vazou arquivo: {leaked}"
+
+
+@pytest.mark.unit
 async def test_forecast_insufficient_data_message():
     summary = _make_summary(total="0", entry_count=0)
     cmd = CostCommand()


### PR DESCRIPTION
## Resumo

Fix para a issue #301 — arquivos mortos `costs_export_<timestamp>.json` (com conteúdo `{"entries": []}`) eram criados na raiz do repositório a cada execução de `/cost export` quando não havia entradas no período, e a cada `pytest` (dois testes leaky).

## Causa-raiz

`cost_tracker.export_costs()` sempre devolve um payload **envelopado** (JSON com cabeçalho + `entries=[]` ou CSV só-header). O guard `if not data:` em `_export_costs` testava string vazia, mas qualquer JSON/CSV envelopado é truthy — então o arquivo era escrito mesmo com zero entradas.

Bug secundário: `test_version_from_version_module` e `test_all_subcommands_dispatched` executavam `/cost export` **sem** `monkeypatch.chdir(tmp_path)`. Cada `pytest` acumulava 1 arquivo morto na raiz do repo (já estavam em `.gitignore`, mas poluíam o working tree).

## Fix

**`deile/commands/builtin/cost_command.py`** — `_export_costs` agora consulta `get_cost_summary` antes de chamar `export_costs`:
- Se `entry_count == 0` → retorna `no_data_panel` **sem** chamar `export_costs` nem escrever arquivo
- Padrão idiomatico com `_show_top` / `_show_categories` / `_show_forecast`
- Guard `if not data:` permanece como defesa para formato inválido / exceção interna do tracker (que devolve `""`)

## Testes

Dois novos testes de regressão:
- `test_export_no_data_does_not_write_file` — JSON envelopado vazio
- `test_export_csv_no_data_does_not_write_file` — CSV só-header

Três testes existentes ajustados:
- `test_version_from_version_module` — agora recebe `tmp_path/monkeypatch` + patcheia `get_cost_summary` com `entry_count>0` para chegar ao success-panel
- `test_export_json_writes_valid_file` — patcheia `get_cost_summary` explicitamente
- `test_all_subcommands_dispatched` — `tmp_path` defensivo contra regressões futuras

## Test plan

- [x] RED verificado: testes novos falham contra `origin/main` (arquivo morto criado)
- [x] GREEN verificado: 20/20 testes de `test_cost_command.py` passam após o fix
- [x] Zero-leak comprovado: `pytest deile/tests/commands/test_cost_command.py` 3x em sequência → 0 arquivos `costs_export_*.json` em CWD
- [x] Suíte completa: **3559 passed, 20 skipped** (coverage gate ≥80% atendido)

## Notas

A suíte completa apresenta **uma única falha pré-existente** em `test_logs_command.py::TestExportSecurity::test_path_traversal_rejected_via_double_dot` — anomalia ambiental do worktree (assume que `../../.env` não existe, mas worktree em `.worktrees/<branch>/` faz `../../.env` apontar para a raiz do repo onde `.env` existe). Falha confirmada **em `origin/main` puro** (via `git stash`) e em CI roda da raiz do repo, então sem impacto no merge gate. Vale abrir issue separada para deixar o teste agnóstico ao CWD.

## Limpeza dos arquivos legados

Os arquivos mortos remanescentes nos checkouts dos desenvolvedores estão em `.gitignore` (linha 80) — pode-se removê-los manualmente:

```bash
rm costs_export_*.json
```

Closes #301