### PR TITLE
feat(panel): toggle pipeline dispatch_mode via TUI (issue #309)

### DIFF
--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -676,6 +676,20 @@ def is_claude_mode(dispatch_mode: Optional[str]) -> bool:
     )
 
 
+def _build_claude_implementer_with_warning() -> "ClaudeImplementer":
+    """Factory single-callsite para :class:`ClaudeImplementer` — emite o
+    aviso de PATH-missing antes de instanciar.
+
+    Toda construção de ``ClaudeImplementer`` em ``build_implementer`` passa
+    por aqui — evita que um caminho novo (ex.: alias acrescentado em
+    ``CLAUDE_ALIASES``) esqueça do warning. Compatibilidade pública: o
+    nome legacy ``_warn_if_claude_unavailable`` continua aceito como alias
+    pra não quebrar callers externos (testes antigos, ferramentas).
+    """
+    _warn_if_claude_unavailable()
+    return ClaudeImplementer()
+
+
 def _warn_if_claude_unavailable() -> None:
     """Aviso de boot quando dispatch_mode=claude mas ``claude`` não tá no PATH.
 
@@ -698,9 +712,12 @@ def _warn_if_claude_unavailable() -> None:
     if shutil.which("claude") is None:
         logger.warning(
             "pipeline dispatch_mode=claude mas binary 'claude' não encontrado "
-            "no PATH. A próxima dispatch falhará com ENOENT. Instale o "
-            "claude CLI (ou rode `claude login`) antes de usar este modo. "
-            "Detalhe: deile/orchestration/pipeline/claude_dispatcher.py "
+            "no PATH. A próxima dispatch PODE falhar com ENOENT — a menos que "
+            "o binary esteja sendo montado por volume/initContainer que "
+            "`shutil.which` não enxerga ainda. Para resolver no caminho "
+            "comum, instale o claude CLI (ou rode `claude login`) antes de "
+            "usar este modo. Detalhe: "
+            "deile/orchestration/pipeline/claude_dispatcher.py "
             "usa shutil.which('claude') ou cai em literal 'claude'."
         )
 
@@ -718,20 +735,20 @@ def build_implementer(
     (ex.: ``deile_woker``) usaria a chave da Anthropic e queimaria budget
     sem o operador perceber. Fail-fast surface o erro imediatamente.
 
-    Issue #309: quando o modo resolvido é ``claude`` mas o binary ``claude``
-    não está no PATH, emite warning de boot. Sem fail-fast — ver
-    :func:`_warn_if_claude_unavailable`.
+    Issue #309: a construção de ``ClaudeImplementer`` é centralizada em
+    :func:`_build_claude_implementer_with_warning`, que emite o warning de
+    boot quando o binary ``claude`` não está no PATH — todo caminho novo
+    para ClaudeImplementer aqui herda o aviso sem precisar repetir a
+    chamada.
     """
     if not dispatch_mode or not dispatch_mode.strip():
         # Legacy default (vazio/None) — usa Claude.
-        _warn_if_claude_unavailable()
-        return ClaudeImplementer()
+        return _build_claude_implementer_with_warning()
     mode = dispatch_mode.strip().lower()
     if mode in WORKER_ALIASES:
         return WorkerImplementer(client=worker_client)
     if mode in CLAUDE_ALIASES:
-        _warn_if_claude_unavailable()
-        return ClaudeImplementer()
+        return _build_claude_implementer_with_warning()
     raise ValueError(
         f"unknown pipeline dispatch_mode {dispatch_mode!r}; "
         f"expected one of {sorted(WORKER_ALIASES | CLAUDE_ALIASES)} "

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -682,9 +682,10 @@ def _build_claude_implementer_with_warning() -> "ClaudeImplementer":
 
     Toda construção de ``ClaudeImplementer`` em ``build_implementer`` passa
     por aqui — evita que um caminho novo (ex.: alias acrescentado em
-    ``CLAUDE_ALIASES``) esqueça do warning. Compatibilidade pública: o
-    nome legacy ``_warn_if_claude_unavailable`` continua aceito como alias
-    pra não quebrar callers externos (testes antigos, ferramentas).
+    ``CLAUDE_ALIASES``) esqueça do warning. Esta função é um wrapper de
+    duas etapas (aviso + instanciação), NÃO um alias: o detector de PATH
+    fica em :func:`_warn_if_claude_unavailable` (continua público para
+    callers externos que queiram checar sem instanciar).
     """
     _warn_if_claude_unavailable()
     return ClaudeImplementer()

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -675,6 +676,35 @@ def is_claude_mode(dispatch_mode: Optional[str]) -> bool:
     )
 
 
+def _warn_if_claude_unavailable() -> None:
+    """Aviso de boot quando dispatch_mode=claude mas ``claude`` não tá no PATH.
+
+    Sem fail-fast: o operador pode estar montando o binary via volume custom
+    que ``shutil.which`` ainda não vê (ex.: deploy K8s com initContainer). A
+    falha real surge no primeiro dispatch quando o subprocess do ``claude -p``
+    estourar ENOENT — mas com este warning na boot o operador já sabe que
+    precisa instalar o CLI antes de ver red no painel.
+
+    Issue #309: o image ``deile-stack:local`` hoje NÃO instala o ``claude``
+    CLI nem monta credentials em ``~/.claude/``. Painel TUI permite flipar
+    para ``claude``, mas a dispatch só funcionará quando o image trouxer o
+    binary e o pod tiver credentials montadas (follow-up infra).
+    """
+    # shutil é import top-level no módulo — patch como
+    # ``deile.orchestration.pipeline.implementer.shutil.which`` para isolamento
+    # robusto sob test pollution (algum suite gigante reordena imports e
+    # patchar ``shutil.which`` global passa a falhar; patchar onde a função
+    # de fato lê resolve isso).
+    if shutil.which("claude") is None:
+        logger.warning(
+            "pipeline dispatch_mode=claude mas binary 'claude' não encontrado "
+            "no PATH. A próxima dispatch falhará com ENOENT. Instale o "
+            "claude CLI (ou rode `claude login`) antes de usar este modo. "
+            "Detalhe: deile/orchestration/pipeline/claude_dispatcher.py "
+            "usa shutil.which('claude') ou cai em literal 'claude'."
+        )
+
+
 def build_implementer(
     dispatch_mode: str, *, worker_client: Optional[object] = None
 ) -> PipelineImplementer:
@@ -687,14 +717,20 @@ def build_implementer(
     Claude silenciosamente — um typo em ``DEILE_PIPELINE_DISPATCH_MODE``
     (ex.: ``deile_woker``) usaria a chave da Anthropic e queimaria budget
     sem o operador perceber. Fail-fast surface o erro imediatamente.
+
+    Issue #309: quando o modo resolvido é ``claude`` mas o binary ``claude``
+    não está no PATH, emite warning de boot. Sem fail-fast — ver
+    :func:`_warn_if_claude_unavailable`.
     """
     if not dispatch_mode or not dispatch_mode.strip():
         # Legacy default (vazio/None) — usa Claude.
+        _warn_if_claude_unavailable()
         return ClaudeImplementer()
     mode = dispatch_mode.strip().lower()
     if mode in WORKER_ALIASES:
         return WorkerImplementer(client=worker_client)
     if mode in CLAUDE_ALIASES:
+        _warn_if_claude_unavailable()
         return ClaudeImplementer()
     raise ValueError(
         f"unknown pipeline dispatch_mode {dispatch_mode!r}; "

--- a/deile/tests/infra/test_panel_dispatch_mode.py
+++ b/deile/tests/infra/test_panel_dispatch_mode.py
@@ -113,6 +113,59 @@ class TestDispatchModeProvider:
             entry = DispatchModeProvider().get(force=True)
         assert entry.mode == "claude"
 
+    def test_aliases_are_canonicalized(self):
+        """Se alguém setou ``worker``/``deile-worker``/``claude_code`` via
+        kubectl set env direto (aliases válidos para ``build_implementer``),
+        o provider canonicaliza para o conjunto whitelist da UI — o picker
+        sabe destacar a linha certa em vez de mostrar um valor solto."""
+        from _panel_data import DispatchModeProvider
+        for raw, expected in [
+            ("worker", "deile_worker"),
+            ("deile-worker", "deile_worker"),
+            ("claude_code", "claude"),
+            ("claude-code", "claude"),
+        ]:
+            with patch("_panel_data._capture_json",
+                       return_value=_deployment_json_with_env({
+                           "DEILE_PIPELINE_DISPATCH_MODE": raw,
+                       })), \
+                 patch("_panel_data.kubectl_bin",
+                       return_value="/fake/kubectl"):
+                entry = DispatchModeProvider().get(force=True)
+            assert entry.mode == expected, (
+                f"alias {raw!r} deveria canonicalizar para {expected!r}, "
+                f"got {entry.mode!r}"
+            )
+
+    def test_unknown_value_passes_through_lowercased(self):
+        """Valor estranho (não-alias, não-canônico) deve passar como-veio em
+        lowercase — não esconde do operador o que está no cluster."""
+        from _panel_data import DispatchModeProvider
+        with patch("_panel_data._capture_json",
+                   return_value=_deployment_json_with_env({
+                       "DEILE_PIPELINE_DISPATCH_MODE": "WeIrD_MoDe",
+                   })), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            entry = DispatchModeProvider().get(force=True)
+        assert entry.mode == "weird_mode"
+
+    def test_namespace_kwarg_passed_to_kubectl(self):
+        """Multi-NS (PR #315): o construtor aceita namespace= e o argv reflete."""
+        from _panel_data import DispatchModeProvider
+        captured_argv = []
+
+        def _capture(argv, timeout=None):
+            captured_argv.append(list(argv))
+            return _deployment_json_with_env({})
+
+        with patch("_panel_data._capture_json", side_effect=_capture), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            DispatchModeProvider(namespace="customns").get(force=True)
+        # `-n customns` no argv (em vez do default `deile`).
+        assert "customns" in captured_argv[0]
+        # E NÃO o default `deile`.
+        # (NS default importado de _panel_data; aqui só validamos o customns.)
+
 
 # ---------------------------------------------------------------------------
 # set_pipeline_dispatch_mode
@@ -202,6 +255,28 @@ class TestSetPipelineDispatchMode:
         assert ok is False
         assert "forbidden" in msg
 
+    def test_subprocess_oserror_returns_clear_error(self):
+        """Quando ``subprocess.run`` levanta ``OSError`` (ex.: kubectl binary
+        sumiu entre o ``kubectl_bin()`` e o ``run``), o setter responde
+        ``(False, msg)`` em vez de propagar a exceção e quebrar o painel."""
+        import subprocess as _sp
+
+        from _panel_data import set_pipeline_dispatch_mode
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run",
+                   side_effect=OSError("binary missing")):
+            ok, msg = set_pipeline_dispatch_mode("claude")
+        assert ok is False
+        assert "binary missing" in msg or "OSError" in msg or "executar" in msg.lower()
+        # Pra garantir que o tipo nominal `subprocess.TimeoutExpired` continua
+        # capturado também (defesa via composição de except (OSError, TE)).
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run",
+                   side_effect=_sp.TimeoutExpired(cmd="kubectl", timeout=15)):
+            ok, msg = set_pipeline_dispatch_mode("claude")
+        assert ok is False
+        assert "executar" in msg.lower() or "timeout" in msg.lower()
+
     def test_namespace_passed_through(self):
         """O painel TUI suporta multi-NS (PR #315). A função deve respeitar
         o ``namespace=`` kwarg em vez de hardcoded ``NS``."""
@@ -220,6 +295,86 @@ class TestSetPipelineDispatchMode:
 # ---------------------------------------------------------------------------
 # clear_pipeline_dispatch_mode
 # ---------------------------------------------------------------------------
+
+
+class TestAuditDispatchModeChange:
+    """Pilar 08 exige que toda mutação privilegiada emita audit. Validamos
+    aqui que ``set_pipeline_dispatch_mode`` chama o audit logger em cada
+    transição relevante (denied, allowed, completed, failed), com o
+    envelope correto (``SECURITY_POLICY_CHANGED``, actor canônico,
+    resource apontando para a env var)."""
+
+    def test_audit_emitted_on_denied_unknown_mode(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        with patch("_panel_data._audit_dispatch_mode_change") as audit:
+            set_pipeline_dispatch_mode("garbage")
+        # Pelo menos uma chamada com result="denied".
+        denied = [c for c in audit.call_args_list
+                  if c.kwargs.get("result") == "denied"]
+        assert denied, audit.call_args_list
+
+    def test_audit_emitted_on_kubectl_missing(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        with patch("_panel_data.kubectl_bin", return_value=None), \
+             patch("_panel_data._audit_dispatch_mode_change") as audit:
+            set_pipeline_dispatch_mode("claude")
+        failed = [c for c in audit.call_args_list
+                  if c.kwargs.get("result") == "failed"]
+        assert failed, audit.call_args_list
+
+    def test_audit_emitted_on_success_allowed_then_completed(self):
+        """O setter audita 2x no caminho feliz: ``allowed`` antes do
+        subprocess (registra a intenção), ``completed`` depois (sucesso
+        confirmado). Isso garante trilha mesmo se o subprocess travar."""
+        from _panel_data import set_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=0, stdout="updated", stderr="")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run", return_value=fake_proc), \
+             patch("_panel_data._audit_dispatch_mode_change") as audit:
+            set_pipeline_dispatch_mode("claude")
+        results = [c.kwargs.get("result") for c in audit.call_args_list]
+        assert "allowed" in results
+        assert "completed" in results
+
+    def test_audit_emitted_on_subprocess_failure(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=1, stdout="",
+                              stderr="forbidden: deployments.apps")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run", return_value=fake_proc), \
+             patch("_panel_data._audit_dispatch_mode_change") as audit:
+            set_pipeline_dispatch_mode("claude")
+        results = [c.kwargs.get("result") for c in audit.call_args_list]
+        assert "failed" in results
+
+    def test_audit_emitted_on_clear_success(self):
+        from _panel_data import clear_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=0, stdout="updated", stderr="")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run", return_value=fake_proc), \
+             patch("_panel_data._audit_dispatch_mode_change") as audit:
+            clear_pipeline_dispatch_mode()
+        results = [c.kwargs.get("result") for c in audit.call_args_list]
+        # Clear path: allowed + completed; ``mode=None`` em todas as chamadas.
+        assert "allowed" in results
+        assert "completed" in results
+        for call in audit.call_args_list:
+            assert call.args[0] is None  # mode arg sempre None no clear
+
+    def test_audit_envelope_is_security_policy_changed(self):
+        """Smoke do envelope real: ``_audit_dispatch_mode_change`` chama o
+        AuditLogger com ``SECURITY_POLICY_CHANGED`` e actor canônico."""
+        from _panel_data import _audit_dispatch_mode_change
+        with patch("deile.security.audit_logger.get_audit_logger") as gal:
+            mock_logger = MagicMock()
+            gal.return_value = mock_logger
+            _audit_dispatch_mode_change(
+                "claude", result="completed", detail="ok",
+            )
+        assert mock_logger.log_event.called
+        kw = mock_logger.log_event.call_args.kwargs
+        assert "SECURITY_POLICY_CHANGED" in str(kw.get("event_type"))
+        assert kw.get("actor") == "panel:set_pipeline_dispatch_mode"
 
 
 class TestClearPipelineDispatchMode:
@@ -361,6 +516,37 @@ class TestDispatchModeViewKeyHandling:
         assert view.mode_modal is None
         assert view.last_ok is False  # default-deny audit msg
 
+    def test_set_confirm_n_emits_cancelled_audit(self):
+        """Paridade com ModelSwitcherView: cancelamento explícito ([n])
+        emite AuditEvent com result='cancelled' — não fica em branch morto."""
+        view, app = self._new_view()
+        view.handle_key("\r", app)
+        with patch("_panel.pd_audit_dispatch_mode_change") as audit:
+            view.handle_key("n", app)
+        results = [c.kwargs.get("result") for c in audit.call_args_list]
+        assert "cancelled" in results
+
+    def test_clear_confirm_n_emits_cancelled_audit(self):
+        view, app = self._new_view()
+        view.handle_key("c", app)
+        with patch("_panel.pd_audit_dispatch_mode_change") as audit:
+            view.handle_key("n", app)
+        results = [c.kwargs.get("result") for c in audit.call_args_list]
+        assert "cancelled" in results
+
+    def test_degenerate_set_modal_state_is_handled(self):
+        """Guarda explícita para o cenário ('set', '') / ('set', None) —
+        em vez de cair silenciosamente em cancel, fecha com erro visível."""
+        view, app = self._new_view()
+        view.mode_modal = ("set", "")
+        with patch("_panel.pd_audit_dispatch_mode_change") as audit:
+            view.handle_key("y", app)
+        assert view.mode_modal is None
+        assert view.last_ok is False
+        # Audit registra "failed" pra trilha — não é cancelamento legítimo.
+        results = [c.kwargs.get("result") for c in audit.call_args_list]
+        assert "failed" in results
+
     def test_set_confirm_unexpected_key_cancels_default_deny(self):
         """Qualquer tecla diferente de [y] cancela. Padrão default-deny
         mirror do ModelSwitcherView (issue #305)."""
@@ -427,6 +613,38 @@ class TestDashboardHotkey:
         assert result.kind == Action.NAV
         assert result.target == "dispatch-mode"
 
+    def test_d_hotkey_only_set_in_dashboard_nav(self):
+        """O ``[d]`` é hotkey exclusiva do dashboard — não deve colidir com
+        outras views. Verificamos que outras views (PodPickerView,
+        IssuesPRsView, StageModelsView, etc) NÃO mapeiam ``d`` no seu
+        ``handle_key`` para uma navegação global (ActionResult.nav).
+
+        Isso protege contra um futuro PR que adicione ``d`` numa view
+        diferente e cause conflito de propagação (hoje o panel propaga
+        global após a view não interceptar — então um ``d`` numa view
+        que não tem handler local cai no dashboard handler depois)."""
+        from _panel import (DashboardView, DispatchModeView, ModelSwitcherView,
+                            PodPickerView, StageModelsView)
+
+        # Cada view abaixo NÃO deve ter um shortcut "d" próprio. O dispatch
+        # view tem `d` listada nas hotkeys da statusline mas não no
+        # handle_key — porque [d] é chamado do dashboard pra abrir essa
+        # view; uma vez na view, a tecla é capturada pelo modal/nav.
+        for view_cls in (PodPickerView, ModelSwitcherView, StageModelsView,
+                         DispatchModeView):
+            # Smoke: instanciar com data=None (demo) não deve crashar e
+            # `handle_key("d", ...)` deve retornar ActionResult sem .target
+            # casando outra view.
+            v = view_cls(data=None)
+            result = v.handle_key("d", MagicMock())
+            # Aceita ActionResult() padrão (default-pass) ou refresh.
+            assert getattr(result, "target", None) != "dispatch-mode" \
+                or view_cls is DashboardView, (
+                f"{view_cls.__name__}.handle_key('d') deveria não navegar para "
+                f"dispatch-mode (só DashboardView pode), got target="
+                f"{getattr(result, 'target', None)}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # build_implementer claude-binary warning (issue #309)
@@ -458,6 +676,9 @@ class TestBuildImplementerClaudeWarning:
         assert mock_warn.called
         msg = mock_warn.call_args[0][0].lower()
         assert "claude" in msg
+        # Mensagem hedged ("PODE falhar") aceita os mesmos tokens da
+        # versão categórica ("vai falhar"); pra os 2 modos serem testados
+        # por um único set de checks, validamos o keyword central.
         assert ("não encontrado" in msg or "not found" in msg
                 or "enoent" in msg)
 

--- a/deile/tests/infra/test_panel_dispatch_mode.py
+++ b/deile/tests/infra/test_panel_dispatch_mode.py
@@ -1,0 +1,506 @@
+"""Tests for the pipeline dispatch-mode panel feature (issue #309).
+
+Cobertura:
+  * ``DispatchModeProvider`` — lê ``DEILE_PIPELINE_DISPATCH_MODE`` da
+    Deployment ``deile-pipeline`` via kubectl get -o json (mockado), tanto
+    quando a env var existe quanto quando cai no default do ConfigMap.
+  * ``set_pipeline_dispatch_mode`` / ``clear_pipeline_dispatch_mode`` —
+    validação, kubectl ausente, sucesso (kubectl set env com argv correto),
+    falha (returncode != 0).
+  * ``DispatchModeView`` — modal state machine (browse → set confirm,
+    browse → clear confirm) e cancelamento default-deny.
+  * ``build_implementer`` — emite warning quando ``dispatch_mode=claude``
+    mas ``shutil.which("claude")`` retorna ``None`` (gap operacional
+    documentado da issue #309).
+
+Mirrors o estilo de ``test_panel_models_per_stage.py`` (issue #305) — mesma
+estratégia de sys.path injection, mesmas fixtures, mesmas convenções.
+"""
+
+from __future__ import annotations
+
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# infra/k8s não é um package — adicionar a sys.path para ``_panel_data`` /
+# ``_panel`` resolverem (mirror de como ``deploy.py panel`` invoca o módulo).
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+if str(_INFRA_K8S) not in sys.path:
+    sys.path.insert(0, str(_INFRA_K8S))
+
+from deile.config.settings import reset_settings  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_settings(monkeypatch):
+    """Garante que env vars do host não contaminam os testes."""
+    monkeypatch.delenv("DEILE_PIPELINE_DISPATCH_MODE", raising=False)
+    reset_settings()
+    yield
+    reset_settings()
+
+
+def _deployment_json_with_env(envs: dict) -> dict:
+    """Builda um kubectl-get-deployment JSON minimal com as env vars dadas."""
+    env_list = [{"name": k, "value": v} for k, v in envs.items()]
+    return {"spec": {"template": {"spec": {"containers": [{"env": env_list}]}}}}
+
+
+# ---------------------------------------------------------------------------
+# DispatchModeProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchModeProvider:
+    """O provider faz um único ``kubectl get -o json`` na Deployment
+    ``deile-pipeline`` e extrai a env var. Mock o ``_capture_json`` para
+    não precisar de cluster.
+    """
+
+    def test_env_var_set_returns_env_source(self):
+        from _panel_data import DispatchModeProvider
+        with patch("_panel_data._capture_json",
+                   return_value=_deployment_json_with_env({
+                       "DEILE_PIPELINE_DISPATCH_MODE": "claude",
+                   })), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            entry = DispatchModeProvider().get(force=True)
+        assert entry.mode == "claude"
+        assert entry.source == "env"
+        assert entry.effective == "claude"
+
+    def test_env_var_absent_falls_back_to_configmap_default(self):
+        from _panel_data import DispatchModeProvider
+        with patch("_panel_data._capture_json",
+                   return_value=_deployment_json_with_env({
+                       "SOME_OTHER_ENV": "x",
+                   })), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            entry = DispatchModeProvider().get(force=True)
+        assert entry.mode is None
+        assert entry.source == "default"
+        # Default do ConfigMap deile-runtime-config.
+        assert entry.effective == "deile_worker"
+
+    def test_env_var_blank_treated_as_unset(self):
+        """Quando a env existe com valor vazio (raro mas legal no k8s),
+        o provider deve cair no default — não devolver string vazia como
+        ``mode``."""
+        from _panel_data import DispatchModeProvider
+        with patch("_panel_data._capture_json",
+                   return_value=_deployment_json_with_env({
+                       "DEILE_PIPELINE_DISPATCH_MODE": "   ",
+                   })), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            entry = DispatchModeProvider().get(force=True)
+        assert entry.mode is None
+        assert entry.source == "default"
+
+    def test_value_normalized_to_lowercase(self):
+        """Mesmo que alguém edite manualmente o Deployment com `CLAUDE`,
+        o provider devolve a forma canônica `claude` — para a view não
+        ficar comparando case-sensitively contra os modos."""
+        from _panel_data import DispatchModeProvider
+        with patch("_panel_data._capture_json",
+                   return_value=_deployment_json_with_env({
+                       "DEILE_PIPELINE_DISPATCH_MODE": "CLAUDE",
+                   })), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            entry = DispatchModeProvider().get(force=True)
+        assert entry.mode == "claude"
+
+
+# ---------------------------------------------------------------------------
+# set_pipeline_dispatch_mode
+# ---------------------------------------------------------------------------
+
+
+class TestSetPipelineDispatchMode:
+    """``set_pipeline_dispatch_mode`` executa kubectl set env — mesmo caminho
+    de ``set_preferred_model`` / ``set_stage_model``. Asserts que paths de
+    rejeição curto-circuitam ANTES de qualquer subprocess, e que o caminho
+    feliz emite a argv certa.
+    """
+
+    def test_rejects_unknown_mode(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        ok, msg = set_pipeline_dispatch_mode("garbage")
+        assert ok is False
+        assert "garbage" in msg
+        assert "inválido" in msg.lower()
+
+    def test_rejects_empty_string(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        ok, msg = set_pipeline_dispatch_mode("")
+        assert ok is False
+        assert "inválido" in msg.lower()
+
+    def test_rejects_non_string(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        ok, msg = set_pipeline_dispatch_mode(42)  # type: ignore[arg-type]
+        assert ok is False
+
+    def test_rejects_typo_variants(self):
+        """Aliases internos (`worker`, `claude_code`) válidos para
+        ``build_implementer`` NÃO são válidos para o painel — manter o
+        conjunto canônico fechado em (claude | deile_worker) evita
+        confusão na UI."""
+        from _panel_data import set_pipeline_dispatch_mode
+        ok, _ = set_pipeline_dispatch_mode("worker")
+        assert ok is False
+        ok, _ = set_pipeline_dispatch_mode("claude_code")
+        assert ok is False
+        ok, _ = set_pipeline_dispatch_mode("deile-worker")  # com hyphen
+        assert ok is False
+
+    def test_kubectl_missing_returns_clear_error(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        with patch("_panel_data.kubectl_bin", return_value=None):
+            ok, msg = set_pipeline_dispatch_mode("claude")
+        assert ok is False
+        assert "kubectl" in msg.lower()
+
+    def test_success_issues_correct_kubectl_argv(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=0, stdout="updated", stderr="")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run",
+                   return_value=fake_proc) as mock_run:
+            ok, _ = set_pipeline_dispatch_mode("claude")
+        assert ok is True
+        argv = mock_run.call_args[0][0]
+        assert argv[0] == "/fake/kubectl"
+        assert "deploy/deile-pipeline" in argv
+        # A env var precisa estar em formato KEY=VALUE canônico.
+        assert "DEILE_PIPELINE_DISPATCH_MODE=claude" in argv
+
+    def test_success_normalizes_uppercase_input(self):
+        """Operador digita `CLAUDE` na CLI — a função canonicaliza para
+        `claude` antes de virar argv (sem case mismatch no Deployment)."""
+        from _panel_data import set_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=0, stdout="updated", stderr="")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run",
+                   return_value=fake_proc) as mock_run:
+            ok, _ = set_pipeline_dispatch_mode("CLAUDE")
+        assert ok is True
+        argv = mock_run.call_args[0][0]
+        # Lowercase no argv, sem typo.
+        assert "DEILE_PIPELINE_DISPATCH_MODE=claude" in argv
+
+    def test_nonzero_returncode_surfaces_stderr(self):
+        from _panel_data import set_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=1, stdout="",
+                              stderr="forbidden: deployments.apps")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run", return_value=fake_proc):
+            ok, msg = set_pipeline_dispatch_mode("claude")
+        assert ok is False
+        assert "forbidden" in msg
+
+    def test_namespace_passed_through(self):
+        """O painel TUI suporta multi-NS (PR #315). A função deve respeitar
+        o ``namespace=`` kwarg em vez de hardcoded ``NS``."""
+        from _panel_data import set_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=0, stdout="updated", stderr="")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run",
+                   return_value=fake_proc) as mock_run:
+            ok, _ = set_pipeline_dispatch_mode("claude", namespace="customns")
+        assert ok is True
+        argv = mock_run.call_args[0][0]
+        # O argv tem '-n customns' (não o default 'deile').
+        assert "customns" in argv
+
+
+# ---------------------------------------------------------------------------
+# clear_pipeline_dispatch_mode
+# ---------------------------------------------------------------------------
+
+
+class TestClearPipelineDispatchMode:
+    def test_kubectl_missing_returns_clear_error(self):
+        from _panel_data import clear_pipeline_dispatch_mode
+        with patch("_panel_data.kubectl_bin", return_value=None):
+            ok, msg = clear_pipeline_dispatch_mode()
+        assert ok is False
+        assert "kubectl" in msg.lower()
+
+    def test_clear_issues_unset_argv(self):
+        """``kubectl set env ... VAR-`` (trailing dash) é a sintaxe do
+        kubectl para unset. Argv tem que carregar a forma com dash —
+        qualquer outra coisa SETa string vazia em vez de limpar."""
+        from _panel_data import clear_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=0, stdout="updated", stderr="")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run",
+                   return_value=fake_proc) as mock_run:
+            ok, _ = clear_pipeline_dispatch_mode()
+        assert ok is True
+        argv = mock_run.call_args[0][0]
+        # Trailing dash é mandatory.
+        assert "DEILE_PIPELINE_DISPATCH_MODE-" in argv
+
+    def test_nonzero_returncode_surfaces_stderr(self):
+        from _panel_data import clear_pipeline_dispatch_mode
+        fake_proc = MagicMock(returncode=1, stdout="",
+                              stderr="forbidden: deployments.apps")
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("_panel_data.subprocess.run", return_value=fake_proc):
+            ok, msg = clear_pipeline_dispatch_mode()
+        assert ok is False
+        assert "forbidden" in msg
+
+
+# ---------------------------------------------------------------------------
+# DispatchModeView
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchModeViewRendering:
+    @pytest.mark.parametrize("width", [80, 120, 200])
+    def test_renders_at_all_breakpoints(self, width):
+        from _panel import DispatchModeView, PanelApp
+        from rich.console import Console
+
+        view = DispatchModeView(data=None)  # demo mode
+        app = PanelApp(views={"dispatch-mode": view}, root="dispatch-mode",
+                       data=None)
+        app.console = Console(width=width, file=StringIO(),
+                              force_terminal=True)
+        layout = view.render(app)
+        capture = Console(width=width, file=StringIO(),
+                          force_terminal=True, record=True)
+        capture.print(layout)
+        text = capture.export_text()
+        # Header da view deve aparecer em todos os breakpoints.
+        assert ("Modo de despacho" in text
+                or "MODOS DISPONÍVEIS" in text)
+
+    def test_demo_mode_shows_both_modes(self):
+        from _panel import DispatchModeView, PanelApp
+        from rich.console import Console
+
+        view = DispatchModeView(data=None)
+        app = PanelApp(views={"dispatch-mode": view}, root="dispatch-mode",
+                       data=None)
+        app.console = Console(width=140, file=StringIO(),
+                              force_terminal=True)
+        layout = view.render(app)
+        capture = Console(width=140, file=StringIO(),
+                          force_terminal=True, record=True)
+        capture.print(layout)
+        text = capture.export_text()
+        # As 2 opções precisam aparecer na lista.
+        assert "deile_worker" in text
+        assert "claude" in text
+
+
+class TestDispatchModeViewKeyHandling:
+    def _new_view(self):
+        from _panel import DispatchModeView, PanelApp
+        v = DispatchModeView(data=None)  # demo mode — sem kubectl
+        app = PanelApp(views={"dispatch-mode": v}, root="dispatch-mode",
+                       data=None)
+        return v, app
+
+    def test_enter_opens_set_confirmation(self):
+        view, app = self._new_view()
+        assert view.mode_modal is None
+        view.handle_key("\r", app)
+        assert view.mode_modal is not None
+        assert view.mode_modal[0] == "set"
+        # Modo selecionado é o do cursor (default 0 → "deile_worker").
+        assert view.mode_modal[1] == "deile_worker"
+
+    def test_c_opens_clear_confirmation(self):
+        view, app = self._new_view()
+        view.handle_key("c", app)
+        assert view.mode_modal is not None
+        assert view.mode_modal[0] == "clear"
+
+    def test_arrow_down_advances_cursor(self):
+        view, app = self._new_view()
+        assert view.cursor == 0
+        view.handle_key("DOWN", app)
+        assert view.cursor == 1
+        # `j` é alias vim.
+        view.handle_key("j", app)
+        # 2 modos só → wraparound para 0.
+        assert view.cursor == 0
+
+    def test_digit_shortcut_jumps_to_row(self):
+        view, app = self._new_view()
+        view.handle_key("2", app)
+        assert view.cursor == 1  # 1-indexed display → 0-indexed cursor
+        view.handle_key("1", app)
+        assert view.cursor == 0
+
+    def test_set_confirm_y_applies(self):
+        """A view chama ``set_pipeline_dispatch_mode`` apenas em data!=None,
+        então em demo mode o ``_apply_set`` registra ``last_ok=False`` sem
+        invocar kubectl."""
+        view, app = self._new_view()
+        view.cursor = 1  # claude
+        view.handle_key("\r", app)
+        assert view.mode_modal == ("set", "claude")
+        view.handle_key("y", app)
+        assert view.mode_modal is None
+        # Demo mode → last_ok=False e mensagem "modo demo".
+        assert view.last_ok is False
+        assert "demo" in (view.last_msg or "").lower()
+
+    def test_set_confirm_n_cancels(self):
+        view, app = self._new_view()
+        view.handle_key("\r", app)  # → modal set
+        view.handle_key("n", app)
+        assert view.mode_modal is None
+        assert view.last_ok is False  # default-deny audit msg
+
+    def test_set_confirm_unexpected_key_cancels_default_deny(self):
+        """Qualquer tecla diferente de [y] cancela. Padrão default-deny
+        mirror do ModelSwitcherView (issue #305)."""
+        view, app = self._new_view()
+        view.handle_key("\r", app)
+        view.handle_key("Z", app)  # tecla aleatória
+        assert view.mode_modal is None
+        assert view.last_ok is False
+
+    def test_clear_confirm_y_applies(self):
+        view, app = self._new_view()
+        view.handle_key("c", app)
+        assert view.mode_modal == ("clear", None)
+        view.handle_key("y", app)
+        assert view.mode_modal is None
+        assert view.last_ok is False  # demo mode
+        assert "demo" in (view.last_msg or "").lower()
+
+    def test_clear_confirm_n_cancels(self):
+        view, app = self._new_view()
+        view.handle_key("c", app)
+        view.handle_key("n", app)
+        assert view.mode_modal is None
+        assert view.last_ok is False
+
+    def test_esc_inside_modal_does_not_pop_view(self):
+        """Regression: ESC dentro do modal precisa fechar o modal, não
+        sair da view (mirror do test no StageModelsView)."""
+        from _panel import DashboardView, DispatchModeView, PanelApp
+        dash = DashboardView(data=None)
+        view = DispatchModeView(data=None)
+        app = PanelApp(views={"dashboard": dash, "dispatch-mode": view},
+                       root="dashboard", data=None)
+        app.push("dispatch-mode")
+        assert app.current_view is view
+        view.mode_modal = ("set", "claude")
+        assert view.intercepts_key("ESC") is True
+        view.handle_key("ESC", app)
+        assert view.mode_modal is None
+        assert app.current_view is view  # ainda na view, não popped
+
+    def test_esc_outside_modal_does_not_intercept(self):
+        view, _ = self._new_view()
+        assert view.mode_modal is None
+        assert view.intercepts_key("ESC") is False
+
+    def test_on_unmount_resets_modal_state(self):
+        """Operador sai da view (q/global hotkey) com modal aberto —
+        re-entry deve aterrissar no estado limpo."""
+        view, app = self._new_view()
+        view.mode_modal = ("set", "claude")
+        view.on_unmount(app)
+        assert view.mode_modal is None
+
+
+class TestDashboardHotkey:
+    """O dashboard mapeia ``[d]`` para a dispatch-mode view (issue #309)."""
+
+    def test_d_hotkey_navigates_to_dispatch_mode(self):
+        from _panel import Action, DashboardView, PanelApp
+        dash = DashboardView(data=None)
+        app = PanelApp(views={"dashboard": dash}, root="dashboard", data=None)
+        result = dash.handle_key("d", app)
+        assert result.kind == Action.NAV
+        assert result.target == "dispatch-mode"
+
+
+# ---------------------------------------------------------------------------
+# build_implementer claude-binary warning (issue #309)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildImplementerClaudeWarning:
+    """Quando ``dispatch_mode=claude`` mas o binary ``claude`` não está
+    no PATH, ``build_implementer`` deve logar warning (sem fail-fast).
+
+    Sem fail-fast porque o operador pode estar montando o binary via volume
+    que ``shutil.which`` ainda não enxerga; a falha real surge no primeiro
+    subprocess.
+
+    Patcha o ``logger.warning`` do módulo implementer diretamente — caplog
+    fica frágil sob a suite completa (alguns testes prévios reconfiguram o
+    logger; ``propagate=False`` bloqueia caplog). Mock direto no logger
+    sobrevive a qualquer pollution prévia.
+    """
+
+    def test_warning_emitted_when_claude_missing(self):
+        from deile.orchestration.pipeline import implementer as impl_mod
+        with patch.object(impl_mod, "shutil") as mock_shutil, \
+             patch.object(impl_mod.logger, "warning") as mock_warn:
+            mock_shutil.which.return_value = None
+            implementer = impl_mod.build_implementer("claude")
+        assert isinstance(implementer, impl_mod.ClaudeImplementer)
+        # Pelo menos uma chamada de warning com a mensagem certa.
+        assert mock_warn.called
+        msg = mock_warn.call_args[0][0].lower()
+        assert "claude" in msg
+        assert ("não encontrado" in msg or "not found" in msg
+                or "enoent" in msg)
+
+    def test_no_warning_when_claude_present(self):
+        from deile.orchestration.pipeline import implementer as impl_mod
+        with patch.object(impl_mod, "shutil") as mock_shutil, \
+             patch.object(impl_mod.logger, "warning") as mock_warn:
+            mock_shutil.which.return_value = "/usr/local/bin/claude"
+            implementer = impl_mod.build_implementer("claude")
+        assert isinstance(implementer, impl_mod.ClaudeImplementer)
+        # Sem warning sobre claude ausente — pode haver outro warning legítimo,
+        # mas nenhum com "não encontrado".
+        for call in mock_warn.call_args_list:
+            text = (call[0][0] if call[0] else "").lower()
+            assert not (
+                "claude" in text
+                and ("não encontrado" in text or "not found" in text)
+            )
+
+    def test_no_warning_when_worker_mode(self):
+        """Modo worker não usa claude — não faz sentido emitir warning,
+        mesmo que o binary esteja ausente."""
+        from deile.orchestration.pipeline import implementer as impl_mod
+        with patch.object(impl_mod, "shutil") as mock_shutil, \
+             patch.object(impl_mod.logger, "warning") as mock_warn:
+            mock_shutil.which.return_value = None
+            impl_mod.build_implementer("deile_worker")
+        # Worker mode não tem caminho que chame _warn_if_claude_unavailable.
+        for call in mock_warn.call_args_list:
+            text = (call[0][0] if call[0] else "").lower()
+            assert not (
+                "claude" in text
+                and ("não encontrado" in text or "not found" in text)
+            )
+
+    def test_empty_dispatch_mode_defaults_claude_and_warns_if_missing(self):
+        """Empty/None dispatch_mode legado cai em ClaudeImplementer — mesmo
+        warning aplica."""
+        from deile.orchestration.pipeline import implementer as impl_mod
+        with patch.object(impl_mod, "shutil") as mock_shutil, \
+             patch.object(impl_mod.logger, "warning") as mock_warn:
+            mock_shutil.which.return_value = None
+            implementer = impl_mod.build_implementer("")
+        assert isinstance(implementer, impl_mod.ClaudeImplementer)
+        assert mock_warn.called
+        assert "claude" in mock_warn.call_args[0][0].lower()

--- a/deile/tests/infra/test_panel_dispatch_mode.py
+++ b/deile/tests/infra/test_panel_dispatch_mode.py
@@ -151,6 +151,7 @@ class TestDispatchModeProvider:
 
     def test_namespace_kwarg_passed_to_kubectl(self):
         """Multi-NS (PR #315): o construtor aceita namespace= e o argv reflete."""
+        from _panel_data import NS as DEFAULT_NS
         from _panel_data import DispatchModeProvider
         captured_argv = []
 
@@ -161,10 +162,63 @@ class TestDispatchModeProvider:
         with patch("_panel_data._capture_json", side_effect=_capture), \
              patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
             DispatchModeProvider(namespace="customns").get(force=True)
-        # `-n customns` no argv (em vez do default `deile`).
-        assert "customns" in captured_argv[0]
-        # E NÃO o default `deile`.
-        # (NS default importado de _panel_data; aqui só validamos o customns.)
+        argv = captured_argv[0]
+        # Posição canônica do `-n customns` no argv (kubectl convenção).
+        assert "-n" in argv
+        ns_idx = argv.index("-n")
+        assert argv[ns_idx + 1] == "customns"
+        # E NÃO o default `deile` no argv inteiro (a menos que NS default
+        # seja literalmente "customns" — robusto a renomeio futuro).
+        if DEFAULT_NS != "customns":
+            assert DEFAULT_NS not in argv
+
+    def test_provider_enabled_false_short_circuits(self):
+        """Demo / --local-only (enabled=False): provider devolve fallback
+        sem chamar kubectl. Sem isso o operador veria erro de subprocess no
+        modo local-only sempre."""
+        from _panel_data import DispatchModeProvider
+        with patch("_panel_data._capture_json") as mock_capture, \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            entry = DispatchModeProvider(enabled=False).get(force=True)
+        # Fallback do Cache (DispatchModeEntry com source="default").
+        assert entry.source == "default"
+        assert entry.mode is None
+        # Crucial: subprocess NÃO foi chamado.
+        mock_capture.assert_not_called()
+
+
+class TestCanonicalizeDispatchAlias:
+    """Cobertura unitária direta do helper de canonicalização — isola
+    regressão do lazy import (custo de cold-import deferido) e da política
+    de fallback (lo em vez de raise)."""
+
+    def test_worker_aliases_to_canonical(self):
+        from _panel_data import _canonicalize_dispatch_alias
+
+        # Cada alias do conjunto WORKER_ALIASES → "deile_worker".
+        for raw in ("worker", "deile-worker", "deile_worker", "deile"):
+            assert _canonicalize_dispatch_alias(raw) == "deile_worker", raw
+
+    def test_claude_aliases_to_canonical(self):
+        from _panel_data import _canonicalize_dispatch_alias
+        for raw in ("claude", "claude_code", "claude-code"):
+            assert _canonicalize_dispatch_alias(raw) == "claude", raw
+
+    def test_uppercase_normalized(self):
+        from _panel_data import _canonicalize_dispatch_alias
+        assert _canonicalize_dispatch_alias("CLAUDE") == "claude"
+        assert _canonicalize_dispatch_alias("WORKER") == "deile_worker"
+
+    def test_whitespace_stripped(self):
+        from _panel_data import _canonicalize_dispatch_alias
+        assert _canonicalize_dispatch_alias("  claude  ") == "claude"
+
+    def test_unknown_value_passes_through(self):
+        """Valor desconhecido NÃO levanta — devolve lowercase. O caller
+        (provider) sabe lidar com isso (exibe no painel)."""
+        from _panel_data import _canonicalize_dispatch_alias
+        assert _canonicalize_dispatch_alias("WeIrD") == "weird"
+        assert _canonicalize_dispatch_alias("xyz") == "xyz"
 
 
 # ---------------------------------------------------------------------------
@@ -526,6 +580,20 @@ class TestDispatchModeViewKeyHandling:
         results = [c.kwargs.get("result") for c in audit.call_args_list]
         assert "cancelled" in results
 
+    def test_set_confirm_unexpected_key_also_emits_cancelled_audit(self):
+        """A rama default-deny (tecla diferente de [y]/[n]/ESC) também
+        precisa emitir audit cancelled com motivo distinto — sem isso, log
+        analysis não distingue cancel intencional de tecla acidental."""
+        view, app = self._new_view()
+        view.handle_key("\r", app)  # → modal set, mode=deile_worker
+        with patch("_panel.pd_audit_dispatch_mode_change") as audit:
+            view.handle_key("Z", app)  # tecla aleatória
+        results = [c.kwargs.get("result") for c in audit.call_args_list]
+        assert "cancelled" in results
+        # O detail carrega a tecla pra trilha de evidência.
+        details = [c.kwargs.get("detail", "") for c in audit.call_args_list]
+        assert any("tecla inesperada" in d or "Z" in d for d in details)
+
     def test_clear_confirm_n_emits_cancelled_audit(self):
         view, app = self._new_view()
         view.handle_key("c", app)
@@ -623,8 +691,8 @@ class TestDashboardHotkey:
         diferente e cause conflito de propagação (hoje o panel propaga
         global após a view não interceptar — então um ``d`` numa view
         que não tem handler local cai no dashboard handler depois)."""
-        from _panel import (DashboardView, DispatchModeView, ModelSwitcherView,
-                            PodPickerView, StageModelsView)
+        from _panel import (DispatchModeView, ModelSwitcherView, PodPickerView,
+                            StageModelsView)
 
         # Cada view abaixo NÃO deve ter um shortcut "d" próprio. O dispatch
         # view tem `d` listada nas hotkeys da statusline mas não no
@@ -632,16 +700,13 @@ class TestDashboardHotkey:
         # view; uma vez na view, a tecla é capturada pelo modal/nav.
         for view_cls in (PodPickerView, ModelSwitcherView, StageModelsView,
                          DispatchModeView):
-            # Smoke: instanciar com data=None (demo) não deve crashar e
-            # `handle_key("d", ...)` deve retornar ActionResult sem .target
-            # casando outra view.
             v = view_cls(data=None)
             result = v.handle_key("d", MagicMock())
-            # Aceita ActionResult() padrão (default-pass) ou refresh.
-            assert getattr(result, "target", None) != "dispatch-mode" \
-                or view_cls is DashboardView, (
-                f"{view_cls.__name__}.handle_key('d') deveria não navegar para "
-                f"dispatch-mode (só DashboardView pode), got target="
+            # Aceita ActionResult() padrão (default-pass) ou refresh — só
+            # rejeita NAV explícito para dispatch-mode.
+            assert getattr(result, "target", None) != "dispatch-mode", (
+                f"{view_cls.__name__}.handle_key('d') deveria não navegar "
+                f"para dispatch-mode (só DashboardView pode), got target="
                 f"{getattr(result, 'target', None)}"
             )
 

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -61,6 +61,8 @@ from _panel_data import _fmt_age  # noqa: F401
 from _panel_data import kubectl_bin  # noqa: F401
 from _panel_data import BackgroundRefresher, PanelData  # noqa: F401
 from _panel_data import \
+    _audit_dispatch_mode_change as pd_audit_dispatch_mode_change
+from _panel_data import \
     _audit_security_policy_change as pd_audit_security_policy_change
 from _panel_data import \
     clear_pipeline_dispatch_mode as pd_clear_pipeline_dispatch_mode
@@ -3468,13 +3470,34 @@ class DispatchModeView(View):
 
     def _handle_set_confirm_key(self, key: str) -> ActionResult:
         mode = self.mode_modal[1] if self.mode_modal else None
+        # Guarda explícita contra mode_modal degenerado (('set', '') /
+        # ('set', None)): em vez de cair silenciosamente no ramo de
+        # cancelamento, fechamos com erro visível pra o operador notar.
+        if key == "y" and not mode:
+            self.mode_modal = None
+            self.last_msg = (
+                "estado interno inconsistente: modo do modal vazio"
+            )
+            self.last_ok = False
+            pd_audit_dispatch_mode_change(
+                None, result="failed",
+                detail="modal state degenerado em _handle_set_confirm_key",
+            )
+            return ActionResult.refresh()
         if key == "y" and mode:
             self._apply_set(mode)
             self.mode_modal = None
             if self.data is not None:
                 self.data.dispatch_mode._cache.invalidate()  # noqa: SLF001
             return ActionResult.refresh()
-        # ESC / n / anything else cancels (default-deny).
+        # ESC / n / anything else cancels (default-deny). Audita
+        # ``cancelled`` para paridade com ModelSwitcherView — o branch
+        # ``cancelled`` em ``_audit_dispatch_mode_change`` não fica morto.
+        reason = ("operador cancelou na confirmação" if key in ("n", "ESC")
+                  else f"tecla inesperada na confirmação: {key!r}")
+        pd_audit_dispatch_mode_change(
+            mode, result="cancelled", detail=reason,
+        )
         self.mode_modal = None
         self.last_msg = "cancelado pelo operador"
         self.last_ok = False
@@ -3487,6 +3510,13 @@ class DispatchModeView(View):
             if self.data is not None:
                 self.data.dispatch_mode._cache.invalidate()  # noqa: SLF001
             return ActionResult.refresh()
+        # Cancelamento auditado — paridade com ModelSwitcherView e com o
+        # ramo "cancelled" reconhecido em ``_audit_dispatch_mode_change``.
+        reason = ("operador cancelou na confirmação" if key in ("n", "ESC")
+                  else f"tecla inesperada na confirmação: {key!r}")
+        pd_audit_dispatch_mode_change(
+            None, result="cancelled", detail=reason,
+        )
         self.mode_modal = None
         self.last_msg = "cancelado pelo operador"
         self.last_ok = False

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -55,13 +55,18 @@ import _panel_demo as demo  # noqa: E402
 # sys.path setup feito por `deploy.py` (que insere `infra/k8s/` no path
 # antes de importar `_panel`). Não trocar para `from infra.k8s. ...` sem
 # revisar como o orquestrador invoca o painel.
+from _panel_data import \
+    NS as _NS_DEFAULT  # noqa: F401  # PR #315 — multi-namespace
 from _panel_data import _fmt_age  # noqa: F401
 from _panel_data import kubectl_bin  # noqa: F401
 from _panel_data import BackgroundRefresher, PanelData  # noqa: F401
 from _panel_data import \
     _audit_security_policy_change as pd_audit_security_policy_change
-from _panel_data import NS as _NS_DEFAULT  # noqa: F401  # PR #315 — multi-namespace
+from _panel_data import \
+    clear_pipeline_dispatch_mode as pd_clear_pipeline_dispatch_mode
 from _panel_data import clear_stage_model as pd_clear_stage_model
+from _panel_data import \
+    set_pipeline_dispatch_mode as pd_set_pipeline_dispatch_mode
 from _panel_data import set_preferred_model as pd_set_preferred_model
 from _panel_data import set_stage_model as pd_set_stage_model
 from rich import box
@@ -870,6 +875,10 @@ class DashboardView(View):
             # distinct keystroke (Shift+m) so it doesn't collide with the
             # deployment-wide ModelSwitcherView on lowercase 'm'.
             "M": "stage-models",
+            # Pipeline dispatch mode (issue #309) — flip
+            # ``DEILE_PIPELINE_DISPATCH_MODE`` (claude vs deile_worker) sem
+            # editar manifests.
+            "d": "dispatch-mode",
         }
         if key in nav:
             return ActionResult.nav(nav[key])
@@ -1222,10 +1231,9 @@ class PodPickerView(View):
             self.last_msg = "modo demo — nenhuma ação aplicada"
             self.last_ok = False
             return
-        from _panel_data import (delete_pod,  # noqa: PLC0415
-                                  kill_local_pid,
-                                  rollout_restart_all,
-                                  rollout_restart_deployment)
+        from _panel_data import delete_pod  # noqa: PLC0415
+        from _panel_data import (kill_local_pid, rollout_restart_all,
+                                 rollout_restart_deployment)
 
         # Multi-NS (issue #297): propagar o namespace do contexto em vez de
         # deixar as funções caírem no default ``NS`` (env DEILE_K8S_NAMESPACE
@@ -3224,6 +3232,289 @@ class StageModelsView(View):
         self.last_msg = msg
 
 
+class DispatchModeView(View):
+    """Editor do dispatch mode do pipeline (issue #309) — layout dinâmico.
+
+    O ``PipelineMonitor`` instancia ``ClaudeImplementer`` (``claude -p`` num
+    worktree local) ou ``WorkerImplementer`` (HTTP → deile-worker), decidido por
+    ``settings.pipeline_dispatch_mode``. A view permite flipar entre os dois
+    sem editar manifest ou ConfigMap: ``kubectl set env`` sobre
+    ``deile-pipeline`` dispara rollout (strategy ``Recreate``) e a próxima
+    dispatch usa o modo novo.
+
+    Limitação operacional: setar ``claude`` só funciona se o binary ``claude``
+    estiver no PATH dentro do pod E houver credentials montadas para
+    ``~/.claude/``. Hoje o image NÃO instala o ``claude`` CLI nem monta
+    credentials — a próxima dispatch falha com um erro `claude binary not
+    found` claro (sem dano além disso). Issue de follow-up cobre o trabalho
+    de infra (Dockerfile + Secret).
+
+    Persistência via ``set_pipeline_dispatch_mode`` (kubectl set env + audit
+    log); o pipeline pega o modo novo no rollout disparado pelo kubectl.
+    """
+
+    name = "dispatch-mode"
+    title = "Modo de despacho do pipeline (deile_worker | claude)"
+    refresh_s = 1.0
+
+    HOTKEYS = ("[↑/↓] navega   [enter] aplicar   [c] limpar override   "
+               "[r] refresh   [esc] volta   [q] sai")
+
+    # Source of truth do conjunto de modos — espelha _DISPATCH_MODES_ALLOWED
+    # em _panel_data.py. Listado aqui (e não importado) para a view continuar
+    # importável quando o painel roda de infra/k8s sem o pacote DEILE no path.
+    _MODES_FALLBACK = ("deile_worker", "claude")
+
+    # Pretty/descrição por modo — visível no painel ajuda escolha sem doc externa.
+    _MODE_DESCRIPTIONS = {
+        "deile_worker": (
+            "DEILE-to-DEILE — pipeline dispara o deile-worker via HTTP "
+            "(default; sem dependência externa)."
+        ),
+        "claude": (
+            "Claude Code one-shot — pipeline roda `claude -p` num worktree "
+            "local. Requer binary `claude` no PATH + credenciais em "
+            "~/.claude/."
+        ),
+    }
+
+    def __init__(self, data: Optional[PanelData] = None):
+        self.data = data
+        self.cursor: int = 0
+        self.last_msg: str = ""
+        self.last_ok: Optional[bool] = None
+        # Modal state: None = browsing; ("set", mode) = confirming apply;
+        # ("clear", None) = confirming reset.
+        self.mode_modal: Optional[tuple] = None
+
+    def on_unmount(self, app: "PanelApp") -> None:
+        # Re-entry should always land on the option list, never on a stale
+        # confirmation modal that the operator dismissed by leaving the view.
+        self.mode_modal = None
+
+    def intercepts_key(self, key: str) -> bool:
+        # ESC inside a modal must close the modal (our own _handle_*),
+        # not pop the view off the app stack.
+        return key == "ESC" and self.mode_modal is not None
+
+    # --- data accessors --------------------------------------------------
+
+    def _current(self):
+        """Return the current ``DispatchModeEntry`` (or a demo-mode stub)."""
+        if self.data is None:
+            # Demo mode: pretend deile-pipeline has no env override and falls
+            # back to the ConfigMap default. Visible to the operator as
+            # "source: default", same shape as a real cluster read.
+            from _panel_data import DispatchModeEntry  # noqa: PLC0415
+            return DispatchModeEntry(
+                mode=None, source="default", effective="deile_worker",
+            )
+        return self.data.dispatch_mode.get()
+
+    # --- rendering -------------------------------------------------------
+
+    def _render_options(self, current_mode: Optional[str],
+                        width: int) -> RenderableType:
+        compact = width < 100
+        tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
+        tbl.add_column(" ", width=2)
+        tbl.add_column("#", width=2, justify="right")
+        tbl.add_column("modo", style="bold")
+        if not compact:
+            tbl.add_column("descrição", overflow="fold")
+        tbl.add_column("ativo", width=8, justify="center")
+        modes = self._MODES_FALLBACK
+        self.cursor = max(0, min(self.cursor, len(modes) - 1))
+        for i, m in enumerate(modes):
+            marker = "▶" if i == self.cursor else " "
+            is_active = (m == current_mode)
+            slug_style = "bold yellow" if is_active else "bold"
+            active_mark = Text("●", style="bold green") if is_active \
+                else Text("", style="dim")
+            row = [
+                Text(marker, style="bold cyan"),
+                Text(f"{i + 1}", style="bold cyan"),
+                Text(m, style=slug_style),
+            ]
+            if not compact:
+                row.append(Text(self._MODE_DESCRIPTIONS.get(m, ""),
+                                style="dim"))
+            row.append(active_mark)
+            tbl.add_row(*row)
+        return Panel(
+            tbl,
+            title="[bold]MODOS DISPONÍVEIS[/bold]",
+            title_align="left", border_style="cyan",
+        )
+
+    def _render_status_panel(self, entry) -> RenderableType:
+        """Painel header com o estado corrente lido do cluster."""
+        source_pretty = {
+            "env": "DEILE_PIPELINE_DISPATCH_MODE (env do Deployment)",
+            "default": "settings.json / ConfigMap (sem env override)",
+        }.get(entry.source, entry.source)
+        lines = [
+            Text.assemble(
+                ("modo efetivo: ", "dim"),
+                (entry.effective, "bold yellow"),
+            ),
+            Text.assemble(
+                ("origem: ", "dim"),
+                (source_pretty, "cyan"),
+            ),
+        ]
+        if entry.mode is None:
+            lines.append(Text(
+                "(sem override per-Deployment — pod usa o default do ConfigMap)",
+                style="dim",
+            ))
+        return Panel(Group(*lines),
+                     title="[bold]ESTADO ATUAL[/bold]",
+                     title_align="left", border_style="yellow")
+
+    def _render_action_status(self) -> Optional[RenderableType]:
+        if not self.last_msg:
+            return None
+        border = "green" if self.last_ok else "red"
+        return Panel(
+            Text(self.last_msg,
+                 style="bold green" if self.last_ok else "bold red"),
+            title="[bold]ÚLTIMA AÇÃO[/bold]",
+            title_align="left", border_style=border,
+        )
+
+    def render(self, app: "PanelApp") -> RenderableType:
+        entry = self._current()
+        width = app.console.size.width or 100
+        layout = Layout()
+        sections: List[Layout] = [
+            Layout(_head_panel(self.title, app), name="head", size=4),
+        ]
+        # Modal confirmação fica em destaque acima da listagem.
+        if self.mode_modal is not None and self.mode_modal[0] == "set":
+            mode = self.mode_modal[1]
+            sections.append(Layout(Panel(
+                Group(
+                    Text(f"Aplicar dispatch_mode = '{mode}' em deile-pipeline?",
+                         style="bold yellow"),
+                    Text("`kubectl set env` dispara rollout (strategy "
+                         "Recreate). A próxima dispatch já roda no modo novo.",
+                         style="dim"),
+                    Text(),
+                    Text("[y] confirmar    [n] cancelar", style="bold cyan"),
+                ),
+                title="[bold yellow]CONFIRMAR APLICAÇÃO[/bold yellow]",
+                title_align="left", border_style="yellow",
+            ), name="confirm", size=8))
+        elif self.mode_modal is not None and self.mode_modal[0] == "clear":
+            sections.append(Layout(Panel(
+                Group(
+                    Text("Limpar override de DEILE_PIPELINE_DISPATCH_MODE?",
+                         style="bold yellow"),
+                    Text("O pipeline voltará a usar o default declarado no "
+                         "ConfigMap (deile_worker) na próxima dispatch.",
+                         style="dim"),
+                    Text(),
+                    Text("[y] confirmar    [n] cancelar", style="bold cyan"),
+                ),
+                title="[bold yellow]CONFIRMAR LIMPEZA[/bold yellow]",
+                title_align="left", border_style="yellow",
+            ), name="confirm", size=8))
+        else:
+            # Browsing — status + opções.
+            sections.append(Layout(self._render_status_panel(entry),
+                                   name="status_header", size=6))
+            sections.append(Layout(self._render_options(entry.effective,
+                                                        width),
+                                   name="body"))
+
+        action_status = self._render_action_status()
+        if action_status is not None:
+            sections.append(Layout(action_status, name="status", size=4))
+
+        sections.append(Layout(_footer_panel(self.HOTKEYS),
+                               name="footer", size=3))
+        layout.split_column(*sections)
+        return layout
+
+    # --- input -----------------------------------------------------------
+
+    def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        # Confirmação modal: y aplica, qualquer outra tecla cancela.
+        if self.mode_modal is not None and self.mode_modal[0] == "set":
+            return self._handle_set_confirm_key(key)
+        if self.mode_modal is not None and self.mode_modal[0] == "clear":
+            return self._handle_clear_confirm_key(key)
+        modes = self._MODES_FALLBACK
+        n = len(modes)
+        if key in ("UP", "k"):
+            self.cursor = (self.cursor - 1) % n
+            return ActionResult.refresh()
+        if key in ("DOWN", "j"):
+            self.cursor = (self.cursor + 1) % n
+            return ActionResult.refresh()
+        if key.isdigit():
+            idx = int(key) - 1
+            if 0 <= idx < n:
+                self.cursor = idx
+                return ActionResult.refresh()
+        if key in ("\r", "\n"):
+            self.mode_modal = ("set", modes[self.cursor])
+            return ActionResult.refresh()
+        if key == "c":
+            self.mode_modal = ("clear", None)
+            return ActionResult.refresh()
+        return ActionResult()
+
+    def _handle_set_confirm_key(self, key: str) -> ActionResult:
+        mode = self.mode_modal[1] if self.mode_modal else None
+        if key == "y" and mode:
+            self._apply_set(mode)
+            self.mode_modal = None
+            if self.data is not None:
+                self.data.dispatch_mode._cache.invalidate()  # noqa: SLF001
+            return ActionResult.refresh()
+        # ESC / n / anything else cancels (default-deny).
+        self.mode_modal = None
+        self.last_msg = "cancelado pelo operador"
+        self.last_ok = False
+        return ActionResult.refresh()
+
+    def _handle_clear_confirm_key(self, key: str) -> ActionResult:
+        if key == "y":
+            self._apply_clear()
+            self.mode_modal = None
+            if self.data is not None:
+                self.data.dispatch_mode._cache.invalidate()  # noqa: SLF001
+            return ActionResult.refresh()
+        self.mode_modal = None
+        self.last_msg = "cancelado pelo operador"
+        self.last_ok = False
+        return ActionResult.refresh()
+
+    # --- writes ----------------------------------------------------------
+
+    def _apply_set(self, mode: str) -> None:
+        if self.data is None:
+            self.last_msg = "modo demo — nenhuma escrita aplicada"
+            self.last_ok = False
+            return
+        ns = self.data.context.namespace if self.data.context else _NS_DEFAULT
+        ok, msg = pd_set_pipeline_dispatch_mode(mode, namespace=ns)
+        self.last_ok = ok
+        self.last_msg = msg
+
+    def _apply_clear(self) -> None:
+        if self.data is None:
+            self.last_msg = "modo demo — nenhuma escrita aplicada"
+            self.last_ok = False
+            return
+        ns = self.data.context.namespace if self.data.context else _NS_DEFAULT
+        ok, msg = pd_clear_pipeline_dispatch_mode(namespace=ns)
+        self.last_ok = ok
+        self.last_msg = msg
+
+
 class StubView(View):
     """Sub-view placeholder enquanto a Fase correspondente não foi feita."""
 
@@ -3266,8 +3557,9 @@ class HelpView(View):
         tbl.add_column("tecla", style="bold cyan", width=18)
         tbl.add_column("ação")
         rows = [
-            ("1-5, a, m, M, n",  "drill em sub-view (no dashboard)"),
+            ("1-5, a, m, M, d, n",  "drill em sub-view (no dashboard)"),
             ("m / M",         "modelo do deployment / modelo por etapa (settings)"),
+            ("d",             "modo de despacho do pipeline (claude | deile_worker)"),
             ("↑/↓ ou j/k",    "navega em listas (picker, issues/PRs, modelos)"),
             ("enter",         "seleciona o item destacado"),
             ("esc",           "volta à view anterior (ou ao dashboard)"),
@@ -3636,6 +3928,8 @@ def _build_views(data: Optional[PanelData] = None) -> Dict[str, View]:
         "notifier-echo": NotifierEchoView(data=data),
         "model-switcher": ModelSwitcherView(data=data),
         "stage-models": StageModelsView(data=data),
+        # Issue #309 — flip pipeline dispatch_mode (deile_worker | claude).
+        "dispatch-mode": DispatchModeView(data=data),
     }
 
 
@@ -3657,7 +3951,8 @@ def run_panel(context: "Optional[Any]" = None,
     locais (modo "local only"). Demo agora exige opt-in explícito.
     """
     # Import local para evitar import circular no topo.
-    from _panel_data import RuntimeContext, discover_deile_namespaces  # noqa: PLC0415
+    from _panel_data import RuntimeContext  # noqa: PLC0415
+    from _panel_data import discover_deile_namespaces  # noqa: PLC0415
 
     if force_demo:
         data: Optional[PanelData] = None
@@ -3698,7 +3993,8 @@ def run_panel(context: "Optional[Any]" = None,
                     context = RuntimeContext.detect(namespace=selected_ns)
                 elif hasattr(context, "__class__"):
                     # RuntimeContext é frozen; cria novo com namespace correto.
-                    from dataclasses import replace as _dc_replace  # noqa: PLC0415
+                    from dataclasses import \
+                        replace as _dc_replace  # noqa: PLC0415
                     context = _dc_replace(context, namespace=selected_ns)
 
         ctx = context if context is not None else RuntimeContext.detect()

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -3495,8 +3495,18 @@ class DispatchModeView(View):
         # ``cancelled`` em ``_audit_dispatch_mode_change`` não fica morto.
         reason = ("operador cancelou na confirmação" if key in ("n", "ESC")
                   else f"tecla inesperada na confirmação: {key!r}")
+        # ``mode`` pode ser falsy (degenerate set state) — passa ``None`` ao
+        # audit nesse caso pra não confundir o discriminador ``action`` (que
+        # vira ``kubectl_unset_env`` quando mode é falsy). ``detail`` carrega
+        # o motivo original e a string vazia/falsy é registrada lá pra log
+        # analysis se necessário.
+        audit_mode = mode if mode else None
+        audit_detail = (
+            reason if mode
+            else f"{reason} (modal state degenerado: mode={mode!r})"
+        )
         pd_audit_dispatch_mode_change(
-            mode, result="cancelled", detail=reason,
+            audit_mode, result="cancelled", detail=audit_detail,
         )
         self.mode_modal = None
         self.last_msg = "cancelado pelo operador"

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -3385,6 +3385,41 @@ class DispatchModeView(View):
             title_align="left", border_style=border,
         )
 
+    def _render_confirm_modal(self, kind: str) -> RenderableType:
+        """Constrói o Panel de confirmação para ``set`` ou ``clear``.
+
+        Mantém os 2 modais com a mesma moldura/posição mas headers e
+        prompts distintos — único callsite no :meth:`render`.
+        """
+        if kind == "set":
+            mode = self.mode_modal[1]
+            header = Text(
+                f"Aplicar dispatch_mode = '{mode}' em deile-pipeline?",
+                style="bold yellow",
+            )
+            detail = Text(
+                "`kubectl set env` dispara rollout (strategy Recreate). "
+                "A próxima dispatch já roda no modo novo.",
+                style="dim",
+            )
+            title = "[bold yellow]CONFIRMAR APLICAÇÃO[/bold yellow]"
+        else:  # "clear"
+            header = Text(
+                "Limpar override de DEILE_PIPELINE_DISPATCH_MODE?",
+                style="bold yellow",
+            )
+            detail = Text(
+                "O pipeline voltará a usar o default declarado no "
+                "ConfigMap (deile_worker) na próxima dispatch.",
+                style="dim",
+            )
+            title = "[bold yellow]CONFIRMAR LIMPEZA[/bold yellow]"
+        return Panel(
+            Group(header, detail, Text(),
+                  Text("[y] confirmar    [n] cancelar", style="bold cyan")),
+            title=title, title_align="left", border_style="yellow",
+        )
+
     def render(self, app: "PanelApp") -> RenderableType:
         entry = self._current()
         width = app.console.size.width or 100
@@ -3393,35 +3428,10 @@ class DispatchModeView(View):
             Layout(_head_panel(self.title, app), name="head", size=4),
         ]
         # Modal confirmação fica em destaque acima da listagem.
-        if self.mode_modal is not None and self.mode_modal[0] == "set":
-            mode = self.mode_modal[1]
-            sections.append(Layout(Panel(
-                Group(
-                    Text(f"Aplicar dispatch_mode = '{mode}' em deile-pipeline?",
-                         style="bold yellow"),
-                    Text("`kubectl set env` dispara rollout (strategy "
-                         "Recreate). A próxima dispatch já roda no modo novo.",
-                         style="dim"),
-                    Text(),
-                    Text("[y] confirmar    [n] cancelar", style="bold cyan"),
-                ),
-                title="[bold yellow]CONFIRMAR APLICAÇÃO[/bold yellow]",
-                title_align="left", border_style="yellow",
-            ), name="confirm", size=8))
-        elif self.mode_modal is not None and self.mode_modal[0] == "clear":
-            sections.append(Layout(Panel(
-                Group(
-                    Text("Limpar override de DEILE_PIPELINE_DISPATCH_MODE?",
-                         style="bold yellow"),
-                    Text("O pipeline voltará a usar o default declarado no "
-                         "ConfigMap (deile_worker) na próxima dispatch.",
-                         style="dim"),
-                    Text(),
-                    Text("[y] confirmar    [n] cancelar", style="bold cyan"),
-                ),
-                title="[bold yellow]CONFIRMAR LIMPEZA[/bold yellow]",
-                title_align="left", border_style="yellow",
-            ), name="confirm", size=8))
+        modal_kind = self.mode_modal[0] if self.mode_modal is not None else None
+        if modal_kind in ("set", "clear"):
+            sections.append(Layout(self._render_confirm_modal(modal_kind),
+                                   name="confirm", size=8))
         else:
             # Browsing — status + opções.
             sections.append(Layout(self._render_status_panel(entry),
@@ -3443,9 +3453,10 @@ class DispatchModeView(View):
 
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
         # Confirmação modal: y aplica, qualquer outra tecla cancela.
-        if self.mode_modal is not None and self.mode_modal[0] == "set":
+        modal_kind = self.mode_modal[0] if self.mode_modal is not None else None
+        if modal_kind == "set":
             return self._handle_set_confirm_key(key)
-        if self.mode_modal is not None and self.mode_modal[0] == "clear":
+        if modal_kind == "clear":
             return self._handle_clear_confirm_key(key)
         modes = self._MODES_FALLBACK
         n = len(modes)

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -2103,6 +2103,261 @@ def clear_stage_model(stage: str, timeout: float = 15.0) -> tuple:
     return True, f"{env_var} unset ({msg})"
 
 
+# ===== Pipeline dispatch mode (issue #309) ==================================
+#
+# O ``PipelineMonitor`` lê ``settings.pipeline_dispatch_mode`` no boot e instancia
+# ``ClaudeImplementer`` (``claude -p`` num worktree local) ou ``WorkerImplementer``
+# (HTTP → deile-worker). O ConfigMap ``deile-runtime-config`` traz o default
+# (``deile_worker``), mas o painel TUI permite flipar o modo sem editar manifest
+# nem ConfigMap: ``kubectl set env deploy/deile-pipeline DEILE_PIPELINE_DISPATCH_MODE=<mode>``.
+#
+# A env var é tecnicamente *deprecated* a favor de ``pipeline.dispatch_mode`` no
+# settings.json (issue #111), mas é o único caminho que NÃO exige editar +
+# re-aplicar ConfigMap (que não propaga live em subPath mounts) — e o
+# ``kubectl set env`` dispara rollout, então a config nova chega no pod novo
+# como qualquer outro `kubectl set env` da casa. Continuamos compat com a env
+# var; quem prefere editar JSON pode editar o ConfigMap manualmente.
+#
+# **Limitação operacional documentada**: setar ``claude`` aqui só funciona se o
+# binary ``claude`` estiver no PATH dentro do pod *e* houver credentials para
+# ``~/.claude/`` (subscription ou API key). Hoje o image NÃO instala o
+# ``claude`` CLI nem monta credentials — follow-up explícito no body do PR
+# de #309 (e a próxima dispatch ``claude`` no pipeline emite warning claro de
+# ``claude binary not found in PATH``).
+_DISPATCH_MODES_ALLOWED: tuple = ("claude", "deile_worker")
+_DISPATCH_DEPLOYMENT = "deile-pipeline"
+_DISPATCH_ENV_VAR = "DEILE_PIPELINE_DISPATCH_MODE"
+
+
+@dataclass(frozen=True)
+class DispatchModeEntry:
+    """Snapshot do dispatch mode lido do cluster (issue #309).
+
+    - ``mode`` — valor corrente de ``DEILE_PIPELINE_DISPATCH_MODE`` no
+      Deployment ``deile-pipeline``. ``None`` quando a env var não está setada
+      (o pod cai no default carregado do settings.json — ``deile_worker``).
+    - ``source`` — ``"env"`` quando lida da Deployment spec; ``"default"``
+      quando não há env e o painel infere o valor declarado no ConfigMap.
+    - ``effective`` — o que o pod realmente vai usar na próxima dispatch:
+      ``mode`` quando presente, senão o default do settings.json layered.
+    """
+
+    mode: Optional[str]
+    source: str
+    effective: str
+
+
+class DispatchModeProvider(_KubectlProviderMixin):
+    """Lê o dispatch mode corrente da Deployment ``deile-pipeline``.
+
+    Mirrors :class:`CurrentModelProvider` (um único ``kubectl get -o json``)
+    mas extrai ``DEILE_PIPELINE_DISPATCH_MODE`` em vez de
+    ``DEILE_PREFERRED_MODEL``. TTL alinhado com ``CurrentModelProvider`` (3s).
+    """
+
+    _DEFAULT_FROM_CONFIGMAP = "deile_worker"
+
+    def __init__(self, ttl_s: float = 3.0, enabled: bool = True):
+        self._kubectl = kubectl_bin()
+        self._enabled = enabled
+        self._cache: Cache[DispatchModeEntry] = Cache(
+            ttl_s, self._fetch,
+            fallback=DispatchModeEntry(
+                mode=None, source="default",
+                effective=self._DEFAULT_FROM_CONFIGMAP,
+            ),
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> DispatchModeEntry:
+        return self._cache.get(force)
+
+    def _fetch(self) -> DispatchModeEntry:
+        self._check_enabled()
+        self._resolve_kubectl()
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        data = _capture_json(
+            [self._kubectl, "-n", NS, "get",
+             f"deployment/{_DISPATCH_DEPLOYMENT}", "-o", "json"],
+            timeout=4.0,
+        )
+        if not data:
+            raise RuntimeError(
+                f"kubectl get deployment/{_DISPATCH_DEPLOYMENT} falhou ou vazio"
+            )
+        containers = (data.get("spec", {}).get("template", {})
+                      .get("spec", {}).get("containers", []) or [])
+        env_value: Optional[str] = None
+        for env in (containers[0].get("env") or []) if containers else []:
+            if env.get("name") == _DISPATCH_ENV_VAR:
+                raw = env.get("value")
+                if isinstance(raw, str) and raw.strip():
+                    env_value = raw.strip().lower()
+                break
+        if env_value:
+            return DispatchModeEntry(
+                mode=env_value, source="env", effective=env_value,
+            )
+        return DispatchModeEntry(
+            mode=None, source="default",
+            effective=self._DEFAULT_FROM_CONFIGMAP,
+        )
+
+
+def _audit_dispatch_mode_change(
+    mode: Optional[str], *, result: str, detail: str,
+    namespace: str = NS,
+) -> None:
+    """Audit ``SECURITY_POLICY_CHANGED`` para troca de dispatch mode (#309).
+
+    Mesma envelope de :func:`_audit_security_policy_change` (preferred_model)
+    e :func:`_audit_stage_model_change` (stage models) para que dashboards
+    grepem os três sob o mesmo event type. ``mode=None`` é a variante
+    clear/reset (volta ao default do settings.json).
+    """
+    try:
+        from deile.security.audit_logger import (  # noqa: PLC0415
+            AuditEventType, SeverityLevel, get_audit_logger)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "audit logger indisponível para set_pipeline_dispatch_mode: %s",
+            exc,
+        )
+        return
+    severity = (SeverityLevel.INFO
+                if result in ("allowed", "completed", "cancelled")
+                else SeverityLevel.WARNING)
+    try:
+        get_audit_logger().log_event(
+            event_type=AuditEventType.SECURITY_POLICY_CHANGED,
+            severity=severity,
+            actor="panel:set_pipeline_dispatch_mode",
+            resource=f"deployment:{namespace}/{_DISPATCH_DEPLOYMENT}:{_DISPATCH_ENV_VAR}",
+            action="kubectl_set_env" if mode else "kubectl_unset_env",
+            result=result,
+            details={"mode": mode or "", "detail": detail[:200]},
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("falha emitindo AuditEvent (dispatch_mode): %s", exc)
+
+
+def set_pipeline_dispatch_mode(
+    mode: str, *, namespace: str = NS, timeout: float = 15.0,
+) -> tuple:
+    """Pin ``DEILE_PIPELINE_DISPATCH_MODE=<mode>`` em ``deile-pipeline`` (#309).
+
+    Usa ``kubectl set env deploy/deile-pipeline`` e dispara o rollout
+    (strategy ``Recreate`` do pipeline). Returns ``(ok, msg)``.
+
+    O argumento ``mode`` é validado contra ``_DISPATCH_MODES_ALLOWED`` ANTES
+    de virar argv — rejeita typos (``claude_p``, ``deile-worker``...) que de
+    outra forma cairiam silenciosamente no fallback do ``build_implementer``
+    e quebrariam a próxima dispatch.
+    """
+    safe_mode = mode if isinstance(mode, str) else repr(mode)
+    if not isinstance(mode, str) or mode.strip().lower() not in _DISPATCH_MODES_ALLOWED:
+        _audit_dispatch_mode_change(
+            safe_mode, result="denied",
+            detail="dispatch_mode fora do conjunto canônico",
+            namespace=namespace,
+        )
+        allowed = ", ".join(sorted(_DISPATCH_MODES_ALLOWED))
+        return False, (
+            f"dispatch_mode '{mode}' inválido — "
+            f"esperado um de: {allowed}"
+        )
+    canonical = mode.strip().lower()
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        _audit_dispatch_mode_change(
+            canonical, result="failed", detail="kubectl não encontrado",
+            namespace=namespace,
+        )
+        return False, "kubectl não encontrado"
+    _audit_dispatch_mode_change(
+        canonical, result="allowed",
+        detail=f"executando kubectl set env {_DISPATCH_ENV_VAR}={canonical}",
+        namespace=namespace,
+    )
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", namespace, "set", "env",
+             f"deploy/{_DISPATCH_DEPLOYMENT}",
+             f"{_DISPATCH_ENV_VAR}={canonical}"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _audit_dispatch_mode_change(
+            canonical, result="failed", detail=f"subprocess: {exc}",
+            namespace=namespace,
+        )
+        return False, f"falha ao executar kubectl: {exc}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        _audit_dispatch_mode_change(
+            canonical, result="failed",
+            detail=f"rc={proc.returncode} {err}", namespace=namespace,
+        )
+        return False, err
+    msg = (proc.stdout or "rollout disparado").strip()
+    _audit_dispatch_mode_change(
+        canonical, result="completed", detail=msg, namespace=namespace,
+    )
+    return True, f"{_DISPATCH_ENV_VAR}={canonical} ({msg})"
+
+
+def clear_pipeline_dispatch_mode(
+    *, namespace: str = NS, timeout: float = 15.0,
+) -> tuple:
+    """Remove o override de dispatch mode no ``deile-pipeline`` (#309).
+
+    Usa ``kubectl set env ... <VAR>-`` (trailing dash = unset). Depois do
+    rollout, o pod relê o settings.json layered e cai no default declarado
+    no ConfigMap ``deile-runtime-config`` (``deile_worker``).
+    """
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        _audit_dispatch_mode_change(
+            None, result="failed", detail="kubectl não encontrado",
+            namespace=namespace,
+        )
+        return False, "kubectl não encontrado"
+    _audit_dispatch_mode_change(
+        None, result="allowed",
+        detail=f"executando kubectl set env {_DISPATCH_ENV_VAR}-",
+        namespace=namespace,
+    )
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", namespace, "set", "env",
+             f"deploy/{_DISPATCH_DEPLOYMENT}",
+             f"{_DISPATCH_ENV_VAR}-"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _audit_dispatch_mode_change(
+            None, result="failed", detail=f"subprocess: {exc}",
+            namespace=namespace,
+        )
+        return False, f"falha ao executar kubectl: {exc}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        _audit_dispatch_mode_change(
+            None, result="failed",
+            detail=f"rc={proc.returncode} {err}", namespace=namespace,
+        )
+        return False, err
+    msg = (proc.stdout or "rollout disparado").strip()
+    _audit_dispatch_mode_change(
+        None, result="completed", detail=msg, namespace=namespace,
+    )
+    return True, f"{_DISPATCH_ENV_VAR} unset ({msg})"
+
+
 # ===== Notifier (bot audit log) =============================================
 
 class NotifierProvider(_KubectlProviderMixin):
@@ -2932,8 +3187,8 @@ class LocalInstancesProvider:
 def _try_load_registry_cls():
     """Importa :class:`Registry` se o pacote ``deile`` estiver disponível."""
     try:
-        from deile.runtime.registry import (Registry,  # noqa: PLC0415
-                                            RegistryEntry)
+        from deile.runtime.registry import Registry  # noqa: PLC0415
+        from deile.runtime.registry import RegistryEntry
         return Registry, RegistryEntry
     except Exception:  # noqa: BLE001
         return None, None
@@ -3037,6 +3292,10 @@ class PanelData:
     models: ModelsProvider
     current_model: CurrentModelProvider
     stage_models: "StageModelsProvider"
+    # Dispatch mode do pipeline (issue #309). Lê
+    # ``DEILE_PIPELINE_DISPATCH_MODE`` da Deployment ``deile-pipeline`` para
+    # mostrar/editar via panel TUI.
+    dispatch_mode: "DispatchModeProvider"
     notifier: NotifierProvider
     local_processes: Optional[LocalProcessesProvider] = None
     local_logs: Optional[LocalLogsProvider] = None
@@ -3108,6 +3367,10 @@ class PanelData:
             # mesma Deployment `deile-worker`. Hardcoded para `NS` global
             # internamente; só recebe `enabled` para respeitar `--local-only`.
             stage_models=StageModelsProvider(enabled=k8s_on),
+            # `DispatchModeProvider` (issue #309) lê
+            # ``DEILE_PIPELINE_DISPATCH_MODE`` da Deployment
+            # ``deile-pipeline`` — single read, baixa frequência (3s).
+            dispatch_mode=DispatchModeProvider(enabled=k8s_on),
             notifier=NotifierProvider(namespace=context.namespace,
                                       deploy=context.bot_deploy,
                                       enabled=k8s_on),
@@ -3127,7 +3390,7 @@ class PanelData:
         """Ordem usada por `force_refresh_all` e `errors`."""
         base = (self.pods, self.pipeline, self.workers, self.github,
                 self.costs, self.models, self.current_model,
-                self.stage_models, self.notifier)
+                self.stage_models, self.dispatch_mode, self.notifier)
         locals_ = tuple(p for p in (self.local_processes, self.local_logs,
                                     self.local_audit, self.local_instances,
                                     self.local_registry)
@@ -3152,7 +3415,8 @@ class PanelData:
         eles seriam ruído visual no painel ALERTS sem trazer informação.
         """
         names = ["pods", "pipeline", "workers", "github", "costs",
-                 "models", "current_model", "stage_models", "notifier"]
+                 "models", "current_model", "stage_models",
+                 "dispatch_mode", "notifier"]
         if self.local_processes is not None:
             names.append("local_processes")
         if self.local_logs is not None:

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -2206,7 +2206,8 @@ class DispatchModeProvider(_KubectlProviderMixin):
         containers = (data.get("spec", {}).get("template", {})
                       .get("spec", {}).get("containers", []) or [])
         env_value: Optional[str] = None
-        for env in (containers[0].get("env") or []) if containers else []:
+        envs = (containers[0].get("env") or []) if containers else []
+        for env in envs:
             if env.get("name") == _DISPATCH_ENV_VAR:
                 raw = env.get("value")
                 if isinstance(raw, str) and raw.strip():

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -2153,13 +2153,27 @@ class DispatchModeProvider(_KubectlProviderMixin):
     Mirrors :class:`CurrentModelProvider` (um único ``kubectl get -o json``)
     mas extrai ``DEILE_PIPELINE_DISPATCH_MODE`` em vez de
     ``DEILE_PREFERRED_MODEL``. TTL alinhado com ``CurrentModelProvider`` (3s).
+
+    Multi-NS (PR #315): aceita ``namespace=`` no construtor para casar com o
+    namespace efetivo do painel. Quando o operador escolhe NS via menu, o
+    provider precisa ler do mesmo NS que :func:`set_pipeline_dispatch_mode`
+    escreve — senão a leitura mostra estado de outro cluster.
     """
 
+    # Default declarado no ConfigMap ``deile-runtime-config`` (manifest 47).
+    # **Drift risk**: se o ConfigMap mudar (ex.: novo default ``claude``), este
+    # valor precisa ser bumpado em sincronia. Hoje não há leitor de ConfigMap
+    # aqui — o painel não monta o ConfigMap no host. Aceito como pequena
+    # constante de espelhamento; alternativa (ler via ``kubectl get cm
+    # deile-runtime-config -o jsonpath=…``) acrescenta um subprocess por
+    # refresh e foi rejeitada pelo custo.
     _DEFAULT_FROM_CONFIGMAP = "deile_worker"
 
-    def __init__(self, ttl_s: float = 3.0, enabled: bool = True):
+    def __init__(self, ttl_s: float = 3.0, enabled: bool = True,
+                 namespace: str = NS):
         self._kubectl = kubectl_bin()
         self._enabled = enabled
+        self._namespace = namespace
         self._cache: Cache[DispatchModeEntry] = Cache(
             ttl_s, self._fetch,
             fallback=DispatchModeEntry(
@@ -2181,7 +2195,7 @@ class DispatchModeProvider(_KubectlProviderMixin):
         if self._kubectl is None:
             raise RuntimeError("kubectl não encontrado")
         data = _capture_json(
-            [self._kubectl, "-n", NS, "get",
+            [self._kubectl, "-n", self._namespace, "get",
              f"deployment/{_DISPATCH_DEPLOYMENT}", "-o", "json"],
             timeout=4.0,
         )
@@ -2196,7 +2210,13 @@ class DispatchModeProvider(_KubectlProviderMixin):
             if env.get("name") == _DISPATCH_ENV_VAR:
                 raw = env.get("value")
                 if isinstance(raw, str) and raw.strip():
-                    env_value = raw.strip().lower()
+                    # Canonicaliza aliases (``worker``, ``claude_code``...) para
+                    # o conjunto whitelist da UI. Se alguém setou manualmente
+                    # ``DEILE_PIPELINE_DISPATCH_MODE=worker`` (alias válido para
+                    # ``build_implementer``), o painel mostra ``deile_worker``
+                    # — alinhado com a opção que aparece no picker, em vez de
+                    # exibir um valor que não destaca nenhuma linha.
+                    env_value = _canonicalize_dispatch_alias(raw)
                 break
         if env_value:
             return DispatchModeEntry(
@@ -2206,6 +2226,27 @@ class DispatchModeProvider(_KubectlProviderMixin):
             mode=None, source="default",
             effective=self._DEFAULT_FROM_CONFIGMAP,
         )
+
+
+def _canonicalize_dispatch_alias(raw: str) -> str:
+    """Normaliza aliases de dispatch_mode para o conjunto canônico da UI.
+
+    ``build_implementer`` aceita aliases (``worker``, ``deile-worker``,
+    ``claude_code``...), mas o painel mostra só o conjunto canônico
+    (``claude`` | ``deile_worker``). Esse helper traduz: alias conhecido →
+    forma canônica; valor desconhecido → devolvido como-veio em lowercase
+    (não esconde valor estranho na UI; o operador vê o que está no cluster).
+    """
+    # Import local pra evitar dependência circular (deile.* importado de
+    # infra/k8s/_panel_data.py durante boot do painel).
+    from deile.orchestration.pipeline.implementer import (  # noqa: PLC0415
+        CLAUDE_ALIASES, WORKER_ALIASES)
+    lo = raw.strip().lower()
+    if lo in WORKER_ALIASES:
+        return "deile_worker"
+    if lo in CLAUDE_ALIASES:
+        return "claude"
+    return lo
 
 
 def _audit_dispatch_mode_change(
@@ -3370,7 +3411,11 @@ class PanelData:
             # `DispatchModeProvider` (issue #309) lê
             # ``DEILE_PIPELINE_DISPATCH_MODE`` da Deployment
             # ``deile-pipeline`` — single read, baixa frequência (3s).
-            dispatch_mode=DispatchModeProvider(enabled=k8s_on),
+            # ``namespace`` propagado do contexto (multi-NS / PR #315) — sem
+            # isso o painel lê de ``deile`` mas escreve no NS escolhido,
+            # quebrando a sincronia de leitura/escrita.
+            dispatch_mode=DispatchModeProvider(enabled=k8s_on,
+                                               namespace=context.namespace),
             notifier=NotifierProvider(namespace=context.namespace,
                                       deploy=context.bot_deploy,
                                       enabled=k8s_on),

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -2237,8 +2237,11 @@ def _canonicalize_dispatch_alias(raw: str) -> str:
     forma canônica; valor desconhecido → devolvido como-veio em lowercase
     (não esconde valor estranho na UI; o operador vê o que está no cluster).
     """
-    # Import local pra evitar dependência circular (deile.* importado de
-    # infra/k8s/_panel_data.py durante boot do painel).
+    # Import local NÃO por dependência circular (infra/k8s/ é leaf no grafo
+    # de imports do DEILE) mas por custo de cold-import: puxar o módulo
+    # ``implementer`` inteiro só pra ler duas frozensets adiciona ~500ms ao
+    # boot do painel. Deferir o import para o primeiro `kubectl get` (que já
+    # paga o custo do subprocess) deixa o painel responsivo na abertura.
     from deile.orchestration.pipeline.implementer import (  # noqa: PLC0415
         CLAUDE_ALIASES, WORKER_ALIASES)
     lo = raw.strip().lower()
@@ -2280,7 +2283,11 @@ def _audit_dispatch_mode_change(
             resource=f"deployment:{namespace}/{_DISPATCH_DEPLOYMENT}:{_DISPATCH_ENV_VAR}",
             action="kubectl_set_env" if mode else "kubectl_unset_env",
             result=result,
-            details={"mode": mode or "", "detail": detail[:200]},
+            # ``mode`` é ``None`` em clear/cancel-without-mode paths — o JSON
+            # canônico do envelope mantém ``None`` em vez de coage para ``""``,
+            # pra log analysis distinguir "mode vazio (set degenerado)" de
+            # "modo absent (clear/cancel-of-clear)".
+            details={"mode": mode, "detail": detail[:200]},
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("falha emitindo AuditEvent (dispatch_mode): %s", exc)


### PR DESCRIPTION
## Resumo

- Painel TUI ganha hotkey `[d]` → nova `DispatchModeView` para flipar `DEILE_PIPELINE_DISPATCH_MODE` na Deployment `deile-pipeline` (claude ↔ deile_worker) sem editar manifests/ConfigMap.
- `_panel_data.py` ganha `DispatchModeProvider` (read via `kubectl get -o json`) + `set_pipeline_dispatch_mode` / `clear_pipeline_dispatch_mode` (write via `kubectl set env`), seguindo o mesmo padrão de `set_preferred_model` (PR #305): validação contra whitelist canônica antes de virar argv, audit `SECURITY_POLICY_CHANGED` em allowed/denied/completed/failed, `namespace=` kwarg (suporte multi-NS do PR #315).
- `build_implementer` emite warning de boot quando dispatch_mode resolve para `claude` mas binary `claude` não está no PATH — sem fail-fast (operador pode estar montando o binary via volume); a falha real continua aparecendo no primeiro subprocess.

## Issues

Closes #309

## Decisões-chave (crítica de abordagem)

- **Alt A (escolhida)**: painel TUI + persistência via `kubectl set env` + audit + tests + warning de boot. Cliente honesto sobre escopo: o image hoje não instala o `claude` CLI nem monta credentials em `~/.claude/`, então flipar para `claude` sem o follow-up de infra falha em runtime com mensagem clara.
- **Alt B (rejeitada)**: pacote completo (Dockerfile instala claude CLI + Secret para credentials + painel + tests de integração). Rebuild de image + teste de credentials exige iteração com cluster real, que estouraria o budget desse one-shot e seria arriscado sem feedback do operador para validar o fluxo de captura de credenciais. Vai como follow-up dedicado.
- **Por que `kubectl set env` e não editar o ConfigMap**: ConfigMap mounts em `subPath` não propagam live, então setar via JSON layered exigiria re-apply do ConfigMap + restart manual. `kubectl set env` dispara rollout automático (strategy `Recreate` do pipeline) e a próxima dispatch usa o modo novo. A env var é tecnicamente *deprecated* (issue #111) mas o loader continua aceitando-a com warning — o operador que prefere o JSON layered ainda pode editar o ConfigMap manualmente.

## O que está pendente para `dispatch_mode=claude` funcionar de ponta a ponta (follow-up infra)

1. Dockerfile (`infra/k8s/Dockerfile`) instala o `claude` CLI no image (camada separada do `gh`/`glab` para layer cache).
2. Secret `claude-credentials` + `volumeMount` em `~/.claude/credentials.json` no Deployment `deile-pipeline` (read-only, defaultMode 0o400).
3. UX para capturar credenciais: `infra/k8s/deploy.py k8s claude-login` que pega o conteúdo de `~/.claude/credentials.json` do host e cria/atualiza o Secret.
4. Teste de integração no `deile-pipeline`: dispatch real `claude -p` confirmando que o binary está no PATH e a auth resolve.

A view atual já está honesta: o warning de boot do `build_implementer` deixa claro o gap; o painel mostra "modo efetivo: claude" mas a próxima dispatch falha com `ENOENT: claude` se o image não tiver o CLI. Operador sabe o que falta.

## Checklist

- [x] pytest 100% verde (4454/4454 passed (iter-3), 21 skipped)
- [x] ruff ok (`ruff check deile/ infra/`)
- [x] isort ok (`isort --check-only deile/ infra/`)
- [x] cobertura mantida (suite full passou; gate `--cov-fail-under` não enforça em pytest.ini local)
- [x] pilares 03/12 respeitados: registry pattern (provider plugado em `PanelData._all_providers`), security-first (validação + audit antes de argv), error handling tipado (`OSError` / `subprocess.TimeoutExpired` capturados explicitamente)
- [x] sem SQL/migration
- [x] sem secrets logados (audit registra apenas mode + detail truncado a 200 chars)
- [x] sem `--no-verify`, sem `git config`, sem force push