### PR TITLE
test(windows): cover platform branches in bash_tool, _path_resolution, cli, ui (#283)

### DIFF
--- a/deile/tests/cli/test_cli_windows.py
+++ b/deile/tests/cli/test_cli_windows.py
@@ -1,0 +1,134 @@
+"""Tests for the Windows-specific branches of the CLI layer.
+
+Two production paths are covered:
+
+* ``deile/cli.py::_stream_with_esc_cancel`` — Unix-only ``termios``/``tty``
+  imports inside a ``try/except ImportError`` block fall back to the plain
+  ``display_streaming_turn`` on Windows. Without this, the ESC-cancel
+  feature would crash the agent on the first message Windows users send.
+* ``deile/ui/cli.py::CLI.clear_screen`` — uses ``cmd /c cls`` when
+  ``os.name == 'nt'`` and ``clear`` elsewhere.
+
+Both paths run the Windows logic on the Linux CI runner via mocks; no
+Windows-only test environment is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _stream_with_esc_cancel — termios fallback
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _empty_stream() -> AsyncIterator:
+    """Tiny async iterator so the test exercises the function signature
+    without depending on real model events."""
+    return
+    yield  # noqa: unreachable — needed to make this an async generator
+
+
+@pytest.mark.unit
+class TestStreamWithEscCancelTermiosFallback:
+    """When ``termios`` cannot be imported (the Windows scenario), the
+    function must fall back to plain ``display_streaming_turn`` and return
+    ``False`` (no cancellation) — never raise.
+
+    Implementation note: we patch ``builtins.__import__`` to selectively
+    raise ``ImportError`` for the Unix-only names. Mutating
+    ``sys.modules`` directly (the more common idiom) ended up polluting
+    pytest's ``caplog`` machinery for subsequent tests — patching
+    ``__import__`` is fully scoped to the ``with`` block and leaves
+    global state untouched.
+    """
+
+    def test_falls_back_when_termios_absent(self) -> None:
+        from deile.cli import _DeileCLI
+
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def _selective_import(name, *args, **kwargs):
+            # Make the lazy `import termios` / `import tty` inside
+            # _stream_with_esc_cancel behave like they do on Windows.
+            if name in ("termios", "tty"):
+                raise ImportError(f"No module named {name!r} (simulated Windows)")
+            return real_import(name, *args, **kwargs)
+
+        cli = _DeileCLI.__new__(_DeileCLI)
+        cli.ui = MagicMock()
+        cli.ui.display_streaming_turn = AsyncMock(return_value=None)
+
+        with patch("builtins.__import__", side_effect=_selective_import):
+            result = asyncio.run(
+                cli._stream_with_esc_cancel(_empty_stream())
+            )
+
+        # Function returned False (no cancellation) because the
+        # termios import raised ImportError — exactly the Windows
+        # behavior we want to preserve.
+        assert result is False
+        # The plain renderer was invoked instead of the cbreak watcher.
+        cli.ui.display_streaming_turn.assert_awaited_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ui/cli.py::CLI.clear_screen — Windows uses `cmd /c cls`
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.ui
+@pytest.mark.unit
+class TestClearScreenWindows:
+    """``CLI.clear_screen`` selects ``cmd /c cls`` on Windows.
+
+    The function is a one-liner ``if os.name == 'nt'`` branch — the
+    risk is a copy-paste regression silently flipping the operator,
+    making ``clear`` run on Windows (where the command doesn't exist
+    and the screen never clears).
+
+    Implementation notes:
+
+    * We avoid calling ``CLI()`` directly because ``__init__`` invokes
+      ``get_logger()``, which sets ``propagate=False`` on a named logger.
+      That mutation is process-global and breaks pytest's ``caplog``
+      fixture in any subsequent test that captures from that logger
+      family. ``__new__`` skips ``__init__`` entirely so the bound
+      ``clear_screen`` method runs without poisoning logging.
+    * ``patch("deile.ui.cli.os.name", "nt")`` mutates the real
+      ``os.name``, which would also make any inline ``Path()`` switch to
+      ``WindowsPath`` (and crash on POSIX). ``clear_screen`` constructs
+      no paths, so the patch is safe here.
+    """
+
+    def _make_cli(self):
+        """Build a CLI instance without running ``__init__``."""
+        from deile.ui.cli import CLI
+        return CLI.__new__(CLI)
+
+    def test_uses_cmd_cls_on_windows(self) -> None:
+        cli = self._make_cli()
+        with patch("deile.ui.cli.os.name", "nt"), \
+             patch("deile.ui.cli.subprocess.run") as mock_run:
+            cli.clear_screen()
+
+        mock_run.assert_called_once()
+        called_args = mock_run.call_args[0][0]
+        assert called_args == ["cmd", "/c", "cls"]
+        # `check=False` so the call never raises — verify the kwarg.
+        assert mock_run.call_args.kwargs.get("check") is False
+
+    def test_uses_clear_on_posix_for_contrast(self) -> None:
+        """Negative control — make sure the Windows assertion isn't vacuously
+        true."""
+        cli = self._make_cli()
+        with patch("deile.ui.cli.os.name", "posix"), \
+             patch("deile.ui.cli.subprocess.run") as mock_run:
+            cli.clear_screen()
+
+        called_args = mock_run.call_args[0][0]
+        assert called_args == ["clear"]

--- a/deile/tests/test_install_functions.py
+++ b/deile/tests/test_install_functions.py
@@ -1032,16 +1032,22 @@ class TestCreateVenvWithDeileWindows:
     HOME_DIR = Path("/tmp")  # so `str(VENV_DIR).startswith(str(HOME_DIR))` is True
 
     @patch("deile.cli_install.os.name", "nt")
+    @patch("deile.cli_install.Path.home")
     @patch("deile.cli_install.Path.resolve")
     @patch("deile.cli_install.Path.exists")
     @patch("deile.cli_install.Path.mkdir")
     @patch("deile.cli_install.asyncio.create_subprocess_exec")
     def test_windows_venv_python_is_scripts_python_exe(
         self, mock_subproc, mock_mkdir, mock_exists, mock_resolve,
+        mock_home,
     ):
         """venv_py path on Windows is `<venv>/Scripts/python.exe`, not `bin/python`."""
         from deile.cli_install import _create_venv_with_deile
 
+        # Path.home() returns a pre-baked PosixPath so it doesn't try to
+        # instantiate WindowsPath (os.name is patched to 'nt', but we're on
+        # Linux). The `.resolve()` on it is mocked separately.
+        mock_home.return_value = self.HOME_DIR
         # 3 `.resolve()` calls: venv_dir, repo_root, Path.home(). All class
         # constants are pre-baked PosixPath so str() keeps forward slashes
         # and the security check `startswith(home)` passes.
@@ -1072,16 +1078,19 @@ class TestCreateVenvWithDeileWindows:
             )
 
     @patch("deile.cli_install.os.name", "nt")
+    @patch("deile.cli_install.Path.home")
     @patch("deile.cli_install.Path.resolve")
     @patch("deile.cli_install.Path.exists")
     @patch("deile.cli_install.Path.mkdir")
     @patch("deile.cli_install.asyncio.create_subprocess_exec")
     def test_windows_missing_deile_exe_raises(
         self, mock_subproc, mock_mkdir, mock_exists, mock_resolve,
+        mock_home,
     ):
         """If `Scripts/deile.exe` is absent after install on Windows, raises."""
         from deile.cli_install import _create_venv_with_deile
 
+        mock_home.return_value = self.HOME_DIR
         mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, self.HOME_DIR]
         # venv_py absent, requirements.txt present, deile_script absent
         mock_exists.side_effect = [False, True, False]
@@ -1106,14 +1115,22 @@ class TestUserScriptsDirWindowsFallback:
     @patch("deile.cli_install.os.name", "nt")
     @patch("deile.cli_install.sysconfig")
     def test_nt_user_scheme_when_preferred_scheme_absent(self, mock_sysconfig):
-        """Old Pythons (<3.10) lack `get_preferred_scheme` → fallback to nt_user."""
+        """Old Pythons (<3.10) lack `get_preferred_scheme` → fallback to nt_user.
+
+        We force ``Path`` to ``PosixPath`` so that constructing a path from
+        a Windows-style string does not try to instantiate ``WindowsPath``
+        on the Linux CI runner (``os.name`` is patched to ``'nt'``).
+        """
+        from pathlib import PosixPath
+
         from deile.cli_install import _user_scripts_dir
 
         # Simulate old Python by removing `get_preferred_scheme` from sysconfig.
         del mock_sysconfig.get_preferred_scheme
         mock_sysconfig.get_path.return_value = "C:/Users/test/AppData/Roaming/Python/Python310/Scripts"
 
-        result = _user_scripts_dir()
+        with patch("deile.cli_install.Path", PosixPath):
+            result = _user_scripts_dir()
 
         # The function must have asked sysconfig for "scripts" under "nt_user".
         mock_sysconfig.get_path.assert_called_once_with("scripts", scheme="nt_user")

--- a/deile/tests/test_install_functions.py
+++ b/deile/tests/test_install_functions.py
@@ -982,3 +982,243 @@ class TestInstallModeValidationOrder:
         # _run_self_install must NOT have been called
         mock_install.assert_not_called()
         assert "--install-mode requires --install" in captured.getvalue()
+
+
+# ===================================================================
+# Windows-specific install branches (issue #283)
+#
+# The existing suite covers `os.name == "nt"` for the simpler helpers
+# (_wrapper_target_dir, _ensure_scripts_dir_on_path, _link_global_command),
+# but three Windows code paths slipped through:
+#
+#   1. `_create_venv_with_deile` builds `venv_dir / "Scripts/python.exe"`
+#      and `venv_dir / "Scripts/deile.exe"` on Windows — never tested.
+#   2. `_user_scripts_dir` selects the `nt_user` sysconfig scheme — only
+#      tested via the (returns a Path) smoke check; the scheme-selection
+#      branch is uncovered.
+#   3. `_run_self_install_async` skips the `which deile` subprocess on
+#      Windows via `if os.name != "nt"` — the Linux CI takes the True
+#      branch every run and the False branch is dead-code in coverage.
+#
+# These tests close those gaps with mock-based assertions that don't
+# require a Windows runner.
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestCreateVenvWithDeileWindows:
+    """_create_venv_with_deile() on Windows builds Scripts\\*.exe paths.
+
+    The function's behavior is governed by `os.name == "nt"` (deciding
+    `Scripts/python.exe` vs `bin/python` and `Scripts/deile.exe` vs
+    `bin/deile`). Path semantics elsewhere are flavour-agnostic — the
+    security check only compares string prefixes — so POSIX-style paths
+    work for the venv/home arguments and keep the test runnable on Linux
+    CI.
+
+    Caveat (and the reason we use POSIX paths here): patching
+    `deile.cli.os.name = "nt"` actually mutates the global `os.name`,
+    which makes `pathlib.Path()` instances constructed inside the patch
+    become `WindowsPath`. Mixing `PosixPath` (constructed at class load)
+    with `WindowsPath` (constructed inside the test) flips slashes and
+    breaks the `str(venv).startswith(str(home))` security gate.
+    """
+
+    # POSIX-style paths — constructed at class-load (PosixPath, forward
+    # slashes). At test time we don't construct any new `Path()` inside the
+    # `os.name=="nt"` patch — every value passes through the mocks we set up.
+    VENV_DIR = Path("/tmp/test-venv-win")
+    REPO_ROOT = Path("/tmp/test-repo-win")
+    HOME_DIR = Path("/tmp")  # so `str(VENV_DIR).startswith(str(HOME_DIR))` is True
+
+    @patch("deile.cli_install.os.name", "nt")
+    @patch("deile.cli_install.Path.resolve")
+    @patch("deile.cli_install.Path.exists")
+    @patch("deile.cli_install.Path.mkdir")
+    @patch("deile.cli_install.asyncio.create_subprocess_exec")
+    def test_windows_venv_python_is_scripts_python_exe(
+        self, mock_subproc, mock_mkdir, mock_exists, mock_resolve,
+    ):
+        """venv_py path on Windows is `<venv>/Scripts/python.exe`, not `bin/python`."""
+        from deile.cli_install import _create_venv_with_deile
+
+        # 3 `.resolve()` calls: venv_dir, repo_root, Path.home(). All class
+        # constants are pre-baked PosixPath so str() keeps forward slashes
+        # and the security check `startswith(home)` passes.
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, self.HOME_DIR]
+        # venv_py absent (trigger creation), requirements.txt present, deile_script present
+        mock_exists.side_effect = [False, True, True]
+
+        ok_proc = MagicMock()
+        ok_proc.returncode = 0
+        ok_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_subproc.return_value = ok_proc
+
+        with patch("deile.cli_install._venv.EnvBuilder"):
+            with patch("deile.cli_install.asyncio.to_thread"):
+                result = asyncio.run(
+                    _create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test")
+                )
+
+        # The function returned `<venv>/Scripts/deile.exe` (NOT `bin/deile`).
+        # That's the actual Windows assertion we care about.
+        assert result == self.VENV_DIR / "Scripts/deile.exe"
+        # And every pip invocation used `<venv>/Scripts/python.exe` as the
+        # interpreter (positional arg 0 of `create_subprocess_exec`).
+        expected_python = str(self.VENV_DIR / "Scripts/python.exe")
+        for call in mock_subproc.call_args_list:
+            assert call[0][0] == expected_python, (
+                f"expected venv python {expected_python!r}, got {call[0][0]!r}"
+            )
+
+    @patch("deile.cli_install.os.name", "nt")
+    @patch("deile.cli_install.Path.resolve")
+    @patch("deile.cli_install.Path.exists")
+    @patch("deile.cli_install.Path.mkdir")
+    @patch("deile.cli_install.asyncio.create_subprocess_exec")
+    def test_windows_missing_deile_exe_raises(
+        self, mock_subproc, mock_mkdir, mock_exists, mock_resolve,
+    ):
+        """If `Scripts/deile.exe` is absent after install on Windows, raises."""
+        from deile.cli_install import _create_venv_with_deile
+
+        mock_resolve.side_effect = [self.VENV_DIR, self.REPO_ROOT, self.HOME_DIR]
+        # venv_py absent, requirements.txt present, deile_script absent
+        mock_exists.side_effect = [False, True, False]
+
+        ok_proc = MagicMock()
+        ok_proc.returncode = 0
+        ok_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_subproc.return_value = ok_proc
+
+        with patch("deile.cli_install._venv.EnvBuilder"):
+            with patch("deile.cli_install.asyncio.to_thread"):
+                with pytest.raises(DEILEInstallError, match="console script not created"):
+                    asyncio.run(
+                        _create_venv_with_deile(self.VENV_DIR, self.REPO_ROOT, "test")
+                    )
+
+
+@pytest.mark.unit
+class TestUserScriptsDirWindowsFallback:
+    """_user_scripts_dir() on old Python (<3.10) on Windows uses nt_user."""
+
+    @patch("deile.cli_install.os.name", "nt")
+    @patch("deile.cli_install.sysconfig")
+    def test_nt_user_scheme_when_preferred_scheme_absent(self, mock_sysconfig):
+        """Old Pythons (<3.10) lack `get_preferred_scheme` → fallback to nt_user."""
+        from deile.cli_install import _user_scripts_dir
+
+        # Simulate old Python by removing `get_preferred_scheme` from sysconfig.
+        del mock_sysconfig.get_preferred_scheme
+        mock_sysconfig.get_path.return_value = "C:/Users/test/AppData/Roaming/Python/Python310/Scripts"
+
+        result = _user_scripts_dir()
+
+        # The function must have asked sysconfig for "scripts" under "nt_user".
+        mock_sysconfig.get_path.assert_called_once_with("scripts", scheme="nt_user")
+        assert isinstance(result, Path)
+
+
+@pytest.mark.unit
+class TestRunSelfInstallAsyncWindowsSkipsWhich:
+    """_run_self_install_async() must NOT run `which deile` on Windows.
+
+    The Linux branch shells out to `/usr/bin/env which deile` to verify the
+    shim is on PATH; on Windows that subprocess is meaningless and the
+    `os.name != "nt"` guard skips it entirely. This regression tests the
+    skip — a single inverted operator would have the install crash on
+    Windows with `FileNotFoundError: /usr/bin/env`.
+
+    Implementation note: we MUST also mock `Path.home` because patching
+    `deile.cli.os.name = "nt"` actually mutates the global `os.name`
+    (since `deile.cli.os` is the singleton `os` module), which makes
+    `pathlib.Path()` constructors default to `WindowsPath`. Instantiating
+    `WindowsPath` on a POSIX system raises `UnsupportedOperation`, so
+    `Path.home()` would crash before we even reach the `which` branch.
+    Returning a plain string from `_wrapper_target_dir`-replacement avoids
+    further constructor work inside the patched scope.
+    """
+
+    @patch("deile.cli_install.os.name", "nt")
+    @patch("deile.cli_install.Path.home")
+    @patch("deile.cli_install._prompt_install_mode", return_value="global")
+    @patch("deile.cli_install._create_venv_with_deile")
+    @patch("deile.cli_install._wrapper_target_dir")
+    @patch("deile.cli_install._link_global_command")
+    @patch("deile.cli_install._ensure_scripts_dir_on_path",
+           return_value=(False, None, "PowerShell hint"))
+    @patch("deile.cli_install.asyncio.to_thread")
+    @patch("builtins.print")
+    def test_which_subprocess_not_called_on_windows(
+        self, mock_print, mock_to_thread, mock_ensure_path,
+        mock_link, mock_wrapper_dir, mock_create_venv, mock_prompt,
+        mock_home,
+    ):
+        from deile.cli_install import _run_self_install_async
+
+        # `Path.home()` is normally called twice inside the function chain;
+        # return a plain MagicMock whose `__truediv__` chains transparently.
+        # The actual returned paths are irrelevant for this assertion — we
+        # only care that `to_thread` (= the which subprocess) is NOT called.
+        home_mock = MagicMock(spec=Path)
+        home_mock.__truediv__.return_value = home_mock
+        mock_home.return_value = home_mock
+
+        wrapper_target = MagicMock(spec=Path)
+        wrapper_target.name = "Scripts"
+        mock_wrapper_dir.return_value = wrapper_target
+
+        deile_script = MagicMock(spec=Path)
+        deile_script.parent.parent = MagicMock()
+        mock_create_venv.return_value = deile_script
+
+        link_target = MagicMock(spec=Path)
+        link_target.name = "deile.cmd"
+        link_target.parent = MagicMock()
+        mock_link.return_value = link_target
+
+        result = asyncio.run(_run_self_install_async(mode=None))
+
+        assert result == 0
+        # `asyncio.to_thread` is what wraps `subprocess.run(['/usr/bin/env',
+        # 'which', 'deile'])`. On Windows that call MUST be skipped — if
+        # `to_thread` was invoked, the `which` branch ran by mistake.
+        mock_to_thread.assert_not_called()
+
+    @patch("deile.cli_install.os.name", "posix")
+    @patch("deile.cli_install._prompt_install_mode", return_value="global")
+    @patch("deile.cli_install._create_venv_with_deile")
+    @patch("deile.cli_install._wrapper_target_dir")
+    @patch("deile.cli_install._link_global_command")
+    @patch("deile.cli_install._ensure_scripts_dir_on_path",
+           return_value=(False, None, ""))
+    @patch("deile.cli_install.asyncio.to_thread")
+    @patch("builtins.print")
+    def test_which_subprocess_called_on_posix_for_contrast(
+        self, mock_print, mock_to_thread, mock_ensure_path,
+        mock_link, mock_wrapper_dir, mock_create_venv, mock_prompt,
+    ):
+        """Negative control: same scenario on POSIX MUST run `which deile`."""
+        from deile.cli_install import _run_self_install_async
+
+        mock_create_venv.return_value = Path("/home/user/.deile/venv/bin/deile")
+        mock_wrapper_dir.return_value = Path("/home/user/.local/bin")
+        mock_link.return_value = Path("/home/user/.local/bin/deile")
+
+        # `to_thread` returns an awaitable, so we have to return a coroutine.
+        async def _fake_to_thread(*args, **kwargs):
+            return MagicMock(returncode=1, stdout="", stderr="")
+
+        mock_to_thread.side_effect = _fake_to_thread
+
+        result = asyncio.run(_run_self_install_async(mode=None))
+
+        assert result == 0
+        # On POSIX `to_thread` IS called — proves the contrast assertion
+        # above is meaningful.
+        mock_to_thread.assert_called_once()
+        # Inspect the subprocess command — must be `/usr/bin/env which deile`.
+        call_args = mock_to_thread.call_args[0]
+        # Signature: (subprocess.run, ['/usr/bin/env', 'which', 'deile'], ...)
+        assert call_args[1] == ["/usr/bin/env", "which", "deile"]

--- a/deile/tests/test_path_normalization.py
+++ b/deile/tests/test_path_normalization.py
@@ -21,7 +21,10 @@ hallucinate where a file ended up.
 
 from __future__ import annotations
 
+import importlib
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -662,3 +665,125 @@ def test_delete_file_parent_relative_hints_bash(tmp_path):
     assert result.is_error
     assert "OUTSIDE" in result.message or "outside" in result.message.lower()
     assert "bash_execute" in result.message
+
+
+# ---------------------------------------------------------------------------
+# 6. Windows-specific platform branches (issue #283)
+#
+# `_path_resolution.py` has two Windows-conditional code paths that the
+# Linux CI never executes:
+#   * `_PYTHON_LAUNCHER = "python" if sys.platform == "win32" else "python3"`
+#     → drives every post-write validation hint (`.py`, `.json`, `.yaml`).
+#   * `_WINDOWS_DRIVE_RE` → strips `C:\foo`, `D:/bar`, etc. so a path the
+#     LLM copy-pasted from a Windows transcript still resolves correctly.
+#
+# These tests mock `sys.platform`, reload the module so the constant is
+# rebuilt, and assert the hint command + regex behave correctly per-platform.
+# ---------------------------------------------------------------------------
+
+
+def _reload_path_resolution_with_platform(target_platform: str):
+    """Reimport `_path_resolution` under a forced `sys.platform`.
+
+    `_PYTHON_LAUNCHER` is captured at import time, so changing
+    `sys.platform` after the fact would not affect it. The test patches
+    `sys.platform`, drops the cached module, and reimports — then yields the
+    fresh module to the caller. Cleanup happens in a `finally` block so the
+    rest of the suite sees the real module afterwards.
+    """
+    sys.modules.pop("deile.tools._path_resolution", None)
+    try:
+        with patch.object(sys, "platform", target_platform):
+            return importlib.import_module("deile.tools._path_resolution")
+    finally:
+        # Restore the real module so subsequent tests use the real impl.
+        sys.modules.pop("deile.tools._path_resolution", None)
+        importlib.import_module("deile.tools._path_resolution")
+
+
+def test_python_launcher_is_python_on_windows():
+    module = _reload_path_resolution_with_platform("win32")
+    assert module._PYTHON_LAUNCHER == "python"
+
+
+def test_python_launcher_is_python3_on_linux():
+    module = _reload_path_resolution_with_platform("linux")
+    assert module._PYTHON_LAUNCHER == "python3"
+
+
+def test_python_launcher_is_python3_on_macos():
+    module = _reload_path_resolution_with_platform("darwin")
+    assert module._PYTHON_LAUNCHER == "python3"
+
+
+def test_post_write_hint_uses_python_on_windows():
+    """`.py` files on Windows get `python -m py_compile`, not `python3`."""
+    module = _reload_path_resolution_with_platform("win32")
+
+    hint = module._post_write_validation_hint("script.py")
+    assert hint is not None
+    assert hint["kind"] == "python_syntax"
+    assert hint["command"] == "python -m py_compile script.py"
+    assert "python3" not in hint["command"]
+
+
+def test_post_write_hint_uses_python3_on_linux():
+    """Negative control: Linux still uses `python3`."""
+    module = _reload_path_resolution_with_platform("linux")
+
+    hint = module._post_write_validation_hint("script.py")
+    assert hint is not None
+    assert hint["command"] == "python3 -m py_compile script.py"
+
+
+def test_post_write_json_hint_uses_python_launcher_on_windows():
+    """JSON and YAML hints inherit `_PYTHON_LAUNCHER` too — verify Windows."""
+    module = _reload_path_resolution_with_platform("win32")
+
+    json_hint = module._post_write_validation_hint("data.json")
+    assert json_hint is not None
+    assert json_hint["command"].startswith("python ")
+    assert "python3" not in json_hint["command"]
+
+    yaml_hint = module._post_write_validation_hint("config.yaml")
+    assert yaml_hint is not None
+    assert yaml_hint["command"].startswith("python ")
+
+
+@pytest.mark.parametrize(
+    "drive_path, expected_remainder",
+    [
+        ("C:\\Users\\foo.py", "Users\\foo.py"),
+        ("D:/data/bar.py", "data/bar.py"),
+        ("c:\\\\baz.py", "baz.py"),
+        ("Z:/x.py", "x.py"),
+        ("a:/y", "y"),
+    ],
+)
+def test_windows_drive_regex_strips_drive_prefix(drive_path, expected_remainder):
+    """`_WINDOWS_DRIVE_RE` matches `<letter>:` followed by one+ slashes/backslashes."""
+    from deile.tools._path_resolution import _WINDOWS_DRIVE_RE
+
+    match = _WINDOWS_DRIVE_RE.match(drive_path)
+    assert match is not None, f"expected regex to match {drive_path!r}"
+
+    stripped = _WINDOWS_DRIVE_RE.sub("", drive_path)
+    assert stripped == expected_remainder
+
+
+@pytest.mark.parametrize(
+    "non_drive_path",
+    [
+        "foo.py",
+        "/tmp/foo",
+        "src/main.py",
+        "@foo.py",
+        "1:invalid",  # leading digit, not a drive letter
+        ":",  # no letter
+    ],
+)
+def test_windows_drive_regex_does_not_match_non_drive_paths(non_drive_path):
+    """Negative control: paths that aren't Windows drives must not match."""
+    from deile.tools._path_resolution import _WINDOWS_DRIVE_RE
+
+    assert _WINDOWS_DRIVE_RE.match(non_drive_path) is None

--- a/deile/tests/tools/test_bash_tool_windows.py
+++ b/deile/tests/tools/test_bash_tool_windows.py
@@ -1,0 +1,269 @@
+"""Tests for the Windows-specific branches of ``BashExecuteTool``.
+
+The CI runs on Linux so the ``self.platform == 'Windows'`` paths in
+``deile/tools/bash_tool.py`` are never exercised. A regression there only
+surfaces when a Windows user runs DEILE in production. These tests mock
+``platform.system()`` / ``sys.platform`` and assert each Windows branch:
+
+* ``_execute_with_subprocess`` shells out via ``cmd.exe /c`` (not
+  ``/bin/bash -c``).
+* ``_prepare_environment`` adds Windows-specific PATH entries instead of
+  the POSIX set, **and** scrubs them via ``os.path.exists`` so the test
+  is deterministic on the Linux CI runner.
+* ``execute_sync`` skips the PTY path on Windows even when ``use_pty=True``
+  is requested.
+* The ``try: import pty, select, tty`` block at module top is tolerant of
+  Windows where those modules don't exist.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deile.tools.base import ToolContext
+
+
+def _make_tool() -> Any:
+    """Build a ``BashExecuteTool`` after forcing ``platform.system()`` to Windows.
+
+    ``self.platform`` is captured in ``__init__`` from ``platform.system()``, so
+    the patch has to be active when the constructor runs — patching after the
+    fact would leave ``self.platform == 'Darwin'`` on macOS / ``'Linux'`` on
+    CI and silently miss every assertion below.
+    """
+    with patch("deile.tools.bash_tool.platform.system", return_value="Windows"):
+        from deile.tools.bash_tool import BashExecuteTool
+        return BashExecuteTool()
+
+
+def _make_ctx(command: str, working_dir: Path, **extra: Any) -> ToolContext:
+    parsed: Dict[str, Any] = {"command": command, "working_directory": str(working_dir)}
+    parsed.update(extra)
+    return ToolContext(
+        user_input="",
+        parsed_args=parsed,
+        working_directory=str(working_dir),
+    )
+
+
+@pytest.mark.bash
+@pytest.mark.unit
+class TestBashExecuteSubprocessWindows:
+    """``_execute_with_subprocess`` must select ``cmd.exe`` on Windows."""
+
+    def test_subprocess_uses_cmd_exe_on_windows(self, tmp_path: Path) -> None:
+        tool = _make_tool()
+        assert tool.platform == "Windows"
+
+        fake_result = MagicMock(stdout="hello\n", stderr="", returncode=0)
+        with patch("deile.tools.bash_tool.subprocess.run", return_value=fake_result) as mock_run:
+            stdout, stderr, exit_code, pty_used = tool._execute_with_subprocess(
+                command="echo hello",
+                working_dir=tmp_path,
+                env={},
+                timeout=5.0,
+            )
+
+        assert stdout == "hello\n"
+        assert stderr == ""
+        assert exit_code == 0
+        assert pty_used is False
+
+        mock_run.assert_called_once()
+        # Positional args[0] is the shell command list — cmd.exe /c <command>.
+        shell_cmd = mock_run.call_args[0][0]
+        assert shell_cmd == ["cmd.exe", "/c", "echo hello"]
+
+    def test_subprocess_uses_bash_on_posix_for_contrast(self, tmp_path: Path) -> None:
+        """Negative control: make sure the Windows assertion above is meaningful.
+
+        If the branch logic ever inverts, the contrast test fails first and
+        points at the regression.
+        """
+        with patch("deile.tools.bash_tool.platform.system", return_value="Linux"):
+            from deile.tools.bash_tool import BashExecuteTool
+            tool = BashExecuteTool()
+
+        fake_result = MagicMock(stdout="", stderr="", returncode=0)
+        with patch("deile.tools.bash_tool.subprocess.run", return_value=fake_result) as mock_run:
+            tool._execute_with_subprocess(
+                command="echo hi",
+                working_dir=tmp_path,
+                env={},
+                timeout=5.0,
+            )
+
+        shell_cmd = mock_run.call_args[0][0]
+        assert shell_cmd == ["/bin/bash", "-c", "echo hi"]
+
+    def test_subprocess_timeout_raises_timeout_error(self, tmp_path: Path) -> None:
+        """``subprocess.TimeoutExpired`` on Windows still surfaces as ``TimeoutError``."""
+        import subprocess as _subprocess
+
+        tool = _make_tool()
+        with patch(
+            "deile.tools.bash_tool.subprocess.run",
+            side_effect=_subprocess.TimeoutExpired(cmd="cmd.exe", timeout=1),
+        ):
+            with pytest.raises(TimeoutError, match="timed out"):
+                tool._execute_with_subprocess(
+                    command="echo hi",
+                    working_dir=tmp_path,
+                    env={},
+                    timeout=1.0,
+                )
+
+
+@pytest.mark.bash
+@pytest.mark.unit
+class TestPrepareEnvironmentWindows:
+    """``_prepare_environment`` must add Windows PATH entries on Windows.
+
+    The Linux CI runner doesn't have ``C:\\Windows\\System32`` etc., so we
+    also patch ``os.path.exists`` to return ``True`` for the Windows paths
+    — otherwise the function's existence guard skips every candidate and
+    the assertion becomes vacuous.
+    """
+
+    WINDOWS_PATHS = {
+        r"C:\Windows\System32",
+        r"C:\Windows",
+        r"C:\Program Files\Git\bin",
+        r"C:\Program Files\Git\cmd",
+    }
+
+    def test_windows_paths_prepended(self, tmp_path: Path) -> None:
+        tool = _make_tool()
+
+        with patch.dict("os.environ", {"PATH": "/existing/path"}, clear=True), \
+             patch("deile.tools.bash_tool.os.path.exists", return_value=True):
+            env = tool._prepare_environment(base_env=None, working_dir=tmp_path)
+
+        # Every Windows path must appear in the resulting PATH string.
+        for win_path in self.WINDOWS_PATHS:
+            assert win_path in env["PATH"], (
+                f"expected {win_path!r} in PATH but got {env['PATH']!r}"
+            )
+
+        # PWD always set to the working directory.
+        assert env["PWD"] == str(tmp_path)
+
+    def test_posix_paths_used_on_linux(self, tmp_path: Path) -> None:
+        """Negative control — make sure the Windows assertion isn't picking
+        up POSIX paths by accident."""
+        with patch("deile.tools.bash_tool.platform.system", return_value="Linux"):
+            from deile.tools.bash_tool import BashExecuteTool
+            tool = BashExecuteTool()
+
+        with patch.dict("os.environ", {"PATH": "/x"}, clear=True), \
+             patch("deile.tools.bash_tool.os.path.exists", return_value=True):
+            env = tool._prepare_environment(base_env=None, working_dir=tmp_path)
+
+        # POSIX paths must be present; Windows paths must be absent.
+        for posix_path in ["/usr/local/bin", "/usr/bin", "/bin"]:
+            assert posix_path in env["PATH"]
+        for win_path in self.WINDOWS_PATHS:
+            assert win_path not in env["PATH"]
+
+
+@pytest.mark.bash
+@pytest.mark.unit
+class TestExecuteSyncSkipsPtyOnWindows:
+    """``execute_sync`` must NOT take the PTY branch on Windows.
+
+    The relevant guard is:
+        ``if should_use_pty and not sandbox and self.platform != 'Windows':``
+    On Windows the PTY branch is bypassed even when ``use_pty=True``.
+    """
+
+    def test_pty_branch_skipped_on_windows(self, tmp_path: Path) -> None:
+        tool = _make_tool()
+
+        # Force ``_should_use_pty`` to return True so the only thing keeping
+        # us off the PTY path is the Windows check.
+        with patch.object(tool, "_should_use_pty", return_value=True), \
+             patch.object(tool, "_execute_with_pty_unix") as mock_pty, \
+             patch.object(
+                tool,
+                "_execute_with_subprocess",
+                return_value=("ok", "", 0, False),
+             ) as mock_subprocess, \
+             patch("deile.tools.bash_tool.get_settings") as mock_settings:
+            mock_settings.return_value.sandbox_code_execution = False
+
+            ctx = _make_ctx("echo hi", tmp_path, use_pty=True)
+            result = tool.execute_sync(ctx)
+
+        # PTY path must NEVER be taken on Windows.
+        mock_pty.assert_not_called()
+        # Subprocess path must be taken instead.
+        mock_subprocess.assert_called_once()
+        assert result.is_success
+        assert result.data["pty_used"] is False
+
+    def test_sandbox_forces_subprocess_on_windows(self, tmp_path: Path) -> None:
+        """Already-covered POSIX invariant — verify it also holds on Windows."""
+        tool = _make_tool()
+
+        with patch.object(tool, "_should_use_pty", return_value=True), \
+             patch.object(tool, "_execute_with_pty_unix") as mock_pty, \
+             patch.object(
+                tool,
+                "_execute_with_subprocess",
+                return_value=("ok", "", 0, False),
+             ) as mock_subprocess, \
+             patch("deile.tools.bash_tool.get_settings") as mock_settings:
+            mock_settings.return_value.sandbox_code_execution = False
+
+            ctx = _make_ctx("echo hi", tmp_path, use_pty=True, sandbox=True)
+            tool.execute_sync(ctx)
+
+        mock_pty.assert_not_called()
+        mock_subprocess.assert_called_once()
+
+
+@pytest.mark.bash
+@pytest.mark.unit
+class TestPtyImportFallback:
+    """Importing ``deile.tools.bash_tool`` must not raise on Windows where
+    ``pty`` / ``select`` / ``tty`` aren't shipped.
+
+    Setting ``sys.modules['pty'] = None`` makes the subsequent ``import pty``
+    raise ``ImportError`` (PEP 328 sentinel semantics). After reload, the
+    module's ``PTY_AVAILABLE`` global must be ``False`` and the rest of the
+    module must remain functional.
+    """
+
+    def test_module_reloads_with_pty_modules_absent(self) -> None:
+        # Snapshot existing references so we don't pollute the test session.
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in ("pty", "select", "tty", "deile.tools.bash_tool")
+        }
+
+        try:
+            sys.modules["pty"] = None  # type: ignore[assignment]
+            sys.modules["select"] = None  # type: ignore[assignment]
+            sys.modules["tty"] = None  # type: ignore[assignment]
+            # Force fresh import so the top-level try/except runs.
+            sys.modules.pop("deile.tools.bash_tool", None)
+
+            module = importlib.import_module("deile.tools.bash_tool")
+            assert module.PTY_AVAILABLE is False
+            # Module still defines its public class.
+            assert hasattr(module, "BashExecuteTool")
+        finally:
+            # Restore originals so subsequent tests see a clean import state.
+            for name, val in saved_modules.items():
+                if val is not None:
+                    sys.modules[name] = val
+                else:
+                    sys.modules.pop(name, None)
+            # Reload the module from disk so other tests see the real PTY state.
+            importlib.import_module("deile.tools.bash_tool")

--- a/deile/tests/ui/test_console_ui_windows.py
+++ b/deile/tests/ui/test_console_ui_windows.py
@@ -1,0 +1,162 @@
+"""Tests for ``ConsoleUIManager`` legacy-Windows construction logic.
+
+``ConsoleUIManager.__init__`` constructs a Rich ``Console`` with
+``legacy_windows=True`` when **all** of these hold:
+
+* ``os.name == 'nt'`` (running on Windows)
+* No ``WT_SESSION`` (i.e. NOT Windows Terminal)
+* No ``ANSICON``
+* No ``ConEmuPID``
+* ``TERM`` is unset, empty, or literally ``'cygwin'``
+
+When any of those env hints is present (modern Windows terminals OR any
+POSIX system), Rich's auto-detection takes over and ``legacy_windows`` is
+left at its default ``False``. Forcing the legacy path on macOS / Linux
+breaks ``Live`` Markdown rendering (see the inline comment in
+``ConsoleUIManager.__init__``), so this branch deserves explicit coverage.
+
+The tests patch the ``Console`` symbol inside ``deile.ui.console_ui`` to
+inspect the keyword arguments the constructor would have received.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+_LEGACY_HINT_KEYS = ("WT_SESSION", "ANSICON", "ConEmuPID", "TERM")
+
+
+def _purge_legacy_hints() -> Dict[str, Optional[str]]:
+    """Strip env hints that would push Rich off the legacy-Windows path.
+
+    Returns the snapshot so callers can restore it in a ``finally``."""
+    saved = {k: os.environ.get(k) for k in _LEGACY_HINT_KEYS}
+    for k in _LEGACY_HINT_KEYS:
+        os.environ.pop(k, None)
+    return saved
+
+
+def _restore_env(saved: Dict[str, Optional[str]]) -> None:
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+@pytest.mark.ui
+@pytest.mark.unit
+class TestConsoleUIManagerLegacyWindows:
+    """``legacy_windows=True`` is forced only when on Windows AND no modern
+    terminal hint is present."""
+
+    def test_legacy_windows_true_when_no_modern_hint(self) -> None:
+        saved = _purge_legacy_hints()
+        try:
+            with patch("os.name", "nt"), \
+                 patch("deile.ui.console_ui.Console") as mock_console:
+                from deile.ui.console_ui import ConsoleUIManager
+                ConsoleUIManager()
+
+            mock_console.assert_called_once()
+            kwargs = mock_console.call_args.kwargs
+            assert kwargs.get("legacy_windows") is True
+            assert kwargs.get("force_terminal") is True
+            assert kwargs.get("_environ") == {"TERM": "ansi"}
+        finally:
+            _restore_env(saved)
+
+    def test_legacy_windows_false_when_wt_session_set(self) -> None:
+        """Windows Terminal user → modern path, legacy_windows NOT set."""
+        saved = _purge_legacy_hints()
+        try:
+            os.environ["WT_SESSION"] = "any-value"
+            with patch("os.name", "nt"), \
+                 patch("deile.ui.console_ui.Console") as mock_console:
+                from deile.ui.console_ui import ConsoleUIManager
+                ConsoleUIManager()
+
+            kwargs = mock_console.call_args.kwargs
+            # Either omitted entirely or explicitly False — both indicate
+            # the modern path.
+            assert kwargs.get("legacy_windows") is not True
+        finally:
+            _restore_env(saved)
+
+    def test_legacy_windows_false_when_ansicon_set(self) -> None:
+        """ANSICON shim user → modern path."""
+        saved = _purge_legacy_hints()
+        try:
+            os.environ["ANSICON"] = "1"
+            with patch("os.name", "nt"), \
+                 patch("deile.ui.console_ui.Console") as mock_console:
+                from deile.ui.console_ui import ConsoleUIManager
+                ConsoleUIManager()
+
+            kwargs = mock_console.call_args.kwargs
+            assert kwargs.get("legacy_windows") is not True
+        finally:
+            _restore_env(saved)
+
+    def test_legacy_windows_false_when_conemu_set(self) -> None:
+        """ConEmu user → modern path."""
+        saved = _purge_legacy_hints()
+        try:
+            os.environ["ConEmuPID"] = "1234"
+            with patch("os.name", "nt"), \
+                 patch("deile.ui.console_ui.Console") as mock_console:
+                from deile.ui.console_ui import ConsoleUIManager
+                ConsoleUIManager()
+
+            kwargs = mock_console.call_args.kwargs
+            assert kwargs.get("legacy_windows") is not True
+        finally:
+            _restore_env(saved)
+
+    def test_legacy_windows_false_when_term_is_set(self) -> None:
+        """Any TERM value other than '', None, or 'cygwin' disables legacy."""
+        saved = _purge_legacy_hints()
+        try:
+            os.environ["TERM"] = "xterm-256color"
+            with patch("os.name", "nt"), \
+                 patch("deile.ui.console_ui.Console") as mock_console:
+                from deile.ui.console_ui import ConsoleUIManager
+                ConsoleUIManager()
+
+            kwargs = mock_console.call_args.kwargs
+            assert kwargs.get("legacy_windows") is not True
+        finally:
+            _restore_env(saved)
+
+    def test_legacy_windows_true_when_term_is_cygwin(self) -> None:
+        """``TERM=cygwin`` is treated like 'no modern terminal'."""
+        saved = _purge_legacy_hints()
+        try:
+            os.environ["TERM"] = "cygwin"
+            with patch("os.name", "nt"), \
+                 patch("deile.ui.console_ui.Console") as mock_console:
+                from deile.ui.console_ui import ConsoleUIManager
+                ConsoleUIManager()
+
+            kwargs = mock_console.call_args.kwargs
+            assert kwargs.get("legacy_windows") is True
+        finally:
+            _restore_env(saved)
+
+    def test_legacy_windows_false_on_posix(self) -> None:
+        """Negative control — POSIX never takes the legacy branch."""
+        saved = _purge_legacy_hints()
+        try:
+            with patch("os.name", "posix"), \
+                 patch("deile.ui.console_ui.Console") as mock_console:
+                from deile.ui.console_ui import ConsoleUIManager
+                ConsoleUIManager()
+
+            kwargs = mock_console.call_args.kwargs
+            assert kwargs.get("legacy_windows") is not True
+        finally:
+            _restore_env(saved)

--- a/deile/tests/ui/test_emoji_windows.py
+++ b/deile/tests/ui/test_emoji_windows.py
@@ -1,0 +1,154 @@
+"""Tests for Windows-specific branches in ``deile/ui/emoji_support.py``.
+
+Two functions take a ``sys.platform == "win32"`` branch to switch the
+console code page to UTF-8 via ``chcp 65001`` so emojis render correctly
+in ``cmd.exe`` / ``conhost.exe``:
+
+* ``EmojiManager._check_emoji_support`` — invoked once during init.
+* ``EmojiManager.enable_unicode_console`` — public helper that callers
+  can invoke later (e.g. after the UI activates).
+
+Both are tested via mocked ``sys.platform`` + mocked ``subprocess.run``
+so the Linux CI never actually shells out to ``cmd``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+
+def _purge_emoji_env() -> Dict[str, Optional[str]]:
+    """Remove env vars that would short-circuit ``_check_emoji_support``.
+
+    The function returns ``True`` immediately if any of these is set, so
+    leaving them in the test environment makes the chcp branch unreachable.
+    Caller is responsible for restoring values via the returned dict.
+    """
+    keys = ("TERM_PROGRAM", "COLORTERM", "WT_SESSION")
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    return saved
+
+
+def _restore_env(saved: Dict[str, Optional[str]]) -> None:
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+@pytest.mark.ui
+@pytest.mark.unit
+class TestCheckEmojiSupportWindows:
+    """``_check_emoji_support`` calls ``chcp 65001`` when ``sys.platform == 'win32'``."""
+
+    def test_runs_chcp_and_returns_true_on_win32(self) -> None:
+        saved = _purge_emoji_env()
+        try:
+            with patch("deile.ui.emoji_support.sys.platform", "win32"), \
+                 patch("deile.ui.emoji_support.subprocess.run") as mock_run:
+                from deile.ui.emoji_support import EmojiManager
+                manager = EmojiManager()
+
+            assert manager.supports_emoji is True
+            mock_run.assert_called_once()
+            assert mock_run.call_args[0][0] == ["cmd", "/c", "chcp", "65001"]
+            # capture_output suppresses any leakage into the test stdout.
+            assert mock_run.call_args.kwargs.get("capture_output") is True
+            # check=False so a missing/erroring chcp never crashes init.
+            assert mock_run.call_args.kwargs.get("check") is False
+        finally:
+            _restore_env(saved)
+
+    def test_returns_false_when_chcp_raises_on_win32(self) -> None:
+        """Bare exception from subprocess.run on Windows → supports_emoji=False.
+
+        Production code wraps ``subprocess.run`` in a try/except that
+        swallows the exception and returns ``False``; nothing must escape.
+        """
+        saved = _purge_emoji_env()
+        try:
+            with patch("deile.ui.emoji_support.sys.platform", "win32"), \
+                 patch(
+                     "deile.ui.emoji_support.subprocess.run",
+                     side_effect=OSError("chcp missing"),
+                 ):
+                from deile.ui.emoji_support import EmojiManager
+                manager = EmojiManager()
+
+            assert manager.supports_emoji is False
+        finally:
+            _restore_env(saved)
+
+
+@pytest.mark.ui
+@pytest.mark.unit
+class TestEnableUnicodeConsoleWindows:
+    """``enable_unicode_console`` is a public no-op on non-Windows, and
+    runs ``chcp 65001`` + sets ``PYTHONIOENCODING=utf-8`` on Windows."""
+
+    def test_runs_chcp_and_sets_pythonioencoding_on_win32(self) -> None:
+        # Snapshot env so the test cleanup is deterministic.
+        saved_env = os.environ.get("PYTHONIOENCODING")
+        try:
+            with patch("deile.ui.emoji_support.sys.platform", "win32"), \
+                 patch("deile.ui.emoji_support.subprocess.run") as mock_run:
+                from deile.ui.emoji_support import EmojiManager
+
+                # Bypass __init__ — we don't want the init-time chcp call to
+                # pollute the call count. ``object.__new__`` skips `__init__`
+                # entirely and we set the fields the method needs directly.
+                manager = EmojiManager.__new__(EmojiManager)
+                manager.supports_emoji = True
+                manager.emoji_map = {}
+
+                result = manager.enable_unicode_console()
+
+            assert result is True
+            mock_run.assert_called_once()
+            assert mock_run.call_args[0][0] == ["cmd", "/c", "chcp", "65001"]
+            assert os.environ.get("PYTHONIOENCODING") == "utf-8"
+        finally:
+            if saved_env is None:
+                os.environ.pop("PYTHONIOENCODING", None)
+            else:
+                os.environ["PYTHONIOENCODING"] = saved_env
+
+    def test_returns_true_without_chcp_on_posix(self) -> None:
+        """Negative control — POSIX path is a no-op that still returns True."""
+        with patch("deile.ui.emoji_support.sys.platform", "linux"), \
+             patch("deile.ui.emoji_support.subprocess.run") as mock_run:
+            from deile.ui.emoji_support import EmojiManager
+            manager = EmojiManager.__new__(EmojiManager)
+            manager.supports_emoji = True
+            manager.emoji_map = {}
+
+            result = manager.enable_unicode_console()
+
+        assert result is True
+        # chcp must NOT be invoked outside Windows.
+        mock_run.assert_not_called()
+
+    def test_returns_false_when_chcp_raises_on_win32(self) -> None:
+        """Exception in subprocess.run → enable_unicode_console returns False
+        and does NOT raise. The fallback is degraded emoji rendering, not a
+        crash on Windows users' first session."""
+        with patch("deile.ui.emoji_support.sys.platform", "win32"), \
+             patch(
+                 "deile.ui.emoji_support.subprocess.run",
+                 side_effect=OSError("chcp missing"),
+             ):
+            from deile.ui.emoji_support import EmojiManager
+            manager = EmojiManager.__new__(EmojiManager)
+            manager.supports_emoji = True
+            manager.emoji_map = {}
+
+            result = manager.enable_unicode_console()
+
+        assert result is False


### PR DESCRIPTION
## Summary

Suite de testes unitários que exercita **todos os branches condicionais de plataforma Windows** existentes hoje em 6 módulos de produção do DEILE, sem depender de um runner Windows real. CI roda em Linux, então esses caminhos nunca foram exercidos — bug latente que só apareceria para um usuário Windows em produção.

Closes #283.

## Cobertura por critério de aceite

| Critério (#283) | Arquivo de teste | Bloco |
|---|---|---|
| `bash_tool.py` 100% Windows branches (cmd.exe, PATH, PTY skip) | `tests/tools/test_bash_tool_windows.py` (novo) | `TestBashExecuteSubprocessWindows`, `TestPrepareEnvironmentWindows`, `TestExecuteSyncSkipsPtyOnWindows`, `TestPtyImportFallback` |
| `_path_resolution.py` `_PYTHON_LAUNCHER`, `_WINDOWS_DRIVE_RE`, post-write hints | `tests/test_path_normalization.py` (expandido) | `test_python_launcher_*`, `test_post_write_hint_*`, `test_windows_drive_regex_*` |
| `cli_install.py` `Scripts/python.exe` / `Scripts/deile.exe` / `nt_user` scheme | `tests/test_install_functions.py` (expandido) | `TestCreateVenvWithDeileWindows`, `TestUserScriptsDirWindowsFallback` |
| `cli_install.py` `which deile` skipped em `os.name == 'nt'` | `tests/test_install_functions.py` (expandido) | `TestRunSelfInstallAsyncWindowsSkipsWhich` (com controle negativo POSIX) |
| `cli.py` termios fallback no `_stream_with_esc_cancel` | `tests/cli/test_cli_windows.py` (novo) | `TestStreamWithEscCancelTermiosFallback` |
| `ui/cli.py::clear_screen` usa `cmd /c cls` | `tests/cli/test_cli_windows.py` (novo) | `TestClearScreenWindows` (com controle negativo POSIX) |
| `ui/emoji_support.py` `chcp 65001` em `sys.platform == 'win32'` | `tests/ui/test_emoji_windows.py` (novo) | `TestCheckEmojiSupportWindows`, `TestEnableUnicodeConsoleWindows` |
| `ui/console_ui.py` `Console(legacy_windows=True)` na matriz correta de env vars | `tests/ui/test_console_ui_windows.py` (novo) | `TestConsoleUIManagerLegacyWindows` (7 cenários incl. `TERM=cygwin`, `WT_SESSION`, `ANSICON`, `ConEmuPID`) |
| Sem `ModuleNotFoundError` em imports mockados | múltiplos | reload de `bash_tool` sem `pty`/`select`/`tty`; `termios`/`tty` ausentes via `__import__` |
| Todos os testes existentes continuam passando | suíte | `3591 passed, 0 failed` |

## Decisões técnicas (que valem revisão)

1. **`patch('os.name', 'nt')` muta `os.name` global** → `pathlib.Path()` construído dentro do escopo do patch vira `WindowsPath`, que crasha em POSIX. Solução: Paths pré-baked fora do patch + `Path.home` mockada quando necessário. Documentado em docstring de `TestCreateVenvWithDeileWindows` e `TestRunSelfInstallAsyncWindowsSkipsWhich`.
2. **`CLI()` chama `get_logger()` que seta `propagate=False`** num logger nomeado, mutação global que silenciosamente quebra `caplog` em testes subsequentes (test_shared, test_settings_json_loading). Solução: `CLI.__new__(CLI)` para pular `__init__`. Documentado em `TestClearScreenWindows`.
3. **`sys.modules['termios'] = None`** (idiom comum para forçar `ImportError`) também polui captura de log pytest. Trocado por `patch('builtins.__import__', ...)` com filtro seletivo — totalmente escopado ao `with`. Documentado em `TestStreamWithEscCancelTermiosFallback`.
4. Negative controls em cada par Windows/POSIX → previne regressões silenciosas caso o branch logic inverta.

## Test plan

- [x] `python3 -m pytest deile/tests/ -q` → 3591 passed, 0 failed
- [x] `ruff check deile/tests/{tools,cli,ui}/test_*windows*.py deile/tests/test_install_functions.py deile/tests/test_path_normalization.py` → 0 issues
- [x] `isort --check-only` → clean
- [x] Cross-contamination verificada: `pytest <novo_arquivo> deile/tests/commands/test_shared.py deile/tests/config/test_settings_json_loading.py` para cada novo arquivo → 0 failures
- [x] /REVIEW-CETICA executado contra os 11 itens dos critérios de aceite — sem gaps