### PR TITLE
feat(k8s): interactive multi-namespace setup verb (#328)

### DIFF
--- a/deile/tests/infra/test_k8s_setup.py
+++ b/deile/tests/infra/test_k8s_setup.py
@@ -209,41 +209,294 @@ class TestEnsureNamespace:
 
 
 # ============================================================================
-# _collect_namespace_plans com --yes
+# _apply_runtime_configmap
 # ============================================================================
 
-class TestCollectPlans:
-    def test_yes_mode_aborts(self, capsys):
-        """--yes não pode rodar (segredos via getpass exigem interativo)."""
-        result = setup._collect_namespace_plans(yes=True, existing_ns=[])
-        assert result == []
+class TestApplyRuntimeConfigmap:
+    def test_renders_then_applies_with_label(self, monkeypatch):
+        """Renderiza CM via --dry-run=client + apply via stdin + label."""
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(list(cmd))
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"
+            m.stderr = ""
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        plan = setup.NamespacePlan(
+            name="deile-x", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker",
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        assert setup._apply_runtime_configmap("kubectl", "deile-x", plan) is True
+        # 3 chamadas: render (create cm --dry-run), apply -f -, label
+        assert any("create" in c and "configmap" in c for c in calls)
+        assert any("apply" in c and "-f" in c for c in calls)
+        assert any("label" in c and "configmap" in c for c in calls)
+        # E o label aplica app=deile
+        label_call = next(c for c in calls if "label" in c and "configmap" in c)
+        assert "app=deile" in label_call
+
+    def test_label_failure_is_warning_not_fatal(self, monkeypatch, capsys):
+        """Falha do `kubectl label configmap` é warning, não fatal — o CM
+        funcional já foi aplicado, label é só para filtros do panel."""
+        call_idx = [0]
+
+        def fake_run(cmd, **kw):
+            call_idx[0] += 1
+            m = MagicMock()
+            m.stdout = "yaml-rendered" if call_idx[0] == 1 else ""
+            # Render OK, apply OK, label FALHA
+            if "label" in cmd and "configmap" in cmd:
+                m.returncode = 1
+                m.stderr = "forbidden"
+            else:
+                m.returncode = 0
+                m.stderr = ""
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        plan = setup.NamespacePlan(
+            name="deile-y", forge_kind="gitlab", repo="g/p",
+            dispatch_mode="deile_worker",
+            llm_keys={"OPENAI_API_KEY": "sk-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        assert setup._apply_runtime_configmap("kubectl", "deile-y", plan) is True
+        captured = capsys.readouterr()
+        assert "label" in captured.out.lower() or "label" in captured.err.lower()
+
+    def test_render_failure_propagates(self, monkeypatch):
+        def fake_run(cmd, **kw):
+            m = MagicMock()
+            m.returncode = 1 if "create" in cmd and "configmap" in cmd else 0
+            m.stdout = ""
+            m.stderr = "invalid"
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        plan = setup.NamespacePlan(
+            name="x", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker",
+            llm_keys={"ANTHROPIC_API_KEY": "sk-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        assert setup._apply_runtime_configmap("kubectl", "x", plan) is False
+
+
+# ============================================================================
+# _wait_for_pods_ready + _deployments_to_wait_for
+# ============================================================================
+
+class TestWaitForPodsReady:
+    def test_skips_deployment_when_not_present(self, monkeypatch):
+        """Deployment ausente é pulado — não conta como falha."""
+        def fake_run(cmd, **kw):
+            m = MagicMock()
+            # `get deployment` → exists=1 (ausente)
+            m.returncode = 1 if "get" in cmd and "deployment" in cmd else 0
+            m.stdout = m.stderr = ""
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        assert setup._wait_for_pods_ready(
+            "kubectl", "deile", ("nope-dep",), timeout_s=1
+        ) is True
+
+    def test_rollout_failure_is_non_fatal_but_returns_false(self, monkeypatch):
+        """`rollout status` falhando despeja logs e retorna False (não levanta)."""
+        def fake_run(cmd, **kw):
+            m = MagicMock()
+            m.stdout = m.stderr = ""
+            if "get" in cmd and "deployment" in cmd:
+                m.returncode = 0  # presente
+            elif "rollout" in cmd:
+                m.returncode = 1  # não ficou Ready
+            else:
+                m.returncode = 0  # logs
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        assert setup._wait_for_pods_ready(
+            "kubectl", "deile", ("deile-worker",), timeout_s=1
+        ) is False
+
+
+class TestDeploymentsToWaitFor:
+    def test_bot_disabled_omits_deilebot(self):
+        plan = setup.NamespacePlan(
+            name="x", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker", bot_enabled=False,
+            llm_keys={"OPENAI_API_KEY": "sk-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        base = ("deilebot", "deile-worker", "deile-shell", "deile-pipeline")
+        result = setup._deployments_to_wait_for(plan, base)
+        assert "deilebot" not in result
+        assert set(result) == {"deile-worker", "deile-shell", "deile-pipeline"}
+
+    def test_bot_enabled_keeps_deilebot(self):
+        plan = setup.NamespacePlan(
+            name="x", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker", bot_enabled=True,
+            llm_keys={"OPENAI_API_KEY": "sk-x"},
+            discord_token="a.b.c", bot_bearer="b", worker_bearer="w",
+        )
+        base = ("deilebot", "deile-worker")
+        assert setup._deployments_to_wait_for(plan, base) == base
+
+
+# ============================================================================
+# _apply_namespace — bot opt-out + sequência de manifests
+# ============================================================================
+
+class TestApplyNamespace:
+    def test_bot_opt_out_skips_bot_manifests_and_bot_secret(self, monkeypatch, tmp_path):
+        """Sem bot habilitado, manifests do bot e `bot-secrets` são pulados."""
+        applied_manifests = []
+        applied_secrets = []
+
+        def fake_run(cmd, **kw):
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = m.stderr = ""
+            if "apply" in cmd and "-f" in cmd:
+                # Captura o último item — o caminho do manifest
+                manifest_path = cmd[-1]
+                applied_manifests.append(Path(manifest_path).name)
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        monkeypatch.setattr(setup, "_ensure_namespace", lambda *_a, **_kw: True)
+        monkeypatch.setattr(
+            setup, "_apply_runtime_configmap", lambda *_a, **_kw: True
+        )
+
+        def fake_apply_secret(kubectl, name, kv, ns=""):
+            applied_secrets.append(name)
+            return True
+
+        plan = setup.NamespacePlan(
+            name="deile-no-bot", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker", bot_enabled=False,
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        ok = setup._apply_namespace(
+            "kubectl", plan, fake_apply_secret, tmp_path,
+            "app.kubernetes.io/managed-by=deile",
+        )
+        assert ok is True
+        # bot-secrets NUNCA aplicado
+        assert "bot-secrets" not in applied_secrets
+        # mas deile-secrets e worker-bearer sim
+        assert "deile-secrets" in applied_secrets
+        assert "worker-bearer" in applied_secrets
+        # Manifests do bot NUNCA aplicados
+        assert "15-bot-config.yaml" not in applied_manifests
+        assert "19-bot-data-pvc.yaml" not in applied_manifests
+        assert "20-bot-deployment.yaml" not in applied_manifests
+        # Mas worker e pipeline sim
+        assert "45-deile-worker-deployment.yaml" in applied_manifests
+        assert "46-deile-pipeline-deployment.yaml" in applied_manifests
+
+    def test_bot_enabled_applies_all_manifests_and_bot_secret(
+        self, monkeypatch, tmp_path
+    ):
+        applied_manifests = []
+        applied_secrets = []
+
+        def fake_run(cmd, **kw):
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = m.stderr = ""
+            if "apply" in cmd and "-f" in cmd:
+                applied_manifests.append(Path(cmd[-1]).name)
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        monkeypatch.setattr(setup, "_ensure_namespace", lambda *_a, **_kw: True)
+        monkeypatch.setattr(
+            setup, "_apply_runtime_configmap", lambda *_a, **_kw: True
+        )
+
+        def fake_apply_secret(kubectl, name, kv, ns=""):
+            applied_secrets.append(name)
+            return True
+
+        plan = setup.NamespacePlan(
+            name="deile-full", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker", bot_enabled=True,
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-x"},
+            discord_token="a.b.c", bot_bearer="b", worker_bearer="w",
+        )
+        ok = setup._apply_namespace(
+            "kubectl", plan, fake_apply_secret, tmp_path,
+            "app.kubernetes.io/managed-by=deile",
+        )
+        assert ok is True
+        assert "bot-secrets" in applied_secrets
+        assert "20-bot-deployment.yaml" in applied_manifests
+
+
+# ============================================================================
+# run_setup — early reject + dry-run + partial-state guidance
+# ============================================================================
+
+class TestRunSetupYesRejection:
+    def test_yes_at_top_returns_2_without_calling_anything(self, capsys, tmp_path):
+        """`--yes` é rejeitado no topo de run_setup — F1 nem roda."""
+        called = {"ensure_k8s": 0, "collect": 0, "apply": 0}
+
+        def _track_ek(*_a, **_kw):
+            called["ensure_k8s"] += 1
+            return True
+
+        def _track_col(*_a, **_kw):
+            called["collect"] += 1
+            return []
+
+        rc = setup.run_setup(
+            {"yes": True, "dry_run": False},
+            kubectl_resolver=lambda: "/usr/bin/kubectl",
+            cluster_reachable_fn=lambda: True,
+            apply_secret_fn=lambda *a, **kw: True,
+            discover_existing_fn=lambda: [],
+            manifests_dir=tmp_path,
+            setup_env_path=tmp_path / "x",
+            deile_ns_label="app.kubernetes.io/managed-by=deile",
+            deployments=("deilebot",),
+        )
+        assert rc == 2
         captured = capsys.readouterr()
         assert "interativo" in captured.out + captured.err
 
 
-# ============================================================================
-# run_setup — fluxo dry_run
-# ============================================================================
-
 class TestRunSetupDryRun:
     def test_dry_run_short_circuits_after_plan(self, monkeypatch, tmp_path):
         """--dry-run imprime o plano e sai sem aplicar."""
-        # Construir um plan stub e simular a coleta.
         plan_stub = setup.NamespacePlan(
             name="deile-dry", forge_kind="github", repo="o/r",
-            dispatch_mode="deile_worker",
+            dispatch_mode="deile_worker", bot_enabled=False,
             llm_keys={"ANTHROPIC_API_KEY": "sk-ant-test"},
             bot_bearer="b", worker_bearer="w",
         )
         monkeypatch.setattr(
             setup, "_collect_namespace_plans", lambda *_a, **_kw: [plan_stub]
         )
-        # _ensure_kubernetes deve passar
-        monkeypatch.setattr(
-            setup, "_ensure_kubernetes", lambda *_a, **_kw: True
-        )
-        # apply_secret e _apply_namespace nunca devem ser chamados
-        called = {"apply_secret": 0, "apply_ns": 0}
+        # _ensure_kubernetes não deve sequer ser chamado em dry-run
+        ensure_called = {"n": 0}
+
+        def _ek(*_a, **_kw):
+            ensure_called["n"] += 1
+            return True
+
+        monkeypatch.setattr(setup, "_ensure_kubernetes", _ek)
+        called = {"apply_secret": 0}
 
         def _no_secret(*a, **kw):
             called["apply_secret"] += 1
@@ -262,6 +515,75 @@ class TestRunSetupDryRun:
         )
         assert rc == 0
         assert called["apply_secret"] == 0
+        assert ensure_called["n"] == 0
+
+
+# ============================================================================
+# _validate — usa filtro de deployments por bot
+# ============================================================================
+
+class TestValidate:
+    def test_validate_skips_deilebot_when_bot_disabled(self, monkeypatch):
+        """`_validate` chama `_wait_for_pods_ready` com `deilebot` removido
+        quando o plan tem ``bot_enabled=False``."""
+        wait_calls = []
+
+        def fake_wait(kubectl, ns, deployments, timeout_s):
+            wait_calls.append(list(deployments))
+            return True
+
+        monkeypatch.setattr(setup, "_wait_for_pods_ready", fake_wait)
+        # Mock subprocess.run para o get pods,deployments,services final
+        monkeypatch.setattr(setup.subprocess, "run", lambda *a, **kw: MagicMock(returncode=0))
+
+        plans = [
+            setup.NamespacePlan(
+                name="ns-bot", forge_kind="github", repo="o/r",
+                dispatch_mode="deile_worker", bot_enabled=True,
+                llm_keys={"ANTHROPIC_API_KEY": "sk-x"}, discord_token="a.b.c",
+                bot_bearer="b", worker_bearer="w",
+            ),
+            setup.NamespacePlan(
+                name="ns-no-bot", forge_kind="github", repo="o/r",
+                dispatch_mode="deile_worker", bot_enabled=False,
+                llm_keys={"ANTHROPIC_API_KEY": "sk-x"},
+                bot_bearer="b", worker_bearer="w",
+            ),
+        ]
+        base_deps = ("deilebot", "deile-worker", "deile-pipeline")
+        setup._validate("kubectl", plans, base_deps, timeout_s=1)
+        assert "deilebot" in wait_calls[0]
+        assert "deilebot" not in wait_calls[1]
+
+
+# ============================================================================
+# NamespacePlan repr — não vaza secrets
+# ============================================================================
+
+class TestPlanRepr:
+    def test_repr_omits_sensitive_fields(self):
+        plan = setup.NamespacePlan(
+            name="x", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker", bot_enabled=True,
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-SUPER-SECRET-VALUE-XYZ"},
+            github_token="ghp_SHOULD-NOT-LEAK-ABC",
+            gitlab_token="glpat-SHOULD-NOT-LEAK-DEF",
+            discord_token="aaa.bbb.ccc-DISCORD-SECRET",
+            bot_bearer="bot-bearer-SECRET",
+            worker_bearer="worker-bearer-SECRET",
+        )
+        r = repr(plan)
+        # Campos seguros aparecem
+        assert "name=" in r
+        assert "forge_kind=" in r
+        assert "repo=" in r
+        assert "bot_enabled=" in r
+        # Nenhum segredo vaza
+        assert "SUPER-SECRET" not in r
+        assert "SHOULD-NOT-LEAK" not in r
+        assert "DISCORD-SECRET" not in r
+        assert "bot-bearer-SECRET" not in r
+        assert "worker-bearer-SECRET" not in r
 
 
 # ============================================================================
@@ -270,7 +592,6 @@ class TestRunSetupDryRun:
 
 class TestDeployWiring:
     def test_setup_verb_registered(self):
-        # Importa deploy.py via path do _setup já configurado nas linhas iniciais
         import deploy
 
         assert "setup" in deploy._K8S

--- a/deile/tests/infra/test_k8s_setup.py
+++ b/deile/tests/infra/test_k8s_setup.py
@@ -396,11 +396,14 @@ class TestApplyNamespace:
         # mas deile-secrets e worker-bearer sim
         assert "deile-secrets" in applied_secrets
         assert "worker-bearer" in applied_secrets
-        # Manifests do bot NUNCA aplicados
-        assert "15-bot-config.yaml" not in applied_manifests
+        # PVC + Deployment do bot NUNCA aplicados
         assert "19-bot-data-pvc.yaml" not in applied_manifests
         assert "20-bot-deployment.yaml" not in applied_manifests
-        # Mas worker e pipeline sim
+        # MAS ``15-bot-config.yaml`` (ConfigMap compartilhado) AINDA aplicado
+        # — worker (45) e shell (35) o montam para `clonable_repos`.
+        assert "15-bot-config.yaml" in applied_manifests
+        # E worker, shell e pipeline sim
+        assert "35-deile-interactive.yaml" in applied_manifests
         assert "45-deile-worker-deployment.yaml" in applied_manifests
         assert "46-deile-pipeline-deployment.yaml" in applied_manifests
 

--- a/deile/tests/infra/test_k8s_setup.py
+++ b/deile/tests/infra/test_k8s_setup.py
@@ -1,0 +1,279 @@
+"""Testes unitários do verbo ``k8s setup`` (issue #328).
+
+Cobre o módulo ``infra/k8s/_setup.py``: validação de tokens, geração do
+ConfigMap por NS, secrets shape, idempotência de namespace, fluxo
+dry-run e modo --yes (que aborta o setup, por ser fundamentalmente
+interativo). Subprocess sempre mockado — nenhum teste toca o cluster.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _setup as setup  # noqa: E402
+
+# ============================================================================
+# NamespacePlan
+# ============================================================================
+
+class TestNamespacePlanSecrets:
+    def test_minimal_plan_has_required_secret_keys(self):
+        plan = setup.NamespacePlan(
+            name="deile",
+            forge_kind="github",
+            repo="owner/repo",
+            dispatch_mode="deile_worker",
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-test"},
+            bot_bearer="bot-bearer-xxx",
+            worker_bearer="worker-bearer-xxx",
+        )
+        bot, deile, worker = plan.secrets_kv()
+        assert bot["DEILE_BOT_CONTROL_PLANE_AUTH_TOKEN"] == "bot-bearer-xxx"
+        assert bot["ANTHROPIC_API_KEY"] == "sk-ant-test"
+        assert "DEILE_BOT_DISCORD_TOKEN" not in bot  # bot opcional
+        assert deile["DEILE_BOT_AUTH_TOKEN"] == "bot-bearer-xxx"
+        assert deile["ANTHROPIC_API_KEY"] == "sk-ant-test"
+        assert "GITHUB_TOKEN" not in deile
+        assert "GITLAB_TOKEN" not in deile
+        assert worker == {"AUTH_TOKEN": "worker-bearer-xxx"}
+
+    def test_dual_forge_includes_both_tokens(self):
+        plan = setup.NamespacePlan(
+            name="deile-dual",
+            forge_kind="auto",
+            repo="owner/repo",
+            dispatch_mode="deile_worker",
+            llm_keys={"OPENAI_API_KEY": "sk-oai-x"},
+            github_token="ghp_xxx",
+            gitlab_token="glpat-yyy",
+            bot_bearer="b",
+            worker_bearer="w",
+        )
+        _, deile, _ = plan.secrets_kv()
+        assert deile["GITHUB_TOKEN"] == "ghp_xxx"
+        assert deile["GITLAB_TOKEN"] == "glpat-yyy"
+
+    def test_discord_token_present_only_when_set(self):
+        without = setup.NamespacePlan(
+            name="a", forge_kind="github", repo="o/r", dispatch_mode="deile_worker",
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        with_d = setup.NamespacePlan(
+            name="b", forge_kind="github", repo="o/r", dispatch_mode="deile_worker",
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-x"},
+            discord_token="abc.def.ghi",
+            bot_bearer="b", worker_bearer="w",
+        )
+        assert "DEILE_BOT_DISCORD_TOKEN" not in without.secrets_kv()[0]
+        assert with_d.secrets_kv()[0]["DEILE_BOT_DISCORD_TOKEN"] == "abc.def.ghi"
+
+
+class TestRuntimeConfigMap:
+    def test_pipeline_settings_carries_overrides(self):
+        plan = setup.NamespacePlan(
+            name="deile-gl", forge_kind="gitlab",
+            repo="group/sub/project", dispatch_mode="claude_subprocess",
+            llm_keys={"DEEPSEEK_API_KEY": "sk-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        data = plan.runtime_configmap_data()
+        # Estrutura completa
+        assert sorted(data) == [
+            "bot-settings.json",
+            "oneshot-settings.json",
+            "pipeline-settings.json",
+            "shell-settings.json",
+            "worker-settings.json",
+        ]
+        # Overrides chegam em pipeline-settings.json
+        parsed = json.loads(data["pipeline-settings.json"])
+        assert parsed["pipeline"]["dispatch_mode"] == "claude_subprocess"
+        assert parsed["pipeline"]["repo"] == "group/sub/project"
+        assert parsed["forge"]["kind"] == "gitlab"
+        assert parsed["approval"]["auto"] is True
+        # Outras seções continuam com defaults estáveis
+        worker = json.loads(data["worker-settings.json"])
+        assert worker["model"]["preferred"]  # algum modelo declarado
+        assert worker["approval"]["auto"] is True
+
+    def test_pipeline_settings_omits_forge_when_auto(self):
+        """forge.kind=auto não vai pro JSON — deixa o detector decidir."""
+        plan = setup.NamespacePlan(
+            name="x", forge_kind="auto", repo="o/r", dispatch_mode="deile_worker",
+            llm_keys={"OPENAI_API_KEY": "sk-x"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        parsed = json.loads(plan.runtime_configmap_data()["pipeline-settings.json"])
+        assert "forge" not in parsed
+
+
+# ============================================================================
+# Token validation
+# ============================================================================
+
+class TestTokenValidation:
+    @pytest.mark.parametrize("env_var,value,expected", [
+        ("ANTHROPIC_API_KEY", "sk-ant-abcdefghijklmnopqrstu", True),
+        ("ANTHROPIC_API_KEY", "sk-other-prefix-xxxxxxxxxxxx", False),
+        ("ANTHROPIC_API_KEY", "", False),
+        ("OPENAI_API_KEY", "sk-abcdefghijklmnopqrstu", True),
+        ("DEEPSEEK_API_KEY", "sk-x", False),  # muito curto
+        ("GITHUB_TOKEN", "ghp_abcdefghijklmnopqrstuv", True),
+        ("GITHUB_TOKEN", "github_pat_11AAAAAAAA_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", True),
+        ("GITHUB_TOKEN", "glpat-mistake", False),  # prefixo errado
+        ("GITLAB_TOKEN", "glpat-abcdefghijklmnop", True),
+        ("GITLAB_TOKEN", "gldt-deploytoken1234567", True),
+        ("GITLAB_TOKEN", "ghp_wrong-forge", False),
+        ("DEILE_BOT_DISCORD_TOKEN", "abc.def-1.ghi_2", True),
+        ("DEILE_BOT_DISCORD_TOKEN", "abc.def", False),  # falta 3o segmento
+    ])
+    def test_format_check(self, env_var, value, expected):
+        assert setup._validate_token_format(env_var, value) is expected
+
+    def test_unknown_env_var_passes_through(self):
+        # Sem pattern registrado → aceita qualquer não-vazio.
+        assert setup._validate_token_format("SOMETHING_NEW", "value") is True
+
+
+# ============================================================================
+# _ensure_namespace
+# ============================================================================
+
+class TestEnsureNamespace:
+    def test_creates_when_missing_and_labels(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(list(cmd))
+            m = MagicMock()
+            # 1ª chamada: get namespace → falha (ausente)
+            # 2ª: create namespace → OK
+            # 3ª: label → OK
+            if len(calls) == 1 and "get" in cmd:
+                m.returncode = 1
+            else:
+                m.returncode = 0
+            m.stdout = ""
+            m.stderr = ""
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        assert setup._ensure_namespace("kubectl", "deile-new",
+                                       "app.kubernetes.io/managed-by=deile")
+        assert any("create" in c and "namespace" in c for c in calls)
+        # Labels PSS restricted + managed-by
+        label_call = next(c for c in calls if "label" in c)
+        assert "pod-security.kubernetes.io/enforce=restricted" in label_call
+        assert "app.kubernetes.io/managed-by=deile" in label_call
+
+    def test_idempotent_when_namespace_exists(self, monkeypatch):
+        """NS já existe → pula `create`, só re-aplica labels."""
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(list(cmd))
+            m = MagicMock()
+            m.returncode = 0  # tudo OK
+            m.stdout = m.stderr = ""
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        assert setup._ensure_namespace("kubectl", "deile",
+                                       "app.kubernetes.io/managed-by=deile")
+        commands = [" ".join(c) for c in calls]
+        assert not any("create namespace" in c for c in commands)
+        assert any("label" in c for c in commands)
+
+    def test_create_failure_propagates(self, monkeypatch):
+        def fake_run(cmd, **kw):
+            m = MagicMock()
+            m.returncode = 1
+            m.stdout = ""
+            m.stderr = "AlreadyExists or quota error"
+            return m
+
+        monkeypatch.setattr(setup.subprocess, "run", fake_run)
+        assert setup._ensure_namespace("kubectl", "deile-x",
+                                       "app.kubernetes.io/managed-by=deile") is False
+
+
+# ============================================================================
+# _collect_namespace_plans com --yes
+# ============================================================================
+
+class TestCollectPlans:
+    def test_yes_mode_aborts(self, capsys):
+        """--yes não pode rodar (segredos via getpass exigem interativo)."""
+        result = setup._collect_namespace_plans(yes=True, existing_ns=[])
+        assert result == []
+        captured = capsys.readouterr()
+        assert "interativo" in captured.out + captured.err
+
+
+# ============================================================================
+# run_setup — fluxo dry_run
+# ============================================================================
+
+class TestRunSetupDryRun:
+    def test_dry_run_short_circuits_after_plan(self, monkeypatch, tmp_path):
+        """--dry-run imprime o plano e sai sem aplicar."""
+        # Construir um plan stub e simular a coleta.
+        plan_stub = setup.NamespacePlan(
+            name="deile-dry", forge_kind="github", repo="o/r",
+            dispatch_mode="deile_worker",
+            llm_keys={"ANTHROPIC_API_KEY": "sk-ant-test"},
+            bot_bearer="b", worker_bearer="w",
+        )
+        monkeypatch.setattr(
+            setup, "_collect_namespace_plans", lambda *_a, **_kw: [plan_stub]
+        )
+        # _ensure_kubernetes deve passar
+        monkeypatch.setattr(
+            setup, "_ensure_kubernetes", lambda *_a, **_kw: True
+        )
+        # apply_secret e _apply_namespace nunca devem ser chamados
+        called = {"apply_secret": 0, "apply_ns": 0}
+
+        def _no_secret(*a, **kw):
+            called["apply_secret"] += 1
+            return True
+
+        rc = setup.run_setup(
+            {"yes": False, "dry_run": True},
+            kubectl_resolver=lambda: "/usr/bin/kubectl",
+            cluster_reachable_fn=lambda: True,
+            apply_secret_fn=_no_secret,
+            discover_existing_fn=lambda: [],
+            manifests_dir=tmp_path,
+            setup_env_path=tmp_path / "setup_environment.py",
+            deile_ns_label="app.kubernetes.io/managed-by=deile",
+            deployments=("deilebot",),
+        )
+        assert rc == 0
+        assert called["apply_secret"] == 0
+
+
+# ============================================================================
+# Wiring no deploy.py (smoke)
+# ============================================================================
+
+class TestDeployWiring:
+    def test_setup_verb_registered(self):
+        # Importa deploy.py via path do _setup já configurado nas linhas iniciais
+        import deploy
+
+        assert "setup" in deploy._K8S
+        assert deploy._K8S["setup"] is deploy.k8s_setup
+        action_names = [a for a, _ in deploy._K8S_ACTIONS]
+        assert "setup" in action_names

--- a/infra/k8s/_setup.py
+++ b/infra/k8s/_setup.py
@@ -389,13 +389,12 @@ def _build_namespace_plan(
 
 def _collect_namespace_plans(
     existing_ns: List[str], dry_run: bool = False
-) -> Optional[List[NamespacePlan]]:
+) -> List[NamespacePlan]:
     """Coleta N planos de NS via prompts.
 
-    Retorna ``None`` para indicar abort (operador cancelou ou input
-    inválido recorrente); ``list`` (não-vazia) para indicar sucesso. A
-    rejeição de ``--yes`` fica em ``run_setup`` — esta função pressupõe
-    fluxo interativo.
+    Retorna sempre uma lista não-vazia (1..8 entradas — o loop interno
+    valida o range). Aborts vivem no caller (rejeição de ``--yes`` em
+    ``run_setup``) — esta função pressupõe fluxo interativo.
     """
     while True:
         raw = ui.ask(

--- a/infra/k8s/_setup.py
+++ b/infra/k8s/_setup.py
@@ -554,9 +554,13 @@ def _apply_namespace(
     """Provisiona um NS inteiro: namespace + network policy + secrets + cm +
     PVCs + Deployments. Idempotente — chama os manifests existentes.
 
-    Quando ``plan.bot_enabled`` é False, os manifests do bot (15-bot-config,
-    19-bot-data-pvc, 20-bot-deployment) são pulados — sem ``bot-secrets``
-    com discord token, o deployment crashlooparia e travaria o ``_validate``.
+    Quando ``plan.bot_enabled`` é False, **só o PVC e o Deployment do bot**
+    (19-bot-data-pvc, 20-bot-deployment) são pulados — sem ``bot-secrets``
+    com discord token, o deployment crashlooparia e travaria o
+    ``_validate``. O ConfigMap ``bot-config`` (manifest 15) continua sendo
+    aplicado mesmo sem bot, porque é também montado por worker (45) e
+    shell (35) para a allowlist ``clonable_repos`` que o ``wrapper.py``
+    consome em todos os pods.
     """
     ns = plan.name
     ui.info(f"[{ns}] provisionando namespace + labels PSS restricted")
@@ -587,17 +591,24 @@ def _apply_namespace(
     if not _apply_runtime_configmap(kubectl, ns, plan):
         return False
 
-    ui.info(f"[{ns}] aplicando PVCs + Deployments")
-    bot_manifests = ("15-bot-config.yaml", "19-bot-data-pvc.yaml", "20-bot-deployment.yaml")
-    core_manifests = (
+    ui.info(f"[{ns}] aplicando ConfigMap bot-config + PVCs + Deployments")
+    # bot-config (manifest 15) é compartilhado: worker (45) e shell (35)
+    # montam-no para a allowlist ``clonable_repos``. Aplica SEMPRE — só o
+    # PVC e o Deployment do bot ficam fora quando ``bot_enabled=False``.
+    base_manifests = (
+        "15-bot-config.yaml",
         "35-deile-interactive.yaml",
         "41-worker-pvc.yaml",
         "45-deile-worker-deployment.yaml",
         "46-deile-pipeline-deployment.yaml",
     )
-    manifests_to_apply = (bot_manifests + core_manifests) if plan.bot_enabled else core_manifests
+    bot_only_manifests = ("19-bot-data-pvc.yaml", "20-bot-deployment.yaml")
+    manifests_to_apply = base_manifests + bot_only_manifests if plan.bot_enabled else base_manifests
     if not plan.bot_enabled:
-        ui.info(f"[{ns}] bot Discord desabilitado — pulando manifests do bot")
+        ui.info(
+            f"[{ns}] bot Discord desabilitado — pulando PVC + Deployment do bot "
+            "(ConfigMap bot-config é compartilhado, continua sendo aplicado)"
+        )
     for manifest in manifests_to_apply:
         rc = subprocess.run(
             [kubectl, "apply", "-n", ns, "-f", str(manifests_dir / manifest)]

--- a/infra/k8s/_setup.py
+++ b/infra/k8s/_setup.py
@@ -1,0 +1,746 @@
+"""Setup interativo da stack DEILE em Kubernetes (issue #328).
+
+Verbo ``python3 infra/k8s/deploy.py k8s setup``. Conduz o operador, em
+um único fluxo guiado, do host zero (sem kubectl, sem cluster, sem
+namespace DEILE) até pipeline rodando, garantindo que nenhum valor
+sensível atravesse a history do shell — todo segredo entra por
+``getpass.getpass`` via :func:`_cli_ui.ask_secret` e é aplicado a Secrets
+K8s por arquivo temporário ``0600`` (mesma estratégia do
+``deploy._apply_secret``), nunca por argv.
+
+A função pública é :func:`run_setup` — ``deploy.py`` injeta callbacks
+para reusar helpers já existentes (``_kubectl``, ``_apply_secret``,
+``cluster_reachable``, ``k8s_status``). Mantém o módulo testável em
+isolamento sem precisar mockar o orquestrador inteiro.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import _cli_ui as ui  # noqa: E402
+
+LLM_KEYS = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DEEPSEEK_API_KEY", "GOOGLE_API_KEY")
+
+_NS_NAME_RE = re.compile(r"^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$")
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.\-]+(/[A-Za-z0-9_.\-]+)+$")
+
+# Prefixos conservadores; o cru também aceita "qualquer coisa não-vazia"
+# quando o operador escolhe pular validação. Não buscamos detectar 100%
+# dos formatos (tokens evoluem) — apenas pegar o erro grosseiro de colar
+# uma chave do provider errado.
+_TOKEN_PATTERNS: Dict[str, re.Pattern] = {
+    "ANTHROPIC_API_KEY": re.compile(r"^sk-ant-[A-Za-z0-9_\-]{20,}$"),
+    "OPENAI_API_KEY": re.compile(r"^sk-[A-Za-z0-9_\-]{20,}$"),
+    "DEEPSEEK_API_KEY": re.compile(r"^sk-[A-Za-z0-9_\-]{20,}$"),
+    "GOOGLE_API_KEY": re.compile(r"^[A-Za-z0-9_\-]{20,}$"),
+    "GITHUB_TOKEN": re.compile(
+        r"^(ghp_|gho_|ghu_|ghs_|ghr_|github_pat_)[A-Za-z0-9_\-]{20,}$"
+    ),
+    "GITLAB_TOKEN": re.compile(
+        r"^(glpat-|gldt-|glptt-|glsoat-)[A-Za-z0-9_\-]{16,}$"
+    ),
+    "DEILE_BOT_DISCORD_TOKEN": re.compile(
+        r"^[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+$"
+    ),
+}
+
+
+@dataclass
+class NamespacePlan:
+    """Plano declarativo de provisionamento de um namespace DEILE.
+
+    Tudo o que o operador escolheu em prompt vive aqui — Secrets e
+    ConfigMap por NS são derivados deste objeto sem novo prompt.
+    """
+
+    name: str
+    forge_kind: str  # "github" | "gitlab"
+    repo: str
+    dispatch_mode: str  # "deile_worker" | "claude_subprocess"
+    llm_keys: Dict[str, str] = field(default_factory=dict)
+    github_token: str = ""
+    gitlab_token: str = ""
+    discord_token: str = ""
+    bot_bearer: str = ""  # gerado automaticamente se vazio
+    worker_bearer: str = ""  # gerado automaticamente se vazio
+
+    def secrets_kv(self) -> Tuple[Dict[str, str], Dict[str, str], Dict[str, str]]:
+        """Retorna (bot_secrets, deile_secrets, worker_bearer) pra aplicar."""
+        bot = {
+            "DEILE_BOT_CONTROL_PLANE_AUTH_TOKEN": self.bot_bearer,
+            **self.llm_keys,
+        }
+        if self.discord_token:
+            bot["DEILE_BOT_DISCORD_TOKEN"] = self.discord_token
+        deile = {"DEILE_BOT_AUTH_TOKEN": self.bot_bearer, **self.llm_keys}
+        if self.github_token:
+            deile["GITHUB_TOKEN"] = self.github_token
+        if self.gitlab_token:
+            deile["GITLAB_TOKEN"] = self.gitlab_token
+        worker = {"AUTH_TOKEN": self.worker_bearer}
+        return bot, deile, worker
+
+    def runtime_configmap_data(self) -> Dict[str, str]:
+        """Gera o ``data:`` do ConfigMap ``deile-runtime-config`` por NS.
+
+        Mantém o mesmo conjunto de chaves do manifest 47, mas aplica os
+        overrides (forge.kind, pipeline.repo, dispatch_mode) escolhidos
+        pelo operador. As entradas para worker/shell/oneshot/bot são
+        idênticas ao manifest base — não tem variação per-NS.
+        """
+        pipeline_settings: Dict[str, object] = {
+            "pipeline": {
+                "dispatch_mode": self.dispatch_mode,
+                "repo": self.repo,
+                "poll_interval": 60,
+            },
+            "approval": {"auto": True},
+        }
+        if self.forge_kind in ("github", "gitlab"):
+            pipeline_settings["forge"] = {"kind": self.forge_kind}
+        return {
+            "pipeline-settings.json": json.dumps(pipeline_settings, indent=2) + "\n",
+            "worker-settings.json": (
+                '{\n  "model": {\n    "preferred": "deepseek:deepseek-v4-pro"\n  },\n'
+                '  "approval": {\n    "auto": true\n  }\n}\n'
+            ),
+            "shell-settings.json": '{\n  "approval": {\n    "auto": true\n  }\n}\n',
+            "oneshot-settings.json": '{\n  "approval": {\n    "auto": true\n  }\n}\n',
+            "bot-settings.json": (
+                '{\n  "cron": {\n    "db_path": "/home/deile/data/cron.db"\n  }\n}\n'
+            ),
+        }
+
+
+# ============================================================================
+# F1 — detecção e instalação resiliente de kubectl/cluster (cross-platform)
+# ============================================================================
+
+def _ensure_kubernetes(
+    yes: bool,
+    cluster_reachable_fn: Callable[[], bool],
+    setup_env_path: Path,
+) -> bool:
+    """Garante kubectl + cluster vivo.
+
+    Reusa ``infra/setup_environment.py`` para a instalação cross-platform —
+    não duplicamos a lógica de k3s/Rancher/colima aqui. Em Windows não há
+    auto-install limpa, apenas instruções.
+    """
+    if cluster_reachable_fn():
+        ui.ok("cluster Kubernetes acessível")
+        return True
+
+    ui.warn("nenhum cluster Kubernetes acessível neste host")
+    if not setup_env_path.is_file():
+        ui.err(f"instalador de ambiente não encontrado em {setup_env_path}")
+        ui.info(
+            "Sem ele não consigo instalar k3s/Rancher Desktop automaticamente. "
+            "Instale manualmente um Kubernetes leve (Rancher Desktop / k3d / k3s) "
+            "e rode `deploy.py k8s setup` de novo."
+        )
+        return False
+
+    if not yes and not ui.confirm(
+        "Rodar o instalador `setup_environment.py --mode container` agora?",
+        default=True,
+    ):
+        ui.info(
+            "OK — instale o k8s manualmente (Rancher Desktop / k3d / k3s) "
+            "e rode `deploy.py k8s setup` de novo."
+        )
+        return False
+
+    cmd = [sys.executable, str(setup_env_path), "--mode", "container"]
+    if yes:
+        cmd.append("--yes")
+    try:
+        rc = subprocess.run(cmd, cwd=str(setup_env_path.parent.parent)).returncode
+    except OSError as exc:
+        ui.err(f"falha ao executar setup_environment.py: {exc}")
+        return False
+    if rc != 0:
+        ui.err("setup_environment.py saiu com erro — ambiente ainda incompleto")
+        return False
+    if not cluster_reachable_fn():
+        ui.err(
+            "instalação concluída mas o cluster ainda não responde. "
+            "Em Rancher Desktop / colima, espere o Kubernetes ficar "
+            "verde no app e rode `deploy.py k8s setup` de novo."
+        )
+        return False
+    ui.ok("cluster Kubernetes pronto")
+    return True
+
+
+# ============================================================================
+# F2 — setup interativo de N namespaces (prompts seguros + secrets + cm)
+# ============================================================================
+
+def _validate_token_format(env_var: str, raw: str) -> bool:
+    """Heurística leve de prefixo. Tokens vazios retornam False (não cobra
+    o erro do operador — quem chama decide se o token é opcional)."""
+    raw = raw.strip()
+    if not raw:
+        return False
+    pattern = _TOKEN_PATTERNS.get(env_var)
+    return bool(pattern.fullmatch(raw)) if pattern else True
+
+
+def _ask_secret_validated(env_var: str, *, optional: bool) -> str:
+    """Pede um segredo via ``getpass``, valida prefixo, oferece pular.
+
+    - Vazio: pula (retorna "") se ``optional=True``; senão repete.
+    - Inválido: avisa e pede ``s`` para aceitar mesmo assim, ``n`` para
+      tentar de novo. Esse opt-out cobre quando o pattern fica defasado.
+    """
+    prompt = f"{env_var}"
+    if optional:
+        prompt += " (Enter para pular)"
+    while True:
+        # ``ask_secret`` em ``_cli_ui`` repete até não-vazio; aqui queremos
+        # permitir vazio quando opcional. Usar ``getpass`` direto, com o
+        # mesmo prefixo visual de cor (paint("?")).
+        from getpass import getpass
+
+        prefix = ui.paint("  ? ", "cyan", "bold")
+        raw = getpass(f"{prefix}{prompt}: ").strip()
+        if not raw:
+            if optional:
+                ui.info(f"{env_var}: pulado")
+                return ""
+            ui.err("valor obrigatório.")
+            continue
+        if _validate_token_format(env_var, raw):
+            return raw
+        ui.warn(f"o valor não casa com o formato esperado de {env_var}.")
+        if ui.confirm("Aceitar mesmo assim?", default=False):
+            return raw
+        # senão, próximo loop pede de novo
+
+
+def _ask_llm_keys(plan_idx: int) -> Dict[str, str]:
+    """Pergunta as 4 LLM keys; exige ao menos UMA (bootstrap_providers)."""
+    ui.section(f"Ambiente {plan_idx}: chaves de LLM (ao menos uma)")
+    collected: Dict[str, str] = {}
+    for env_var in LLM_KEYS:
+        val = _ask_secret_validated(env_var, optional=True)
+        if val:
+            collected[env_var] = val
+    if not collected:
+        ui.err(
+            "nenhuma chave de LLM configurada — DEILE não sobe sem ao menos uma "
+            "de ANTHROPIC/OPENAI/DEEPSEEK/GOOGLE. Repetindo este bloco."
+        )
+        return _ask_llm_keys(plan_idx)
+    return collected
+
+
+def _ask_forge(plan_idx: int) -> Tuple[str, str, str, str]:
+    """Pergunta forge_kind + repo + tokens (GH e/ou GL conforme o modo)."""
+    ui.section(f"Ambiente {plan_idx}: forge alvo")
+    forge_kind = ui.choose(
+        "Qual forge este ambiente atende?",
+        [
+            ("github", "GitHub.com ou GHES (single-forge)"),
+            ("gitlab", "GitLab.com ou self-hosted (single-forge)"),
+            ("dual", "Ambos (GH + GL) na mesma stack"),
+        ],
+    )
+    repo_help = (
+        "owner/repo (GH) ou group/(sub/)*project (GL)"
+        if forge_kind in ("github", "gitlab")
+        else "repo padrão do pipeline (owner/repo no caso de dual)"
+    )
+    while True:
+        repo = ui.ask(f"Repositório principal — {repo_help}").strip()
+        if _REPO_RE.fullmatch(repo):
+            break
+        ui.err("formato inválido — use `owner/repo` ou `group/sub/project`.")
+
+    gh_token = ""
+    gl_token = ""
+    if forge_kind in ("github", "dual"):
+        gh_token = _ask_secret_validated(
+            "GITHUB_TOKEN", optional=(forge_kind == "dual")
+        )
+    if forge_kind in ("gitlab", "dual"):
+        gl_token = _ask_secret_validated(
+            "GITLAB_TOKEN", optional=(forge_kind == "dual")
+        )
+    # Em modo dual, ao menos um token deve existir para o pipeline rodar.
+    if forge_kind == "dual" and not gh_token and not gl_token:
+        ui.err(
+            "modo dual exige ao menos um dos tokens (GH ou GL). Repetindo o forge."
+        )
+        return _ask_forge(plan_idx)
+
+    # ``forge_kind`` resolvido pro settings JSON: dual fica como "auto"
+    # para o detector decidir via URL/host.
+    kind_for_settings = "auto" if forge_kind == "dual" else forge_kind
+    return kind_for_settings, repo, gh_token, gl_token
+
+
+def _ask_bot(plan_idx: int) -> Tuple[str, str]:
+    """Pergunta token do Discord + bearer do bot. Ambos opcionais (bot pode
+    ficar desabilitado neste NS) — o bearer auto-gerado se vazio."""
+    ui.section(f"Ambiente {plan_idx}: bot Discord (opcional)")
+    if not ui.confirm("Habilitar o bot Discord neste namespace?", default=False):
+        return "", ""
+    discord = _ask_secret_validated("DEILE_BOT_DISCORD_TOKEN", optional=False)
+    bearer = _ask_secret_validated(
+        "DEILE_BOT_CONTROL_PLANE_AUTH_TOKEN (Enter = gerar automaticamente)",
+        optional=True,
+    )
+    return discord, bearer
+
+
+def _build_namespace_plan(
+    plan_idx: int, existing_ns: List[str]
+) -> NamespacePlan:
+    """Monta um ``NamespacePlan`` interativamente."""
+    ui.section(f"Ambiente {plan_idx}: identidade")
+    while True:
+        suggested = "deile" if plan_idx == 1 else f"deile-{plan_idx}"
+        name = ui.ask(
+            "Nome do namespace Kubernetes (DNS-1123)", default=suggested
+        ).strip()
+        if not _NS_NAME_RE.fullmatch(name):
+            ui.err(
+                "nome inválido — minúsculas + dígitos + hífen, "
+                "começa/termina com alfanumérico, até 63 chars."
+            )
+            continue
+        if name in existing_ns:
+            ui.warn(
+                f"o namespace `{name}` já existe — `setup` não sobrescreve. "
+                "Escolha outro nome ou rode `k8s up --namespace {name}` "
+                "manualmente para atualizar."
+            )
+            continue
+        break
+
+    dispatch_mode = ui.choose(
+        "Como o pipeline dispara implementações?",
+        [
+            ("deile_worker", "via deile-worker (DEILE-to-DEILE, default)"),
+            ("claude_subprocess", "via claude -p (CCR cloud / subscription)"),
+        ],
+    )
+    kind, repo, gh_token, gl_token = _ask_forge(plan_idx)
+    llm = _ask_llm_keys(plan_idx)
+    discord, bearer_manual = _ask_bot(plan_idx)
+
+    # Bearers auto-gerados quando vazios — entropy do ``secrets`` stdlib.
+    import secrets as _secrets
+
+    bot_bearer = bearer_manual or _secrets.token_urlsafe(32)
+    worker_bearer = _secrets.token_urlsafe(32)
+
+    return NamespacePlan(
+        name=name,
+        forge_kind=kind,
+        repo=repo,
+        dispatch_mode=dispatch_mode,
+        llm_keys=llm,
+        github_token=gh_token,
+        gitlab_token=gl_token,
+        discord_token=discord,
+        bot_bearer=bot_bearer,
+        worker_bearer=worker_bearer,
+    )
+
+
+def _collect_namespace_plans(
+    yes: bool, existing_ns: List[str]
+) -> List[NamespacePlan]:
+    """Coleta N planos de NS via prompts. ``--yes`` aborta — o fluxo é
+    fundamentalmente interativo (segredos via getpass)."""
+    if yes:
+        ui.err(
+            "`k8s setup` é interativo (segredos via getpass) — `--yes` não "
+            "se aplica aqui. Para automação não-interativa, use "
+            "`k8s up` com Secrets pré-criados via `kubectl apply`."
+        )
+        return []
+
+    while True:
+        raw = ui.ask(
+            "Quantos ambientes (namespaces) DEILE você quer criar?", default="1"
+        )
+        try:
+            count = int(raw)
+        except ValueError:
+            ui.err("número inválido.")
+            continue
+        if 1 <= count <= 8:
+            break
+        ui.err("escolha entre 1 e 8.")
+
+    plans: List[NamespacePlan] = []
+    taken = list(existing_ns)
+    for i in range(1, count + 1):
+        plan = _build_namespace_plan(i, taken)
+        plans.append(plan)
+        taken.append(plan.name)
+    return plans
+
+
+# ============================================================================
+# Apply: namespace + secrets + configmap (por NS)
+# ============================================================================
+
+def _ensure_namespace(kubectl: str, name: str, deile_ns_label: str) -> bool:
+    """Cria namespace (idempotente) com labels PSS restricted + managed-by."""
+    proc = subprocess.run(
+        [kubectl, "get", "namespace", name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if proc.returncode != 0:
+        ui.info(f"criando namespace `{name}`")
+        create = subprocess.run(
+            [kubectl, "create", "namespace", name],
+            capture_output=True,
+            text=True,
+        )
+        if create.returncode != 0:
+            ui.err(f"falha ao criar namespace `{name}`: {create.stderr.strip()}")
+            return False
+    label_key, label_val = deile_ns_label.split("=", 1)
+    label = subprocess.run(
+        [
+            kubectl,
+            "label",
+            "namespace",
+            name,
+            f"{label_key}={label_val}",
+            "pod-security.kubernetes.io/enforce=restricted",
+            "pod-security.kubernetes.io/enforce-version=v1.29",
+            "pod-security.kubernetes.io/audit=restricted",
+            "pod-security.kubernetes.io/audit-version=v1.29",
+            "pod-security.kubernetes.io/warn=restricted",
+            "pod-security.kubernetes.io/warn-version=v1.29",
+            "--overwrite",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if label.returncode != 0:
+        ui.err(f"falha ao etiquetar namespace `{name}`: {label.stderr.strip()}")
+        return False
+    return True
+
+
+def _apply_runtime_configmap(
+    kubectl: str, ns: str, plan: NamespacePlan
+) -> bool:
+    """Renderiza e aplica o ``deile-runtime-config`` ConfigMap por NS.
+
+    Usa arquivo temporário modo ``0600`` para não passar JSON multilinha
+    por argv (escape inferno no shell)."""
+    data = plan.runtime_configmap_data()
+    with tempfile.TemporaryDirectory(prefix="deile-cm-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        file_args: List[str] = []
+        for fname, content in data.items():
+            f = tmp_path / fname
+            f.write_text(content, encoding="utf-8")
+            file_args += [f"--from-file={fname}={f}"]
+        rendered = subprocess.run(
+            [
+                kubectl,
+                "-n",
+                ns,
+                "create",
+                "configmap",
+                "deile-runtime-config",
+                *file_args,
+                "--dry-run=client",
+                "-o",
+                "yaml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if rendered.returncode != 0:
+            ui.err(
+                f"falha ao renderizar ConfigMap deile-runtime-config "
+                f"para `{ns}`: {rendered.stderr.strip()}"
+            )
+            return False
+        # Patch labels do manifest 47 (app: deile) — kubectl create cm não
+        # adiciona labels; injetamos via apply de patch leve em sequência.
+        apply = subprocess.run(
+            [kubectl, "apply", "-f", "-"],
+            input=rendered.stdout,
+            text=True,
+            capture_output=True,
+        )
+        if apply.returncode != 0:
+            ui.err(
+                f"falha ao aplicar ConfigMap deile-runtime-config "
+                f"em `{ns}`: {apply.stderr.strip()}"
+            )
+            return False
+        subprocess.run(
+            [
+                kubectl,
+                "-n",
+                ns,
+                "label",
+                "configmap",
+                "deile-runtime-config",
+                "app=deile",
+                "--overwrite",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    return True
+
+
+def _apply_namespace(
+    kubectl: str,
+    plan: NamespacePlan,
+    apply_secret_fn: Callable[..., bool],
+    manifests_dir: Path,
+    deile_ns_label: str,
+) -> bool:
+    """Provisiona um NS inteiro: namespace + network policy + secrets + cm +
+    PVCs + Deployments. Idempotente — chama os manifests existentes."""
+    ns = plan.name
+    ui.info(f"[{ns}] provisionando namespace + labels PSS restricted")
+    if not _ensure_namespace(kubectl, ns, deile_ns_label):
+        return False
+
+    ui.info(f"[{ns}] aplicando network policies")
+    rc = subprocess.run(
+        [kubectl, "apply", "-n", ns, "-f", str(manifests_dir / "40-network-policy.yaml")]
+    ).returncode
+    if rc != 0:
+        ui.err(f"[{ns}] falha ao aplicar network policies")
+        return False
+
+    bot_kv, deile_kv, worker_kv = plan.secrets_kv()
+    ui.info(f"[{ns}] criando Secrets (nada é impresso)")
+    if not apply_secret_fn(kubectl, "bot-secrets", bot_kv, ns=ns):
+        return False
+    if not apply_secret_fn(kubectl, "deile-secrets", deile_kv, ns=ns):
+        return False
+    if not apply_secret_fn(kubectl, "worker-bearer", worker_kv, ns=ns):
+        return False
+
+    ui.info(f"[{ns}] aplicando ConfigMap deile-runtime-config (overrides por NS)")
+    if not _apply_runtime_configmap(kubectl, ns, plan):
+        return False
+
+    ui.info(f"[{ns}] aplicando ConfigMap bot-config + PVCs + Deployments")
+    for manifest in (
+        "15-bot-config.yaml",
+        "19-bot-data-pvc.yaml",
+        "20-bot-deployment.yaml",
+        "35-deile-interactive.yaml",
+        "41-worker-pvc.yaml",
+        "45-deile-worker-deployment.yaml",
+        "46-deile-pipeline-deployment.yaml",
+    ):
+        rc = subprocess.run(
+            [kubectl, "apply", "-n", ns, "-f", str(manifests_dir / manifest)]
+        ).returncode
+        if rc != 0:
+            ui.err(f"[{ns}] falha ao aplicar {manifest}")
+            return False
+    return True
+
+
+# ============================================================================
+# F3 — pós-validação + diagnóstico
+# ============================================================================
+
+def _wait_for_pods_ready(
+    kubectl: str,
+    ns: str,
+    deployments: Tuple[str, ...],
+    timeout_s: int = 90,
+) -> bool:
+    """Aguarda cada deployment ficar pronto. Falhas viram logs (não-fatal)."""
+    all_ok = True
+    for dep in deployments:
+        exists = subprocess.run(
+            [kubectl, "-n", ns, "get", "deployment", dep],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        if exists != 0:
+            ui.info(f"[{ns}] deployment/{dep} não presente — pulando wait")
+            continue
+        rc = subprocess.run(
+            [
+                kubectl,
+                "-n",
+                ns,
+                "rollout",
+                "status",
+                f"deployment/{dep}",
+                f"--timeout={timeout_s}s",
+            ]
+        ).returncode
+        if rc != 0:
+            ui.warn(f"[{ns}] deployment/{dep} não ficou pronto em {timeout_s}s")
+            subprocess.run(
+                [kubectl, "-n", ns, "logs", f"deploy/{dep}", "--tail=40"],
+                stderr=subprocess.STDOUT,
+            )
+            all_ok = False
+    return all_ok
+
+
+def _validate(
+    kubectl: str,
+    plans: List[NamespacePlan],
+    deployments: Tuple[str, ...],
+    timeout_s: int = 90,
+) -> bool:
+    """Para cada NS: aguarda pods + imprime status final."""
+    ui.section("Validação pós-setup")
+    overall = True
+    for plan in plans:
+        ui.info(f"[{plan.name}] aguardando pods ficarem prontos…")
+        ok = _wait_for_pods_ready(kubectl, plan.name, deployments, timeout_s)
+        # Status sempre — mesmo se pods não vieram, queremos o snapshot.
+        subprocess.run(
+            [kubectl, "-n", plan.name, "get", "pods,deployments,services"]
+        )
+        if ok:
+            ui.ok(f"[{plan.name}] todos os deployments prontos")
+        else:
+            overall = False
+    return overall
+
+
+# ============================================================================
+# Orquestração — entry point chamado pelo deploy.py
+# ============================================================================
+
+def _print_plan(plans: List[NamespacePlan]) -> None:
+    """Imprime resumo declarativo do que será aplicado (segredos como
+    contagem, jamais valores)."""
+    ui.section("Plano consolidado")
+    for plan in plans:
+        ui.info(
+            f"  • {plan.name}: forge={plan.forge_kind} repo={plan.repo} "
+            f"dispatch={plan.dispatch_mode}"
+        )
+        keys_n = len(plan.llm_keys)
+        flags: List[str] = [f"{keys_n} LLM key(s)"]
+        if plan.github_token:
+            flags.append("GITHUB_TOKEN")
+        if plan.gitlab_token:
+            flags.append("GITLAB_TOKEN")
+        if plan.discord_token:
+            flags.append("Discord")
+        ui.detail("    Secrets: " + ", ".join(flags))
+
+
+def run_setup(
+    args: dict,
+    *,
+    kubectl_resolver: Callable[[], Optional[str]],
+    cluster_reachable_fn: Callable[[], bool],
+    apply_secret_fn: Callable[..., bool],
+    discover_existing_fn: Callable[[], List[str]],
+    manifests_dir: Path,
+    setup_env_path: Path,
+    deile_ns_label: str,
+    deployments: Tuple[str, ...],
+) -> int:
+    """Entry point. Devolve exit code (0 = sucesso, 1 = erro, 2 = abortado).
+
+    Não usa ``announce_plan`` do deploy.py porque o plano só fica conhecido
+    APÓS os prompts — imprimimos o plano internamente entre coleta e apply.
+    """
+    yes = bool(args.get("yes"))
+    dry_run = bool(args.get("dry_run"))
+
+    ui.header("DEILE — setup interativo (k8s do zero ao pipeline)")
+    ui.info("Este verbo:")
+    ui.detail("• detecta o cluster k8s (oferece instalar se faltar)")
+    ui.detail("• cria 1..N namespaces DEILE com PSS restricted")
+    ui.detail("• pergunta segredos via getpass (nada vai pra history do shell)")
+    ui.detail("• aplica Secrets + ConfigMap por NS")
+    ui.detail("• aguarda pods ficarem prontos e imprime status")
+
+    # F1 — k8s
+    ui.section("1. Cluster Kubernetes")
+    if not _ensure_kubernetes(yes, cluster_reachable_fn, setup_env_path):
+        return 1
+    kubectl = kubectl_resolver()
+    if kubectl is None:
+        ui.err("kubectl ainda inacessível após a checagem — abortando.")
+        return 1
+
+    # F2 — coleta
+    existing_ns = discover_existing_fn() if not dry_run else []
+    if existing_ns:
+        ui.info(
+            "Namespaces DEILE já presentes no cluster: " + ", ".join(existing_ns)
+        )
+    plans = _collect_namespace_plans(yes, existing_ns)
+    if not plans:
+        return 2
+
+    _print_plan(plans)
+    if dry_run:
+        ui.warn("--dry-run: nada foi aplicado.")
+        return 0
+    if not ui.confirm("Confirmar e aplicar?", default=True):
+        ui.info("Cancelado pelo operador.")
+        return 2
+
+    # F2 — apply
+    ui.section("2. Aplicando manifests")
+    failed: List[str] = []
+    for plan in plans:
+        ok = _apply_namespace(
+            kubectl, plan, apply_secret_fn, manifests_dir, deile_ns_label
+        )
+        if not ok:
+            failed.append(plan.name)
+    if failed:
+        ui.err(
+            f"falha em {len(failed)} de {len(plans)} namespace(s): "
+            + ", ".join(failed)
+        )
+        return 1
+
+    # F3 — validação
+    overall = _validate(kubectl, plans, deployments, timeout_s=90)
+
+    ui.section("Resumo")
+    for plan in plans:
+        ui.ok(
+            f"[{plan.name}] forge={plan.forge_kind} repo={plan.repo} "
+            f"dispatch={plan.dispatch_mode}"
+        )
+    if not overall:
+        ui.warn(
+            "Alguns deployments não ficaram prontos no tempo esperado — veja "
+            "os logs acima. Rode `deploy.py --namespace <ns> k8s logs` para "
+            "diagnosticar e `k8s status` periodicamente."
+        )
+        return 1
+    ui.ok("Setup completo. Pipeline pronto pra rodar.")
+    return 0
+
+
+__all__ = ["NamespacePlan", "run_setup"]

--- a/infra/k8s/_setup.py
+++ b/infra/k8s/_setup.py
@@ -18,10 +18,12 @@ from __future__ import annotations
 
 import json
 import re
+import secrets as _secrets
 import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass, field
+from getpass import getpass
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -60,18 +62,23 @@ class NamespacePlan:
 
     Tudo o que o operador escolheu em prompt vive aqui — Secrets e
     ConfigMap por NS são derivados deste objeto sem novo prompt.
+
+    Campos sensíveis (tokens, bearers, llm_keys) usam ``field(repr=False)``
+    para que ``logger.exception(plan)`` ou qualquer formatador padrão de
+    dataclass não vaze segredos na trilha de auditoria.
     """
 
     name: str
-    forge_kind: str  # "github" | "gitlab"
+    forge_kind: str  # "github" | "gitlab" | "auto" (auto = pipeline detecta GH vs GL por URL)
     repo: str
     dispatch_mode: str  # "deile_worker" | "claude_subprocess"
-    llm_keys: Dict[str, str] = field(default_factory=dict)
-    github_token: str = ""
-    gitlab_token: str = ""
-    discord_token: str = ""
-    bot_bearer: str = ""  # gerado automaticamente se vazio
-    worker_bearer: str = ""  # gerado automaticamente se vazio
+    bot_enabled: bool = False  # True quando o operador habilitou bot Discord neste NS
+    llm_keys: Dict[str, str] = field(default_factory=dict, repr=False)
+    github_token: str = field(default="", repr=False)
+    gitlab_token: str = field(default="", repr=False)
+    discord_token: str = field(default="", repr=False)
+    bot_bearer: str = field(default="", repr=False)  # gerado automaticamente se vazio
+    worker_bearer: str = field(default="", repr=False)  # gerado automaticamente se vazio
 
     def secrets_kv(self) -> Tuple[Dict[str, str], Dict[str, str], Dict[str, str]]:
         """Retorna (bot_secrets, deile_secrets, worker_bearer) pra aplicar."""
@@ -196,23 +203,26 @@ def _validate_token_format(env_var: str, raw: str) -> bool:
     return bool(pattern.fullmatch(raw)) if pattern else True
 
 
-def _ask_secret_validated(env_var: str, *, optional: bool) -> str:
+def _ask_secret_validated(env_var: str, *, optional: bool, dry_run: bool = False) -> str:
     """Pede um segredo via ``getpass``, valida prefixo, oferece pular.
 
+    - ``dry_run=True``: retorna ``"<dry-run>"`` (sentinel não-vazio) sem
+      prompt — evita forçar o operador a digitar segredos em modo de
+      visualização do plano.
     - Vazio: pula (retorna "") se ``optional=True``; senão repete.
     - Inválido: avisa e pede ``s`` para aceitar mesmo assim, ``n`` para
       tentar de novo. Esse opt-out cobre quando o pattern fica defasado.
     """
+    if dry_run:
+        # Sentinel não-vazio — o caller distingue "operador informou" de
+        # "pulado" pelo truthiness; em dry-run não há valor real, mas o
+        # presença da entrada importa pra modelar o plano corretamente.
+        return "<dry-run>"
     prompt = f"{env_var}"
     if optional:
         prompt += " (Enter para pular)"
+    prefix = ui.paint("  ? ", "cyan", "bold")
     while True:
-        # ``ask_secret`` em ``_cli_ui`` repete até não-vazio; aqui queremos
-        # permitir vazio quando opcional. Usar ``getpass`` direto, com o
-        # mesmo prefixo visual de cor (paint("?")).
-        from getpass import getpass
-
-        prefix = ui.paint("  ? ", "cyan", "bold")
         raw = getpass(f"{prefix}{prompt}: ").strip()
         if not raw:
             if optional:
@@ -225,87 +235,106 @@ def _ask_secret_validated(env_var: str, *, optional: bool) -> str:
         ui.warn(f"o valor não casa com o formato esperado de {env_var}.")
         if ui.confirm("Aceitar mesmo assim?", default=False):
             return raw
-        # senão, próximo loop pede de novo
 
 
-def _ask_llm_keys(plan_idx: int) -> Dict[str, str]:
-    """Pergunta as 4 LLM keys; exige ao menos UMA (bootstrap_providers)."""
-    ui.section(f"Ambiente {plan_idx}: chaves de LLM (ao menos uma)")
-    collected: Dict[str, str] = {}
-    for env_var in LLM_KEYS:
-        val = _ask_secret_validated(env_var, optional=True)
-        if val:
-            collected[env_var] = val
-    if not collected:
+def _ask_llm_keys(plan_idx: int, dry_run: bool = False) -> Dict[str, str]:
+    """Pergunta as 4 LLM keys; exige ao menos UMA (bootstrap_providers).
+
+    Loop até obter ao menos uma chave (sem recursão — evita stack growth
+    em interações longas com erros).
+    """
+    while True:
+        ui.section(f"Ambiente {plan_idx}: chaves de LLM (ao menos uma)")
+        collected: Dict[str, str] = {}
+        for env_var in LLM_KEYS:
+            val = _ask_secret_validated(env_var, optional=True, dry_run=dry_run)
+            if val:
+                collected[env_var] = val
+        if collected:
+            return collected
         ui.err(
             "nenhuma chave de LLM configurada — DEILE não sobe sem ao menos uma "
             "de ANTHROPIC/OPENAI/DEEPSEEK/GOOGLE. Repetindo este bloco."
         )
-        return _ask_llm_keys(plan_idx)
-    return collected
 
 
-def _ask_forge(plan_idx: int) -> Tuple[str, str, str, str]:
-    """Pergunta forge_kind + repo + tokens (GH e/ou GL conforme o modo)."""
-    ui.section(f"Ambiente {plan_idx}: forge alvo")
-    forge_kind = ui.choose(
-        "Qual forge este ambiente atende?",
-        [
-            ("github", "GitHub.com ou GHES (single-forge)"),
-            ("gitlab", "GitLab.com ou self-hosted (single-forge)"),
-            ("dual", "Ambos (GH + GL) na mesma stack"),
-        ],
-    )
-    repo_help = (
-        "owner/repo (GH) ou group/(sub/)*project (GL)"
-        if forge_kind in ("github", "gitlab")
-        else "repo padrão do pipeline (owner/repo no caso de dual)"
-    )
+def _ask_forge(
+    plan_idx: int, dry_run: bool = False
+) -> Tuple[str, str, str, str, str]:
+    """Pergunta forge_kind + repo + tokens (GH e/ou GL conforme o modo).
+
+    Retorna ``(kind_for_settings, repo, gh_token, gl_token, ui_label)``:
+    o ``ui_label`` preserva o termo escolhido pelo operador (``dual``)
+    para apresentação, enquanto ``kind_for_settings`` é o que vai para o
+    JSON do ConfigMap (``auto`` quando o operador escolheu ``dual``,
+    deixando o detector decidir GH vs GL por URL).
+    """
     while True:
-        repo = ui.ask(f"Repositório principal — {repo_help}").strip()
-        if _REPO_RE.fullmatch(repo):
-            break
-        ui.err("formato inválido — use `owner/repo` ou `group/sub/project`.")
-
-    gh_token = ""
-    gl_token = ""
-    if forge_kind in ("github", "dual"):
-        gh_token = _ask_secret_validated(
-            "GITHUB_TOKEN", optional=(forge_kind == "dual")
+        ui.section(f"Ambiente {plan_idx}: forge alvo")
+        forge_choice = ui.choose(
+            "Qual forge este ambiente atende?",
+            [
+                ("github", "GitHub.com ou GHES (single-forge)"),
+                ("gitlab", "GitLab.com ou self-hosted (single-forge)"),
+                ("dual", "Ambos (GH + GL) na mesma stack"),
+            ],
         )
-    if forge_kind in ("gitlab", "dual"):
-        gl_token = _ask_secret_validated(
-            "GITLAB_TOKEN", optional=(forge_kind == "dual")
+        repo_help = (
+            "owner/repo (GH) ou group/(sub/)*project (GL)"
+            if forge_choice in ("github", "gitlab")
+            else "repo padrão do pipeline (owner/repo no caso de dual)"
         )
-    # Em modo dual, ao menos um token deve existir para o pipeline rodar.
-    if forge_kind == "dual" and not gh_token and not gl_token:
-        ui.err(
-            "modo dual exige ao menos um dos tokens (GH ou GL). Repetindo o forge."
-        )
-        return _ask_forge(plan_idx)
+        while True:
+            repo = ui.ask(f"Repositório principal — {repo_help}").strip()
+            if _REPO_RE.fullmatch(repo):
+                break
+            ui.err("formato inválido — use `owner/repo` ou `group/sub/project`.")
 
-    # ``forge_kind`` resolvido pro settings JSON: dual fica como "auto"
-    # para o detector decidir via URL/host.
-    kind_for_settings = "auto" if forge_kind == "dual" else forge_kind
-    return kind_for_settings, repo, gh_token, gl_token
+        gh_token = ""
+        gl_token = ""
+        if forge_choice in ("github", "dual"):
+            gh_token = _ask_secret_validated(
+                "GITHUB_TOKEN",
+                optional=(forge_choice == "dual"),
+                dry_run=dry_run,
+            )
+        if forge_choice in ("gitlab", "dual"):
+            gl_token = _ask_secret_validated(
+                "GITLAB_TOKEN",
+                optional=(forge_choice == "dual"),
+                dry_run=dry_run,
+            )
+        if forge_choice == "dual" and not gh_token and not gl_token:
+            ui.err(
+                "modo dual exige ao menos um dos tokens (GH ou GL). Repetindo o forge."
+            )
+            continue
+
+        kind_for_settings = "auto" if forge_choice == "dual" else forge_choice
+        return kind_for_settings, repo, gh_token, gl_token, forge_choice
 
 
-def _ask_bot(plan_idx: int) -> Tuple[str, str]:
-    """Pergunta token do Discord + bearer do bot. Ambos opcionais (bot pode
-    ficar desabilitado neste NS) — o bearer auto-gerado se vazio."""
+def _ask_bot(plan_idx: int, dry_run: bool = False) -> Tuple[bool, str, str]:
+    """Pergunta token do Discord + bearer do bot. Retorna
+    ``(enabled, discord_token, bearer)`` — ``enabled=False`` desliga o
+    deployment do bot inteiramente neste NS (skip de ``20-bot-deployment.yaml``).
+    O bearer manual é opcional (auto-gerado se vazio)."""
     ui.section(f"Ambiente {plan_idx}: bot Discord (opcional)")
     if not ui.confirm("Habilitar o bot Discord neste namespace?", default=False):
-        return "", ""
-    discord = _ask_secret_validated("DEILE_BOT_DISCORD_TOKEN", optional=False)
+        return False, "", ""
+    discord = _ask_secret_validated(
+        "DEILE_BOT_DISCORD_TOKEN", optional=False, dry_run=dry_run
+    )
     bearer = _ask_secret_validated(
         "DEILE_BOT_CONTROL_PLANE_AUTH_TOKEN (Enter = gerar automaticamente)",
         optional=True,
+        dry_run=dry_run,
     )
-    return discord, bearer
+    return True, discord, bearer
 
 
 def _build_namespace_plan(
-    plan_idx: int, existing_ns: List[str]
+    plan_idx: int, existing_ns: List[str], dry_run: bool = False
 ) -> NamespacePlan:
     """Monta um ``NamespacePlan`` interativamente."""
     ui.section(f"Ambiente {plan_idx}: identidade")
@@ -323,7 +352,7 @@ def _build_namespace_plan(
         if name in existing_ns:
             ui.warn(
                 f"o namespace `{name}` já existe — `setup` não sobrescreve. "
-                "Escolha outro nome ou rode `k8s up --namespace {name}` "
+                f"Escolha outro nome ou rode `k8s up --namespace {name}` "
                 "manualmente para atualizar."
             )
             continue
@@ -336,12 +365,9 @@ def _build_namespace_plan(
             ("claude_subprocess", "via claude -p (CCR cloud / subscription)"),
         ],
     )
-    kind, repo, gh_token, gl_token = _ask_forge(plan_idx)
-    llm = _ask_llm_keys(plan_idx)
-    discord, bearer_manual = _ask_bot(plan_idx)
-
-    # Bearers auto-gerados quando vazios — entropy do ``secrets`` stdlib.
-    import secrets as _secrets
+    kind, repo, gh_token, gl_token, _forge_ui = _ask_forge(plan_idx, dry_run=dry_run)
+    llm = _ask_llm_keys(plan_idx, dry_run=dry_run)
+    bot_enabled, discord, bearer_manual = _ask_bot(plan_idx, dry_run=dry_run)
 
     bot_bearer = bearer_manual or _secrets.token_urlsafe(32)
     worker_bearer = _secrets.token_urlsafe(32)
@@ -351,6 +377,7 @@ def _build_namespace_plan(
         forge_kind=kind,
         repo=repo,
         dispatch_mode=dispatch_mode,
+        bot_enabled=bot_enabled,
         llm_keys=llm,
         github_token=gh_token,
         gitlab_token=gl_token,
@@ -361,18 +388,15 @@ def _build_namespace_plan(
 
 
 def _collect_namespace_plans(
-    yes: bool, existing_ns: List[str]
-) -> List[NamespacePlan]:
-    """Coleta N planos de NS via prompts. ``--yes`` aborta — o fluxo é
-    fundamentalmente interativo (segredos via getpass)."""
-    if yes:
-        ui.err(
-            "`k8s setup` é interativo (segredos via getpass) — `--yes` não "
-            "se aplica aqui. Para automação não-interativa, use "
-            "`k8s up` com Secrets pré-criados via `kubectl apply`."
-        )
-        return []
+    existing_ns: List[str], dry_run: bool = False
+) -> Optional[List[NamespacePlan]]:
+    """Coleta N planos de NS via prompts.
 
+    Retorna ``None`` para indicar abort (operador cancelou ou input
+    inválido recorrente); ``list`` (não-vazia) para indicar sucesso. A
+    rejeição de ``--yes`` fica em ``run_setup`` — esta função pressupõe
+    fluxo interativo.
+    """
     while True:
         raw = ui.ask(
             "Quantos ambientes (namespaces) DEILE você quer criar?", default="1"
@@ -389,7 +413,7 @@ def _collect_namespace_plans(
     plans: List[NamespacePlan] = []
     taken = list(existing_ns)
     for i in range(1, count + 1):
-        plan = _build_namespace_plan(i, taken)
+        plan = _build_namespace_plan(i, taken, dry_run=dry_run)
         plans.append(plan)
         taken.append(plan.name)
     return plans
@@ -416,14 +440,13 @@ def _ensure_namespace(kubectl: str, name: str, deile_ns_label: str) -> bool:
         if create.returncode != 0:
             ui.err(f"falha ao criar namespace `{name}`: {create.stderr.strip()}")
             return False
-    label_key, label_val = deile_ns_label.split("=", 1)
     label = subprocess.run(
         [
             kubectl,
             "label",
             "namespace",
             name,
-            f"{label_key}={label_val}",
+            deile_ns_label,
             "pod-security.kubernetes.io/enforce=restricted",
             "pod-security.kubernetes.io/enforce-version=v1.29",
             "pod-security.kubernetes.io/audit=restricted",
@@ -446,8 +469,13 @@ def _apply_runtime_configmap(
 ) -> bool:
     """Renderiza e aplica o ``deile-runtime-config`` ConfigMap por NS.
 
-    Usa arquivo temporário modo ``0600`` para não passar JSON multilinha
-    por argv (escape inferno no shell)."""
+    Materializa o JSON multilinha em arquivos sob ``TemporaryDirectory`` e
+    delega a renderização ao ``kubectl create configmap --from-file ...
+    --dry-run=client -o yaml`` — sem JSON em argv (escape hell no shell).
+    O ConfigMap contém apenas configuração funcional (forge.kind,
+    pipeline.repo, dispatch_mode); zero token. ``Path.write_text`` segue
+    o ``umask`` corrente, e o diretório temp é apagado ao sair do bloco.
+    """
     data = plan.runtime_configmap_data()
     with tempfile.TemporaryDirectory(prefix="deile-cm-") as tmpdir:
         tmp_path = Path(tmpdir)
@@ -478,8 +506,6 @@ def _apply_runtime_configmap(
                 f"para `{ns}`: {rendered.stderr.strip()}"
             )
             return False
-        # Patch labels do manifest 47 (app: deile) — kubectl create cm não
-        # adiciona labels; injetamos via apply de patch leve em sequência.
         apply = subprocess.run(
             [kubectl, "apply", "-f", "-"],
             input=rendered.stdout,
@@ -492,7 +518,11 @@ def _apply_runtime_configmap(
                 f"em `{ns}`: {apply.stderr.strip()}"
             )
             return False
-        subprocess.run(
+        # Label ``app=deile`` para alinhar com o ConfigMap base do manifest
+        # 47 (filtros do panel selecionam por essa label). Falha aqui não
+        # bloqueia o NS — o ConfigMap funcional já foi aplicado — mas
+        # avisa para o operador não procurar bug fantasma depois.
+        label = subprocess.run(
             [
                 kubectl,
                 "-n",
@@ -503,9 +533,14 @@ def _apply_runtime_configmap(
                 "app=deile",
                 "--overwrite",
             ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
         )
+        if label.returncode != 0:
+            ui.warn(
+                f"[{ns}] não consegui aplicar label `app=deile` no "
+                f"ConfigMap (não-fatal): {label.stderr.strip()}"
+            )
     return True
 
 
@@ -517,7 +552,12 @@ def _apply_namespace(
     deile_ns_label: str,
 ) -> bool:
     """Provisiona um NS inteiro: namespace + network policy + secrets + cm +
-    PVCs + Deployments. Idempotente — chama os manifests existentes."""
+    PVCs + Deployments. Idempotente — chama os manifests existentes.
+
+    Quando ``plan.bot_enabled`` é False, os manifests do bot (15-bot-config,
+    19-bot-data-pvc, 20-bot-deployment) são pulados — sem ``bot-secrets``
+    com discord token, o deployment crashlooparia e travaria o ``_validate``.
+    """
     ns = plan.name
     ui.info(f"[{ns}] provisionando namespace + labels PSS restricted")
     if not _ensure_namespace(kubectl, ns, deile_ns_label):
@@ -533,8 +573,11 @@ def _apply_namespace(
 
     bot_kv, deile_kv, worker_kv = plan.secrets_kv()
     ui.info(f"[{ns}] criando Secrets (nada é impresso)")
-    if not apply_secret_fn(kubectl, "bot-secrets", bot_kv, ns=ns):
-        return False
+    # bot-secrets só sai quando o bot foi habilitado — caso contrário,
+    # nenhum pod consumidor existe (manifests do bot são pulados abaixo).
+    if plan.bot_enabled:
+        if not apply_secret_fn(kubectl, "bot-secrets", bot_kv, ns=ns):
+            return False
     if not apply_secret_fn(kubectl, "deile-secrets", deile_kv, ns=ns):
         return False
     if not apply_secret_fn(kubectl, "worker-bearer", worker_kv, ns=ns):
@@ -544,16 +587,18 @@ def _apply_namespace(
     if not _apply_runtime_configmap(kubectl, ns, plan):
         return False
 
-    ui.info(f"[{ns}] aplicando ConfigMap bot-config + PVCs + Deployments")
-    for manifest in (
-        "15-bot-config.yaml",
-        "19-bot-data-pvc.yaml",
-        "20-bot-deployment.yaml",
+    ui.info(f"[{ns}] aplicando PVCs + Deployments")
+    bot_manifests = ("15-bot-config.yaml", "19-bot-data-pvc.yaml", "20-bot-deployment.yaml")
+    core_manifests = (
         "35-deile-interactive.yaml",
         "41-worker-pvc.yaml",
         "45-deile-worker-deployment.yaml",
         "46-deile-pipeline-deployment.yaml",
-    ):
+    )
+    manifests_to_apply = (bot_manifests + core_manifests) if plan.bot_enabled else core_manifests
+    if not plan.bot_enabled:
+        ui.info(f"[{ns}] bot Discord desabilitado — pulando manifests do bot")
+    for manifest in manifests_to_apply:
         rc = subprocess.run(
             [kubectl, "apply", "-n", ns, "-f", str(manifests_dir / manifest)]
         ).returncode
@@ -573,7 +618,12 @@ def _wait_for_pods_ready(
     deployments: Tuple[str, ...],
     timeout_s: int = 90,
 ) -> bool:
-    """Aguarda cada deployment ficar pronto. Falhas viram logs (não-fatal)."""
+    """Aguarda cada deployment ficar pronto. Falhas viram logs (não-fatal).
+
+    ``deployments`` é o conjunto que o caller espera ver Ready — para um
+    NS sem bot habilitado, ``deilebot`` é omitido pelo caller (não é
+    deployado neste NS).
+    """
     all_ok = True
     for dep in deployments:
         exists = subprocess.run(
@@ -605,18 +655,34 @@ def _wait_for_pods_ready(
     return all_ok
 
 
+def _deployments_to_wait_for(
+    plan: NamespacePlan, all_deployments: Tuple[str, ...]
+) -> Tuple[str, ...]:
+    """Filtra o conjunto base por ``plan.bot_enabled`` — sem bot habilitado,
+    ``deilebot`` é omitido (manifest do bot foi pulado em ``_apply_namespace``).
+    """
+    if plan.bot_enabled:
+        return all_deployments
+    return tuple(d for d in all_deployments if d != "deilebot")
+
+
 def _validate(
     kubectl: str,
     plans: List[NamespacePlan],
     deployments: Tuple[str, ...],
     timeout_s: int = 90,
 ) -> bool:
-    """Para cada NS: aguarda pods + imprime status final."""
+    """Para cada NS: aguarda pods esperados + imprime status final."""
     ui.section("Validação pós-setup")
     overall = True
     for plan in plans:
         ui.info(f"[{plan.name}] aguardando pods ficarem prontos…")
-        ok = _wait_for_pods_ready(kubectl, plan.name, deployments, timeout_s)
+        ok = _wait_for_pods_ready(
+            kubectl,
+            plan.name,
+            _deployments_to_wait_for(plan, deployments),
+            timeout_s,
+        )
         # Status sempre — mesmo se pods não vieram, queremos o snapshot.
         subprocess.run(
             [kubectl, "-n", plan.name, "get", "pods,deployments,services"]
@@ -634,11 +700,18 @@ def _validate(
 
 def _print_plan(plans: List[NamespacePlan]) -> None:
     """Imprime resumo declarativo do que será aplicado (segredos como
-    contagem, jamais valores)."""
+    presença/ausência, jamais valores). O label do ``forge`` traduz
+    ``auto`` para ``dual`` quando ambos os tokens estão presentes — o
+    operador escolheu ``dual``, e ``auto`` é detalhe de implementação do
+    ConfigMap.
+    """
     ui.section("Plano consolidado")
     for plan in plans:
+        ui_forge = plan.forge_kind
+        if plan.forge_kind == "auto":
+            ui_forge = "dual (auto-detect)"
         ui.info(
-            f"  • {plan.name}: forge={plan.forge_kind} repo={plan.repo} "
+            f"  • {plan.name}: forge={ui_forge} repo={plan.repo} "
             f"dispatch={plan.dispatch_mode}"
         )
         keys_n = len(plan.llm_keys)
@@ -647,9 +720,35 @@ def _print_plan(plans: List[NamespacePlan]) -> None:
             flags.append("GITHUB_TOKEN")
         if plan.gitlab_token:
             flags.append("GITLAB_TOKEN")
-        if plan.discord_token:
-            flags.append("Discord")
+        if plan.bot_enabled:
+            flags.append("Discord bot")
+        else:
+            flags.append("bot desabilitado")
         ui.detail("    Secrets: " + ", ".join(flags))
+
+
+def _summarize_partial(applied: List[NamespacePlan], failed: List[str]) -> None:
+    """Emite guidance para o operador sobre cleanup/resume de NS parciais."""
+    if applied:
+        ui.warn(
+            "Namespaces que JÁ FORAM aplicados (continuam no cluster): "
+            + ", ".join(p.name for p in applied)
+        )
+        ui.info(
+            "Para remover esses NS: rode `deploy.py --namespace <ns> k8s down` "
+            "em cada um. Para tentar reaproveitar e seguir manualmente: "
+            "`deploy.py --namespace <ns> k8s up`."
+        )
+    if failed:
+        ui.err(
+            "Namespaces que FALHARAM (Secrets/ConfigMap podem ter sido "
+            "criados parcialmente): " + ", ".join(failed)
+        )
+        ui.info(
+            "Verifique com `kubectl -n <ns> get all,configmap,secret` e "
+            "decida entre rodar `k8s down` para limpar ou aplicar de novo "
+            "via `deploy.py k8s setup`."
+        )
 
 
 def run_setup(
@@ -672,6 +771,19 @@ def run_setup(
     yes = bool(args.get("yes"))
     dry_run = bool(args.get("dry_run"))
 
+    # ``--yes`` é incompatível com qualquer fase deste verbo (F1 chama
+    # setup_environment.py que respeita --yes, mas F2 não pode rodar sem
+    # TTY). Rejeitar logo no topo evita gastar tempo na detecção de k8s
+    # para depois abortar na coleta de planos.
+    if yes:
+        ui.err(
+            "`k8s setup` é fundamentalmente interativo (segredos via getpass) "
+            "— `--yes` não se aplica. Para CI/automação não-interativa, use "
+            "`deploy.py k8s up` com Secrets/ConfigMaps pré-criados via "
+            "`kubectl apply` manual."
+        )
+        return 2
+
     ui.header("DEILE — setup interativo (k8s do zero ao pipeline)")
     ui.info("Este verbo:")
     ui.detail("• detecta o cluster k8s (oferece instalar se faltar)")
@@ -679,15 +791,24 @@ def run_setup(
     ui.detail("• pergunta segredos via getpass (nada vai pra history do shell)")
     ui.detail("• aplica Secrets + ConfigMap por NS")
     ui.detail("• aguarda pods ficarem prontos e imprime status")
+    if dry_run:
+        ui.info(
+            "--dry-run: vou perguntar identidade/forge/dispatch/bot e modelar "
+            "o plano, mas tokens NÃO serão pedidos e nada será aplicado."
+        )
 
-    # F1 — k8s
-    ui.section("1. Cluster Kubernetes")
-    if not _ensure_kubernetes(yes, cluster_reachable_fn, setup_env_path):
-        return 1
-    kubectl = kubectl_resolver()
-    if kubectl is None:
-        ui.err("kubectl ainda inacessível após a checagem — abortando.")
-        return 1
+    # F1 — k8s (pulado em dry-run; ``--yes`` aqui é sempre False).
+    if not dry_run:
+        ui.section("1. Cluster Kubernetes")
+        if not _ensure_kubernetes(False, cluster_reachable_fn, setup_env_path):
+            return 1
+        kubectl = kubectl_resolver()
+        if kubectl is None:
+            ui.err("kubectl ainda inacessível após a checagem — abortando.")
+            return 1
+    else:
+        ui.section("1. Cluster Kubernetes (pulado em --dry-run)")
+        kubectl = kubectl_resolver() or ""
 
     # F2 — coleta
     existing_ns = discover_existing_fn() if not dry_run else []
@@ -695,7 +816,7 @@ def run_setup(
         ui.info(
             "Namespaces DEILE já presentes no cluster: " + ", ".join(existing_ns)
         )
-    plans = _collect_namespace_plans(yes, existing_ns)
+    plans = _collect_namespace_plans(existing_ns, dry_run=dry_run)
     if not plans:
         return 2
 
@@ -709,18 +830,22 @@ def run_setup(
 
     # F2 — apply
     ui.section("2. Aplicando manifests")
+    applied: List[NamespacePlan] = []
     failed: List[str] = []
     for plan in plans:
         ok = _apply_namespace(
             kubectl, plan, apply_secret_fn, manifests_dir, deile_ns_label
         )
-        if not ok:
+        if ok:
+            applied.append(plan)
+        else:
             failed.append(plan.name)
     if failed:
         ui.err(
             f"falha em {len(failed)} de {len(plans)} namespace(s): "
             + ", ".join(failed)
         )
+        _summarize_partial(applied, failed)
         return 1
 
     # F3 — validação

--- a/infra/k8s/deploy.py
+++ b/infra/k8s/deploy.py
@@ -432,6 +432,48 @@ def k8s_down(args: dict) -> int:
     return rc
 
 
+# ===== k8s: setup (interativo, multi-NS, prompts seguros) ====================
+
+def k8s_setup(args: dict) -> int:
+    """Setup interativo da stack DEILE — issue #328.
+
+    Delega a ``infra/k8s/_setup.py``. Conduz o operador do host limpo
+    (sem k8s, sem NS) até o pipeline rodando, com Secrets carregados via
+    ``getpass`` e ConfigMaps gerados por NS com os overrides escolhidos.
+
+    Para CI/automação não-interativa, prefira ``k8s up`` com Secrets
+    pré-criados manualmente — ``setup`` é fundamentalmente interativo
+    (segredos via getpass).
+    """
+    # Import tardio: ``_setup`` carrega apenas em sessões interativas, não
+    # paga o custo de import quando o operador chama outro verbo.
+    from _setup import run_setup  # noqa: PLC0415
+
+    # ``discover_deile_namespaces`` vive em ``_panel_data`` (mesmo módulo
+    # que ``cmd_menu`` já reusa) — evita duplicar a query de label.
+    def _discover() -> List[str]:
+        if _kubectl() is None:
+            return []
+        try:
+            from _panel_data import discover_deile_namespaces  # noqa: PLC0415
+
+            return list(discover_deile_namespaces())
+        except (ImportError, OSError):
+            return []
+
+    return run_setup(
+        args,
+        kubectl_resolver=_kubectl,
+        cluster_reachable_fn=cluster_reachable,
+        apply_secret_fn=_apply_secret,
+        discover_existing_fn=_discover,
+        manifests_dir=MANIFESTS,
+        setup_env_path=SETUP_ENV,
+        deile_ns_label=_DEILE_NS_LABEL,
+        deployments=K8S_DEPLOYMENTS,
+    )
+
+
 # ===== k8s: ciclo de vida (scale / rollout) ==================================
 
 def k8s_start(args: dict) -> int:
@@ -928,6 +970,7 @@ _K8S = {
     "restart": k8s_restart, "status": k8s_status, "logs": k8s_logs,
     "build": k8s_build, "test": k8s_test, "clone": k8s_clone,
     "list": k8s_list, "panel": k8s_panel, "doctor": cmd_doctor,
+    "setup": k8s_setup,
 }
 _LOCAL = {
     "start": local_start, "stop": local_stop, "restart": local_restart,
@@ -938,6 +981,7 @@ _LOCAL = {
 # menu por exigir um argumento <owner/repo>.
 _K8S_ACTIONS = [
     ("panel", "painel TUI ao vivo (pods + pipeline + GitHub + custos)"),
+    ("setup", "setup interativo do zero ao pipeline (multi-NS, getpass)"),
     ("list", "listar namespaces DEILE no cluster"),
     ("status", "ver pods, deployments e services"),
     ("up", "provisionar / atualizar a stack (idempotente)"),


### PR DESCRIPTION
## Resumo

Adiciona o verbo `python3 infra/k8s/deploy.py k8s setup` que leva o operador de um host limpo (sem kubectl, sem cluster, sem namespace DEILE) até pipeline rodando em um único fluxo guiado. Três blocos da issue fundidos (F1 detecção, F2 setup interativo multi-NS, F3 pós-validação) — a entrega percebida é "um comando do zero ao pipeline rodando".

## Issues

Closes #328

## Decisões-chave (crítica de abordagem)

- **Alternativa A** — Inline em `deploy.py`: simples mas inflaria o arquivo (já com 1189 linhas) violando SRP (pilar 03 §1).
- **Alternativa B** — Módulo separado `infra/k8s/_setup.py`: lógica de prompts/validação/aplicação isolada; `deploy.py` adiciona apenas wrapper thin `k8s_setup(args)` que injeta callbacks dos helpers existentes (`_kubectl`, `_apply_secret`, `cluster_reachable`, `discover_deile_namespaces`).
- **Escolhida: B** — alinha com o pattern dos vizinhos (`_panel.py`, `_worker_resume.py`), testável em isolamento (25 testes unitários sem precisar mockar o orquestrador inteiro), mantém SRP.

Reusa `setup_environment.py` para a instalação cross-platform de k8s (sem duplicar lógica de k3s/Rancher/colima) e gera o ConfigMap `deile-runtime-config` per-NS programaticamente — sem editar o manifest 47 base.

## O que muda

| Onde | O quê |
|---|---|
| `infra/k8s/_setup.py` (novo) | Módulo com `NamespacePlan` + helpers de prompt/validação/apply + `run_setup()` |
| `infra/k8s/deploy.py` | Registra `setup` em `_K8S` e `_K8S_ACTIONS`; adiciona wrapper `k8s_setup(args)` thin |
| `deile/tests/infra/test_k8s_setup.py` (novo) | 25 testes unitários cobrindo plan/secrets/configmap/regex/idempotência/dry-run/wiring |

## Comportamento

1. **Detecta o cluster** (F1) e oferece rodar `setup_environment.py --mode container` se ausente. Em Windows, instruções (sem auto-install).
2. **Pergunta quantos namespaces** criar (1-8). Para cada um, prompts em ordem:
   - Nome (validação DNS-1123 + check de conflito com NS existentes)
   - `dispatch_mode` (`deile_worker` default ou `claude_subprocess`)
   - Forge (`github`/`gitlab`/`dual`) + repo (regex `[A-Za-z0-9_.\-]+/...`)
   - Tokens via `getpass.getpass` com validação de prefixo (`sk-ant-`, `ghp_`, `glpat-`, `gldt-`, `glptt-`, `glsoat-`, etc.) e opt-out para aceitar formato desconhecido
   - Chaves de LLM (ao menos uma exigida por `bootstrap_providers`)
   - Discord bot opcional + bearer auto-gerado se vazio
3. **Plano consolidado**: lista cada NS com forge/repo/dispatch e contagem de secrets (nunca valores) antes do apply.
4. **Apply por NS**: `_ensure_namespace` (PSS restricted v1.29 + label `managed-by=deile`), NetworkPolicy, 3 Secrets (`bot-secrets`/`deile-secrets`/`worker-bearer` via arquivo temp 0600 — nunca em argv), ConfigMap `deile-runtime-config` gerado per-NS, PVCs e Deployments dos manifests existentes.
5. **Pós-validação** (F3): `rollout status` por 90s/deployment + status final (pods/deployments/services). Pods que não vieram não abortam o setup — apenas alertam e despejam logs.

## Segurança (pilar 08)

- Todos os segredos via `getpass.getpass` (módulo `_cli_ui.ask_secret`) — zero ecoamento na shell history.
- Secrets aplicados via `_apply_secret` (arquivo temp 0600 + `kubectl create secret --dry-run=client -o yaml | kubectl apply -f -`) — nunca em argv (`ps` jamais vê o valor).
- ConfigMap só com configuração funcional (forge.kind, pipeline.repo, dispatch_mode) — zero token.
- PSS `restricted` v1.29 enforce/audit/warn em todo NS novo.
- `--yes` é **rejeitado** explicitamente em `setup` — segredos via getpass exigem TTY interativo. Para CI/automação, o operador usa `k8s up` com Secrets pré-criados manualmente.

## Cobertura

25 testes unitários novos, todos passam isolados:

- `TestNamespacePlanSecrets` (3): secrets shape com/sem tokens opcionais; dual-forge inclui ambos GH+GL; Discord só quando setado.
- `TestRuntimeConfigMap` (2): pipeline-settings carrega overrides; `forge.kind=auto` é omitido (deixa o detector decidir).
- `TestTokenValidation` (14): parametrizado com casos válidos e inválidos de cada provedor (Anthropic, OpenAI, DeepSeek, Google, GitHub PAT/fine-grained, GitLab `glpat-`/`gldt-`, Discord 3-segments) + env var desconhecida passa.
- `TestEnsureNamespace` (3): criação quando ausente + labels PSS; idempotência quando NS já existe; propagação de falha.
- `TestCollectPlans` (1): `--yes` aborta com mensagem clara.
- `TestRunSetupDryRun` (1): `--dry-run` termina sem aplicar (call count em `apply_secret` = 0).
- `TestDeployWiring` (1): `setup` está em `_K8S` e `_K8S_ACTIONS`.

## Checklist

- [x] pytest verde — 4501 passed, 25 skipped (suite completa com cov gate ≥80%)
- [x] ruff check ok
- [x] isort ok
- [x] pilares 03/08/09/12/14 respeitados
- [x] sem SQL/migration
- [x] secrets via getpass, nunca em argv/history
- [x] PSS restricted em todo NS novo
- [x] testes unitários isolados (subprocess sempre mockado, zero toque em cluster real)
