### PR TITLE
feat(ui): Textual app skeleton + --ui textual flag (Phase 0+1 of #317)

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -892,6 +892,36 @@ async def _run_command_flag(
     return 0 if result.success else 1
 
 
+def _run_textual_ui() -> int:
+    """Bootstrap o shell Textual (issue #317 Phase 0+1, opt-in via --ui textual).
+
+    Mantemos a importacao tardia para que ``deile/cli.py`` carregue sem o
+    extra ``[ui]`` instalado — usuarios que nunca passam ``--ui textual``
+    nao precisam de ``textual`` na cadeia de import. Quando o extra falta,
+    devolvemos um erro claro (exit 2) com instrucao de install.
+    """
+    try:
+        from deile.ui.textual_app import (TEXTUAL_INSTALL_HINT,
+                                          ensure_textual_available,
+                                          run_textual_app)
+    except ImportError as exc:
+        # Caminho raro: ``deile/ui/textual_app.py`` esta no pacote (definido
+        # nas extras_packages), mas algum import interno explodiu antes do
+        # try/except do modulo. Surfacear o erro original ajuda o usuario.
+        print(f"ERROR: nao consegui carregar deile.ui.textual_app: {exc}", file=sys.stderr)
+        return 2
+    try:
+        ensure_textual_available()
+    except ImportError:
+        print(TEXTUAL_INSTALL_HINT, file=sys.stderr)
+        return 2
+    try:
+        return run_textual_app()
+    except Exception as exc:  # noqa: BLE001 — last-resort para nao mascarar bugs
+        print(f"ERROR: falha ao executar a app Textual: {exc}", file=sys.stderr)
+        return 1
+
+
 def _format_help_with_commands(parser: "argparse.ArgumentParser") -> str:
     """Append the slash-command catalog to argparse's stock --help output.
 
@@ -946,7 +976,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
 
-    # No args → interactive
+    # No args → interactive (legacy shell — Textual opt-in requires --ui)
     if not argv:
         _silence_logging()
         asyncio.run(_DeileCLI().run_interactive())
@@ -973,6 +1003,17 @@ def main(argv: Optional[list[str]] = None) -> int:
         dest="model",
         metavar="PROVIDER:MODEL_ID",
         help="Force a specific model (e.g. deepseek:deepseek-v4-pro).",
+    )
+    parser.add_argument(
+        "--ui",
+        dest="ui",
+        choices=("legacy", "textual"),
+        default="legacy",
+        help=(
+            "Shell UI mode. 'legacy' (default) is the current Rich shell. "
+            "'textual' boots the experimental Textual-based shell (issue "
+            "#317 Phase 0+1 — skeleton; requires 'pip install -e \".[ui]\"')."
+        ),
     )
     parser.add_argument(
         "--install",
@@ -1051,6 +1092,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     if not msg and not sys.stdin.isatty():
         msg = sys.stdin.read().strip()
     if not msg:
+        # --ui textual launches the experimental Textual shell (issue #317
+        # Phase 0+1 — opt-in). Combined with a positional message, --ui is
+        # silently ignored: one-shot mode has no interactive shell to swap.
+        if getattr(args, "ui", "legacy") == "textual":
+            _silence_logging()
+            return _run_textual_ui()
         # --debug or --model without a message → fall through to interactive mode.
         if getattr(args, "debug", False) or args.model:
             _silence_logging()

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -899,7 +899,14 @@ def _run_textual_ui() -> int:
     extra ``[ui]`` instalado — usuarios que nunca passam ``--ui textual``
     nao precisam de ``textual`` na cadeia de import. Quando o extra falta,
     devolvemos um erro claro (exit 2) com instrucao de install.
+
+    Mensagens de erro usam ``type(exc).__name__`` em vez de ``str(exc)`` no
+    stderr para evitar vazar caminhos absolutos do filesystem em erros de
+    ``ImportError`` (pilar 08). O stacktrace completo vai pro logger via
+    ``exc_info=True`` — operadores com log file ativo veem o detalhe.
     """
+    import logging as _logging
+    _log = _logging.getLogger(__name__)
     try:
         from deile.ui.textual_app import (TEXTUAL_INSTALL_HINT,
                                           ensure_textual_available,
@@ -907,8 +914,12 @@ def _run_textual_ui() -> int:
     except ImportError as exc:
         # Caminho raro: ``deile/ui/textual_app.py`` esta no pacote (definido
         # nas extras_packages), mas algum import interno explodiu antes do
-        # try/except do modulo. Surfacear o erro original ajuda o usuario.
-        print(f"ERROR: nao consegui carregar deile.ui.textual_app: {exc}", file=sys.stderr)
+        # try/except do modulo.
+        _log.error("Falha ao importar deile.ui.textual_app", exc_info=True)
+        print(
+            f"ERROR: nao consegui carregar deile.ui.textual_app ({type(exc).__name__}).",
+            file=sys.stderr,
+        )
         return 2
     try:
         ensure_textual_available()
@@ -918,7 +929,11 @@ def _run_textual_ui() -> int:
     try:
         return run_textual_app()
     except Exception as exc:  # noqa: BLE001 — last-resort para nao mascarar bugs
-        print(f"ERROR: falha ao executar a app Textual: {exc}", file=sys.stderr)
+        _log.error("Falha ao executar a app Textual", exc_info=True)
+        print(
+            f"ERROR: falha ao executar a app Textual ({type(exc).__name__}).",
+            file=sys.stderr,
+        )
         return 1
 
 
@@ -1091,10 +1106,20 @@ def main(argv: Optional[list[str]] = None) -> int:
     msg = " ".join(args.message).strip()
     if not msg and not sys.stdin.isatty():
         msg = sys.stdin.read().strip()
+    # --ui textual + mensagem positional: a flag exige um shell interativo,
+    # mas a mensagem dispara one-shot. O usuario provavelmente esqueceu uma
+    # das duas — emitimos warning e seguimos no one-shot (preserva o intent
+    # de "responda a essa mensagem"). Sem warning, a UX silenciosa confunde.
+    if msg and getattr(args, "ui", "legacy") == "textual":
+        print(
+            "WARNING: --ui textual ignorado em modo one-shot (mensagem posicional "
+            "presente). Rode 'deile --ui textual' sem mensagem para abrir o shell "
+            "Textual.",
+            file=sys.stderr,
+        )
     if not msg:
         # --ui textual launches the experimental Textual shell (issue #317
-        # Phase 0+1 — opt-in). Combined with a positional message, --ui is
-        # silently ignored: one-shot mode has no interactive shell to swap.
+        # Phase 0+1 — opt-in).
         if getattr(args, "ui", "legacy") == "textual":
             _silence_logging()
             return _run_textual_ui()

--- a/deile/runtime/__init__.py
+++ b/deile/runtime/__init__.py
@@ -19,7 +19,8 @@ Ver issue #303 e ``docs/system_design/DECISOES.md`` #35 (state file + heartbeat)
 """
 
 from deile.runtime.instance_state import (InstanceState, get_instance_state,
-                                          pid_alive, reset_instance_state)
+                                          peek_instance_state, pid_alive,
+                                          reset_instance_state)
 from deile.runtime.registry import (REGISTRY_SCHEMA_VERSION, Registry,
                                     RegistryEntry)
 from deile.runtime.status_server import (MAX_LINE_BYTES, StatusClient,
@@ -29,6 +30,7 @@ __all__ = [
     # instance_state
     "InstanceState",
     "get_instance_state",
+    "peek_instance_state",
     "pid_alive",
     "reset_instance_state",
     # status_server

--- a/deile/runtime/instance_state.py
+++ b/deile/runtime/instance_state.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
 __all__ = [
     "InstanceState",
     "get_instance_state",
+    "peek_instance_state",
     "reset_instance_state",
     "pid_alive",
     "VALID_ROLES",
@@ -585,3 +586,19 @@ def reset_instance_state() -> None:
         if _instance_singleton is not None:
             _instance_singleton.close()
             _instance_singleton = None
+
+
+def peek_instance_state() -> Optional[InstanceState]:
+    """Retorna o singleton atual SEM criar um se ainda não existe.
+
+    Diferente de :func:`get_instance_state`, esta acessor não tem side-effect:
+    nada é instanciado, nenhum state file é publicado, nenhuma task asyncio é
+    agendada. Pensada para *sub-readers* (surfaces de UI, painel, observador
+    externo) que querem ler o estado vivo apenas se algum bootstrap (CLI,
+    worker, bot, pipeline) já tomou ownership do processo. Caso contrário,
+    devolve ``None`` e o caller decide degradar para placeholders.
+
+    Issue #317 + DECISOES #37/#38: o singleton é dono do state file + atexit;
+    sub-readers consomem, nunca produzem.
+    """
+    return _instance_singleton

--- a/deile/tests/ui/test_textual_app.py
+++ b/deile/tests/ui/test_textual_app.py
@@ -229,3 +229,93 @@ async def test_app_clear_log_binding_empties_history():
         await pilot.press("ctrl+l")
         await pilot.pause()
         assert len(log.lines) == 0
+
+
+def _rendered_text(rich_log) -> str:
+    """Helper: extrai o texto cru de todos os segments do RichLog.
+
+    ``RichLog.lines`` devolve ``rich.segment.Strip`` (lista de ``Segment``);
+    ``str(line)`` e o repr (com truncamento), nao o texto renderizado.
+    Concatenamos ``segment.text`` em ordem para obter a string visivel.
+    """
+    parts = []
+    for strip in rich_log.lines:
+        for segment in strip:
+            parts.append(segment.text)
+        parts.append("\n")
+    return "".join(parts)
+
+
+@pytest.mark.ui
+async def test_app_escapes_rich_markup_in_user_input():
+    """Regressao do achado de seguranca do Revisor 2: usuario digita
+    ``[red]inject[/red]`` no Input — o RichLog tem ``markup=True`` e ecoaria
+    como Rich markup (spoofing visual). A sanitizacao via
+    ``rich.markup.escape`` deve renderizar as tags como texto literal."""
+    if not textual_app.TEXTUAL_AVAILABLE:
+        pytest.skip("textual nao instalado — pulando smoke real do App")
+
+    from textual.widgets import Input, RichLog
+
+    app = textual_app.DEILEApp(
+        instance_state_snapshot={"role": "cli", "stats": {"turns": 0}}
+    )
+    payloads = [
+        "[red]inject[/red]",
+        "ola unicode áéíóú \U0001f680",
+    ]
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.screen.query_one("#prompt", Input)
+        log = app.screen.query_one("#chat_history", RichLog)
+        for payload in payloads:
+            prompt.value = payload
+            await pilot.press("enter")
+            await pilot.pause()
+        rendered = _rendered_text(log)
+        # As tags brutas (com colchetes) precisam estar literais no buffer:
+        # sem o escape, Rich consumiria ``[red]...[/red]`` como style e
+        # nenhum texto literal apareceria.
+        assert "[red]inject[/red]" in rendered, rendered
+        # Acentos/emoji devem aparecer intactos (Unicode-clean path).
+        assert "áéíóú" in rendered, rendered
+        assert "\U0001f680" in rendered, rendered
+
+
+@pytest.mark.ui
+def test_snapshot_instance_state_does_not_create_singleton(monkeypatch):
+    """Regressao do achado major do Revisor 2: ``_snapshot_instance_state``
+    NAO pode criar o singleton InstanceState (que dispara side-effects:
+    state file, atexit, StatusServer, Registry). Quando o singleton e None,
+    deve retornar ``{}`` sem importar/criar nada novo."""
+    from deile.runtime import instance_state as _is_mod
+
+    # Garante que comecamos sem singleton.
+    monkeypatch.setattr(_is_mod, "_instance_singleton", None, raising=False)
+    snap = textual_app._snapshot_instance_state()
+    assert snap == {}
+    # E o singleton continua None — nada foi instanciado.
+    assert _is_mod._instance_singleton is None
+
+
+@pytest.mark.ui
+def test_cli_warns_when_ui_textual_combined_with_message(monkeypatch, capsys):
+    """Regressao do achado minor (R1+R2): combinar ``--ui textual`` com
+    mensagem one-shot deve emitir warning em stderr explicando o conflito,
+    em vez de ignorar silenciosamente."""
+    import sys as _sys
+
+    from deile import cli as cli_module
+
+    monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+
+    async def _fake_oneshot(*args, **kwargs) -> int:
+        return 0
+
+    monkeypatch.setattr(cli_module, "_run_oneshot", _fake_oneshot)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-ignored-by-fake-oneshot")
+    cli_module.main(["--ui", "textual", "olha so essa mensagem"])
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "--ui textual" in captured.err
+    assert "one-shot" in captured.err

--- a/deile/tests/ui/test_textual_app.py
+++ b/deile/tests/ui/test_textual_app.py
@@ -1,0 +1,231 @@
+"""Smoke tests do shell Textual (issue #317 Fase 0+1).
+
+Estes testes:
+  1. Sao skipped quando ``textual`` nao esta instalado (extra ``[ui]``
+     opcional, evita quebrar a suite default).
+  2. Cobrem o caminho de erro sem dependencia externa: stubs/helpers do
+     proprio modulo (``TEXTUAL_INSTALL_HINT``, ``_format_header_subtitle``).
+  3. Quando ``textual`` esta presente, sobem a app via ``App.run_test()`` e
+     simulam 3 mensagens via ``Input``, verificando que o ``RichLog``
+     contem cada uma.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.ui import textual_app
+
+
+@pytest.mark.ui
+def test_install_hint_mentions_extra():
+    """A mensagem de install precisa mencionar a extra ``[ui]`` exatamente
+    como aparece em ``pyproject.toml``, para que o usuario consiga copiar e
+    colar sem traducao."""
+    assert "[ui]" in textual_app.TEXTUAL_INSTALL_HINT
+    assert "pip install" in textual_app.TEXTUAL_INSTALL_HINT
+
+
+@pytest.mark.ui
+def test_ensure_textual_available_raises_clearly_when_absent():
+    """Quando textual nao esta instalado, ``ensure_textual_available`` levanta
+    um ``ImportError`` com mensagem util — nao um ``ModuleNotFoundError`` cru
+    de uma linha de import interna."""
+    if textual_app.TEXTUAL_AVAILABLE:
+        pytest.skip("textual instalado — caso de erro nao reproduzivel sem mock")
+    with pytest.raises(ImportError) as excinfo:
+        textual_app.ensure_textual_available()
+    assert "[ui]" in str(excinfo.value)
+
+
+@pytest.mark.ui
+@pytest.mark.parametrize(
+    "snap,expected_substrings",
+    [
+        ({}, ["role=?", "action=idle", "turns=0"]),
+        (
+            {
+                "role": "cli",
+                "current_action": {"kind": "tool_execution", "detail": "execute_bash"},
+                "stats": {"turns": 7},
+            },
+            ["role=cli", "action=tool_execution:execute_bash", "turns=7"],
+        ),
+        (
+            {
+                "role": "worker",
+                "current_action": None,
+                "stats": {"turns": 0, "cost_usd": 0.42},
+            },
+            ["role=worker", "action=idle", "turns=0"],
+        ),
+    ],
+)
+def test_format_header_subtitle_handles_partial_snapshots(snap, expected_substrings):
+    """O Header deve degradar gracioso quando o snapshot do InstanceState
+    nao tem todas as chaves. Cobre os tres cenarios principais: snapshot
+    vazio (sem singleton), snapshot completo com acao em curso, snapshot
+    com ``current_action=None`` (idle)."""
+    out = textual_app._format_header_subtitle(snap)
+    for expected in expected_substrings:
+        assert expected in out, f"esperava '{expected}' em '{out}'"
+
+
+@pytest.mark.ui
+async def test_app_run_test_renders_input_messages():
+    """App.run_test smoke: instancia a DEILEApp, simula tres submits no Input
+    e verifica que o ``RichLog`` contem cada mensagem (echo)."""
+    if not textual_app.TEXTUAL_AVAILABLE:
+        pytest.skip("textual nao instalado — pulando smoke real do App")
+
+    # Importacao tardia: so quando textual existe.
+    from textual.widgets import Input, RichLog
+
+    app = textual_app.DEILEApp(
+        instance_state_snapshot={"role": "cli", "stats": {"turns": 0}}
+    )
+    messages = ["primeira", "segunda", "terceira"]
+
+    async with app.run_test() as pilot:
+        # Espera o ChatScreen ser empurrado e widgets virem mounted.
+        await pilot.pause()
+        # ``query_one`` em escopo de app desce ate a tela ativa via ``screen``.
+        prompt = app.screen.query_one("#prompt", Input)
+        log = app.screen.query_one("#chat_history", RichLog)
+        assert prompt is not None
+        assert log is not None
+
+        for msg in messages:
+            prompt.value = msg
+            await pilot.press("enter")
+            await pilot.pause()
+
+        # O ``RichLog.lines`` expoe cada linha renderizada. Procuramos cada
+        # mensagem em qualquer linha (o handler prepende ``> `` + tag bold).
+        rendered = "\n".join(str(line) for line in log.lines)
+        for msg in messages:
+            assert msg in rendered, f"mensagem '{msg}' nao apareceu no log"
+
+        # E o input deve estar limpo apos cada submit.
+        assert prompt.value == ""
+
+
+@pytest.mark.ui
+async def test_app_subtitle_reflects_injected_snapshot():
+    """A subtitle do App deve refletir o snapshot injetado (testabilidade
+    sem precisar de InstanceState singleton)."""
+    if not textual_app.TEXTUAL_AVAILABLE:
+        pytest.skip("textual nao instalado — pulando smoke real do App")
+
+    app = textual_app.DEILEApp(
+        instance_state_snapshot={
+            "role": "cli",
+            "current_action": {"kind": "llm_call", "detail": "anthropic"},
+            "stats": {"turns": 3},
+        }
+    )
+    async with app.run_test():
+        # on_mount roda sincrono antes do primeiro frame; sub_title ja foi
+        # setado quando run_test entrega o controle.
+        assert app.sub_title == "role=cli | action=llm_call:anthropic | turns=3"
+
+
+@pytest.mark.ui
+def test_cli_flag_routes_to_textual_runner(monkeypatch):
+    """``deile --ui textual`` (sem mensagem) deve invocar ``_run_textual_ui``
+    e devolver o exit code dele, sem cair no caminho legacy."""
+    import sys as _sys
+
+    from deile import cli as cli_module
+
+    # Limpa qualquer env de chave que possa fazer a CLI tentar bootstrap.
+    for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DEEPSEEK_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    # ``main`` so cai no ``sys.stdin.read()`` quando o stdin nao e TTY (o pytest
+    # captura stdin → ``isatty()`` retorna False). Forcamos True para evitar
+    # OSError "reading from stdin while output is captured".
+    monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+
+    calls = {"count": 0}
+
+    def _fake_runner() -> int:
+        calls["count"] += 1
+        return 0
+
+    monkeypatch.setattr(cli_module, "_run_textual_ui", _fake_runner)
+    exit_code = cli_module.main(["--ui", "textual"])
+    assert exit_code == 0
+    assert calls["count"] == 1
+
+
+@pytest.mark.ui
+def test_cli_flag_default_legacy_does_not_call_textual(monkeypatch):
+    """Sem ``--ui textual`` (default legacy + uma mensagem one-shot),
+    ``_run_textual_ui`` NUNCA pode ser chamado — invariante anti-regressao
+    pra evitar o Textual ser bootado por engano e quebrar o caminho default."""
+    import sys as _sys
+
+    from deile import cli as cli_module
+
+    monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+
+    called = {"textual": 0, "oneshot": 0}
+
+    def _fake_textual() -> int:
+        called["textual"] += 1
+        return 0
+
+    async def _fake_oneshot(*args, **kwargs) -> int:
+        called["oneshot"] += 1
+        return 0
+
+    monkeypatch.setattr(cli_module, "_run_textual_ui", _fake_textual)
+    monkeypatch.setattr(cli_module, "_run_oneshot", _fake_oneshot)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-ignored-by-fake-oneshot")
+    cli_module.main(["mensagem qualquer"])
+    assert called["textual"] == 0
+
+
+@pytest.mark.ui
+def test_run_textual_ui_emits_install_hint_when_extra_missing(monkeypatch, capsys):
+    """Quando ``ensure_textual_available`` levanta ``ImportError``, o helper
+    da CLI deve imprimir o ``TEXTUAL_INSTALL_HINT`` no stderr e devolver
+    exit code 2 — usuario sai sem stacktrace e com instrucao acionavel."""
+    from deile import cli as cli_module
+    from deile.ui import textual_app as ta
+
+    def _raise() -> None:
+        raise ImportError(ta.TEXTUAL_INSTALL_HINT)
+
+    monkeypatch.setattr(ta, "ensure_textual_available", _raise)
+    code = cli_module._run_textual_ui()
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "[ui]" in captured.err
+
+
+@pytest.mark.ui
+async def test_app_clear_log_binding_empties_history():
+    """Ctrl+L deve limpar o RichLog sem encerrar a app."""
+    if not textual_app.TEXTUAL_AVAILABLE:
+        pytest.skip("textual nao instalado — pulando smoke real do App")
+
+    from textual.widgets import Input, RichLog
+
+    app = textual_app.DEILEApp(
+        instance_state_snapshot={"role": "cli", "stats": {"turns": 0}}
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.screen.query_one("#prompt", Input)
+        log = app.screen.query_one("#chat_history", RichLog)
+
+        prompt.value = "mensagem antes do clear"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert len(log.lines) > 0
+
+        await pilot.press("ctrl+l")
+        await pilot.pause()
+        assert len(log.lines) == 0

--- a/deile/tests/ui/test_textual_app.py
+++ b/deile/tests/ui/test_textual_app.py
@@ -287,7 +287,8 @@ def test_snapshot_instance_state_does_not_create_singleton(monkeypatch):
     """Regressao do achado major do Revisor 2: ``_snapshot_instance_state``
     NAO pode criar o singleton InstanceState (que dispara side-effects:
     state file, atexit, StatusServer, Registry). Quando o singleton e None,
-    deve retornar ``{}`` sem importar/criar nada novo."""
+    deve retornar ``{}`` sem importar/criar nada novo. Usa a API publica
+    ``peek_instance_state`` (issue #317 — sub-readers consomem, nao produzem)."""
     from deile.runtime import instance_state as _is_mod
 
     # Garante que comecamos sem singleton.
@@ -295,7 +296,23 @@ def test_snapshot_instance_state_does_not_create_singleton(monkeypatch):
     snap = textual_app._snapshot_instance_state()
     assert snap == {}
     # E o singleton continua None — nada foi instanciado.
-    assert _is_mod._instance_singleton is None
+    assert _is_mod.peek_instance_state() is None
+
+
+@pytest.mark.ui
+def test_peek_instance_state_returns_singleton_or_none(monkeypatch):
+    """API publica ``peek_instance_state``: contrato e devolver o singleton
+    se existe, ou ``None`` se nao. Sem criar. Sub-readers (Header da app
+    Textual, painel) consomem via essa porta."""
+    from deile.runtime import instance_state as _is_mod
+    from deile.runtime.instance_state import peek_instance_state
+
+    monkeypatch.setattr(_is_mod, "_instance_singleton", None, raising=False)
+    assert peek_instance_state() is None
+
+    sentinel = object()
+    monkeypatch.setattr(_is_mod, "_instance_singleton", sentinel, raising=False)
+    assert peek_instance_state() is sentinel
 
 
 @pytest.mark.ui

--- a/deile/tests/ui/test_textual_app.py
+++ b/deile/tests/ui/test_textual_app.py
@@ -16,6 +16,24 @@ import pytest
 
 from deile.ui import textual_app
 
+# Marker reutilizavel para os smoke tests reais (que precisam do extra ``[ui]``).
+requires_textual = pytest.mark.skipif(
+    not textual_app.TEXTUAL_AVAILABLE,
+    reason="textual nao instalado — pulando smoke real do App",
+)
+
+
+@pytest.fixture
+def app_with_cli_snapshot():
+    """DEILEApp instanciada com snapshot minimo de role=cli/turns=0.
+
+    Usada pelos smoke tests que so precisam de um app rodando — evita
+    repetir o dict literal em cada teste.
+    """
+    return textual_app.DEILEApp(
+        instance_state_snapshot={"role": "cli", "stats": {"turns": 0}}
+    )
+
 
 @pytest.mark.ui
 def test_install_hint_mentions_extra():
@@ -72,18 +90,14 @@ def test_format_header_subtitle_handles_partial_snapshots(snap, expected_substri
 
 
 @pytest.mark.ui
-async def test_app_run_test_renders_input_messages():
+@requires_textual
+async def test_app_run_test_renders_input_messages(app_with_cli_snapshot):
     """App.run_test smoke: instancia a DEILEApp, simula tres submits no Input
     e verifica que o ``RichLog`` contem cada mensagem (echo)."""
-    if not textual_app.TEXTUAL_AVAILABLE:
-        pytest.skip("textual nao instalado — pulando smoke real do App")
-
     # Importacao tardia: so quando textual existe.
     from textual.widgets import Input, RichLog
 
-    app = textual_app.DEILEApp(
-        instance_state_snapshot={"role": "cli", "stats": {"turns": 0}}
-    )
+    app = app_with_cli_snapshot
     messages = ["primeira", "segunda", "terceira"]
 
     async with app.run_test() as pilot:
@@ -111,12 +125,10 @@ async def test_app_run_test_renders_input_messages():
 
 
 @pytest.mark.ui
+@requires_textual
 async def test_app_subtitle_reflects_injected_snapshot():
     """A subtitle do App deve refletir o snapshot injetado (testabilidade
     sem precisar de InstanceState singleton)."""
-    if not textual_app.TEXTUAL_AVAILABLE:
-        pytest.skip("textual nao instalado — pulando smoke real do App")
-
     app = textual_app.DEILEApp(
         instance_state_snapshot={
             "role": "cli",
@@ -206,16 +218,12 @@ def test_run_textual_ui_emits_install_hint_when_extra_missing(monkeypatch, capsy
 
 
 @pytest.mark.ui
-async def test_app_clear_log_binding_empties_history():
+@requires_textual
+async def test_app_clear_log_binding_empties_history(app_with_cli_snapshot):
     """Ctrl+L deve limpar o RichLog sem encerrar a app."""
-    if not textual_app.TEXTUAL_AVAILABLE:
-        pytest.skip("textual nao instalado — pulando smoke real do App")
-
     from textual.widgets import Input, RichLog
 
-    app = textual_app.DEILEApp(
-        instance_state_snapshot={"role": "cli", "stats": {"turns": 0}}
-    )
+    app = app_with_cli_snapshot
     async with app.run_test() as pilot:
         await pilot.pause()
         prompt = app.screen.query_one("#prompt", Input)
@@ -247,19 +255,15 @@ def _rendered_text(rich_log) -> str:
 
 
 @pytest.mark.ui
-async def test_app_escapes_rich_markup_in_user_input():
+@requires_textual
+async def test_app_escapes_rich_markup_in_user_input(app_with_cli_snapshot):
     """Regressao do achado de seguranca do Revisor 2: usuario digita
     ``[red]inject[/red]`` no Input — o RichLog tem ``markup=True`` e ecoaria
     como Rich markup (spoofing visual). A sanitizacao via
     ``rich.markup.escape`` deve renderizar as tags como texto literal."""
-    if not textual_app.TEXTUAL_AVAILABLE:
-        pytest.skip("textual nao instalado — pulando smoke real do App")
-
     from textual.widgets import Input, RichLog
 
-    app = textual_app.DEILEApp(
-        instance_state_snapshot={"role": "cli", "stats": {"turns": 0}}
-    )
+    app = app_with_cli_snapshot
     payloads = [
         "[red]inject[/red]",
         "ola unicode áéíóú \U0001f680",

--- a/deile/ui/textual_app.py
+++ b/deile/ui/textual_app.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, Optional
 _TEXTUAL_AVAILABLE = True
 _TEXTUAL_IMPORT_ERROR: Optional[ImportError] = None
 try:
+    from rich.markup import escape as _rich_escape
     from textual import on
     from textual.app import App, ComposeResult
     from textual.containers import Vertical
@@ -38,6 +39,10 @@ try:
 except ImportError as exc:  # pragma: no cover — exercised when extra absent
     _TEXTUAL_AVAILABLE = False
     _TEXTUAL_IMPORT_ERROR = exc
+
+    def _rich_escape(text: str) -> str:  # type: ignore[no-redef]
+        """Fallback identity escape — usado nos shims sem textual instalado."""
+        return text
 
 
 __all__ = [
@@ -80,15 +85,23 @@ _CSS_FILE = Path(__file__).with_suffix(".tcss")
 def _snapshot_instance_state() -> Dict[str, Any]:
     """Retorna snapshot defensivo do InstanceState do processo, ou {}.
 
-    Best-effort: a Fase 1 deste refactor nao requer InstanceState para
-    funcionar (alguns ambientes de teste nem instanciam o singleton). Quando
-    indisponivel, o Header degrada para placeholders. Issue #303 ja garante
-    que o singleton e barato de criar — o try/except aqui cobre o caso de
-    instanciacao bloqueada (filesystem read-only, sandbox sem $HOME, etc.).
+    **Nao cria singleton**: lemos diretamente o ``_instance_singleton`` do
+    modulo. Se a CLI principal nao bootou (caso da app Textual ainda em
+    Fase 1, sem integracao com ``_DeileCLI.initialize``), o singleton e
+    ``None`` e o Header degrada para placeholders — sem side-effect de
+    publicar state file, registrar no Registry ou abrir StatusServer. Esses
+    side-effects sao responsabilidade do bootstrap da CLI/worker/bot,
+    nao de uma surface de UI lida em ``on_mount``.
+
+    Issue #317 + #303 (DECISOES #37/#38): o singleton e dono do estado vivo
+    e atexit. Sub-readers (Header, painel) so consomem; nunca produzem.
     """
     try:
-        from deile.runtime.instance_state import get_instance_state
-        return get_instance_state().snapshot()
+        from deile.runtime import instance_state as _is_mod
+        singleton = getattr(_is_mod, "_instance_singleton", None)
+        if singleton is None:
+            return {}
+        return singleton.snapshot()
     except Exception:  # noqa: BLE001 — Header is best-effort
         return {}
 
@@ -184,19 +197,25 @@ else:
             log.write("")
 
         @on(Input.Submitted, "#prompt")
-        def _handle_submit(self, event: "Input.Submitted") -> None:  # type: ignore[name-defined]
+        async def _handle_submit(self, event: "Input.Submitted") -> None:  # type: ignore[name-defined]
             """Eco o input no historico e limpa o campo.
 
             Fase 1: implementacao minima — apenas registra a mensagem do
             usuario no ``RichLog``. Fase 2 substituira o corpo por
             ``await agent.process_input_stream(...)`` iterando os eventos
-            e atualizando um container de streaming dedicado.
+            e atualizando um container de streaming dedicado. Mantendo o
+            handler ``async`` ja agora alinha com §1 (Async-First) e reduz
+            churn no PR da Fase 2.
+
+            Sanitizacao: a entrada do usuario passa por ``rich.markup.escape``
+            antes de ir ao ``RichLog`` (que tem ``markup=True``) para evitar
+            spoofing visual via ``[red]oops[/red]`` etc. Pilar 08 (Security).
             """
             text = (event.value or "").strip()
             if not text:
                 return
             log = self.query_one("#chat_history", RichLog)
-            log.write(f"[bold]>[/bold] {text}")
+            log.write(f"[bold]>[/bold] {_rich_escape(text)}")
             log.write(
                 "[yellow](integracao com o agente vira na Fase 2 — "
                 "issue #317)[/yellow]"

--- a/deile/ui/textual_app.py
+++ b/deile/ui/textual_app.py
@@ -85,20 +85,21 @@ _CSS_FILE = Path(__file__).with_suffix(".tcss")
 def _snapshot_instance_state() -> Dict[str, Any]:
     """Retorna snapshot defensivo do InstanceState do processo, ou {}.
 
-    **Nao cria singleton**: lemos diretamente o ``_instance_singleton`` do
-    modulo. Se a CLI principal nao bootou (caso da app Textual ainda em
-    Fase 1, sem integracao com ``_DeileCLI.initialize``), o singleton e
-    ``None`` e o Header degrada para placeholders — sem side-effect de
-    publicar state file, registrar no Registry ou abrir StatusServer. Esses
-    side-effects sao responsabilidade do bootstrap da CLI/worker/bot,
-    nao de uma surface de UI lida em ``on_mount``.
+    **Nao cria singleton**: usa ``peek_instance_state`` (API publica que so
+    devolve o singleton se ja existe, sem instanciar). Se a CLI principal
+    nao bootou (caso da app Textual ainda em Fase 1, sem integracao com
+    ``_DeileCLI.initialize``), o singleton e ``None`` e o Header degrada
+    para placeholders — sem side-effect de publicar state file, registrar
+    no Registry ou abrir StatusServer. Esses side-effects sao
+    responsabilidade do bootstrap da CLI/worker/bot, nao de uma surface
+    de UI lida em ``on_mount``.
 
     Issue #317 + #303 (DECISOES #37/#38): o singleton e dono do estado vivo
     e atexit. Sub-readers (Header, painel) so consomem; nunca produzem.
     """
     try:
-        from deile.runtime import instance_state as _is_mod
-        singleton = getattr(_is_mod, "_instance_singleton", None)
+        from deile.runtime.instance_state import peek_instance_state
+        singleton = peek_instance_state()
         if singleton is None:
             return {}
         return singleton.snapshot()

--- a/deile/ui/textual_app.py
+++ b/deile/ui/textual_app.py
@@ -27,10 +27,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+# ``rich`` e dependencia core do DEILE (pyproject.toml), entao o escape vive
+# fora do try/except do textual — disponivel em qualquer ambiente.
+from rich.markup import escape as _rich_escape
+
 _TEXTUAL_AVAILABLE = True
 _TEXTUAL_IMPORT_ERROR: Optional[ImportError] = None
 try:
-    from rich.markup import escape as _rich_escape
     from textual import on
     from textual.app import App, ComposeResult
     from textual.containers import Vertical
@@ -39,10 +42,6 @@ try:
 except ImportError as exc:  # pragma: no cover — exercised when extra absent
     _TEXTUAL_AVAILABLE = False
     _TEXTUAL_IMPORT_ERROR = exc
-
-    def _rich_escape(text: str) -> str:  # type: ignore[no-redef]
-        """Fallback identity escape — usado nos shims sem textual instalado."""
-        return text
 
 
 __all__ = [

--- a/deile/ui/textual_app.py
+++ b/deile/ui/textual_app.py
@@ -1,0 +1,260 @@
+"""Textual app skeleton para o shell CLI do DEILE — Fase 0+1 da issue #317.
+
+Resolve em parte a issue #307 (resize do terminal). PR #312 entregou o "Nivel 1
+pragmatico" (Live perpetuo em comandos opt-in, Rule entre turnos), mas conteudo
+ja commitado ao scrollback nao reflowa em resize porque vive no buffer do
+emulador, fora do alcance da aplicacao. A solucao definitiva e refatorar o
+shell para o framework Textual, onde TODA a UI vive dentro de um App reativo
+cuja layout engine adapta a SIGWINCH em qualquer parte da tela.
+
+Esta entrega (Fase 0 + Fase 1 minima):
+  - DEILEApp + ChatScreen + CSS .tcss adaptativo
+  - Header com identidade do processo (lendo InstanceState quando disponivel)
+  - RichLog#chat_history como historico reflowable (substitui o scrollback)
+  - Input#prompt com handler de submit (apenas eco no historico — sem
+    integracao com process_input_stream nesta fase; vem na Fase 2)
+  - Footer com hint de saida e placeholder de stats
+  - Falha graciosa quando ``textual`` nao esta instalado (mensagem clara)
+
+Fases 2-6 (integracao com agente, comandos slash, sub-DEILEs, polimento,
+cleanup) sao tracked como follow-ups separados na issue #317. Esta entrega
+nao remove o shell legado: a flag ``--ui textual`` em ``deile/cli.py`` e
+opt-in; default permanece o shell atual.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_TEXTUAL_AVAILABLE = True
+_TEXTUAL_IMPORT_ERROR: Optional[ImportError] = None
+try:
+    from textual import on
+    from textual.app import App, ComposeResult
+    from textual.containers import Vertical
+    from textual.screen import Screen
+    from textual.widgets import Footer, Header, Input, RichLog
+except ImportError as exc:  # pragma: no cover — exercised when extra absent
+    _TEXTUAL_AVAILABLE = False
+    _TEXTUAL_IMPORT_ERROR = exc
+
+
+__all__ = [
+    "TEXTUAL_AVAILABLE",
+    "TEXTUAL_IMPORT_ERROR",
+    "TEXTUAL_INSTALL_HINT",
+    "ensure_textual_available",
+    "DEILEApp",
+    "ChatScreen",
+    "run_textual_app",
+]
+
+TEXTUAL_AVAILABLE: bool = _TEXTUAL_AVAILABLE
+TEXTUAL_IMPORT_ERROR: Optional[ImportError] = _TEXTUAL_IMPORT_ERROR
+
+TEXTUAL_INSTALL_HINT = (
+    "O framework Textual nao esta instalado. Para usar a UI Textual:\n"
+    '    pip install -e ".[ui]"\n'
+    "ou, se ja tem o DEILE instalado:\n"
+    "    pip install 'textual>=0.80'\n"
+    "Veja issue #317 e docs/system_design/03-PRINCIPIOS-ARQUITETURAIS.md (UI)."
+)
+
+
+def ensure_textual_available() -> None:
+    """Levanta ``ImportError`` com instrucao de install se textual nao existe.
+
+    Chamado pelo entry point antes de instanciar :class:`DEILEApp`. Mantem
+    a checagem em um unico lugar e evita que callers caiam num erro de
+    import obscuro de dentro do pacote.
+    """
+    if not TEXTUAL_AVAILABLE:
+        raise ImportError(TEXTUAL_INSTALL_HINT) from TEXTUAL_IMPORT_ERROR
+
+
+# Path para o CSS sidecar (mesma pasta deste modulo).
+_CSS_FILE = Path(__file__).with_suffix(".tcss")
+
+
+def _snapshot_instance_state() -> Dict[str, Any]:
+    """Retorna snapshot defensivo do InstanceState do processo, ou {}.
+
+    Best-effort: a Fase 1 deste refactor nao requer InstanceState para
+    funcionar (alguns ambientes de teste nem instanciam o singleton). Quando
+    indisponivel, o Header degrada para placeholders. Issue #303 ja garante
+    que o singleton e barato de criar — o try/except aqui cobre o caso de
+    instanciacao bloqueada (filesystem read-only, sandbox sem $HOME, etc.).
+    """
+    try:
+        from deile.runtime.instance_state import get_instance_state
+        return get_instance_state().snapshot()
+    except Exception:  # noqa: BLE001 — Header is best-effort
+        return {}
+
+
+def _format_header_subtitle(snap: Dict[str, Any]) -> str:
+    """Constroi a subtitle do Header a partir do snapshot do InstanceState.
+
+    Formato: ``role=<role> | action=<kind:detail> | turns=<N>``. Mantemos
+    curto porque o Header tem 1 linha e ja exibe o titulo na esquerda.
+    """
+    role = snap.get("role") or "?"
+    action = snap.get("current_action") or {}
+    kind = action.get("kind") if isinstance(action, dict) else None
+    detail = action.get("detail") if isinstance(action, dict) else None
+    action_str = kind or "idle"
+    if kind and detail:
+        action_str = f"{kind}:{detail}"
+    stats = snap.get("stats") or {}
+    turns = stats.get("turns", 0) if isinstance(stats, dict) else 0
+    return f"role={role} | action={action_str} | turns={turns}"
+
+
+# Quando Textual nao esta instalado, definimos shims minimos pra que o
+# ``from .textual_app import DEILEApp`` no CLI nao quebre o import time.
+# A checagem de disponibilidade fica em ``ensure_textual_available``; este
+# bloco mantem os simbolos importaveis para introspeccao/teste.
+if not TEXTUAL_AVAILABLE:  # pragma: no cover — exercised in no-textual envs
+
+    class ChatScreen:  # type: ignore[no-redef]
+        """Stub — Textual nao instalado. Use ensure_textual_available()."""
+
+    class DEILEApp:  # type: ignore[no-redef]
+        """Stub — Textual nao instalado. Use ensure_textual_available()."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            ensure_textual_available()
+
+else:
+
+    class ChatScreen(Screen):  # type: ignore[misc, no-redef]
+        """Tela principal: chat reflowable + input fixo no rodape.
+
+        Layout (definido em ``textual_app.tcss``)::
+
+            Header                      <- 1 linha, top-docked
+            ┌─ Vertical#main ──────────┐
+            │  RichLog#chat_history    │  <- 1fr, scrollavel, reflowa em resize
+            │  Input#prompt            │  <- auto height, bottom-docked
+            └──────────────────────────┘
+            Footer                      <- 1 linha, bottom-docked
+
+        Issue #317 Fase 1: o handler ``on_input`` apenas echo a entrada no
+        ``RichLog``. A integracao real com ``DeileAgent.process_input_stream``
+        e tracked como Fase 2 (issue follow-up).
+        """
+
+        BINDINGS = [
+            ("ctrl+q", "quit_app", "Sair"),
+            ("ctrl+l", "clear_log", "Limpar historico"),
+        ]
+
+        def compose(self) -> "ComposeResult":  # type: ignore[name-defined]
+            yield Header(show_clock=False)
+            with Vertical(id="main"):
+                yield RichLog(
+                    id="chat_history",
+                    highlight=True,
+                    markup=True,
+                    wrap=True,
+                    auto_scroll=True,
+                )
+                yield Input(
+                    id="prompt",
+                    placeholder="Digite uma mensagem (Ctrl+Q para sair)...",
+                )
+            yield Footer()
+
+        def on_mount(self) -> None:
+            """Foca o input no boot e renderiza a mensagem de boas-vindas."""
+            self.query_one("#prompt", Input).focus()
+            log = self.query_one("#chat_history", RichLog)
+            log.write(
+                "[bold cyan]DEILE — shell Textual (Fase 1 skeleton)[/bold cyan]"
+            )
+            log.write(
+                "[dim]Esta fase ainda nao integra o agente. Mensagens sao "
+                "apenas ecoadas no historico abaixo.[/dim]"
+            )
+            log.write(
+                "[dim]Issue #317 — Fase 2+ traz a integracao com "
+                "process_input_stream.[/dim]"
+            )
+            log.write("")
+
+        @on(Input.Submitted, "#prompt")
+        def _handle_submit(self, event: "Input.Submitted") -> None:  # type: ignore[name-defined]
+            """Eco o input no historico e limpa o campo.
+
+            Fase 1: implementacao minima — apenas registra a mensagem do
+            usuario no ``RichLog``. Fase 2 substituira o corpo por
+            ``await agent.process_input_stream(...)`` iterando os eventos
+            e atualizando um container de streaming dedicado.
+            """
+            text = (event.value or "").strip()
+            if not text:
+                return
+            log = self.query_one("#chat_history", RichLog)
+            log.write(f"[bold]>[/bold] {text}")
+            log.write(
+                "[yellow](integracao com o agente vira na Fase 2 — "
+                "issue #317)[/yellow]"
+            )
+            log.write("")
+            event.input.value = ""
+
+        def action_clear_log(self) -> None:
+            """Binding Ctrl+L: limpa o historico (mas mantem a app rodando)."""
+            self.query_one("#chat_history", RichLog).clear()
+
+        def action_quit_app(self) -> None:
+            """Binding Ctrl+Q: encerra a app limpamente."""
+            self.app.exit()
+
+    class DEILEApp(App):  # type: ignore[misc, no-redef]
+        """Shell Textual do DEILE (esqueleto — Fase 1 da issue #317).
+
+        Layout reativo: ``Header``, ``ChatScreen`` (RichLog + Input), ``Footer``.
+        Toda a UI vive dentro deste ``App``, entao SIGWINCH gera re-layout
+        automatico via Textual em qualquer parte da tela — incluindo o
+        historico ja renderizado (resolve a limitacao fundamental do
+        scrollback documentada na issue #307).
+        """
+
+        CSS_PATH = str(_CSS_FILE)
+        TITLE = "DEILE"
+        SUB_TITLE = "shell Textual (skeleton)"
+
+        def __init__(
+            self,
+            *,
+            instance_state_snapshot: Optional[Dict[str, Any]] = None,
+            **kwargs: Any,
+        ) -> None:
+            super().__init__(**kwargs)
+            # Snapshot injetavel pra facilitar teste sem singleton real;
+            # quando None, lemos via ``_snapshot_instance_state``.
+            self._snap_override = instance_state_snapshot
+
+        def on_mount(self) -> None:
+            """Push da ChatScreen + ajuste de subtitle conforme InstanceState."""
+            snap = (
+                self._snap_override
+                if self._snap_override is not None
+                else _snapshot_instance_state()
+            )
+            self.sub_title = _format_header_subtitle(snap)
+            self.push_screen(ChatScreen())
+
+
+def run_textual_app() -> int:
+    """Entry point sincrono — instancia e roda :class:`DEILEApp`.
+
+    Chamado por ``deile/cli.py`` quando o usuario passa ``--ui textual``.
+    Retorna o exit code (0 = sucesso).
+    """
+    ensure_textual_available()
+    app = DEILEApp()
+    app.run()
+    return 0

--- a/deile/ui/textual_app.tcss
+++ b/deile/ui/textual_app.tcss
@@ -1,7 +1,7 @@
 /*
  * deile/ui/textual_app.tcss — layout reativo do shell Textual (issue #317).
  *
- * Toda a area do terminal e cobrita por um Screen vertical. O RichLog
+ * Toda a area do terminal e coberta por um Screen vertical. O RichLog
  * ocupa 1fr (todo o espaco disponivel apos Header/Footer/Input) e
  * recalcula layout em cada SIGWINCH automaticamente. O Input tem altura
  * fixa de 3 linhas e fica docked no bottom.

--- a/deile/ui/textual_app.tcss
+++ b/deile/ui/textual_app.tcss
@@ -1,0 +1,40 @@
+/*
+ * deile/ui/textual_app.tcss — layout reativo do shell Textual (issue #317).
+ *
+ * Toda a area do terminal e cobrita por um Screen vertical. O RichLog
+ * ocupa 1fr (todo o espaco disponivel apos Header/Footer/Input) e
+ * recalcula layout em cada SIGWINCH automaticamente. O Input tem altura
+ * fixa de 3 linhas e fica docked no bottom.
+ *
+ * Mantenha esta folha pequena: cores e estilos finos virao na Fase 5
+ * (polimento). A regra raiz e: nenhum width fixo, tudo proporcional.
+ */
+
+Screen {
+    layout: vertical;
+}
+
+#main {
+    height: 1fr;
+    layout: vertical;
+}
+
+#chat_history {
+    height: 1fr;
+    border: tall $primary 30%;
+    padding: 0 1;
+}
+
+#prompt {
+    dock: bottom;
+    height: 3;
+    border: tall $accent;
+}
+
+Header {
+    background: $primary 20%;
+}
+
+Footer {
+    background: $primary 10%;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,13 @@ dependencies = [
 bot = ["deilebot @ git+https://github.com/elimarcavalli/deilebot.git@main"]
 scheduler = ["apscheduler>=3.10"]
 webhook = ["fastapi>=0.100", "uvicorn>=0.23"]
-test = ["aiohttp>=3.9", "pytest>=7", "pytest-asyncio>=0.23", "pytest-cov>=4"]
+test = [
+    "aiohttp>=3.9",
+    "pytest>=7",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=4",
+    "pytest-textual-snapshot>=1.0",
+]
 # Observabilidade enterprise via OpenTelemetry (issue #303 fase 4).
 # DEILE roda em no-op se este extra não está instalado OU se
 # DEILE_OTLP_ENDPOINT não está set — instale apenas quando quiser correlacionar
@@ -89,9 +95,10 @@ otel = [
 # Quando ``textual`` nao esta instalado, ``python3 deile.py --ui textual``
 # falha graciosamente com mensagem clara apontando ``pip install -e ".[ui]"``.
 # O shell legado (sem flag) continua intocado e nao depende de textual.
+# Plugin de teste (``pytest-textual-snapshot``) vive na extra ``[test]`` —
+# usuario final nao precisa instalar pytest pra usar o shell.
 ui = [
     "textual>=0.80",
-    "pytest-textual-snapshot>=1.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,14 @@ otel = [
     "opentelemetry-sdk>=1.27.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.27.0",
 ]
+# Shell CLI baseado em Textual (issue #317, Fase 0+1 — opt-in).
+# Quando ``textual`` nao esta instalado, ``python3 deile.py --ui textual``
+# falha graciosamente com mensagem clara apontando ``pip install -e ".[ui]"``.
+# O shell legado (sem flag) continua intocado e nao depende de textual.
+ui = [
+    "textual>=0.80",
+    "pytest-textual-snapshot>=1.0",
+]
 
 [project.scripts]
 deile = "deile.cli:main"


### PR DESCRIPTION
## Resumo

- Fase 0 (issue #317): adiciona extra opcional `[ui]` no `pyproject.toml` com `textual>=0.80` + `pytest-textual-snapshot>=1.0`. Nenhuma dependencia nova no default.
- Fase 1 minima: cria `deile/ui/textual_app.py` (skeleton `DEILEApp` + `ChatScreen` + helpers) + folha de estilos `textual_app.tcss` + flag opt-in `--ui textual` em `deile/cli.py`. Default permanece o shell legado.
- 10 testes novos em `deile/tests/ui/test_textual_app.py`, incluindo smoke real via `App.run_test()` e antiregressao do path legacy.

## Refs

Refs #317 — **NAO** Closes. Esta PR entrega Fase 0 + esqueleto Fase 1 (~600 linhas). A propria issue recomenda PR por fase ("Pode ser fasiado entre PRs independentes — cada fase fecha numa PR separada"). Fases 2-6 (integracao agente, comandos slash, sub-DEILEs, polimento, cleanup) ficam como follow-ups e a issue permanece aberta. Detalhe da justificativa de escopo no comentario [#317 (comment)](https://github.com/elimarcavalli/deile/issues/317#issuecomment-4541716965).

## Decisao de design (critica de abordagem)

**Alternativa A — entregar tudo num PR gigante**: 8-11 dias num PR seria mal revisado, alto risco de regressao no caminho critico (CLI = experiencia inteira do usuario), e contraria a propria recomendacao da issue.

**Alternativa B (escolhida) — PR por fase, esqueleto opt-in primeiro**: este PR estabelece a fundacao (modulo, CSS, flag, tests) com zero impacto no default. Fases seguintes constroem incrementalmente sobre esta base, cada uma com sua revisao independente. Risco distribuido, escopo digerivel, rollback trivial via `--ui legacy` (que, na verdade, e o default).

Pre-requisito da issue (`feat/runtime-instance-state` mergeado em `main`) ja esta atendido — `deile/runtime/`, `deile/observability/`, `deile/ui/_stdin_owner.py`, `deile/ui/subagent_panel.py`, `deile/ui/dynamic_render.py` e `infra/k8s/_panel*.py` todos existem no `HEAD = 68049e0`.

## O que esta dentro deste PR

- `pyproject.toml`: extra `[ui]` com `textual>=0.80` + `pytest-textual-snapshot>=1.0`.
- `deile/ui/textual_app.py` (260 linhas):
  - `DEILEApp(App)` + `ChatScreen(Screen)` com layout vertical reativo (Header / `Vertical#main` com `RichLog#chat_history` + `Input` docked / Footer).
  - Header com subtitle gerada do snapshot do `InstanceState` (issue #303). Degrada gracioso quando ausente.
  - Bindings basicos: `Ctrl+Q` (sai limpo), `Ctrl+L` (limpa o historico).
  - Handler `on Input.Submitted` apenas echo no `RichLog` (smoke; integracao com agente vem na Fase 2).
  - `ensure_textual_available()` + `run_textual_app()` + `TEXTUAL_INSTALL_HINT` para falha graciosa sem `[ui]`.
- `deile/ui/textual_app.tcss` (40 linhas): layout proporcional, sem larguras fixas (pilar 03 §15).
- `deile/cli.py` (+49 linhas): flag `--ui {legacy|textual}` (default `legacy`) + helper `_run_textual_ui` com importacao tardia e exit code 2 + install hint se o extra faltar.
- `deile/tests/ui/test_textual_app.py` (231 linhas): 10 testes, incluindo `App.run_test()` real e antiregressao do default.

## O que NAO entra (issues filhas)

- Fase 2 — `on_input_submitted` chama `DeileAgent.process_input_stream` (com cancelamento via ESC, USAGE_FINAL → commit no `RichLog`).
- Fase 3 — comandos slash via `push_screen` para selectors complexos.
- Fase 4 — sub-DEILEs paralelos como `Screen` dedicada (porta `subagent_panel.py`).
- Fase 5 — polimento (welcome reativo, snapshot de performance com 10k mensagens).
- Fase 6 — cleanup (`console_ui.py`, `streaming_renderer.py` removidos; Textual vira default; flag `--ui legacy` retida por 1-2 releases).

## Checklist

- [x] pytest 100% verde (4420 passed, 41 skipped, 0 failed em 189s)
- [x] ruff ok (`ruff check` nos arquivos novos/modificados)
- [x] isort ok (`isort --check-only` nos arquivos novos/modificados)
- [x] cobertura ≥80% — os arquivos NOVOS deste PR estao cobertos pelos 10 testes (varredura global da suite continua passando o gate)
- [x] pilares respeitados: §1 async-first (smoke tests sao `async def`); §10 extensibilidade (flag opt-in, zero impacto no default); §14 deps resolveveis (extra `[ui]` opcional); §15 UI adaptativa (CSS sem larguras literais)
- [x] sem SQL/migration
- [x] sem secret/`print` esquecido (a unica string `sk-test-*` e literal de teste claramente identificado)
- [x] sem `--no-verify`, `--admin`, `git config`, force push

## Test plan

- [x] `python3 -m pytest deile/tests/ui/test_textual_app.py -q` → 10 passed, 1 skipped (skip somente quando textual faltando, exclusivo mutuamente)
- [x] `python3 -m pytest deile/tests/ -q` (suite completa) → 4420 passed, 41 skipped, 0 failed
- [x] `python3 -m ruff check deile/ui/textual_app.py deile/tests/ui/test_textual_app.py deile/cli.py` → All checks passed
- [x] `python3 -m isort --check-only deile/ui/textual_app.py deile/tests/ui/test_textual_app.py deile/cli.py` → ok
- [ ] Validacao manual interativa (`python3 deile.py --ui textual` em terminal real) — opcional, fora do gate automatizado nesta fase: smoke `run_test()` ja cobre o caminho funcional sem precisar de TTY.