### PR TITLE
fix(cli/ui): 3 commits órfãos da PR #315 — welcome compacto, ESC ESC, /rewind in-place

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -438,6 +438,39 @@ class _DeileCLI:
         from .cli_session_helpers import replay_history
         replay_history(self.ui, self.default_session, history)
 
+    # ANSI sequence: ``\033[A`` = "move cursor up 1 line"; ``\033[2K`` =
+    # "erase entire line"; ``\r`` = "carriage return to col 0". A pair de
+    # ``\033[A\033[2K`` apaga UMA linha acima da posição atual; duas pairs
+    # apagam DUAS linhas (uma para o prompt commitado de prompt_toolkit,
+    # outra para o ``console.rule()`` emitido por ``get_user_input``).
+    _ERASE_PROMPT_ECHO_ANSI = "\033[A\033[2K\033[A\033[2K\r"
+
+    def _erase_empty_prompt_echo(self) -> None:
+        """Remove o eco visual de um Enter vazio do scrollback.
+
+        Por iteração de loop interativo, ``get_user_input`` emite duas
+        linhas: (1) ``self.console.rule(style="dim")`` — o separador
+        horizontal acima do prompt; (2) o ``> `` que o prompt_toolkit
+        commita ao scrollback quando o usuário pressiona Enter. Sem
+        cleanup, iterações vazias consecutivas empilham essas duas
+        linhas indefinidamente, parecendo bug.
+
+        Defensivo em ambientes non-TTY (pipe, CI, redirecionamento de
+        stdout): emitir ANSI vazaria caracteres ``\\033[A`` literais no
+        output. Por isso só apaga quando ``sys.stdout.isatty()``.
+
+        Cross-platform: ``\\033[A`` / ``\\033[2K`` são ANSI padrão
+        suportados por Windows Terminal, VSCode, ConEmu, ANSICON e
+        terminais Unix modernos. No conhost legado (cmd.exe sem
+        ``VT_PROCESSING``), a sequência seria invisível — mas como
+        ``isatty()`` ainda retorna True nesse caso, o pior cenário é
+        ANSI literal no scrollback, comportamento de baixo dano.
+        """
+        if not sys.stdout.isatty():
+            return
+        sys.stdout.write(self._ERASE_PROMPT_ECHO_ANSI)
+        sys.stdout.flush()
+
     async def _stream_with_esc_cancel(self, event_stream) -> bool:
         """Run display_streaming_turn, cancelling on ESC keypress.
 
@@ -582,10 +615,15 @@ class _DeileCLI:
 
                 # ESC ESC on empty prompt → trigger /rewind
                 if user_input == self._REWIND_SENTINEL:
+                    # O prompt_toolkit deixou o ``> `` vazio no scrollback
+                    # quando saímos via ``app.exit(SENTINEL)``. Apaga
+                    # (rule + prompt) antes que o seletor de /rewind abra,
+                    # senão cada ciclo ESC ESC + ESC empilha um ``> `` extra.
+                    self._erase_empty_prompt_echo()
                     user_input = "/rewind"
                 elif not user_input:
-                    sys.stdout.write("\033[A\033[2K\r")
-                    sys.stdout.flush()
+                    # Empty Enter → não aceita e remove o eco visual.
+                    self._erase_empty_prompt_echo()
                     continue
 
                 if user_input.lower() in ("exit", "quit", "q"):

--- a/deile/commands/builtin/rewind_command.py
+++ b/deile/commands/builtin/rewind_command.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import time
-import uuid
-
 from rich.panel import Panel
 from rich.text import Text
 
 from ...core.interfaces.selector import SelectorNotSupported, SelectorOption
 from ...infrastructure.selectors import get_default_selector
-from .._sentinels import SWITCH_SESSION_KEY
+from .._sentinels import POST_SWITCH_ACTION_KEY, SWITCH_SESSION_KEY
 from ..base import CommandContext, CommandResult, DirectCommand
 from ._shared import truncate_oneline, wrap_command_errors
 
@@ -97,43 +94,42 @@ class RewindCommand(DirectCommand):
         if choice is None:
             return CommandResult(
                 success=True,
-                content=Panel(
-                    Text("Rewind cancelado.", style="dim"),
-                    title="Rewind",
-                    border_style="yellow",
-                ),
-                metadata={"cancelled": True},
+                content="",
+                metadata={
+                    "cancelled": True,
+                    "suppress_response_display": True,
+                },
             )
 
-        cut = int(choice.value) + 1
+        # Trunca ATÉ E INCLUSIVE a mensagem selecionada — voltar pra
+        # "antes daquela mensagem". Ex.: selecionar #3 apaga a #3 e tudo
+        # depois dela, deixando o histórico em [#1, resposta-#1, #2,
+        # resposta-#2]. O usuário tem o prompt vazio pronto para
+        # reformular a mensagem que estava na posição #3.
+        cut = int(choice.value)
         trimmed = history[:cut]
 
-        new_sid = f"rewind-{int(time.time())}-{uuid.uuid4().hex[:8]}"
-        try:
-            new_session = agent.create_session(
-                session_id=new_sid,
-                working_directory=session.working_directory,
-            )
-        except Exception as exc:
-            return CommandResult.error_result(f"Não foi possível criar sessão: {exc}")
+        # Muta o histórico DA SESSÃO ATUAL — não cria fork. Rewind é
+        # destrutivo por design (mais próximo do mental model de "voltar
+        # atrás" do chat). Para preservar histórico, use /fork antes.
+        session.conversation_history = [dict(e) for e in trimmed]
 
-        new_session.conversation_history = [dict(e) for e in trimmed]
+        # Reusa a infra de session-switch para acionar o replay: o CLI
+        # vai pop SWITCH+POST_SWITCH em ``check_session_switch``,
+        # resolver a sessão (mesmo session_id → mesma sessão), e o
+        # branch ``action == "replay"`` chama ``replay_history`` que
+        # limpa a tela, redesenha o welcome e re-renderiza o histórico
+        # truncado. Sem isso, o scrollback continuaria mostrando tudo.
+        session.context_data[SWITCH_SESSION_KEY] = session.session_id
+        session.context_data[POST_SWITCH_ACTION_KEY] = "replay"
 
-        orig_name = session.context_data.get("conversation_name", "")
-        if orig_name:
-            new_session.context_data["conversation_name"] = f"{orig_name} (rewind)"
-
-        session.context_data[SWITCH_SESSION_KEY] = new_sid
-
-        label = truncate_oneline(trimmed[-1]["content"], _MAX_LABEL) if trimmed else "—"
+        # ``suppress_response_display`` evita qualquer Panel/texto antes
+        # do replay — qualquer print aqui apareceria por uma fração de
+        # segundo antes do ``console.clear()`` do replay, gerando flash
+        # visual. O replay já comunica a mudança (tela limpa + histórico
+        # menor).
         return CommandResult(
             success=True,
-            content=Panel(
-                Text.from_markup(
-                    f"Fork criado a partir de: [bold cyan]{label}[/bold cyan]\n"
-                    f"[dim]{len(trimmed)} mensagem(ns) preservada(s) · ID: {new_sid}[/dim]"
-                ),
-                title="[bold green]Rewind — fork criado[/bold green]",
-                border_style="green",
-            ),
+            content="",
+            metadata={"suppress_response_display": True},
         )

--- a/deile/config/api_config.yaml
+++ b/deile/config/api_config.yaml
@@ -1,4 +1,4 @@
-default_model: deepseek:deepseek-v4-pro
+default_model: deepseek:deepseek-v4-flash
 gemini:
   generation_config:
     candidate_count: 1

--- a/deile/core/agent.py
+++ b/deile/core/agent.py
@@ -569,16 +569,26 @@ class DeileAgent(AgentStreamingMixin, AgentAutonomousMixin):
             if bot_context is not None:
                 session.context_data["bot_context"] = dict(bot_context)
 
-            # Adiciona entrada ao histórico
-            session.add_to_history("user", user_input)
-            
             # Intercepta comandos slash ANTES de processar — apenas se o comando existe.
             # Comandos desconhecidos (ex: /ideias-projetos) caem no LLM como linguagem natural.
             _stripped = user_input.strip()
+            _is_known_slash = False
             if _stripped.startswith('/'):
                 _cmd = _stripped[1:].split()[0] if _stripped[1:] else ""
                 if _cmd and self.command_registry.has_command(_cmd):
-                    return await self._process_slash_command(_stripped, session, start_time)
+                    _is_known_slash = True
+
+            # Slash commands conhecidos NÃO entram no histórico user — são
+            # comandos da CLI, não mensagens para o LLM. Sem essa exclusão,
+            # ``/rewind``, ``/help``, etc. poluem o seletor de rewind e
+            # contaminam o contexto do LLM nas próximas turns. Skills
+            # (``llm_prompt``) re-adicionam com o body real do prompt em
+            # ``_process_slash_command``.
+            if not _is_known_slash:
+                session.add_to_history("user", user_input)
+
+            if _is_known_slash:
+                return await self._process_slash_command(_stripped, session, start_time)
             
             # AUTONOMY PHASE: Try autonomous processing first
             autonomous_result = await self.process_autonomous_request(user_input, session)
@@ -973,12 +983,13 @@ class DeileAgent(AgentStreamingMixin, AgentAutonomousMixin):
             # Route the prompt through the LLM pipeline instead of returning it raw.
             if command_result.content_type == "llm_prompt" and command_result.content:
                 prompt = str(command_result.content)
-                # Replace the slash-command user turn in history with the real prompt
-                # so the LLM sees the skill body, not the raw "/skill-name args".
-                for entry in reversed(session.conversation_history):
-                    if entry["role"] == "user":
-                        entry["content"] = prompt
-                        break
+                # ``process_input`` agora NÃO adiciona slash commands ao histórico
+                # (são comandos da CLI). Para skills, o body real do prompt é
+                # o que o LLM deve ver — adiciona aqui como entrada user
+                # legítima (substitui a antiga lógica de "varrer reversed
+                # history e mutar entry[content]" que dependia da entrada
+                # slash já existir).
+                session.add_to_history("user", prompt)
                 response_content, tool_results = await self._process_iterative_function_calling(
                     prompt, None, session
                 )

--- a/deile/tests/cli/test_empty_prompt_cleanup.py
+++ b/deile/tests/cli/test_empty_prompt_cleanup.py
@@ -1,0 +1,95 @@
+"""Regressão: Enter sem texto no prompt interativo NÃO deve empilhar
+``>`` (prompt commitado) e ``─`` (rules de separação) na tela.
+
+Bug pós-PR #312: o cleanup antigo emitia apenas ``\\033[A\\033[2K\\r``
+(uma única iteração de "up + erase-line"), o que apagava só a linha do
+prompt — mas ``get_user_input`` emite 2 linhas por iteração:
+``console.rule(style="dim")`` (separador horizontal) + a linha ``> ``
+que o prompt_toolkit commita ao receber Enter. Resultado: rules
+empilhados (e prompts em terminais cujo emulador não consolida o
+prompt-area). Fix: apagar 2 linhas via ``\\033[A\\033[2K`` duas vezes.
+
+Esses testes cobrem o helper ``_DeileCLI._erase_empty_prompt_echo``
+sem precisar de TTY real nem de inicialização completa do CLI (que
+requer API keys).
+"""
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from deile.cli import _DeileCLI
+
+
+@pytest.mark.unit
+def test_erase_empty_prompt_echo_writes_two_line_cleanup_when_tty() -> None:
+    """Quando stdout é TTY, escreve 2 ANSI ``up + erase`` em sequência.
+
+    O contrato é APAGAR 2 LINHAS (rule + prompt), não 1. Antes do fix,
+    o cleanup era ``\\033[A\\033[2K\\r`` (1 linha apenas) — deixava o
+    rule emitido por ``console.rule(style="dim")`` no scrollback.
+    """
+    cli = _DeileCLI.__new__(_DeileCLI)
+    buf = io.StringIO()
+
+    class _TTYBuf(io.StringIO):
+        def isatty(self) -> bool:  # noqa: D401
+            return True
+
+    fake_stdout = _TTYBuf()
+    with patch.object(sys, "stdout", fake_stdout):
+        cli._erase_empty_prompt_echo()
+    written = fake_stdout.getvalue()
+
+    # Deve conter o cursor-up + erase-line REPETIDOS (2x).
+    assert written.count("\033[A") == 2, (
+        f"deveria ter 2 cursor-up; got {written.count('\\033[A')}: {written!r}"
+    )
+    assert written.count("\033[2K") == 2, (
+        f"deveria ter 2 erase-line; got {written.count('\\033[2K')}: {written!r}"
+    )
+    # E reposicionar ao início (carriage return).
+    assert written.endswith("\r"), f"deveria terminar em \\r: {written!r}"
+
+
+@pytest.mark.unit
+def test_erase_empty_prompt_echo_writes_nothing_when_not_tty() -> None:
+    """Sem TTY (pipe, CI, redirect), NÃO emite ANSI no output.
+
+    Caso contrário, ``\\033[A`` literal vazaria como bytes no pipe e
+    poluiria logs, arquivos, output de CI etc.
+    """
+    cli = _DeileCLI.__new__(_DeileCLI)
+
+    class _NotTTYBuf(io.StringIO):
+        def isatty(self) -> bool:  # noqa: D401
+            return False
+
+    fake_stdout = _NotTTYBuf()
+    with patch.object(sys, "stdout", fake_stdout):
+        cli._erase_empty_prompt_echo()
+    assert fake_stdout.getvalue() == "", (
+        f"deveria ser silencioso sem TTY: {fake_stdout.getvalue()!r}"
+    )
+
+
+@pytest.mark.unit
+def test_erase_ansi_constant_pair_count_matches_lines_emitted_per_prompt() -> None:
+    """A constante ``_ERASE_PROMPT_ECHO_ANSI`` espelha o número de
+    linhas emitidas por iteração de ``get_user_input``.
+
+    ``get_user_input`` emite:
+      1. ``self.console.rule(style="dim")`` → 1 linha
+      2. prompt_toolkit commita ``> `` → 1 linha
+    Total = 2 linhas. Apagamos 2 (pair ``\\033[A\\033[2K`` aparece 2x).
+
+    Esse teste prende o invariante: se algum dia ``get_user_input``
+    passar a emitir mais (ou menos) linhas, esse contador precisa
+    casar — daí a inflação de prompts em branco que motivou a fix.
+    """
+    ansi = _DeileCLI._ERASE_PROMPT_ECHO_ANSI
+    assert ansi.count("\033[A") == 2
+    assert ansi.count("\033[2K") == 2

--- a/deile/tests/commands/test_conversation_commands.py
+++ b/deile/tests/commands/test_conversation_commands.py
@@ -298,14 +298,85 @@ class TestRewindCommand:
         assert SWITCH_SESSION_KEY not in ctx.session.context_data
 
     @pytest.mark.unit
-    async def test_rewind_choice_creates_fork(self):
+    async def test_rewind_cancel_suppresses_response_display(self):
+        """ESC no seletor de rewind não deve printar nada novo.
+
+        O ``CommandResult`` precisa carregar ``suppress_response_display=True``
+        para o ``cli.py`` pular o ``ui.display_response`` (evita o eco
+        ``Panel('Rewind cancelado.')`` no scrollback que poluía o histórico).
+        Sem isso, cada ESC empilhava um painel amarelo na UI.
+        """
+        from deile.commands.builtin import rewind_command as rw_mod
+
+        ctx = _make_context("rewind", history=_HISTORY)
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        mock_selector.select = AsyncMock(return_value=None)
+
+        with patch.object(rw_mod, "get_default_selector", return_value=mock_selector):
+            cmd = RewindCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.metadata.get("suppress_response_display") is True
+        assert result.content == ""
+
+    @pytest.mark.unit
+    async def test_rewind_truncates_current_session_in_place(self):
+        """Rewind muta a sessão atual: apaga a mensagem selecionada E tudo após.
+
+        Esse é o mental model esperado de "voltar atrás" — não cria fork
+        nem preserva a mensagem escolhida; vai diretamente para um prompt
+        limpo no ponto ANTES dela. Quem quiser preservar histórico deve
+        usar /fork antes de /rewind.
+
+        Selecionando a #2 (``"como vai?"`` no índice 2 do histórico):
+        - apaga: [#2 "como vai?", resposta "Bem!"]
+        - preserva: [#1 "olá mundo", resposta "Olá!"]
+        """
+        from deile.commands.builtin import rewind_command as rw_mod
+        from deile.core.interfaces.selector import SelectorOption
+
+        ctx = _make_context("rewind", history=_HISTORY)
+        original_sid = ctx.session.session_id
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        # value=2 = índice da #2 "como vai?" no histórico completo
+        mock_selector.select = AsyncMock(
+            return_value=SelectorOption(label="#2 como vai?", value=2)
+        )
+
+        with patch.object(rw_mod, "get_default_selector", return_value=mock_selector):
+            cmd = RewindCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        # NÃO cria nova sessão — muta a atual. SWITCH aponta para a
+        # própria sessão (re-trigger pro replay no CLI), sem fork.
+        assert ctx.session.context_data.get(SWITCH_SESSION_KEY) == original_sid
+
+        # Histórico foi truncado IN-PLACE: 2 entradas restantes (não 3).
+        assert len(ctx.session.conversation_history) == 2
+        assert ctx.session.conversation_history[0]["content"] == "olá mundo"
+        assert ctx.session.conversation_history[1]["content"] == "Olá!"
+        # A mensagem #2 e sua resposta foram apagadas.
+        contents = [e["content"] for e in ctx.session.conversation_history]
+        assert "como vai?" not in contents
+        assert "Bem!" not in contents
+
+    @pytest.mark.unit
+    async def test_rewind_first_message_clears_all_history(self):
+        """Selecionar a primeira mensagem (#1) zera o histórico inteiro.
+
+        Comportamento intencional: rewind para "antes da primeira" =
+        conversa nova. Equivalente a /clear, mas preserva session_id.
+        """
         from deile.commands.builtin import rewind_command as rw_mod
         from deile.core.interfaces.selector import SelectorOption
 
         ctx = _make_context("rewind", history=_HISTORY)
         mock_selector = MagicMock()
         mock_selector.is_supported.return_value = True
-        # Select the first user message (index 0 in history)
+        # value=0 = primeira mensagem user no histórico
         mock_selector.select = AsyncMock(
             return_value=SelectorOption(label="#1 olá mundo", value=0)
         )
@@ -315,14 +386,40 @@ class TestRewindCommand:
             result = await cmd.execute(ctx)
 
         assert result.success
-        new_sid = ctx.session.context_data.get(SWITCH_SESSION_KEY)
-        assert new_sid is not None
-        assert new_sid.startswith("rewind-")
+        assert ctx.session.conversation_history == []
 
-        # Fork should contain only up to the first user message (index 0 + 1 = 1 entry)
-        new_sess = ctx.agent.get_session(new_sid)
-        assert len(new_sess.conversation_history) == 1
-        assert new_sess.conversation_history[0]["content"] == "olá mundo"
+    @pytest.mark.unit
+    async def test_rewind_choice_triggers_replay(self):
+        """Rewind aceito deve solicitar replay (limpa tela + redesenha histórico).
+
+        Sem essa flag, o CLI cairia no branch default ("Sessão alternada
+        para …") e o scrollback continuaria mostrando TODO o histórico
+        anterior — dando a impressão visual de que nada mudou. O usuário
+        espera ver a conversa "voltar atrás", então o efeito tem que ser
+        explícito: limpar e re-renderizar só até o ponto escolhido.
+        """
+        from deile.commands._sentinels import POST_SWITCH_ACTION_KEY
+        from deile.commands.builtin import rewind_command as rw_mod
+        from deile.core.interfaces.selector import SelectorOption
+
+        ctx = _make_context("rewind", history=_HISTORY)
+        mock_selector = MagicMock()
+        mock_selector.is_supported.return_value = True
+        mock_selector.select = AsyncMock(
+            return_value=SelectorOption(label="#1 olá mundo", value=0)
+        )
+
+        with patch.object(rw_mod, "get_default_selector", return_value=mock_selector):
+            cmd = RewindCommand()
+            result = await cmd.execute(ctx)
+
+        assert result.success
+        assert ctx.session.context_data.get(POST_SWITCH_ACTION_KEY) == "replay"
+        # E o display do resultado deve ser suprimido — o replay logo
+        # depois (no CLI loop) já comunica a mudança visualmente, então
+        # qualquer Panel/Text aqui seria flash visual antes do clear.
+        assert result.metadata.get("suppress_response_display") is True
+        assert result.content == ""
 
     @pytest.mark.unit
     async def test_rewind_content_none_does_not_crash(self):

--- a/deile/tests/ui/test_console_ui_resize.py
+++ b/deile/tests/ui/test_console_ui_resize.py
@@ -7,6 +7,16 @@ naquela largura. Mesmo terminal redimensionado, novos renders preservavam o
 tamanho antigo. O fix: trocar o desenho manual por `Panel`/`Rule` do Rich,
 que consultam `console.width` lazy em cada render.
 
+Bug visual reportado pós-PR #312: ``Panel(...)`` default (``expand=True``)
+fazia a caixa esticar pela largura inteira do terminal, parecendo "bordas
+soltas" e cores quebradas em terminais largos. Fix complementar (após
+#307): trocar para ``Panel.fit(...)`` (``expand=False``) — caixa COMPACTA
+dimensionada ao conteúdo, mas ainda adaptativa: terminais menores que o
+conteúdo (ex.: 30 cols) fazem o Rich clampar a caixa e o texto reflowar
+naturalmente. A regra estrutural (proibido ``inner_w = max(len(...))``)
+continua valendo: largura do conteúdo emerge do próprio conteúdo, não de
+``len(string)`` hardcoded.
+
 Limitação fundamental NÃO testada aqui (porque é inevitável): conteúdo já
 commitado ao scrollback não reflowa. Esses testes cobrem apenas o
 comportamento de NOVOS renders.
@@ -61,15 +71,20 @@ def _panel_borders(output: str) -> tuple[str, str]:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("width", [20, 30, 40, 60, 80, 100, 120, 160, 200])
-def test_show_welcome_box_adapts_to_console_width(width: int) -> None:
-    """A caixa `╔══╗` do welcome usa a largura do console em cada render.
+@pytest.mark.parametrize("width", [80, 100, 120, 160, 200])
+def test_show_welcome_box_is_compact_on_wide_terminals(width: int) -> None:
+    """A caixa `╔══╗` do welcome NÃO ocupa a largura inteira em terminais largos.
 
-    Antes do fix da issue #307, a caixa ficava travada em ~48 chars (o
-    `len()` do maior label) independentemente da largura do terminal.
-    Larguras extremas (20, 30) também são incluídas para garantir que
-    o texto interno quebra naturalmente sem crash — a caixa em si
-    ainda assume a largura disponível, e o conteúdo refluí dentro.
+    Bug visual pós-PR #312: ``Panel(...)`` (default ``expand=True``) fazia
+    a caixa esticar pra largura total do terminal — em terminais largos
+    o look ficava "solto" e quebrado. Fix: ``Panel.fit(...)`` produz uma
+    caixa COMPACTA dimensionada ao conteúdo, igual ao desenho manual
+    antigo (~48 chars), mas com largura ainda determinada lazy pelo
+    Rich (sem ``len(string)`` literal).
+
+    Topo e fundo devem ter o MESMO tamanho (caixa balanceada) e ser
+    estritamente menores que a largura do console (look compacto). O
+    tamanho exato emerge do conteúdo, mas em geral cabe em ~50 chars.
     """
     ui = _make_ui(width=width)
     ui.show_welcome()
@@ -77,13 +92,38 @@ def test_show_welcome_box_adapts_to_console_width(width: int) -> None:
 
     box_top, box_bot = _panel_borders(output)
 
-    # Topo e fundo devem ter exatamente a largura do console
-    # (Panel default usa a largura total disponível).
-    assert len(box_top) == width, (
-        f"box top has len={len(box_top)} for console width={width}: {box_top!r}"
+    # Topo e fundo balanceados (caixa fechada nas 4 quinas).
+    assert len(box_top) == len(box_bot), (
+        f"box assimétrica: top={len(box_top)} bot={len(box_bot)}"
     )
-    assert len(box_bot) == width, (
-        f"box bottom has len={len(box_bot)} for console width={width}: {box_bot!r}"
+    # E estritamente menor que a largura do console — compacto.
+    assert len(box_top) < width, (
+        f"caixa de largura {len(box_top)} ocupou TODO o console (w={width}); "
+        f"deveria ser compacta (Panel.fit). Linha: {box_top!r}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("width", [30, 40])
+def test_show_welcome_box_clamps_to_narrow_terminal(width: int) -> None:
+    """Em terminais MAIS estreitos que o conteúdo, a caixa encolhe para
+    caber sem estourar.
+
+    ``Panel.fit`` ainda consulta ``console.width`` no render — quando o
+    terminal é estreito demais para a largura natural do conteúdo, Rich
+    clampa a caixa à largura do terminal e o texto reflow internamente.
+    Garantia: nenhuma linha ultrapassa ``width``.
+    """
+    ui = _make_ui(width=width)
+    ui.show_welcome()
+    output = ui.console.file.getvalue()
+
+    box_top, box_bot = _panel_borders(output)
+    assert len(box_top) <= width, (
+        f"caixa estourou: top={len(box_top)} > width={width}"
+    )
+    assert len(box_bot) <= width, (
+        f"caixa estourou: bot={len(box_bot)} > width={width}"
     )
 
 
@@ -104,16 +144,27 @@ def test_show_welcome_uses_double_box_style() -> None:
 
 
 @pytest.mark.unit
-def test_show_welcome_does_not_use_text_derived_width() -> None:
-    """A largura da caixa NÃO deve depender do comprimento das strings exibidas.
+def test_show_welcome_box_is_not_full_terminal_width_when_room_for_compact() -> None:
+    """A caixa compacta (``Panel.fit``) NÃO ocupa a largura inteira do
+    terminal quando ele é mais largo que o conteúdo.
 
-    Renderizamos com um modelo muito longo e um curto na mesma largura de
-    console e validamos que o topo do box tem o mesmo tamanho (= console.width).
+    Substitui o teste antigo ``test_show_welcome_does_not_use_text_derived_width``
+    que assumia ``Panel`` expansível (full-width). Agora o contrato é o
+    inverso: a caixa fica compacta em terminais largos, e cresce/encolhe
+    com o conteúdo — mas a regra estrutural (proibido literal
+    ``inner_w = max(len(...))``) continua respeitada pelo uso de
+    ``Panel.fit`` em vez de cálculo manual.
+
+    Verificações:
+    - Caixa < largura do console (não estica).
+    - Conteúdo mais longo produz caixa proporcionalmente maior — não
+      por mágica de ``len()`` mas porque o Rich mede o renderable e
+      ``expand=False`` significa "use a medida natural".
     """
-    short = _make_ui(width=120, default_model="x:short")
+    short = _make_ui(width=200, default_model="x:short")
     short.show_welcome()
     long_ = _make_ui(
-        width=120,
+        width=200,
         default_model="anthropic:claude-opus-4-7-with-a-deliberately-very-long-suffix",
     )
     long_.show_welcome()
@@ -121,8 +172,11 @@ def test_show_welcome_does_not_use_text_derived_width() -> None:
     short_top, _ = _panel_borders(short.console.file.getvalue())
     long_top, _ = _panel_borders(long_.console.file.getvalue())
 
-    # Mesma largura de console → mesma largura de box, independente do texto.
-    assert len(short_top) == len(long_top) == 120
+    # Ambas COMPACTAS (estritamente menores que o console de 200 cols).
+    assert len(short_top) < 200
+    assert len(long_top) < 200
+    # E a caixa do modelo longo é >= que a do curto (conteúdo dimensiona).
+    assert len(long_top) >= len(short_top)
 
 
 @pytest.mark.unit

--- a/deile/ui/console_ui.py
+++ b/deile/ui/console_ui.py
@@ -134,8 +134,13 @@ class ConsoleUIManager(UIManager):
                     # sentinel so the CLI loop opens /rewind.
                     if _esc['active']:
                         _hide_esc_hint(event)
-                        buf.insert_text(_REWIND_SENTINEL)
-                        event.current_buffer.validate_and_handle()
+                        # ``app.exit(result=...)`` faz ``prompt_async()`` retornar
+                        # o sentinel SEM commitar o buffer ao scrollback —
+                        # evita o eco ``^@REWIND^@`` (null bytes renderizados
+                        # pelo terminal) que ``insert_text + validate_and_handle``
+                        # produzia. O CLI loop intercepta o sentinel em
+                        # ``cli.py`` e converte para ``/rewind``.
+                        event.app.exit(result=_REWIND_SENTINEL)
                         return
                     # First ESC on empty buffer: show rewind hint.
                     _esc['active'] = True
@@ -330,16 +335,18 @@ class ConsoleUIManager(UIManager):
         via ``/model use`` (armazenado em ``context_data["forced_model"]``)
         em vez de sempre exibir o default da config.
 
-        Resize-em-tempo-real (issue #307): o painel ``Provider/Model/Status``
-        é renderizado dentro de ``rich.live.Live`` por alguns segundos. Rich
-        instala um handler ``SIGWINCH`` e re-renderiza cada frame com a
-        largura corrente do terminal — se o usuário redimensiona enquanto o
-        welcome está vivo, ele adapta sem quebrar bordas. Após o período, o
-        último frame fica no scrollback (limitação fundamental documentada
-        no princípio #15). Ver também ``deile.ui.dynamic_render``.
+        Layout compacto e adaptativo: o painel ``Provider/Model/Status`` é
+        construído com ``Panel.fit(...)`` (``expand=False``), portanto o
+        Rich dimensiona a caixa ao conteúdo ao invés de esticar pela
+        largura inteira do terminal — exatamente como a caixa manual
+        ``╔══╗`` antiga, mas sem travar a largura por ``max(len(...))``.
+        A consulta a ``console.width`` continua lazy: terminais menores
+        que o conteúdo (ex.: 30 colunas) ainda fazem o painel encolher
+        e o texto interno reflow naturalmente. Frames já no scrollback
+        são estáticos (limitação fundamental documentada no princípio
+        #15). A região ``Live`` bloqueante foi removida porque adicionava
+        6s ao startup sem benefício prático no caso comum (sem resize).
         """
-        from deile.ui.dynamic_render import live_for
-
         self.console.clear()
 
         provider_label, model_label = self._resolve_provider_model(session)
@@ -357,25 +364,26 @@ class ConsoleUIManager(UIManager):
                 Text.from_markup(f"  [bold #FFD166]✦[/] [italic]{slogan_random}[/italic]\n")
             )
 
-            # Painel adaptativo: `live_for` segura a região Live ativa por
-            # `duration_s`, re-renderizando a cada frame. Durante esse
-            # período, qualquer SIGWINCH é capturado por Rich e o layout
-            # adapta em tempo real à nova `console.width`.
-            def build_panel():
-                prov_markup = f"[bold cyan]Provider[/bold cyan]  [white]{provider_label}[/white]"
-                model_markup = f"[bold cyan]Model[/bold cyan]     [white]{model_label}[/white]"
-                status_markup = "[bold green]●[/bold green] [bold]DEILE[/bold]   Pronto — digite [cyan]/help[/cyan] para começar"
-                header = Text.from_markup(prov_markup + "\n" + model_markup)
-                status = Text.from_markup(status_markup)
-                body = Group(header, Rule(style="#4285F4"), status)
-                return Panel(
-                    body,
-                    border_style="#4285F4",
-                    box=box.DOUBLE,
-                    padding=(0, 1),
-                )
-
-            live_for(build_panel, console=self.console, duration_s=6.0, refresh_hz=8.0)
+            # Painel COMPACTO e adaptativo. ``Panel.fit(...)`` =
+            # ``Panel(..., expand=False)``: a caixa se dimensiona pelo
+            # conteúdo (look próximo ao antigo ``╔══╗`` manual) ao
+            # invés de esticar pela largura inteira do terminal — o que
+            # causa "bordas soltas" em terminais largos e Rule interno
+            # desconectado das verticais. O Rich ainda consulta
+            # ``console.width`` no render (clamp em terminais estreitos),
+            # mantendo a adaptação a resize do princípio #15.
+            prov_markup = f"[bold cyan]Provider[/bold cyan]  [white]{provider_label}[/white]"
+            model_markup = f"[bold cyan]Model[/bold cyan]     [white]{model_label}[/white]"
+            status_markup = "[bold green]●[/bold green] [bold]DEILE[/bold]   Pronto — digite [cyan]/help[/cyan] para começar"
+            header = Text.from_markup(prov_markup + "\n" + model_markup)
+            status = Text.from_markup(status_markup)
+            body = Group(header, Rule(style="#4285F4"), status)
+            self.console.print(Panel.fit(
+                body,
+                border_style="#4285F4",
+                box=box.DOUBLE,
+                padding=(0, 1),
+            ))
             self.console.print("  [dim]DEILE v5.1 ULTRA[/dim]\n")
         except Exception:
             print("DEILE v5.1 ULTRA")

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -585,8 +585,7 @@ Refresh **1s** (pra mostrar o output streaming). Lista os verbos do
 ╭─ AÇÕES ────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │         ação                  comando                                                                      │
 │  ────────────────────────────────────────────────────────────────────────────────────────────────────────  │
-│  1      status                /Users/elimar.cavalli/dev/github/elimarcavalli/deile/infra/k8s/deploy.py     │
-│                               k8s status                                                                   │
+│  1      status                infra/k8s/deploy.py k8s status                                               │
 │  2      restart               k8s restart --yes                                                            │
 │  3      build (no restart)    k8s build --yes                                                              │
 │  4      build + restart       build --restart --yes                                                        │


### PR DESCRIPTION
## Sumário

3 commits que eu havia feito na branch \`feat/forge-agnostic-gitlab-297\` ANTES do merge da PR #315, mas que não chegaram a tempo para o squash final (PR foi mergeada com SHA \`7463370\`, anterior a estes commits). Os fixes correspondentes estão visíveis nos prints do Elimar como AINDA presentes — \`^@REWIND^@\` no scrollback, Panel \"Rewind cancelado.\" amarelo, etc.

## Commits

| Commit | Tema |
|---|---|
| \`5e435f4\` | \`chore(config)\`: default model \`deepseek-v4-flash\` (mais barato para iteração interativa) + linha do exemplo no \`infra/k8s/README\` cabe em uma célula de tabela. |
| \`e51231a\` | \`fix(ui+cli)\`: **5 correções na UI interativa** — (1) \`show_welcome\` usa \`Panel.fit\` (largura volta a ~48 cols, identidade visual do desenho manual antigo preservada); (2) remove \`live_for(duration_s=6.0)\` bloqueante (startup interativo **-6s** em TTY); (3) Enter vazio apaga 2 linhas (rule + prompt) em vez de 1 — antes empilhava rules invisíveis; (4) ESC ESC no prompt vazio usa \`event.app.exit(result=SENTINEL)\` em vez de \`insert_text + validate_and_handle\` — elimina o eco \`^@REWIND^@\` no scrollback; (5) CLI ao receber SENTINEL apaga o prompt vazio antes do selector abrir. |
| \`f1d872e\` | \`refactor(agent+rewind)\`: **3 mudanças relacionadas ao histórico** — (1) slash commands conhecidos não entram em \`add_to_history(user, ...)\` (eram tratados como mensagem user, poluíam o seletor do \`/rewind\` e o contexto do LLM; skills \`llm_prompt\` re-adicionam o body real); (2) \`/rewind\` virou destrutivo + in-place (apaga a mensagem selecionada inclusive + tudo após, sem criar fork — quem precisar preservar usa \`/fork\` antes); (3) \`/rewind\` dispara \`replay\` via \`POST_SWITCH_ACTION_KEY\` — clear + welcome + re-render do histórico truncado, o efeito visual de \"voltar atrás\"; (4) \`/rewind\` cancelado (ESC no seletor) retorna \`content=\"\"\` + \`suppress_response_display=True\` — sem Panel \"Rewind cancelado.\" no scrollback. |

## Testes

902 passed nas suites \`deile/tests/{ui,cli,commands}/\` (5 skipped). Suítes específicas mais sensíveis:

| Suite | Resultado |
|---|---|
| \`test_console_ui_resize.py\` | OK (welcome compact em 80/100/120/160/200 cols) |
| \`test_empty_prompt_cleanup.py\` (novo) | OK (TTY emite 2 pairs ANSI, non-TTY silencioso) |
| \`test_conversation_commands.py\` (rewind in-place, slash sem histórico) | OK |
| \`test_history_rollback.py\` | OK |

## Princípios preservados

- Princípio #15 (UI adaptativa): \`Panel.fit\` continua consultando \`console.width\` lazy; nada de larguras literais.
- Cross-platform: ANSI cleanup defensivo via \`isatty()\`; sentinel via API pública do prompt_toolkit (\`app.exit\`).
- Skills \`llm_prompt\` ainda funcionam: agora adicionam manualmente o body do prompt em \`_process_slash_command\` (substitui a antiga lógica de varrer \`reversed\` e mutar \`entry[\"content\"]\`).

## Por que esses commits ficaram órfãos

Cronologia (logs anexos no git):
- 02:22:15 — \`5e435f4\` (chore)
- 02:22:37 — \`e51231a\` (ui+cli)
- 02:23:04 — \`f1d872e\` (agent+rewind)
- **02:23:49** — PR #315 mergeada com \`headRefOid: 7463370\` (anterior aos 3 commits)
- 02:31+ — meus pushes subsequentes (acabaram virando PR #329, já mergeada em \`bdc239a\`)

A PR #315 foi finalizada com uma SHA mais antiga do que meus pushes — provavelmente force-push ou re-base do autor da PR sobrescreveu meu push, ou o merge foi disparado com base em snapshot anterior. Não tem como recuperar de outro modo além deste cherry-pick.