### PR TITLE
fix(cli/subagents): 5 polish fixes para UX interativo + leak de stdout dos sub-DEILEs

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -422,8 +422,11 @@ class _DeileCLI:
         persist_session(self.default_session, user_input)
 
     def _rollback_history(self, baseline_len: int) -> None:
-        from .cli_session_helpers import rollback_history
-        rollback_history(self.default_session, baseline_len)
+        # Renomeado conceitualmente para "marcar como cancelado" — não
+        # apaga mais a entrada user. Mantém + adiciona placeholder
+        # assistant. Ver ``mark_turn_cancelled`` em cli_session_helpers.
+        from .cli_session_helpers import mark_turn_cancelled
+        mark_turn_cancelled(self.default_session, baseline_len)
 
     def _check_session_switch(self) -> None:
         from .cli_session_helpers import check_session_switch

--- a/deile/cli_session_helpers.py
+++ b/deile/cli_session_helpers.py
@@ -33,18 +33,62 @@ def persist_session(session: Any, user_input: str) -> None:
         pass
 
 
-def rollback_history(session: Any, baseline_len: int) -> None:
-    """Trim ``conversation_history`` back to ``baseline_len``.
+_CANCELLED_MARKER_TEXT = "(cancelado pelo usuário)"
 
-    Required after ESC/Ctrl+C: providers (DeepSeek, OpenAI) collapse two
-    consecutive ``user`` turns with ``/`` as a separator, so leaving an orphan
-    user entry poisons the next reply.
+
+def mark_turn_cancelled(
+    session: Any,
+    baseline_len: int,
+    marker_text: str = _CANCELLED_MARKER_TEXT,
+) -> None:
+    """Marca o turno cancelado no histórico ao invés de apagá-lo.
+
+    Mantém a entrada ``user`` que motivou o turno e adiciona um placeholder
+    ``assistant`` com ``marker_text`` (default ``"(cancelado pelo usuário)"``)
+    para o LLM saber que aquilo foi cancelado E para evitar duas entradas
+    ``user`` consecutivas (que DeepSeek/OpenAI colapsam com ``/`` como
+    separador — bug histórico que motivou o rollback original).
+
+    Apaga apenas eventuais entradas ``assistant`` parciais que o agente
+    tenha escrito antes do cancel (caso o stream tenha começado a responder
+    antes do ESC).
+
+    Por que essa é a opção certa: visualmente o texto da request cancelada
+    fica no scrollback do terminal. Se o histórico do LLM não tivesse
+    aquela entrada, o usuário olharia para a tela e pensaria "ele viu
+    isso", mandaria uma mensagem dependente daquilo, e o LLM teria
+    amnésia da request anterior. Manter a entrada (com marker explícito
+    de cancelamento) preserva o mental model do usuário.
     """
     history = getattr(session, "conversation_history", None)
     if history is None:
         return
+
+    # Apaga entradas parciais APÓS a entrada user do turno cancelado.
+    # Mantém a entrada user em ``baseline_len`` (se houver — algumas
+    # callsites podem invocar com baseline_len == len(history)).
+    if len(history) > baseline_len + 1:
+        del history[baseline_len + 1:]
+
+    # Se há uma entrada user em ``baseline_len``, adiciona placeholder
+    # assistant. Sem isso, próximo turno teria duas user consecutivas
+    # (o bug histórico do separador ``/`` em DeepSeek/OpenAI).
     if len(history) > baseline_len:
-        del history[baseline_len:]
+        entry = history[baseline_len]
+        if entry.get("role") == "user":
+            import time as _time
+            history.append({
+                "role": "assistant",
+                "content": marker_text,
+                "timestamp": _time.time(),
+                "metadata": {"cancelled": True},
+            })
+
+
+# Alias retrocompatível para callers externos que ainda esperem
+# ``rollback_history``. Comportamento agora é "mark cancelled", não
+# "delete". Documentação atualizada acima.
+rollback_history = mark_turn_cancelled
 
 
 def replay_history(ui: Any, session: Any, history: list) -> None:

--- a/deile/commands/builtin/rewind_command.py
+++ b/deile/commands/builtin/rewind_command.py
@@ -51,13 +51,11 @@ class RewindCommand(DirectCommand):
         ]
 
         if not user_entries:
+            # Histórico vazio — fecha silenciosamente, igual ao cancel via ESC.
             return CommandResult(
                 success=True,
-                content=Panel(
-                    Text("Nenhuma mensagem no histórico desta conversa.", style="dim"),
-                    title="Rewind",
-                    border_style="yellow",
-                ),
+                content="",
+                metadata={"suppress_response_display": True},
             )
 
         selector = get_default_selector()

--- a/deile/orchestration/subagents/_capture.py
+++ b/deile/orchestration/subagents/_capture.py
@@ -122,6 +122,134 @@ class CappedBuffer:
         return "".join(self._chunks)
 
 
+class _DiscardSink:
+    """``TextIO``-like sink que descarta silenciosamente todo write.
+
+    Usado como destino de fallback para o :class:`SwitchableStream` depois que
+    o dispatch encerra — qualquer thread orfã que ainda tente escrever recebe
+    sucesso (sem ``BrokenPipeError``, sem flooding na captura) mas o byte é
+    aniquilado.
+    """
+
+    __slots__ = ()
+
+    def write(self, s) -> int:  # noqa: D401 — file protocol
+        return len(s) if isinstance(s, str) else 0
+
+    def flush(self) -> None:
+        return None
+
+    def writelines(self, lines) -> None:
+        return None
+
+    def isatty(self) -> bool:
+        return False
+
+    @property
+    def encoding(self) -> str:
+        return "utf-8"
+
+
+class SwitchableStream:
+    """``TextIO``-like proxy que delega para um destino mutável.
+
+    Substituído por :class:`SubAgentOrchestrator` no lugar de ``sys.stdout`` /
+    ``sys.stderr`` durante a execução. ``set_target(target)`` troca o destino
+    em tempo real **sem reatribuir** ``sys.stdout``.
+
+    Issue #257 round-X fix (orphan-thread leak): ``asyncio.to_thread`` cria
+    worker threads no pool global que **não respondem a `Task.cancel()`** —
+    quando o budget estoura ou o caller cancela, o orquestrador cancela a
+    task de await mas a thread continua rodando ``execute_sync`` (ex.:
+    ``bash_tool`` no meio de ``subprocess.run`` longo). O ``finally`` então
+    restaurava ``sys.stdout = prev_stdout``; a thread orfã, ao chamar
+    ``print(data, ...)`` em sequência, escrevia direto no terminal real.
+
+    Solução: nunca reatribuir ``sys.stdout`` para o stream original. Em vez
+    disso, instalar este wrapper ``UMA VEZ``; trocar ``target`` para o buffer
+    de captura no início, e para o **stream real** ou para :class:`_DiscardSink`
+    no encerramento. Threads orfãs que herdaram a referência ao
+    ``SwitchableStream`` continuam escrevendo nele sem afetar o terminal.
+
+    No ``release()`` chamado pelo orquestrador, o caller decide pra onde os
+    writes pós-dispatch devem ir: ``DISCARD`` para silenciá-los (default em
+    ``capture_output=True``) ou ``PASSTHROUGH`` para deixá-los aparecer no
+    terminal (caso onde o caller quer transparência total para writes legítimos
+    do CLI principal após o dispatch terminar — explicado abaixo).
+
+    Threading: ``set_target`` é atômico (assignment de atributo é GIL-protegido
+    em CPython); leituras em ``write`` veem o valor mais recente ou um valor
+    consistente anterior. Aceita-se a janela em que uma thread orfã pode
+    escrever no ``_CappedBuffer`` por mais alguns writes após ``release()`` —
+    é exatamente o resultado que queremos (não vazar para o terminal).
+    """
+
+    __slots__ = ("_target", "_real")
+
+    def __init__(self, real_stream) -> None:
+        # ``_real`` é o stream original do processo (terminal/pipe). Mantido para
+        # restauração no modo PASSTHROUGH, isatty/encoding fallback e o painel
+        # construir seu próprio Console com ``file=real_stream``.
+        self._real = real_stream
+        self._target = real_stream
+
+    @property
+    def real(self):
+        """O stream original que envelopamos — usado pelo painel para
+        renderizar diretamente no terminal mesmo enquanto a captura está
+        ativa."""
+        return self._real
+
+    def set_target(self, target) -> None:
+        """Troca o destino atual atomicamente. ``target`` deve ter ``write``."""
+        self._target = target
+
+    def write(self, s) -> int:
+        try:
+            return self._target.write(s)
+        except (BrokenPipeError, ValueError):
+            # ``ValueError`` cobre StringIO já fechado em pytest teardown;
+            # ``BrokenPipeError`` quando o terminal real foi fechado.
+            return len(s) if isinstance(s, str) else 0
+
+    def flush(self) -> None:
+        try:
+            self._target.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+
+    def writelines(self, lines) -> None:
+        for line in lines:
+            self.write(line)
+
+    def isatty(self) -> bool:
+        try:
+            return self._real.isatty()
+        except Exception:
+            return False
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._real, "encoding", "utf-8") or "utf-8"
+
+    @property
+    def buffer(self):
+        # Algumas libs (Rich, prompt_toolkit) consultam ``sys.stdout.buffer``
+        # para escrever bytes crus. Expõe o buffer do stream real — esses
+        # writes BYPASSAM a captura intencionalmente (são para uso de coisas
+        # como o painel que JÁ queremos no terminal). Sub-DEILEs não usam
+        # ``buffer`` diretamente; ``print()`` e ``subprocess`` passam por
+        # ``write``, que é o caminho redirecionado.
+        return getattr(self._real, "buffer", None)
+
+    def fileno(self) -> int:
+        # Quando o destino é o real stream, retorna fd dele; quando é o
+        # _CappedBuffer, levanta UnsupportedOperation como qualquer StringIO.
+        # Subprocessos que herdam fds não passam por aqui — usam o fd 1
+        # diretamente, fora do nosso controle.
+        return self._real.fileno()
+
+
 # Singleton ``LoopBoundLock`` que serializa dispatches do orquestrador com
 # ``capture_output=True``. Vive aqui (módulo de captura) em vez de attribute
 # da classe ``SubAgentOrchestrator`` — a classe ainda expõe o atributo
@@ -143,6 +271,8 @@ def get_capture_lock() -> asyncio.Lock:
 
 __all__ = [
     "CappedBuffer",
+    "SwitchableStream",
+    "_DiscardSink",
     "get_capture_buffer_max_bytes",
     "get_capture_lock",
     "_capture_lock_holder",

--- a/deile/orchestration/subagents/orchestrator.py
+++ b/deile/orchestration/subagents/orchestrator.py
@@ -37,14 +37,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, List, Literal, Optional, TextIO
+from typing import Any, Callable, ClassVar, List, Literal, Optional, Set, TextIO
 
 from deile.config.settings import get_settings
 
-from ._capture import (CappedBuffer, _capture_lock_holder,
-                       get_capture_buffer_max_bytes, get_capture_lock)
+from ._capture import (CappedBuffer, SwitchableStream, _capture_lock_holder,
+                       _DiscardSink, get_capture_buffer_max_bytes,
+                       get_capture_lock)
 from ._loop_lock import LoopBoundLock
 from .events import SubAgentEvent, SubAgentState, SubAgentTask
 from .runner import SubAgentRunner
@@ -281,6 +283,7 @@ class SubAgentOrchestrator:
         # o painel continua aparecendo no terminal mesmo enquanto ``sys.stdout``
         # está redirecionado para suprimir os ``print()`` dos sub-DEILEs.
         real_stdout: TextIO = sys.stdout
+        real_stderr: TextIO = sys.stderr
 
         # Renderer é opcional: tests + chamadas headless passam None.
         renderer = None
@@ -302,13 +305,52 @@ class SubAgentOrchestrator:
         # diretamente, e isso polui o terminal do usuário em sub-DEILEs locais.
         # Redirecionamos sys.stdout/sys.stderr para buffers durante a execução.
         # O painel mantém referência ao stdout REAL, então continua renderizando.
+        #
+        # Issue #297-bookkeeping (orphan-thread leak): a versão anterior
+        # reatribuía ``sys.stdout = prev_stdout`` no ``finally``. Quando uma
+        # ``asyncio.to_thread(execute_sync)`` invocação ignorava cancel
+        # (caso típico: ``bash_tool`` no meio de ``subprocess.run`` longo,
+        # cancel pelo budget/ESC), a thread orfã continuava rodando e
+        # invocava ``print(data, end='')`` em sequência — escrevia direto no
+        # terminal real porque ``sys.stdout`` já tinha sido restaurado.
+        #
+        # A fix instala um :class:`SwitchableStream` UMA VEZ. Trocas de
+        # destino são feitas via ``set_target`` (atomic). Threads orfãs
+        # continuam escrevendo no wrapper; no encerramento, redirecionamos
+        # seus writes para :class:`_DiscardSink` (silencia sem error) em
+        # vez de para o terminal real.
         captured_out = _CappedBuffer() if self._capture_output else None
         captured_err = _CappedBuffer() if self._capture_output else None
         prev_stdout = sys.stdout
         prev_stderr = sys.stderr
+        switch_out: Optional[SwitchableStream] = None
+        switch_err: Optional[SwitchableStream] = None
         if self._capture_output:
-            sys.stdout = captured_out  # type: ignore[assignment]
-            sys.stderr = captured_err  # type: ignore[assignment]
+            # Idempotente: se já há um SwitchableStream instalado (dispatch
+            # aninhado seria proibido pelo lock, mas por defesa), reusa-o
+            # para evitar empilhamento de wrappers.
+            if isinstance(prev_stdout, SwitchableStream):
+                switch_out = prev_stdout
+            else:
+                switch_out = SwitchableStream(prev_stdout)
+                sys.stdout = switch_out  # type: ignore[assignment]
+            if isinstance(prev_stderr, SwitchableStream):
+                switch_err = prev_stderr
+            else:
+                switch_err = SwitchableStream(prev_stderr)
+                sys.stderr = switch_err  # type: ignore[assignment]
+            # Aponta para o buffer de captura — começa a capturar agora.
+            switch_out.set_target(captured_out)
+            switch_err.set_target(captured_err)
+
+        # Snapshot do conjunto de threads vivas pré-dispatch. Usado para
+        # detectar threads "orfãs" no encerramento: ``asyncio.to_thread``
+        # cancela o Task mas NÃO a thread do executor — bash_tool no meio
+        # de ``subprocess.run`` longo continua escrevendo em ``sys.stdout``
+        # após ``await asyncio.to_thread(...)`` ter sido cancelado.
+        # ``threading.enumerate()`` é thread-safe e barato (snapshot do
+        # internal _active dict).
+        pre_threads: Set[int] = {t.ident for t in threading.enumerate() if t.ident is not None}
 
         runner_tasks: List[asyncio.Task] = []
         renderer_task: Optional[asyncio.Task] = None
@@ -446,9 +488,68 @@ class SubAgentOrchestrator:
                         logger.error("runner task raised: %s", exc, exc_info=exc)
         finally:
             # Restore stdout/stderr ANTES de qualquer print pós-execução.
-            if self._capture_output:
-                sys.stdout = prev_stdout
-                sys.stderr = prev_stderr
+            #
+            # Issue #297-bookkeeping (orphan-thread leak): se algum runner ainda
+            # está vivo (orfã que ignorou cancel — caso típico:
+            # ``asyncio.to_thread(execute_sync)`` no meio de ``subprocess.run``
+            # longo), NÃO reatribuir ``sys.stdout = prev_stdout`` — a thread
+            # orfã, em seu próximo ``print(data, ...)``, escreveria direto no
+            # terminal real e visualmente vazaria por cima do painel/CLI.
+            #
+            # Em vez disso, deixamos o :class:`SwitchableStream` permanentemente
+            # instalado em ``sys.stdout``/``sys.stderr`` e:
+            #   * Apontamos ``target`` para :class:`_DiscardSink` — writes
+            #     orfãos são silenciosamente descartados (não vazam, não
+            #     enchem buffer).
+            #   * Quem chamar ``sys.stdout`` legitimamente após este ponto
+            #     (CLI principal, próximo turno) deveria reatribuir ``target``
+            #     ou substituir ``sys.stdout`` — o caller principal (cli.py)
+            #     também envelopa internamente, então o wrapper é transparente.
+            #
+            # Quando NÃO há orfãs, restauramos normalmente para não vazar o
+            # SwitchableStream para callers que não conhecem ele.
+            if self._capture_output and switch_out is not None and switch_err is not None:
+                # Detecção de orfãs em DUAS camadas:
+                #   (a) asyncio Tasks que ainda não retornaram (raro — só
+                #       quando ``asyncio.wait_for`` desistiu por timeout);
+                #   (b) THREADS do executor (asyncio.to_thread) que continuam
+                #       vivas após ``await`` ter sido cancelado — caso típico
+                #       de ``bash_tool`` no meio de ``subprocess.run`` longo
+                #       (a thread só termina quando ``execute_sync`` retorna).
+                # Comparamos enumerate() atual vs snapshot pre-dispatch.
+                task_orphans = sum(1 for t in runner_tasks if not t.done())
+                new_threads = [
+                    t for t in threading.enumerate()
+                    if t.ident is not None and t.ident not in pre_threads and t.is_alive()
+                ]
+                thread_orphans = len(new_threads)
+                if task_orphans > 0 or thread_orphans > 0:
+                    logger.warning(
+                        "SubAgentOrchestrator: %d task(s) + %d thread(s) ainda "
+                        "vivo(s) no encerramento; mantendo SwitchableStream + "
+                        "DISCARD para evitar leak no terminal.",
+                        task_orphans, thread_orphans,
+                    )
+                    # Aponta para o sink que descarta — orfãs imprimindo
+                    # ``print(data, ...)`` no ``sys.stdout`` corrente cairão
+                    # aqui, NÃO no terminal real.
+                    #
+                    # Nota: NÃO restauramos ``sys.stdout`` para ``prev_stdout``
+                    # — o SwitchableStream fica permanentemente lá. Como ele
+                    # é um proxy transparente, callers normais que escrevem
+                    # via ``print()`` continuam funcionando (write delega
+                    # ao ``target``). Quando o próximo dispatch acontece,
+                    # ele reusa este mesmo wrapper (ramo idempotente acima).
+                    switch_out.set_target(_DiscardSink())
+                    switch_err.set_target(_DiscardSink())
+                else:
+                    # Caminho normal: restaura sys.stdout/stderr para o stream
+                    # original. Idempotente — se o caller já instalou outro
+                    # wrapper entre o início e agora, respeita esse outro.
+                    if sys.stdout is switch_out:
+                        sys.stdout = prev_stdout
+                    if sys.stderr is switch_err:
+                        sys.stderr = prev_stderr
 
         # MA3 (iter-2 review): se o cancel veio do parent, re-raise APÓS o
         # cleanup completo (Pilar 03 §6 — CancelledError nunca capturada

--- a/deile/tests/cli/test_history_rollback.py
+++ b/deile/tests/cli/test_history_rollback.py
@@ -1,16 +1,19 @@
-"""Regression test for ESC-cancel rollback of conversation history.
+"""Regressão: ESC durante streaming MARCA o turno como cancelado, não apaga.
 
-Before this fix, pressing ESC during a streaming turn would cancel the
-asyncio task but leave the user message that ``DeileAgent.process_input_stream``
-had already appended to ``session.conversation_history``. The orphan user
-entry poisoned the next turn — providers (DeepSeek/OpenAI) collapse two
-consecutive ``user`` messages with ``/`` as a separator, so the next turn
-would echo the cancelled message in the assistant's reply (manifested as
-``"o que eu pedi / o que acabei de dizer?"``).
+Antes, ``_rollback_history`` apagava a entrada ``user`` do histórico — o
+LLM perdia a memória do que o usuário tinha pedido. Mas o texto ficava no
+scrollback do terminal, então o usuário olhava pra tela achando que o LLM
+"viu" e mandava follow-ups que dependiam daquilo. Resultado: amnésia
+silenciosa.
 
-This test exercises ``_DeileCLI._rollback_history`` directly with a fake
-session, since spinning up the full agent + a real ESC keypress is not
-feasible in pytest.
+Agora a entrada ``user`` fica preservada, eventuais entradas ``assistant``
+parciais (escritas antes do cancel) são removidas, e um placeholder
+``assistant`` com ``"(cancelado pelo usuário)"`` é inserido. Isso:
+
+* mantém o mental model do usuário (o LLM "lembra" da request cancelada);
+* explicita o cancelamento pro LLM via marker textual;
+* evita duas entradas ``user`` consecutivas (que DeepSeek/OpenAI colapsavam
+  com ``/`` como separador — bug histórico que motivou o rollback original).
 """
 
 from __future__ import annotations
@@ -26,7 +29,8 @@ def _make_cli(history: list) -> _DeileCLI:
     return cli
 
 
-def test_rollback_removes_orphan_user_entry() -> None:
+def test_cancel_preserves_user_entry_and_adds_placeholder() -> None:
+    """ESC após o user enviar a mensagem: entrada user fica + placeholder."""
     history = [
         {"role": "user", "content": "earlier turn", "timestamp": 0.0, "metadata": {}},
         {"role": "assistant", "content": "earlier reply", "timestamp": 0.1, "metadata": {}},
@@ -34,14 +38,17 @@ def test_rollback_removes_orphan_user_entry() -> None:
     ]
     cli = _make_cli(history)
     cli._rollback_history(baseline_len=2)
-    assert len(history) == 2
+
+    assert len(history) == 4
+    assert history[-2]["role"] == "user"
+    assert history[-2]["content"] == "cancelled message"
     assert history[-1]["role"] == "assistant"
-    assert history[-1]["content"] == "earlier reply"
+    assert "cancelado" in history[-1]["content"].lower()
+    assert history[-1]["metadata"].get("cancelled") is True
 
 
-def test_rollback_removes_orphan_user_plus_partial_assistant() -> None:
-    """Cancellation during the assistant generation must also clear any
-    partial assistant entry the agent wrote before the cancel point."""
+def test_cancel_during_partial_response_removes_partial_keeps_user() -> None:
+    """ESC com partial assistant: apaga só o partial, mantém user + placeholder."""
     history = [
         {"role": "user", "content": "earlier turn", "timestamp": 0.0, "metadata": {}},
         {"role": "assistant", "content": "earlier reply", "timestamp": 0.1, "metadata": {}},
@@ -50,13 +57,18 @@ def test_rollback_removes_orphan_user_plus_partial_assistant() -> None:
     ]
     cli = _make_cli(history)
     cli._rollback_history(baseline_len=2)
-    assert len(history) == 2
-    assert history[-1]["content"] == "earlier reply"
+
+    # 'half of a reply' partial foi removido; user permanece; placeholder adicionado
+    assert len(history) == 4
+    contents = [e["content"] for e in history]
+    assert "half of a reply" not in contents
+    assert "cancelled message" in contents
+    assert history[-1]["role"] == "assistant"
+    assert history[-1]["metadata"].get("cancelled") is True
 
 
-def test_rollback_noop_when_history_already_at_baseline() -> None:
-    """If the turn completed cleanly (no cancel), the baseline-length call
-    on the *unchanged* post-turn length should not delete anything."""
+def test_no_cancel_no_change() -> None:
+    """Se a baseline já cobre todo o histórico, nada muda."""
     history = [
         {"role": "user", "content": "u1", "timestamp": 0.0, "metadata": {}},
         {"role": "assistant", "content": "a1", "timestamp": 0.1, "metadata": {}},
@@ -64,21 +76,49 @@ def test_rollback_noop_when_history_already_at_baseline() -> None:
     cli = _make_cli(history)
     cli._rollback_history(baseline_len=2)
     assert len(history) == 2
+    # Nenhum placeholder porque não há entrada user em baseline_len=2.
 
 
-def test_rollback_handles_session_without_history_attribute() -> None:
-    """Must not crash if the session somehow lacks ``conversation_history``."""
+def test_handles_session_without_history_attribute() -> None:
+    """Não crasha se a sessão não tem ``conversation_history``."""
     cli = _DeileCLI()
-    cli.default_session = SimpleNamespace()  # no conversation_history
-    cli._rollback_history(baseline_len=0)  # should silently no-op
+    cli.default_session = SimpleNamespace()
+    cli._rollback_history(baseline_len=0)  # silent no-op
 
 
-def test_rollback_from_empty_baseline() -> None:
-    """First-ever turn cancelled: baseline_len=0, history had one entry
-    appended by the agent, rollback must clear everything."""
+def test_first_turn_cancel_keeps_user_and_adds_placeholder() -> None:
+    """Primeira mensagem cancelada: user fica + placeholder, total 2 entradas."""
     history = [
         {"role": "user", "content": "first ever", "timestamp": 0.0, "metadata": {}},
     ]
     cli = _make_cli(history)
     cli._rollback_history(baseline_len=0)
-    assert history == []
+
+    assert len(history) == 2
+    assert history[0]["role"] == "user"
+    assert history[0]["content"] == "first ever"
+    assert history[1]["role"] == "assistant"
+    assert history[1]["metadata"].get("cancelled") is True
+
+
+def test_cancel_then_new_turn_preserves_alternation() -> None:
+    """Próxima mensagem após cancel: alternância user→assistant→user mantida.
+
+    Esse é o invariante que protege contra o bug histórico onde providers
+    (DeepSeek/OpenAI) colapsavam 2 entradas user consecutivas usando ``/``
+    como separador. Com o placeholder, NUNCA há duas user consecutivas.
+    """
+    history = [
+        {"role": "user", "content": "cancelled", "timestamp": 0.0, "metadata": {}},
+    ]
+    cli = _make_cli(history)
+    cli._rollback_history(baseline_len=0)
+    # Simula a próxima mensagem user que o CLI adicionaria
+    history.append({"role": "user", "content": "next turn", "timestamp": 1.0, "metadata": {}})
+
+    # Sequência final: user → assistant(cancelado) → user
+    roles = [e["role"] for e in history]
+    assert roles == ["user", "assistant", "user"]
+    # E nenhum par consecutivo é user-user
+    for i in range(len(roles) - 1):
+        assert not (roles[i] == "user" and roles[i + 1] == "user")

--- a/deile/tests/commands/test_conversation_commands.py
+++ b/deile/tests/commands/test_conversation_commands.py
@@ -261,7 +261,9 @@ class TestRewindCommand:
         cmd = RewindCommand()
         result = await cmd.execute(ctx)
         assert result.success
-        # No session switch when history is empty
+        # Histórico vazio: fecha silenciosamente (paridade com cancel via ESC).
+        assert result.content == ""
+        assert result.metadata.get("suppress_response_display") is True
         assert SWITCH_SESSION_KEY not in ctx.session.context_data
 
     @pytest.mark.unit

--- a/deile/tests/orchestration/test_subagent_orchestrator.py
+++ b/deile/tests/orchestration/test_subagent_orchestrator.py
@@ -602,6 +602,117 @@ async def test_cancellation_reason_user_esc():
     assert "ESC" in md or "esc" in md.lower()
 
 
+async def test_orphan_thread_after_cancel_does_not_leak_to_real_stdout():
+    """Issue #297-bookkeeping (orphan-thread leak): quando o budget estoura,
+    o ``asyncio.Task`` que aguarda ``asyncio.to_thread(execute_sync)`` recebe
+    cancel — mas a thread do executor continua viva (não há API asyncio para
+    cancelá-la). Em produção, ``bash_tool`` no meio de ``subprocess.run``
+    longo pode ainda imprimir ``print(data, ...)`` *DEPOIS* que o orquestrador
+    restaurou ``sys.stdout`` — vazando direto no terminal por cima do painel.
+
+    Esta fix detecta threads novas vivas no encerramento e mantém o
+    :class:`SwitchableStream` instalado apontando para :class:`_DiscardSink`
+    — orfãs continuam imprimindo no wrapper, mas o byte é silenciosamente
+    descartado em vez de chegar ao terminal real.
+    """
+    import io
+    import sys as _sys
+    import threading
+    import time as _time
+
+    class _ToThreadRunner:
+        async def run_one(self, state, *, on_event):
+            state.status = "running"
+            state.started_at = 0.0
+            def _blocking_with_prints():
+                # Simula execute_sync de bash_tool — print() em sequência.
+                # ``time.sleep`` aqui é intencional (não respondem a cancel
+                # do asyncio Task, replicando o caso real).
+                for i in range(6):
+                    _time.sleep(0.15)
+                    print(f"ORPHAN_LEAK_{i}", flush=True)
+            try:
+                await asyncio.to_thread(_blocking_with_prints)
+            except asyncio.CancelledError:
+                pass
+            state.status = "ok"
+            state.finished_at = 0.05
+
+    # Instala um StringIO no lugar do terminal — qualquer write que escapar
+    # do redirect do orquestrador acaba aqui (proxy do "terminal real").
+    real_stdout_proxy = io.StringIO()
+    saved = _sys.stdout
+    _sys.stdout = real_stdout_proxy
+
+    # Budget pequeno → força timeout no orquestrador → cancel das runner tasks
+    # → thread orfã continua viva imprimindo.
+    import deile.orchestration.subagents.orchestrator as oc_mod
+    orig_get_budget = oc_mod._get_budget_s
+    oc_mod._get_budget_s = lambda: 0.3
+    try:
+        orch = SubAgentOrchestrator(_ToThreadRunner(), max_parallel=1, capture_output=True)
+        await orch.run(_mk_tasks(1))
+        # Aguarda thread orfã terminar de imprimir todos os 6 prints.
+        _time.sleep(1.5)
+    finally:
+        oc_mod._get_budget_s = orig_get_budget
+        _sys.stdout = saved
+
+    # CONTRATO: ``ORPHAN_LEAK_<N>`` NUNCA pode aparecer no terminal real.
+    leaked = real_stdout_proxy.getvalue()
+    assert "ORPHAN_LEAK" not in leaked, (
+        f"Orphan thread leaked to real terminal: {leaked!r}"
+    )
+
+
+async def test_capture_output_keeps_switchable_when_orphan_detected():
+    """Quando o orquestrador detecta orfãs no encerramento, NÃO reatribui
+    ``sys.stdout = prev_stdout`` — em vez disso mantém o
+    :class:`SwitchableStream` instalado com target=``_DiscardSink``. Garante
+    que escritas futuras de orfãs (que ainda têm a referência ao
+    ``SwitchableStream`` capturada pelo lookup dinâmico de ``print``) cheguem
+    ao sink, não ao terminal.
+    """
+    import io
+    import sys as _sys
+    import time as _time
+    from deile.orchestration.subagents._capture import SwitchableStream
+
+    class _ToThreadOrphanRunner:
+        async def run_one(self, state, *, on_event):
+            state.status = "running"
+            state.started_at = 0.0
+            def _orphan():
+                _time.sleep(0.5)  # ainda vivo no encerramento
+            try:
+                await asyncio.to_thread(_orphan)
+            except asyncio.CancelledError:
+                pass
+            state.status = "ok"
+            state.finished_at = 0.05
+
+    saved = _sys.stdout
+    _sys.stdout = io.StringIO()
+    import deile.orchestration.subagents.orchestrator as oc_mod
+    orig_get_budget = oc_mod._get_budget_s
+    oc_mod._get_budget_s = lambda: 0.1
+    try:
+        orch = SubAgentOrchestrator(
+            _ToThreadOrphanRunner(), max_parallel=1, capture_output=True,
+        )
+        await orch.run(_mk_tasks(1))
+        # No encerramento, ``sys.stdout`` permanece o SwitchableStream porque
+        # orfãs foram detectadas.
+        assert isinstance(_sys.stdout, SwitchableStream), (
+            f"esperava SwitchableStream em sys.stdout, vi {type(_sys.stdout).__name__}"
+        )
+        # Aguarda orfã terminar antes de finalizar o teste.
+        _time.sleep(1.0)
+    finally:
+        oc_mod._get_budget_s = orig_get_budget
+        _sys.stdout = saved
+
+
 async def test_cancellation_reason_field_in_dataclass_signature():
     """NT5: o campo ``cancellation_reason`` aceita os literais válidos e
     default None — garante que SubAgentResult não regrediu a assinatura.

--- a/deile/tests/ui/test_streaming_renderer.py
+++ b/deile/tests/ui/test_streaming_renderer.py
@@ -1241,3 +1241,252 @@ async def test_budget_exceeded_error_includes_action_hint():
     output = console.file.getvalue()
     assert "Session x would exceed limit" in output
     assert "/model budget" in output
+
+
+# ----------------------------------------------------------------------
+# Bug A — Spinner flicker reduction (issue: dispatch_parallel_subagents)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spinner_skips_refresh_when_parent_live_is_suspended():
+    """Bug A: durante a execução de ``dispatch_parallel_subagents``,
+    o ``SubAgentPanelRenderer`` chama ``prev_live.stop()`` no Live do
+    streaming_renderer pai (Rich só permite um Live ativo por console).
+    Mas o ``_thinking_spinner`` continuava chamando ``live_obj.update()``
+    + ``refresh()`` a cada 100ms — gerando flicker quando o Live era
+    restaurado.
+
+    Garantia: o spinner consulta ``live_obj.is_started`` antes de
+    chamar update/refresh. Quando o Live está parado, o tick é
+    no-op.
+    """
+    from rich.live import Live
+    from rich.text import Text
+
+    # Mock minimal Live-like object — só precisa de ``is_started``,
+    # ``update`` e ``refresh``. Conta quantas vezes refresh é chamado.
+    class _MockLive:
+        def __init__(self):
+            self.is_started = False
+            self.refresh_calls = 0
+            self.update_calls = 0
+
+        def update(self, renderable):
+            self.update_calls += 1
+
+        def refresh(self):
+            self.refresh_calls += 1
+
+    # Para o teste, construo o estado do spinner manualmente e
+    # disparo um tick — assim isolamos a lógica do guard de
+    # ``is_started`` sem precisar de TTY real.
+    import inspect
+
+    from deile.ui import streaming_renderer as sr_module
+
+    src = inspect.getsource(sr_module.StreamingRenderer._render_live)
+    # Verificação estrutural: a guarda ``is_started`` está presente,
+    # e o sleep aumentou de 0.1 para 0.25 (60% menos refresh).
+    assert "is_started" in src, (
+        "o spinner deve checar live.is_started antes de refresh — "
+        "sem isso, refreshes em Live suspenso causam flicker quando o "
+        "Live pai é restaurado por subagent_panel"
+    )
+    assert "asyncio.sleep(0.25)" in src, (
+        "sleep do _thinking_spinner deve ser 0.25s (4Hz) para reduzir "
+        "carga de refresh em 60% vs 0.1s (10Hz). Não use valores "
+        "diferentes sem justificativa explícita."
+    )
+
+
+@pytest.mark.asyncio
+async def test_spinner_refresh_rate_is_reasonable_for_animation():
+    """Cobre a parte (a) do fix do Bug A: refresh a 4Hz ainda é
+    animação visível (spinner com 6+ frames muda de quadro a cada
+    ~250ms — suficiente pra parecer 'vivo' sem saturar stdout).
+    Esta é uma validação documental — se alguém futuramente trocar
+    o sleep, este teste avisa.
+    """
+    import inspect
+
+    from deile.ui import streaming_renderer as sr_module
+
+    src = inspect.getsource(sr_module.StreamingRenderer._render_live)
+    # Não deve regredir para 100ms (10Hz era o original muito-flicker).
+    assert "asyncio.sleep(0.1)" not in src, (
+        "spinner regredido para 10Hz — voltaria a piscar excessivamente "
+        "durante dispatch_parallel_subagents (Bug A)."
+    )
+
+
+# ----------------------------------------------------------------------
+# Bug B — Silent stream stall (MarkupError swallowing repaints)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_does_not_stall_on_tool_name_with_brackets():
+    """Bug B: tool name contendo ``[`` literal não pode derrubar a
+    Live region. ``Text.from_markup`` levanta ``MarkupError`` em
+    ``[`` não-fechado, e antes do fix isso parava o repaint até
+    o final do turno (estilo "trava silenciosamente").
+
+    Garantia: o stream completa, todos os eventos posteriores chegam
+    na saída, e o nome com colchete aparece escapado/preservado.
+    """
+    console = _capture_console()
+    renderer = StreamingRenderer(
+        console=console, legacy_windows=False, markdown=False, refresh_per_second=60.0
+    )
+    events = [
+        UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, text="antes"),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_USE_START,
+            tool_call_id="t1",
+            tool_name="weird[tool",  # nome com colchete literal
+        ),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_USE_END,
+            tool_call_id="t1",
+            tool_name="weird[tool",
+            arguments={"x": "v"},
+        ),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_RESULT,
+            tool_call_id="t1",
+            tool_name="weird[tool",
+            tool_status="success",
+            tool_result_summary="ok",
+        ),
+        UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, text="depois"),
+        UnifiedStreamEvent(
+            type=StreamEventType.USAGE_FINAL,
+            usage=ModelUsageSnapshot(input_tokens=1, output_tokens=1),
+        ),
+    ]
+    result = await renderer.render(_replay(events))
+    output = console.file.getvalue()
+    # Stream completou — texto pré E pós-tool presentes (o sintoma do
+    # bug era que tudo após o ponto de quebra ficava preso).
+    assert "antes" in output
+    assert "depois" in output
+    # Tool foi contabilizada — o pipeline interno não quebrou.
+    assert result.tool_invocations == 1
+    # Texto final consistente
+    assert result.full_text == "antesdepois"
+
+
+@pytest.mark.asyncio
+async def test_stream_does_not_stall_on_tool_args_with_brackets():
+    """Bug B: args de tool com ``[`` literal não derrubam o repaint.
+    Antes do fix, args como ``{'pattern': '[a-z]+'}`` (regex comum)
+    quebravam o cabeçalho com MarkupError.
+    """
+    console = _capture_console()
+    renderer = StreamingRenderer(
+        console=console, legacy_windows=False, markdown=False, refresh_per_second=60.0
+    )
+    events = [
+        UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, text="começo"),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_USE_START,
+            tool_call_id="t1", tool_name="grep_search",
+        ),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_USE_END,
+            tool_call_id="t1", tool_name="grep_search",
+            arguments={"pattern": "[a-z]+", "path": "[abc]"},
+        ),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_RESULT,
+            tool_call_id="t1", tool_name="grep_search",
+            tool_status="success", tool_result_summary="2 hits",
+        ),
+        UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, text="fim"),
+        UnifiedStreamEvent(
+            type=StreamEventType.USAGE_FINAL,
+            usage=ModelUsageSnapshot(input_tokens=1, output_tokens=1),
+        ),
+    ]
+    result = await renderer.render(_replay(events))
+    output = console.file.getvalue()
+    # Repaint não parou — todo o stream pós-tool chegou.
+    assert "começo" in output
+    assert "fim" in output
+    assert "2 hits" in output
+    assert result.tool_invocations == 1
+
+
+@pytest.mark.asyncio
+async def test_render_loop_logs_and_continues_on_apply_event_error(monkeypatch):
+    """Bug B: se ``_apply_event`` levantar (deveria ser inalcançável
+    com input bem-formado, mas providers às vezes mandam payload
+    inesperado), o stream NÃO pode parar de repintar — loga e segue.
+
+    Simulamos forçando ``_apply_event`` a falhar em UM evento; o
+    stream deve continuar consumindo os demais.
+    """
+    console = _capture_console()
+    renderer = StreamingRenderer(
+        console=console, legacy_windows=False, markdown=False, refresh_per_second=60.0
+    )
+
+    original = renderer._apply_event
+    call_count = {"n": 0}
+
+    def faulty_apply(event, blocks, result):
+        call_count["n"] += 1
+        # 2º evento explode — simula falha mid-stream.
+        if call_count["n"] == 2:
+            raise RuntimeError("provider sent malformed delta")
+        return original(event, blocks, result)
+
+    monkeypatch.setattr(renderer, "_apply_event", faulty_apply)
+
+    events = [
+        UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, text="primeiro "),
+        UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, text="ATAQUE"),  # quebra aqui
+        UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, text="terceiro"),
+        UnifiedStreamEvent(
+            type=StreamEventType.USAGE_FINAL,
+            usage=ModelUsageSnapshot(input_tokens=1, output_tokens=1),
+        ),
+    ]
+    # Não levanta (antes do fix, a exception escaparia o async-for).
+    result = await renderer.render(_replay(events))
+    output = console.file.getvalue()
+    # Os eventos válidos foram processados — "primeiro " e "terceiro"
+    # aparecem; o que falhou ("ATAQUE") foi pulado mas o stream seguiu.
+    assert "primeiro " in output
+    assert "terceiro" in output
+    # full_text reflete o que entrou nos blocks — "ATAQUE" foi
+    # pulado, então não está lá.
+    assert "ATAQUE" not in result.full_text
+
+
+@pytest.mark.asyncio
+async def test_error_event_with_brackets_in_message_does_not_break():
+    """Bug B: error_envelope.message contendo ``[`` literal não pode
+    quebrar ``Text.from_markup`` (chamado em _compose para source=error).
+    Ex.: provider error message com regex pattern ou tag XML.
+    """
+    console = _capture_console()
+    renderer = StreamingRenderer(console=console, legacy_windows=False, markdown=False)
+    events = [
+        UnifiedStreamEvent(
+            type=StreamEventType.ERROR,
+            error_envelope={
+                "message": "validation failed: regex [a-z]+ rejected",
+                "error_type": "ValidationError",
+            },
+        ),
+    ]
+    # Antes do fix, isso levantaria MarkupError dentro de Live.update
+    # e deixaria o turno congelado.
+    result = await renderer.render(_replay(events))
+    output = console.file.getvalue()
+    # Mensagem visível — pode ter escape de colchete mas o conteúdo
+    # essencial aparece.
+    assert result.error_message and "regex" in result.error_message
+    assert "regex" in output

--- a/deile/tests/ui/test_subagent_panel.py
+++ b/deile/tests/ui/test_subagent_panel.py
@@ -147,6 +147,194 @@ def test_truncate_helper_inside_renderer_limits_long_titles():
     assert _truncate("short", 50) == "short"
 
 
+# -------------------------------------------------------------------- #
+# Round 6 — parse_key_buffer (issue: setas em rajada → ESC falso)        #
+# -------------------------------------------------------------------- #
+
+
+def test_parse_key_buffer_single_arrow_right():
+    """1 seta direita inteira no buffer → 1 sequência CSI."""
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs, rem = parse_key_buffer("\x1b[C")
+    assert seqs == ["\x1b[C"]
+    assert rem == ""
+
+
+def test_parse_key_buffer_burst_of_arrows_yields_each_seq_no_esc():
+    """Rajada de 5 setas direitas num único buffer → 5 sequências,
+    NENHUMA delas é ESC isolado. Esse é o cenário do bug raiz: o usuário
+    aperta setas em rajada e o kernel entrega tudo de uma vez; o parser
+    legacy quebrava entre os bytes e disparava ESC falso.
+    """
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    burst = "\x1b[C" * 5
+    seqs, rem = parse_key_buffer(burst)
+    assert seqs == ["\x1b[C"] * 5
+    assert rem == ""
+    assert "\x1b" not in seqs  # ESC isolado nunca aparece
+
+
+def test_parse_key_buffer_mixed_burst_no_false_esc():
+    """Rajada mista de setas L/R/digit no buffer → cada um separado,
+    sem ESC falso.
+    """
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    burst = "\x1b[C\x1b[D2\x1b[Ch"
+    seqs, rem = parse_key_buffer(burst)
+    assert seqs == ["\x1b[C", "\x1b[D", "2", "\x1b[C", "h"]
+    assert rem == ""
+
+
+def test_parse_key_buffer_lone_esc_goes_to_remainder():
+    """ESC sozinho NÃO sai como sequência — vai pro remainder para o
+    caller decidir via timeout. Esse é o coração da fix: ESC genuíno
+    só dispara quando o caller confirma que nada mais veio em 200ms.
+    """
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs, rem = parse_key_buffer("\x1b")
+    assert seqs == []
+    assert rem == "\x1b"
+
+
+def test_parse_key_buffer_partial_csi_goes_to_remainder():
+    """CSI incompleta (``\\x1b[`` sem terminador) vai pro remainder."""
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs, rem = parse_key_buffer("\x1b[")
+    assert seqs == []
+    assert rem == "\x1b["
+
+    # E o resto fecha numa rodada seguinte:
+    seqs2, rem2 = parse_key_buffer(rem + "C")
+    assert seqs2 == ["\x1b[C"]
+    assert rem2 == ""
+
+
+def test_parse_key_buffer_ss3_introducer():
+    """SS3 (``\\x1bOC`` etc.) é sempre 3 bytes."""
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs, rem = parse_key_buffer("\x1bOC\x1bOD")
+    assert seqs == ["\x1bOC", "\x1bOD"]
+    assert rem == ""
+
+
+def test_parse_key_buffer_ss3_partial_goes_to_remainder():
+    """SS3 com só introducer espera no remainder."""
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs, rem = parse_key_buffer("\x1bO")
+    assert seqs == []
+    assert rem == "\x1bO"
+
+
+def test_parse_key_buffer_esc_followed_by_garbage_does_not_emit_esc():
+    """``\\x1b`` seguido de algo que não é introducer CSI/SS3 NÃO emite
+    ESC genuíno — descarta o ``\\x1b`` e processa o byte como char normal.
+    Esse foi um dos caminhos do bug legacy: o read(1) podia retornar ``""``
+    ou um byte inesperado e o código original disparava ``_on_key("\\x1b")``.
+    """
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs, rem = parse_key_buffer("\x1bXh")
+    # ``\x1b`` descartado, ``X`` e ``h`` processados.
+    assert "\x1b" not in seqs
+    assert "X" in seqs
+    assert "h" in seqs
+    assert rem == ""
+
+
+def test_parse_key_buffer_csi_with_modifiers_is_treated_as_single_seq():
+    """CSI com modificadores (ex.: Shift+Right ``\\x1b[1;2C``) é uma seq."""
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs, rem = parse_key_buffer("\x1b[1;2C")
+    assert seqs == ["\x1b[1;2C"]
+    assert rem == ""
+
+
+def test_parse_key_buffer_csi_split_across_buffers_does_not_leak_esc():
+    """Mesmo se a CSI vier em pedaços (kernel entrega ``\\x1b[`` numa
+    syscall e ``C`` na próxima), o ``\\x1b`` fica no remainder e nunca
+    é emitido como cancel. Cobre o cenário em que o usuário aperta as
+    setas com pausa natural entre teclas.
+    """
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    seqs1, rem1 = parse_key_buffer("\x1b[")
+    assert seqs1 == []
+    assert rem1 == "\x1b["
+
+    seqs2, rem2 = parse_key_buffer(rem1 + "C")
+    assert seqs2 == ["\x1b[C"]
+    assert rem2 == ""
+
+    # Em nenhum dos chunks o ESC isolado aparece.
+    assert all("\x1b" != s for s in seqs1 + seqs2)
+
+
+def test_parse_key_buffer_no_false_esc_under_30_arrow_burst():
+    """30 setas em rajada extrema (pior caso humano plausível) — nenhuma
+    delas vira ESC falso e o foco anda como esperado.
+    """
+    from deile.ui.subagent_panel import parse_key_buffer
+
+    burst = ("\x1b[C\x1b[D" * 15)  # 30 setas alternando
+    seqs, rem = parse_key_buffer(burst)
+    assert len(seqs) == 30
+    assert all(s in ("\x1b[C", "\x1b[D") for s in seqs)
+    assert rem == ""
+
+
+# -------------------------------------------------------------------- #
+# _on_key + parse_key_buffer integração — foco vs. cancel               #
+# -------------------------------------------------------------------- #
+
+
+def test_arrow_burst_does_not_set_cancel_or_change_focus_past_end():
+    """Cenário do bug do usuário: foco na última frente, aperta seta
+    direita várias vezes → painel NÃO deve fechar (cancel_requested
+    permanece False).
+
+    Como ``_on_key`` é definido dentro de ``_start_keyboard_watcher``
+    (closure), instanciamos um renderer e simulamos o despacho das
+    sequências chamando o método público ``_compose_compact`` antes/depois
+    e validando ``_focus``/``_cancel_requested`` diretamente.
+    """
+    states = [_mk_state(i, f"task {i}", status="running") for i in (1, 2, 3)]
+    renderer, _, _ = _make_renderer(states)
+    renderer._focus = 3  # já no último
+
+    # Simula o que o watcher faria depois de parsear a rajada:
+    # despacha 10 setas direitas em sequência.
+    from deile.ui.subagent_panel import parse_key_buffer
+    seqs, _ = parse_key_buffer("\x1b[C" * 10)
+    assert len(seqs) == 10
+
+    # Aplicação manual da lógica de _on_key (sem precisar do thread):
+    n_states = len(states)
+    for seq in seqs:
+        if seq == "\x1b":
+            if renderer._focus is not None:
+                renderer._focus = None
+            else:
+                renderer._cancel_requested = True
+        elif seq in ("\x1b[C", "\x1bOC"):
+            if renderer._focus and renderer._focus < n_states:
+                renderer._focus += 1
+        elif seq in ("\x1b[D", "\x1bOD"):
+            if renderer._focus and renderer._focus > 1:
+                renderer._focus -= 1
+
+    # Ainda no último, ainda aberto.
+    assert renderer._focus == 3
+    assert renderer._cancel_requested is False
+
+
 async def test_run_completes_when_all_states_terminal(tmp_path):
     """Smoke test: ``run()`` encerra cedo quando todos os states já estão
     em terminal (ok/error/cancelled). Sem TTY → keyboard watcher é skipado.

--- a/deile/ui/streaming_renderer.py
+++ b/deile/ui/streaming_renderer.py
@@ -307,16 +307,30 @@ class StreamingRenderer:
         spinner_frame_idx = [0]
 
         async def _thinking_spinner(live_obj: Live) -> None:
+            # Anti-flicker (Bug A): durante a execução de tools que abrem o
+            # próprio Rich Live (ex.: ``dispatch_parallel_subagents`` via
+            # :class:`SubAgentPanelRenderer`), o Live pai é suspenso
+            # (``prev_live.stop()``); tentar ``refresh()`` num Live parado
+            # é no-op interno do Rich, mas qualquer ciclo extra colide com
+            # o repaint do painel filho quando o pai é restaurado. Guarda
+            # via ``is_started`` (API pública do Rich) para pular o tick
+            # nesse caso. Também subimos o sleep de 100ms → 250ms (4 Hz):
+            # o spinner ainda parece animado mas reduz refresh em 60%.
             try:
                 while not turn_done[0]:
-                    if blocks and isinstance(blocks[-1], _StageBlock):
+                    # ``is_started`` é False quando o Live foi parado por um
+                    # consumidor que precisava de exclusividade no console
+                    # (ex.: subagent_panel). Skip o tick para evitar flicker
+                    # ao retomar.
+                    started = getattr(live_obj, "is_started", True)
+                    if started and blocks and isinstance(blocks[-1], _StageBlock):
                         spinner_frame_idx[0] = (spinner_frame_idx[0] + 1) % len(_SPINNER_FRAMES)
                         live_obj.update(self._compose(
                             blocks[committed_count:],
                             spinner_frame=_SPINNER_FRAMES[spinner_frame_idx[0]],
                         ))
                         live_obj.refresh()
-                    await asyncio.sleep(0.1)
+                    await asyncio.sleep(0.25)
             except asyncio.CancelledError:
                 return
 
@@ -341,7 +355,33 @@ class StreamingRenderer:
             spinner_task = asyncio.create_task(_thinking_spinner(live))
             try:
                 async for event in event_stream:
-                    self._apply_event(event, blocks, result)
+                    # Bug B mitigation: o loop de render NUNCA pode quebrar
+                    # silenciosamente. Se ``_apply_event``, ``_compose`` ou um
+                    # ``Text.from_markup`` no caminho levantar (ex.: ``MarkupError``
+                    # por ``[`` literal em args de tool, summary de tool com
+                    # markup malformado, ou Markdown com sintaxe quebrada), o
+                    # ``async for`` continua consumindo eventos mas a Live
+                    # region NÃO REPINTA — usuário vê o stream "travar
+                    # silenciosamente" até o turn terminar (quando o `finally`
+                    # ou um caller acima força um repaint final).
+                    #
+                    # A defesa aqui: cada *etapa* do laço é isolada num
+                    # try/except que LOGA com contexto e segue. Histórico
+                    # ainda é registrado normalmente (esse caminho é do
+                    # core/agent.py, não daqui). O usuário pode perder um
+                    # frame intermediário, mas o turno completa e a Live
+                    # mostra todo o conteúdo no próximo evento bem-formado.
+                    try:
+                        self._apply_event(event, blocks, result)
+                    except Exception as exc:
+                        logger.warning(
+                            "streaming_renderer: _apply_event falhou em %s — pulando frame",
+                            getattr(event, "type", "?"),
+                            exc_info=True,
+                        )
+                        # Não retornamos — drenar o stream é essencial; o
+                        # próximo evento pode reconciliar o estado.
+                        continue
                     if event.type is StreamEventType.USAGE_FINAL and event.usage:
                         u = event.usage
                         usage_footer = (
@@ -354,23 +394,42 @@ class StreamingRenderer:
 
                     # Determine the first "active" block (the one currently
                     # being modified). Everything before it can be committed.
-                    active_idx = self._first_active_block_idx(blocks, committed_count)
-                    if active_idx > committed_count:
-                        # First, shrink the Live region so the to-be-committed
-                        # blocks aren't rendered both in Live AND in scrollback
-                        # for a single frame.
-                        live.update(self._compose(blocks[active_idx:]))
-                        live.refresh()
-                        # Now flush the completed blocks to scrollback.
-                        # Each committed block is followed by a blank line so
-                        # tool blocks and text blocks never appear glued
-                        # together (matches the spacer rule in _compose).
-                        for i in range(committed_count, active_idx):
-                            renderable = self._render_single_block(blocks[i])
-                            if renderable is not None:
-                                self._console.print(renderable)
-                                self._console.print()
-                        committed_count = active_idx
+                    try:
+                        active_idx = self._first_active_block_idx(blocks, committed_count)
+                        if active_idx > committed_count:
+                            # First, shrink the Live region so the to-be-committed
+                            # blocks aren't rendered both in Live AND in scrollback
+                            # for a single frame.
+                            live.update(self._compose(blocks[active_idx:]))
+                            live.refresh()
+                            # Now flush the completed blocks to scrollback.
+                            # Each committed block is followed by a blank line so
+                            # tool blocks and text blocks never appear glued
+                            # together (matches the spacer rule in _compose).
+                            for i in range(committed_count, active_idx):
+                                try:
+                                    renderable = self._render_single_block(blocks[i])
+                                except Exception:
+                                    logger.warning(
+                                        "streaming_renderer: render do bloco %d falhou",
+                                        i, exc_info=True,
+                                    )
+                                    renderable = None
+                                if renderable is not None:
+                                    try:
+                                        self._console.print(renderable)
+                                        self._console.print()
+                                    except Exception:
+                                        logger.warning(
+                                            "streaming_renderer: console.print falhou no bloco %d",
+                                            i, exc_info=True,
+                                        )
+                            committed_count = active_idx
+                    except Exception:
+                        logger.warning(
+                            "streaming_renderer: commit-to-scrollback falhou — segue",
+                            exc_info=True,
+                        )
 
                     # AGORA (após texto/blocos precedentes irem para scrollback)
                     # comprometemos cabeçalho/summary de tools direct-print. Isso
@@ -379,14 +438,29 @@ class StreamingRenderer:
                     # Sem este reordenamento, o cabeçalho da bash sairia ANTES
                     # do texto precedente do modelo (todo o texto ficava preso
                     # na Live region até o final do turno).
-                    self._commit_direct_print_tools(blocks)
+                    try:
+                        self._commit_direct_print_tools(blocks)
+                    except Exception:
+                        logger.warning(
+                            "streaming_renderer: commit direct-print falhou — segue",
+                            exc_info=True,
+                        )
 
                     # Refresh on every event. With auto_refresh=False this is
                     # the ONLY way pixels reach the terminal — and there's no
                     # background thread to race against, so unconditional
                     # refresh is safe and gives the most responsive feel.
-                    live.update(self._compose(blocks[committed_count:]))
-                    live.refresh()
+                    try:
+                        live.update(self._compose(blocks[committed_count:]))
+                        live.refresh()
+                    except Exception:
+                        # Live.update/refresh ou _compose pode levantar
+                        # (MarkupError, ConsoleError, etc.). Loga e segue —
+                        # o próximo evento tem outra chance de repintar.
+                        logger.warning(
+                            "streaming_renderer: live.update/refresh falhou — frame perdido",
+                            exc_info=True,
+                        )
                 # Final flush — pass force_complete=True so any trailing
                 # in-progress table (no closing blank line) commits as a
                 # real Markdown table in the scrollback, instead of the
@@ -824,7 +898,11 @@ class StreamingRenderer:
             display_msg = result.error_message
             if isinstance(event.error_envelope, dict) and event.error_envelope.get("budget_exceeded"):
                 display_msg += "\nUse /model budget to view limits, or wait for the next window."
-            blocks.append(_TextBlock(text=f"[red]✗[/red] {display_msg}", source="error"))
+            # Escapa colchetes do display_msg — caso a mensagem do provider
+            # contenha ``[`` literal, ``Text.from_markup`` (usado em _compose
+            # via source="error") levantaria MarkupError. Bug B defense.
+            safe_msg = self._safe_markup(display_msg)
+            blocks.append(_TextBlock(text=f"[red]✗[/red] {safe_msg}", source="error"))
 
     @staticmethod
     def _find_tool_block(blocks: List[Any], tool_call_id: Optional[str]) -> Optional[_ToolBlock]:
@@ -919,17 +997,42 @@ class StreamingRenderer:
         return Group(*rendered) if rendered else Text("")
 
     def _tool_renderable(self, block: _ToolBlock):
-        return Text.from_markup(self._tool_head_markup(block) + self._tool_summary_markup(block))
+        # Bug B defense: ``from_markup`` levanta ``MarkupError`` se o
+        # display_name ou args injetados contiverem ``[`` literal (vindo
+        # de nome de tool com colchete, ou args com markup acidental). O
+        # fallback degrada para texto plano em vez de derrubar o frame.
+        try:
+            return Text.from_markup(self._tool_head_markup(block) + self._tool_summary_markup(block))
+        except Exception:
+            return Text(self._tool_head_plain(block) + self._tool_summary_plain(block))
 
     def _tool_head_markup(self, block: _ToolBlock) -> str:
         """Cabeçalho `● Name(args)` com cor conforme status."""
-        display_name = _TOOL_DISPLAY_NAME.get(block.tool_name, block.tool_name)
-        args_inline = self._render_args_inline(block.tool_name, block.args)
+        display_name = self._safe_markup(
+            _TOOL_DISPLAY_NAME.get(block.tool_name, block.tool_name)
+        )
+        args_inline = self._safe_markup(
+            self._render_args_inline(block.tool_name, block.args)
+        )
         if block.status == "running":
             return f"[yellow]●[/yellow] [bold]{display_name}[/bold]({args_inline}) [dim]running…[/dim]"
         if block.status == "success":
             return f"[green]●[/green] [bold]{display_name}[/bold]({args_inline})"
         return f"[red]●[/red] [bold]{display_name}[/bold]({args_inline})"
+
+    def _tool_head_plain(self, block: _ToolBlock) -> str:
+        """Versão plain-text do cabeçalho — fallback se ``from_markup`` falhar."""
+        display_name = _TOOL_DISPLAY_NAME.get(block.tool_name, block.tool_name)
+        args_inline = self._render_args_inline(block.tool_name, block.args)
+        marker = {"running": "●", "success": "●", "error": "●"}.get(block.status, "●")
+        suffix = " running…" if block.status == "running" else ""
+        return f"{marker} {display_name}({args_inline}){suffix}"
+
+    def _tool_summary_plain(self, block: _ToolBlock) -> str:
+        """Versão plain-text do summary — fallback se ``from_markup`` falhar."""
+        if not block.summary:
+            return ""
+        return f"\n  ⎿ {block.summary}"
 
     def _tool_summary_markup(self, block: _ToolBlock) -> str:
         """Linha `  ⎿ summary` quando há resumo; vazio caso contrário."""

--- a/deile/ui/subagent_panel.py
+++ b/deile/ui/subagent_panel.py
@@ -15,16 +15,34 @@ Round 2 (post-feedback):
     timeout de 200ms (não 50ms — era apertado demais e levava ``ESC`` a
     disparar quando o usuário pressionava arrows em rajada — issue #257
     feedback ponto 4).
+
+Round 6 (rajada de setas → ESC falso):
+  * Parser byte-a-byte do round 2 tinha 3 falhas reais em rajadas:
+    (1) ``read(1)`` pode retornar ``""`` em meio à drain (interrompido por
+        sinal), e o branch ``intro not in ("[", "O")`` então disparava
+        ``_on_key("\\x1b")`` — fechando o painel;
+    (2) drain de 50ms com select por byte de 5ms era frágil para teclados
+        que entregam bytes em rajada num único batch (kernel buffer);
+    (3) entre iterações do loop, se a segunda seta chegasse atrasada (≥200ms
+        — pause natural em rajada manual), o ``\\x1b`` solo expirava o
+        timeout e ainda disparava cancel.
+  * Solução: ler em rajada com ``os.read(fd, N)`` (atômico, pega tudo que
+    o kernel já tem) e parsear o buffer com state-machine puro
+    (:func:`parse_key_buffer`), testável sem TTY. Bytes pendentes no buffer
+    ficam para a próxima iteração — sem timeout artificial pra sequências
+    completas. ESC genuíno só dispara quando o ``\\x1b`` chega *isolado* no
+    buffer E não há mais bytes em 200ms (timeout só nesse caso).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 import threading
 import time
-from typing import List, Optional, TextIO
+from typing import List, Optional, TextIO, Tuple
 
 from rich.console import Console, Group
 from rich.live import Live
@@ -43,14 +61,100 @@ logger = logging.getLogger(__name__)
 
 
 _REFRESH_HZ = 6.0
-# Timeout (segundos) após receber ``\x1b`` para decidir se é ESC genuíno ou
-# prefixo de escape-sequence (seta etc.). 200ms é a recomendação clássica de
+# Timeout (segundos) após receber ``\x1b`` ISOLADO no buffer para decidir se
+# é ESC genuíno ou prefixo de seta. 200ms é a recomendação clássica de
 # editores curses; cobre teclados USB em rajada sem deixar ESC perceptível.
 _ESC_SEQUENCE_TIMEOUT_S = 0.20
-# Janela para coletar o resto da escape-sequence depois do CSI introducer
-# (``\x1b[`` ou ``\x1bO``). Suficiente para até ~5 bytes (todas as teclas
-# que nos importam — setas/F-keys têm no máximo 4-5 bytes).
-_ESC_SEQUENCE_DRAIN_S = 0.05
+# Tamanho máximo de uma leitura atômica do stdin (``os.read``). 64 cobre
+# folgada qualquer rajada plausível de setas/teclas em <200ms (cada seta é
+# 3 bytes; >20 teclas/100ms é mais rápido que qualquer humano).
+_STDIN_READ_CHUNK = 64
+
+
+def parse_key_buffer(buf: str) -> Tuple[List[str], str]:
+    """Parsea ``buf`` em sequências de tecla reconhecidas.
+
+    Retorna ``(seqs, remainder)`` onde ``seqs`` é a lista de sequências
+    completas em ordem de chegada e ``remainder`` é o sufixo do buffer que
+    ainda não forma uma sequência completa (deve voltar pra próxima rodada).
+
+    Sequências reconhecidas (cada item de ``seqs`` casa com o que o legacy
+    ``_on_key`` espera):
+
+    * ``"\\x1b"``: ESC isolado. **Só emitido quando o caller decide que o
+      buffer não vai crescer mais** — ver ``flush=True`` abaixo. Por default
+      ESC fica em ``remainder``, aguardando os bytes da sequência.
+    * ``"\\x1b[A/B/C/D"``: setas via CSI introducer.
+    * ``"\\x1bOA/B/C/D"``: setas via SS3 introducer (terminal alt-mode).
+    * ``"\\x1b[<digits><final>"``: outras CSI (PageUp/Down, Home/End com
+      modificadores); ignoradas pelo caller.
+    * 1 char ASCII printable (dígito, letra) cada um vira sua própria seq.
+
+    Bytes inesperados em meio à CSI quebram a sequência: o ``\\x1b`` é
+    descartado (NÃO emitido como ESC genuíno — comportamento pré round 6
+    causava cancel falso) e o resto vai pra próxima iteração.
+
+    Args:
+        buf: string acumulada de stdin (pode conter múltiplas teclas em
+            sequência num único batch do kernel).
+
+    Returns:
+        ``(seqs, remainder)``. ``remainder`` pode incluir ``"\\x1b"`` solto
+        no fim — só vira ESC após o timeout do caller.
+    """
+    seqs: List[str] = []
+    i = 0
+    n = len(buf)
+    while i < n:
+        ch = buf[i]
+        if ch != "\x1b":
+            # ASCII char comum (dígito, letra, etc.)
+            seqs.append(ch)
+            i += 1
+            continue
+
+        # ESC encontrado — pode ser ESC isolado OU prefixo de CSI/SS3.
+        if i + 1 >= n:
+            # Último byte do buffer — devolve como remainder pro caller
+            # decidir (timeout → ESC genuíno; chegada de mais bytes →
+            # próxima rodada de parse).
+            return seqs, buf[i:]
+
+        intro = buf[i + 1]
+        if intro not in ("[", "O"):
+            # ``\x1b`` seguido de algo que não é CSI/SS3 introducer.
+            # Round 6 fix: NÃO interpretamos como ESC genuíno — o usuário
+            # quase nunca digita ESC seguido de letra; mais provável é um
+            # glitch do kernel ou sequência exótica. Descarta o ``\x1b``
+            # e continua processando o byte como ASCII normal.
+            i += 1  # pula o \x1b
+            continue
+
+        # Procura o terminador da CSI/SS3.
+        # CSI (\x1b[): termina em byte final A-Z/a-z (0x40-0x7e).
+        # SS3 (\x1bO): SEMPRE 3 bytes (\x1bO + 1 char).
+        if intro == "O":
+            if i + 2 >= n:
+                # Sequência SS3 incompleta — guarda no remainder.
+                return seqs, buf[i:]
+            seqs.append(buf[i:i + 3])
+            i += 3
+            continue
+
+        # CSI: varre até achar terminador.
+        end = i + 2
+        while end < n:
+            b = buf[end]
+            if 0x40 <= ord(b) <= 0x7e:
+                break
+            end += 1
+        if end >= n:
+            # CSI incompleta — guarda no remainder.
+            return seqs, buf[i:]
+        seqs.append(buf[i:end + 1])
+        i = end + 1
+
+    return seqs, ""
 
 
 _STATUS_GLYPH = {
@@ -465,6 +569,9 @@ class SubAgentPanelRenderer:
         # Ctrl+C / exit abrupto.
         try:
             fd = sys.stdin.fileno()
+        except Exception:
+            return None  # sem fd, sem watcher
+        try:
             current_attrs = termios.tcgetattr(fd)
             # lflag está no índice 3; ICANON ativo = modo cooked.
             already_cbreak = not bool(current_attrs[3] & termios.ICANON)
@@ -525,65 +632,66 @@ class SubAgentPanelRenderer:
                 pass
 
         def _watch() -> None:
+            """Lê stdin em rajada e despacha sequências completas.
+
+            Round 6: substitui o parser byte-a-byte por leitura atômica via
+            ``os.read(fd, 64)`` + parser de buffer. Vantagens:
+              * Rajadas (3+ setas <50ms) chegam num único ``os.read`` —
+                kernel já tem tudo no buffer e o select acorda só uma vez.
+                ``parse_key_buffer`` separa cada seta em sua própria
+                sequência sem usar timeouts ad-hoc.
+              * ``read(1)`` que retornava ``""`` (signal) ou ``intro`` vazio
+                não pode mais disparar ``_on_key("\\x1b")`` falso —
+                ``parse_key_buffer`` descarta ``\\x1b`` órfão silenciosamente.
+              * ESC genuíno só dispara após 200ms COM o ``\\x1b`` isolado
+                no remainder do buffer (nenhuma outra tecla seguiu).
+            """
             try:
-                # stdin já está em cbreak (configurado pelo CLI watcher).
-                # Não chamamos setcbreak aqui pra não criar um segundo
-                # snapshot que poderia ser restaurado fora de ordem.
+                # ``fd`` já foi capturado no escopo externo (mesmo fd usado
+                # pra detectar cbreak). Reutilizamos para evitar diferenças
+                # de file descriptor entre threads.
+                pending = ""        # bytes não-parseáveis (CSI incompleta)
+                esc_deadline = 0.0  # > 0 quando ESC isolado está aguardando
                 while not stop_event.is_set():
-                    # Bloco curto pro stop_event ser checado a cada 100ms.
-                    r, _, _ = _select.select([sys.stdin], [], [], 0.1)
+                    # Timeout do select: curto pra reagir a stop_event e
+                    # apertado o suficiente pra confirmar ESC isolado.
+                    timeout = 0.1
+                    if esc_deadline > 0:
+                        remaining = esc_deadline - time.monotonic()
+                        if remaining <= 0:
+                            # ESC isolado expirou — dispara cancel.
+                            _on_key("\x1b")
+                            pending = ""
+                            esc_deadline = 0.0
+                            continue
+                        timeout = min(timeout, remaining)
+                    r, _, _ = _select.select([sys.stdin], [], [], timeout)
                     if not r:
                         continue
+                    # Leitura ATÔMICA — pega tudo o que o kernel tem no
+                    # buffer agora (até 64 bytes, folgado p/ rajada manual).
                     try:
-                        ch = sys.stdin.read(1)
+                        chunk = os.read(fd, _STDIN_READ_CHUNK)
                     except (OSError, ValueError):
                         break
-                    if not ch:
-                        continue
-                    if ch != "\x1b":
-                        _on_key(ch)
-                        continue
-
-                    # ESC recebido — pode ser ESC genuíno OU prefixo de
-                    # escape-sequence (setas, F-keys, etc.). Espera até
-                    # _ESC_SEQUENCE_TIMEOUT_S por mais bytes.
-                    r2, _, _ = _select.select([sys.stdin], [], [], _ESC_SEQUENCE_TIMEOUT_S)
-                    if not r2:
-                        _on_key("\x1b")
-                        continue
-                    # Lê introducer ('[' ou 'O').
-                    try:
-                        intro = sys.stdin.read(1)
-                    except (OSError, ValueError):
+                    if not chunk:
+                        # EOF — stdin fechou.
                         break
-                    if intro not in ("[", "O"):
-                        # ESC seguido de algo inesperado — interpreta como
-                        # ESC genuíno e processa o próximo byte separadamente.
-                        _on_key("\x1b")
-                        _on_key(intro)
-                        continue
-                    seq = "\x1b" + intro
-                    # Drena o resto da sequência. Pra setas/F-keys: 1-2 bytes.
-                    # _ESC_SEQUENCE_DRAIN_S por byte é cómodo no teclado USB.
-                    deadline = time.monotonic() + _ESC_SEQUENCE_DRAIN_S
-                    while time.monotonic() < deadline and len(seq) < 8:
-                        r3, _, _ = _select.select([sys.stdin], [], [], 0.005)
-                        if not r3:
-                            break
-                        try:
-                            nxt = sys.stdin.read(1)
-                        except (OSError, ValueError):
-                            break
-                        if not nxt:
-                            break
-                        seq += nxt
-                        # CSI termina em uma letra A-Z/a-z (códigos finais).
-                        if 0x40 <= ord(nxt) <= 0x7e and intro == "[":
-                            break
-                        # SS3 (ESC O X) é sempre 3 bytes.
-                        if intro == "O":
-                            break
-                    _on_key(seq)
+                    try:
+                        new_data = chunk.decode("utf-8", errors="replace")
+                    except Exception:
+                        new_data = ""
+                    pending += new_data
+                    seqs, pending = parse_key_buffer(pending)
+                    for seq in seqs:
+                        _on_key(seq)
+                    # Se sobrou ``\x1b`` solto no remainder, arma o
+                    # deadline pra confirmar ESC genuíno em 200ms.
+                    if pending == "\x1b":
+                        if esc_deadline == 0:
+                            esc_deadline = time.monotonic() + _ESC_SEQUENCE_TIMEOUT_S
+                    else:
+                        esc_deadline = 0.0
             except Exception:
                 logger.debug("keyboard watcher crashed", exc_info=True)
             finally:
@@ -660,4 +768,4 @@ def _escape_markup(text) -> str:
     return _rich_escape(str(text))
 
 
-__all__ = ["SubAgentPanelRenderer"]
+__all__ = ["SubAgentPanelRenderer", "parse_key_buffer"]


### PR DESCRIPTION
## Sumário

Cinco correções pontuais para o caminho interativo do CLI, motivadas por feedback empírico em uso real. Quatro delas saíram da PR #315 (ficaram órfãs após o merge — pushadas momentos depois) e o último é um fix substancial no orquestrador de sub-DEILEs.

| Commit | Tema |
|---|---|
| `adbe19b` | `fix(cli)`: ESC durante streaming MANTÉM a entrada user no histórico + adiciona placeholder assistant `(cancelado pelo usuário)`. Antes apagava — texto continuava no scrollback mas o LLM ficava com amnésia, gerando follow-ups dependentes que confundiam. Placeholder evita 2 user consecutivos (bug histórico do separador `/` em DeepSeek/OpenAI). |
| `1232f5b` | `fix(ui/streaming)`: dois bugs — (a) spinner piscava durante `dispatch_parallel_subagents` porque `_thinking_spinner` ignorava `live.is_started`; agora pula tick quando suspenso + sleep 10Hz → 4Hz; (b) stream travava silenciosamente até o fim do turn — `Text.from_markup` levantando `MarkupError` em args/summary com `[` literal escapava do loop `async for` e nada repintava; agora `try/except` por etapa + `_safe_markup` em `display_name`/`args_inline`/branch `ERROR`. **Rejeitada** a hipótese de "delay 50ms entre prints" — diagnóstico real era exceção engolida, delay só pioraria. |
| `bb4ba37` | `fix(ui/subagent_panel)`: rajada de setas no painel multipainel não dispara cancel falso. Parser byte-a-byte substituído por leitura atômica (`os.read(fd, 64)`) + state machine puro (`parse_key_buffer`) testável sem TTY. ESC genuíno só dispara após `_ESC_SEQUENCE_TIMEOUT_S` sem mais bytes; sequências malformadas são descartadas silenciosamente. |
| `1199f37` | `fix(rewind)`: histórico vazio fecha silenciosamente (paridade com cancel via ESC) em vez de mostrar `Panel(\"Nenhuma mensagem...\")` que poluía o scrollback. |
| `4a32166` | `fix(subagents)`: **orphan thread após cancel não vaza stdout no terminal**. Sub-DEILEs em paralelo vazavam fragmentos de output direto no terminal (por cima do painel) quando o orquestrador restaurava `sys.stdout` no `finally` mas threads do `asyncio.to_thread` (ex.: `bash_tool` no meio de `subprocess.run`) ainda estavam vivas. Solução: wrapper indireto `SwitchableStream` instalado em `sys.stdout/stderr` no início do dispatch; no finally troca-se o `target` em vez de reatribuir. Detecção de orfãs em duas camadas (tasks asyncio pendentes + diff de `threading.enumerate()`). Quando há orfãs, target vira `_DiscardSink` — writes silenciosamente descartados. Sem orfãs, restauração normal (preserva comportamento standalone do `bash_tool` fora do `dispatch_parallel_subagents`). |

## Testes

| Suite | Resultado |
|---|---|
| `deile/tests/ui/` | **125 passed** |
| `deile/tests/cli/` | OK |
| `deile/tests/commands/` (rewind + history) | **8 + 6 passed** |
| `deile/tests/orchestration/test_subagent_*.py` + `tools/test_dispatch_parallel_*.py` + `tools/test_bash_tool_fd_leak.py` | **84 passed, 1 skipped** |

## Princípios preservados

- Princípio #15 (UI adaptativa): toda construção visual continua consultando `console.width` lazy.
- Princípio #6 (error handling): `try/except` por etapa no streaming renderer usa `logger.warning(exc_info=True)` + `continue` — drena o stream sem mascarar bugs.
- Decisão #34 (`_DIRECT_PRINT_TOOLS`): `bash_tool` continua imprimindo output em sessões standalone — o wrapper `SwitchableStream` só age quando o orquestrador instala.
- Cross-platform: ANSI cleanup via `isatty()`; parser de teclado isolado por `try: import termios`; orchestrator detection works on POSIX (threading.enumerate é cross-platform).