### PR TITLE
feat(preferences): PreferenceStore + remember/list/forget_preference tools

### DIFF
--- a/deile/preferences/__init__.py
+++ b/deile/preferences/__init__.py
@@ -1,0 +1,9 @@
+"""Preference persistence layer for DEILE.
+
+Provides :class:`PreferenceStore` — a per-user key-value store backed by
+``~/.deile/preferences.json`` with atomic writes and file locking.
+"""
+
+from .store import PreferenceStore
+
+__all__ = ["PreferenceStore"]

--- a/deile/preferences/store.py
+++ b/deile/preferences/store.py
@@ -1,0 +1,206 @@
+"""Per-user preference store backed by ``~/.deile/preferences.json``.
+
+Operations are atomic using tempfile + atomic rename. Valid value types:
+string, number, boolean, null (no nested objects). Keys must match
+``^[a-z][a-z0-9_.]{0,127}$`` (snake_case, max 128 chars). Values are
+capped at 4096 characters.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────
+
+_KEY_REGEX = re.compile(r"^[a-z][a-z0-9_.]{0,127}$")
+_MAX_VALUE_CHARS = 4096
+_VALID_VALUE_TYPES = (str, int, float, bool, type(None))
+_PREFS_DIR = Path.home() / ".deile"
+_PREFS_FILE = _PREFS_DIR / "preferences.json"
+
+# ── Validation helpers ──────────────────────────────────────────────────
+
+
+def _validate_key(key: str) -> None:
+    """Raise ``ValueError`` if *key* does not match the allowed pattern."""
+    if not isinstance(key, str):
+        raise ValueError(f"Preference key must be a string, got {type(key).__name__}")
+    if not _KEY_REGEX.match(key):
+        raise ValueError(
+            f"Invalid preference key: '{key}'. Keys must be snake_case "
+            f"(a-z, 0-9, _, .), start with a letter, max 128 chars."
+        )
+
+
+def _validate_value(value: Any) -> None:
+    """Raise ``ValueError`` if *value* is not an allowed type / too long."""
+    if not isinstance(value, _VALID_VALUE_TYPES):
+        raise ValueError(
+            f"Preference value type {type(value).__name__} is not allowed. "
+            f"Allowed types: string, number, boolean, null."
+        )
+    if isinstance(value, str) and len(value) > _MAX_VALUE_CHARS:
+        raise ValueError(
+            f"Preference value exceeds maximum length of {_MAX_VALUE_CHARS} "
+            f"characters (got {len(value)})."
+        )
+
+
+# ── Atomic file operations ──────────────────────────────────────────────
+
+
+def _ensure_prefs_dir() -> None:
+    """Create ``~/.deile/`` if it does not exist (idempotent)."""
+    _PREFS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _atomic_write(data: Dict[str, Any]) -> None:
+    """Write *data* to a deterministic temp file and atomically rename
+    it over ``_PREFS_FILE``.
+
+    The temp path is derived from the current ``_PREFS_FILE`` (so tests
+    that patch ``_PREFS_FILE`` / ``_PREFS_DIR`` get a temp file on the
+    same filesystem). Uses a fixed name (``.preferences.tmp``) alongside
+    the target file so ``os.replace`` stays atomic. Because all
+    read-modify-write paths that call this already hold ``fcntl.flock``
+    on the main file, there is no risk of concurrent writers trampling
+    each other's temp file.
+
+    The deterministic name avoids ``mkstemp`` which creates a new inode
+    per call and can exhaust inode-limited filesystems (e.g. tmpfs in
+    containers).
+    """
+    _ensure_prefs_dir()
+    tmp_file = _PREFS_DIR / ".preferences.tmp"
+    with open(tmp_file, "w", encoding="utf-8") as tmp_f:
+        json.dump(data, tmp_f, indent=2, sort_keys=True, ensure_ascii=False)
+        tmp_f.flush()
+        os.fsync(tmp_f.fileno())
+    os.replace(tmp_file, _PREFS_FILE)
+
+
+def _read_prefs_file() -> Dict[str, Any]:
+    """Read the full preferences.json file, returning an empty dict on
+    missing or unparseable file (corruption is recovered silently)."""
+    _ensure_prefs_dir()
+    try:
+        with open(_PREFS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            logger.warning(
+                "preferences.json is not a JSON object — recovering with empty dict"
+            )
+            return {}
+        return data
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        logger.debug("preferences.json: %s — returning empty dict", exc)
+        return {}
+
+
+def _write_prefs_file(data: Dict[str, Any]) -> None:
+    """Atomically write *data* to preferences.json.
+
+    Acquires an exclusive file lock before writing so concurrent readers
+    never see a partial file."""
+    _ensure_prefs_dir()
+    with open(_PREFS_FILE, "a+") as lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        except OSError:
+            logger.warning(
+                "fcntl.flock not available — falling back to rename-only atomicity"
+            )
+        _atomic_write(data)
+
+
+# ── PreferenceStore ─────────────────────────────────────────────────────
+
+
+class PreferenceStore:
+    """Per-user key-value store for DEILE preferences.
+
+    All operations targeting the same user_id are atomic (read-modify-write
+    under a file lock). Preference values must be string, number, boolean,
+    or null. Keys are snake_case with optional dot-namespacing (max 128
+    chars).
+    """
+
+    def store(self, user_id: str, key: str, value: Any) -> None:
+        """Persist a single *key* / *value* pair for *user_id*.
+
+        Raises:
+            ValueError: if key or value fails validation.
+        """
+        _validate_key(key)
+        _validate_value(value)
+
+        _ensure_prefs_dir()
+        with open(_PREFS_FILE, "a+") as lock_file:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            except OSError:
+                pass
+
+            # Read from the actual file path (not the lock fd) so we
+            # always see the latest data even after another thread's
+            # os.replace switched the inode under us.
+            data = _read_prefs_file()
+            data.setdefault(user_id, {})[key] = value
+            _atomic_write(data)
+
+    def get(self, user_id: str, key: str) -> Any:
+        """Return the value for *key* under *user_id*, or ``None`` if not
+        set."""
+        data = _read_prefs_file()
+        user_prefs = data.get(user_id, {})
+        if not isinstance(user_prefs, dict):
+            return None
+        return user_prefs.get(key)
+
+    def get_all(self, user_id: str) -> Dict[str, Any]:
+        """Return all preferences for *user_id* as a dict."""
+        data = _read_prefs_file()
+        user_prefs = data.get(user_id, {})
+        if not isinstance(user_prefs, dict):
+            return {}
+        return dict(user_prefs)
+
+    def delete(self, user_id: str, key: str) -> bool:
+        """Delete *key* for *user_id*. Returns ``True`` if the key existed,
+        ``False`` otherwise. Idempotent — deleting a nonexistent key
+        succeeds (returns ``False``)."""
+        _ensure_prefs_dir()
+        existed = False
+        with open(_PREFS_FILE, "a+") as lock_file:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            except OSError:
+                pass
+
+            # Read from the actual file path (not the lock fd) so we
+            # always see the latest data even after another thread's
+            # os.replace switched the inode under us.
+            data = _read_prefs_file()
+            if user_id in data and isinstance(data[user_id], dict):
+                existed = key in data[user_id]
+                data[user_id].pop(key, None)
+                if not data[user_id]:
+                    del data[user_id]
+            _atomic_write(data)
+        return existed
+
+    def list_keys(self, user_id: str) -> List[str]:
+        """Return all key names for *user_id*, sorted alphabetically."""
+        data = _read_prefs_file()
+        user_prefs = data.get(user_id, {})
+        if not isinstance(user_prefs, dict):
+            return []
+        return sorted(user_prefs.keys())

--- a/deile/tests/cli/test_empty_prompt_cleanup.py
+++ b/deile/tests/cli/test_empty_prompt_cleanup.py
@@ -45,11 +45,13 @@ def test_erase_empty_prompt_echo_writes_two_line_cleanup_when_tty() -> None:
     written = fake_stdout.getvalue()
 
     # Deve conter o cursor-up + erase-line REPETIDOS (2x).
-    assert written.count("\033[A") == 2, (
-        f"deveria ter 2 cursor-up; got {written.count('\\033[A')}: {written!r}"
+    up_count = written.count("\033[A")
+    assert up_count == 2, (
+        f"deveria ter 2 cursor-up; got {up_count}: {written!r}"
     )
-    assert written.count("\033[2K") == 2, (
-        f"deveria ter 2 erase-line; got {written.count('\\033[2K')}: {written!r}"
+    erase_count = written.count("\033[2K")
+    assert erase_count == 2, (
+        f"deveria ter 2 erase-line; got {erase_count}: {written!r}"
     )
     # E reposicionar ao início (carriage return).
     assert written.endswith("\r"), f"deveria terminar em \\r: {written!r}"

--- a/deile/tests/preferences/test_store.py
+++ b/deile/tests/preferences/test_store.py
@@ -1,0 +1,297 @@
+"""Unit tests for ``deile.preferences.store.PreferenceStore``."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from deile.preferences.store import (
+    PreferenceStore,
+    _validate_key,
+    _validate_value,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> PreferenceStore:
+    """Return a PreferenceStore whose backing file lives inside *tmp_path*."""
+    prefs_file = tmp_path / "preferences.json"
+    with patch(
+        "deile.preferences.store._PREFS_FILE", prefs_file
+    ), patch(
+        "deile.preferences.store._PREFS_DIR", tmp_path
+    ):
+        yield PreferenceStore()
+
+
+# ── Key / value validation ────────────────────────────────────────────────
+
+
+class TestKeyValidation:
+    def test_valid_keys(self):
+        _validate_key("a")
+        _validate_key("subagents.mode")
+        _validate_key("ui_theme")
+        _validate_key("a" * 128)
+
+    def test_key_must_start_with_letter(self):
+        with pytest.raises(ValueError, match="Invalid preference key"):
+            _validate_key("1key")
+
+    def test_key_no_uppercase(self):
+        with pytest.raises(ValueError, match="Invalid preference key"):
+            _validate_key("SubAgent")
+
+    def test_key_no_special_chars(self):
+        with pytest.raises(ValueError, match="Invalid preference key"):
+            _validate_key("key-name")
+
+    def test_key_max_129_chars_rejected(self):
+        with pytest.raises(ValueError, match="Invalid preference key"):
+            _validate_key("a" * 129)
+
+    def test_key_not_string(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            _validate_key(123)
+
+
+class TestValueValidation:
+    def test_string_ok(self):
+        _validate_value("hello")
+
+    def test_int_ok(self):
+        _validate_value(42)
+
+    def test_float_ok(self):
+        _validate_value(3.14)
+
+    def test_bool_ok(self):
+        _validate_value(True)
+
+    def test_null_ok(self):
+        _validate_value(None)
+
+    def test_list_rejected(self):
+        with pytest.raises(ValueError, match="not allowed"):
+            _validate_value([1, 2, 3])
+
+    def test_dict_rejected(self):
+        with pytest.raises(ValueError, match="not allowed"):
+            _validate_value({"nested": True})
+
+    def test_string_too_long(self):
+        with pytest.raises(ValueError, match="maximum length"):
+            _validate_value("x" * 4097)
+
+
+# ── CRUD tests ────────────────────────────────────────────────────────────
+
+
+class TestStoreAndRetrieve:
+    def test_store_and_get(self, store):
+        store.store("u1", "theme", "dark")
+        assert store.get("u1", "theme") == "dark"
+
+    def test_get_nonexistent_key(self, store):
+        assert store.get("u1", "missing") is None
+
+    def test_get_nonexistent_user(self, store):
+        assert store.get("ghost", "any") is None
+
+    def test_overwrite(self, store):
+        store.store("u1", "lang", "en")
+        store.store("u1", "lang", "pt")
+        assert store.get("u1", "lang") == "pt"
+
+    def test_multiple_users(self, store):
+        store.store("alice", "theme", "light")
+        store.store("bob", "theme", "dark")
+        assert store.get("alice", "theme") == "light"
+        assert store.get("bob", "theme") == "dark"
+
+    def test_boolean_value(self, store):
+        store.store("u1", "enabled", True)
+        assert store.get("u1", "enabled") is True
+
+    def test_integer_value(self, store):
+        store.store("u1", "count", 42)
+        assert store.get("u1", "count") == 42
+
+    def test_null_value(self, store):
+        store.store("u1", "reset", None)
+        assert store.get("u1", "reset") is None
+
+    def test_dot_namespaced_key(self, store):
+        store.store("u1", "subagents.mode", "manual")
+        assert store.get("u1", "subagents.mode") == "manual"
+
+
+class TestDelete:
+    def test_delete_existing(self, store):
+        store.store("u1", "theme", "dark")
+        assert store.delete("u1", "theme") is True
+        assert store.get("u1", "theme") is None
+
+    def test_delete_nonexistent_idempotent(self, store):
+        assert store.delete("u1", "ghost") is False
+
+    def test_delete_nonexistent_user_idempotent(self, store):
+        assert store.delete("ghost", "any") is False
+
+    def test_delete_last_key_removes_user(self, store):
+        store.store("u1", "theme", "dark")
+        store.delete("u1", "theme")
+        assert store.get_all("u1") == {}
+
+
+class TestListKeys:
+    def test_list_empty(self, store):
+        assert store.list_keys("u1") == []
+
+    def test_list_sorted(self, store):
+        store.store("u1", "z_key", 1)
+        store.store("u1", "a_key", 2)
+        assert store.list_keys("u1") == ["a_key", "z_key"]
+
+    def test_list_nonexistent_user(self, store):
+        assert store.list_keys("ghost") == []
+
+
+class TestGetAll:
+    def test_get_all_empty(self, store):
+        assert store.get_all("u1") == {}
+
+    def test_get_all_returns_dict(self, store):
+        store.store("u1", "a", 1)
+        store.store("u1", "b", "two")
+        result = store.get_all("u1")
+        assert result == {"a": 1, "b": "two"}
+
+    def test_get_all_nonexistent_user(self, store):
+        assert store.get_all("ghost") == {}
+
+
+# ── Persistence (read-back after new store instance) ──────────────────────
+
+
+def test_persistence_across_instances(tmp_path: Path):
+    prefs_file = tmp_path / "preferences.json"
+    with patch(
+        "deile.preferences.store._PREFS_FILE", prefs_file
+    ), patch(
+        "deile.preferences.store._PREFS_DIR", tmp_path
+    ):
+        s1 = PreferenceStore()
+        s1.store("u1", "theme", "dark")
+
+        s2 = PreferenceStore()
+        assert s2.get("u1", "theme") == "dark"
+
+
+# ── Corrupted JSON recovery ───────────────────────────────────────────────
+
+
+def test_corrupted_json_recovery(tmp_path: Path):
+    prefs_file = tmp_path / "preferences.json"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    prefs_file.write_text("this is not json {{{")
+
+    with patch(
+        "deile.preferences.store._PREFS_FILE", prefs_file
+    ), patch(
+        "deile.preferences.store._PREFS_DIR", tmp_path
+    ):
+        store = PreferenceStore()
+        # get should not crash — returns None
+        assert store.get("u1", "theme") is None
+        # store should overwrite the corrupted file
+        store.store("u1", "theme", "dark")
+        assert store.get("u1", "theme") == "dark"
+
+
+def test_not_a_dict_recovers(tmp_path: Path):
+    prefs_file = tmp_path / "preferences.json"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    prefs_file.write_text("[]")
+
+    with patch(
+        "deile.preferences.store._PREFS_FILE", prefs_file
+    ), patch(
+        "deile.preferences.store._PREFS_DIR", tmp_path
+    ):
+        store = PreferenceStore()
+        assert store.get("u1", "x") is None
+        store.store("u1", "x", 1)
+        assert store.get("u1", "x") == 1
+
+
+# ── Concurrent writes ─────────────────────────────────────────────────────
+
+
+def test_concurrent_writes_no_corruption(tmp_path: Path):
+    """Two writers hammering the same file should not corrupt it."""
+    prefs_file = tmp_path / "preferences.json"
+    errors = []
+
+    def writer(uid: str, start: int):
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ):
+            s = PreferenceStore()
+            for i in range(start, start + 20):
+                try:
+                    s.store(uid, f"key_{i}", i)
+                except Exception as exc:
+                    errors.append(exc)
+
+    t1 = threading.Thread(target=writer, args=("u1", 0))
+    t2 = threading.Thread(target=writer, args=("u1", 500))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"Concurrent write errors: {errors}"
+
+    # Verify file is valid JSON
+    with patch(
+        "deile.preferences.store._PREFS_FILE", prefs_file
+    ), patch(
+        "deile.preferences.store._PREFS_DIR", tmp_path
+    ):
+        s = PreferenceStore()
+        all_prefs = s.get_all("u1")
+        assert len(all_prefs) > 0
+        # Validate every value
+        for k, v in all_prefs.items():
+            assert isinstance(k, str)
+            assert isinstance(v, (str, int, float, bool, type(None)))
+
+
+# ── Invalid keys rejected at store level ──────────────────────────────────
+
+
+def test_store_invalid_key_rejected(store):
+    with pytest.raises(ValueError, match="Invalid preference key"):
+        store.store("u1", "BadKey", "value")
+
+
+def test_store_invalid_value_rejected(store):
+    with pytest.raises(ValueError, match="not allowed"):
+        store.store("u1", "key", {"nested": True})
+
+
+def test_store_value_too_long_rejected(store):
+    with pytest.raises(ValueError, match="maximum length"):
+        store.store("u1", "key", "x" * 4097)

--- a/deile/tests/tools/test_preference_tools.py
+++ b/deile/tests/tools/test_preference_tools.py
@@ -1,0 +1,396 @@
+"""Unit tests for ``deile.tools.preference_tools``."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from deile.tools.base import ToolContext, ToolResult, ToolStatus
+from deile.tools.preference_tools import (
+    ForgetPreferenceTool,
+    ListPreferencesTool,
+    RememberPreferenceTool,
+    _coerce_value,
+    _resolve_user_id,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_prefs_file(tmp_path: Path):
+    """Redirect the PreferenceStore backing file to a temp path."""
+    prefs_file = tmp_path / "preferences.json"
+    with patch(
+        "deile.preferences.store._PREFS_FILE", prefs_file
+    ), patch(
+        "deile.preferences.store._PREFS_DIR", tmp_path
+    ), patch(
+        "deile.tools.preference_tools.PreferenceStore",
+    ) as mock_store_cls:
+        # We use the real store but with patched file paths.
+        # So let the PreferenceStore class resolve normally.
+        pass
+
+
+def _ctx(user_id: str = "test_user", **parsed_args) -> ToolContext:
+    return ToolContext(
+        user_input="",
+        parsed_args=parsed_args,
+        session_data={"user_id": user_id},
+    )
+
+
+def _bypass_permission():
+    """Make _check_write_permission always return True."""
+    return patch(
+        "deile.tools.preference_tools._check_write_permission",
+        return_value=True,
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+class TestResolveUserId:
+    def test_from_session_data(self):
+        ctx = ToolContext(
+            user_input="",
+            parsed_args={},
+            session_data={"user_id": "alice"},
+        )
+        assert _resolve_user_id(ctx) == "alice"
+
+    def test_from_metadata(self):
+        ctx = ToolContext(
+            user_input="",
+            parsed_args={},
+            metadata={"user_id": "bob"},
+        )
+        assert _resolve_user_id(ctx) == "bob"
+
+    def test_fallback_unknown(self):
+        ctx = ToolContext(user_input="", parsed_args={})
+        assert _resolve_user_id(ctx) == "unknown"
+
+
+class TestCoerceValue:
+    def test_true_false(self):
+        assert _coerce_value("true") is True
+        assert _coerce_value("false") is False
+
+    def test_integers(self):
+        assert _coerce_value("42") == 42
+        assert _coerce_value("-7") == -7
+
+    def test_floats(self):
+        assert _coerce_value("3.14") == 3.14
+
+    def test_null_none(self):
+        assert _coerce_value("null") is None
+        assert _coerce_value("none") is None
+
+    def test_string_passthrough(self):
+        assert _coerce_value("hello world") == "hello world"
+
+
+# ── remember_preference ──────────────────────────────────────────────────
+
+
+class TestRememberPreference:
+
+    @pytest.mark.asyncio
+    async def test_success(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", key="theme", value="dark")
+            result = await tool.execute(ctx)
+
+        assert result.is_success
+        assert "stored successfully" in result.message
+
+    @pytest.mark.asyncio
+    async def test_invalid_key_rejected(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", key="BadKey!", value="x")
+            result = await tool.execute(ctx)
+
+        assert result.is_error
+        assert "Invalid preference key" in result.message
+
+    @pytest.mark.asyncio
+    async def test_value_too_long_rejected(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", key="x", value="y" * 4097)
+            result = await tool.execute(ctx)
+
+        assert result.is_error
+        assert "maximum length" in result.message
+
+    @pytest.mark.asyncio
+    async def test_missing_key(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ):
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", value="x")
+            result = await tool.execute(ctx)
+
+        assert result.is_error
+        assert "key" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_value(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ):
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", key="x")
+            result = await tool.execute(ctx)
+
+        assert result.is_error
+        assert "value" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_permission_denied(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), patch(
+            "deile.tools.preference_tools._check_write_permission",
+            return_value=False,
+        ):
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", key="theme", value="dark")
+            result = await tool.execute(ctx)
+
+        assert result.is_error
+        assert "Permission denied" in result.message
+
+    @pytest.mark.asyncio
+    async def test_boolean_coerced(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", key="auto_mode", value="true")
+            result = await tool.execute(ctx)
+
+        assert result.is_success
+        assert result.data["value"] is True
+
+    @pytest.mark.asyncio
+    async def test_dot_namespaced_key(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            tool = RememberPreferenceTool()
+            ctx = _ctx(user_id="u1", key="subagents.mode", value="manual")
+            result = await tool.execute(ctx)
+
+        assert result.is_success
+
+
+# ── list_preferences ──────────────────────────────────────────────────────
+
+
+class TestListPreferences:
+
+    @pytest.mark.asyncio
+    async def test_empty(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ):
+            tool = ListPreferencesTool()
+            ctx = _ctx(user_id="u1")
+            result = await tool.execute(ctx)
+
+        assert result.is_success
+        assert result.data["preferences"] == {}
+
+    @pytest.mark.asyncio
+    async def test_list_all(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            store_tool = RememberPreferenceTool()
+            await store_tool.execute(_ctx(user_id="u1", key="theme", value="dark"))
+            await store_tool.execute(
+                _ctx(user_id="u1", key="lang", value="pt")
+            )
+
+            list_tool = ListPreferencesTool()
+            result = await list_tool.execute(_ctx(user_id="u1"))
+
+        assert result.is_success
+        prefs = result.data["preferences"]
+        assert prefs["theme"] == "dark"
+        assert prefs["lang"] == "pt"
+
+    @pytest.mark.asyncio
+    async def test_list_with_prefix(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            store_tool = RememberPreferenceTool()
+            await store_tool.execute(
+                _ctx(user_id="u1", key="subagents.mode", value="auto")
+            )
+            await store_tool.execute(
+                _ctx(user_id="u1", key="subagents.count", value="3")
+            )
+            await store_tool.execute(
+                _ctx(user_id="u1", key="ui.theme", value="light")
+            )
+
+            list_tool = ListPreferencesTool()
+            result = await list_tool.execute(
+                _ctx(user_id="u1", prefix="subagents")
+            )
+
+        assert result.is_success
+        prefs = result.data["preferences"]
+        assert "subagents.mode" in prefs
+        assert "subagents.count" in prefs
+        assert "ui.theme" not in prefs
+
+
+# ── forget_preference ─────────────────────────────────────────────────────
+
+
+class TestForgetPreference:
+
+    @pytest.mark.asyncio
+    async def test_forget_existing(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            store_tool = RememberPreferenceTool()
+            await store_tool.execute(_ctx(user_id="u1", key="theme", value="dark"))
+
+            forget_tool = ForgetPreferenceTool()
+            result = await forget_tool.execute(_ctx(user_id="u1", key="theme"))
+
+        assert result.is_success
+        assert result.data["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_forget_nonexistent_idempotent(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), _bypass_permission():
+            tool = ForgetPreferenceTool()
+            result = await tool.execute(_ctx(user_id="u1", key="ghost"))
+
+        assert result.is_success
+        assert result.data["deleted"] is False
+        assert "did not exist" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_key(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ):
+            tool = ForgetPreferenceTool()
+            ctx = _ctx(user_id="u1")
+            result = await tool.execute(ctx)
+
+        assert result.is_error
+        assert "key" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_permission_denied(self, tmp_path: Path):
+        prefs_file = tmp_path / "preferences.json"
+        with patch(
+            "deile.preferences.store._PREFS_FILE", prefs_file
+        ), patch(
+            "deile.preferences.store._PREFS_DIR", tmp_path
+        ), patch(
+            "deile.tools.preference_tools._check_write_permission",
+            return_value=False,
+        ):
+            tool = ForgetPreferenceTool()
+            ctx = _ctx(user_id="u1", key="theme")
+            result = await tool.execute(ctx)
+
+        assert result.is_error
+        assert "Permission denied" in result.message
+
+
+# ── Tool registration ─────────────────────────────────────────────────────
+
+
+def test_tools_discoverable():
+    """All three tools should be auto-discovered via DEFAULT_TOOL_PACKAGES."""
+    from deile.tools.discovery import DEFAULT_TOOL_PACKAGES, discover_tools_in_package
+    from deile.tools.registry import ToolRegistry
+
+    assert "deile.tools.preference_tools" in DEFAULT_TOOL_PACKAGES
+
+    registry = ToolRegistry()
+    count = discover_tools_in_package(registry, "deile.tools.preference_tools")
+    assert count == 3
+
+    assert "remember_preference" in registry
+    assert "list_preferences" in registry
+    assert "forget_preference" in registry
+
+    # Verify category
+    from deile.tools.base import ToolCategory
+
+    assert registry.get("remember_preference").category == ToolCategory.SYSTEM.value
+    assert registry.get("list_preferences").category == ToolCategory.SYSTEM.value
+    assert registry.get("forget_preference").category == ToolCategory.SYSTEM.value

--- a/deile/tools/discovery.py
+++ b/deile/tools/discovery.py
@@ -42,6 +42,7 @@ DEFAULT_TOOL_PACKAGES = [
     "deile.tools.dispatch_deile_task",
     "deile.tools.dispatch_parallel_subagents",
     "deile.tools.skill_tools",
+    "deile.tools.preference_tools",
 ]
 
 

--- a/deile/tools/preference_tools.py
+++ b/deile/tools/preference_tools.py
@@ -44,8 +44,15 @@ def _resolve_user_id(context: ToolContext) -> str:
     return "unknown"
 
 
-def _check_write_permission(context: ToolContext, key: str) -> bool:
-    """Consult PermissionManager before writing. Fail-closed."""
+def _check_write_permission(
+    context: ToolContext, tool_name: str, key: str
+) -> bool:
+    """Consult PermissionManager before writing. Fail-closed.
+
+    *tool_name* is the invoking tool (``remember_preference`` or
+    ``forget_preference``) — passed through so operators can write rules
+    that differentiate the two (e.g. allow remember, deny forget).
+    """
     try:
         from ..security.permissions import get_permission_manager
 
@@ -60,7 +67,7 @@ def _check_write_permission(context: ToolContext, key: str) -> bool:
     try:
         return bool(
             pm.check_permission(
-                tool_name="remember_preference",
+                tool_name=tool_name,
                 resource=resource,
                 action="write",
                 context={"key": key},
@@ -149,7 +156,7 @@ class RememberPreferenceTool(Tool):
         except ValueError as exc:
             return ToolResult.error_result(message=str(exc))
 
-        if not _check_write_permission(context, key):
+        if not _check_write_permission(context, "remember_preference", key):
             return ToolResult.error_result(
                 message=(
                     "Permission denied: preference writes are not enabled. "
@@ -274,7 +281,7 @@ class ForgetPreferenceTool(Tool):
 
         user_id = _resolve_user_id(context)
 
-        if not _check_write_permission(context, key):
+        if not _check_write_permission(context, "forget_preference", key):
             return ToolResult.error_result(
                 message=(
                     "Permission denied: preference writes are not enabled. "

--- a/deile/tools/preference_tools.py
+++ b/deile/tools/preference_tools.py
@@ -1,0 +1,331 @@
+"""Function-call tools for managing user preferences.
+
+Three tools — ``remember_preference``, ``list_preferences``,
+``forget_preference`` — backed by :class:`~deile.preferences.store.PreferenceStore`.
+Auto-discovery picks them up via ``DEFAULT_TOOL_PACKAGES``.
+
+Security: writes pass through :class:`~deile.security.permissions.PermissionManager`
+before touching disk (fail-closed, aligned with ``settings_write``). Secrets
+and PII must never be stored — the tool description warns LLMs of this.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from ..preferences.store import PreferenceStore
+from .base import (
+    SecurityLevel,
+    Tool,
+    ToolCategory,
+    ToolContext,
+    ToolResult,
+    ToolSchema,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _resolve_user_id(context: ToolContext) -> str:
+    """Best-effort extract a user_id from the tool context.
+
+    Probes ``session_data``, then ``metadata``, then ``extra``. Falls back
+    to ``"unknown"`` when no id is discoverable (tests and unattended
+    environments).
+    """
+    for source in (context.session_data, context.metadata, context.extra):
+        uid = source.get("user_id") if isinstance(source, dict) else None
+        if uid:
+            return str(uid)
+    return "unknown"
+
+
+def _check_write_permission(context: ToolContext, key: str) -> bool:
+    """Consult PermissionManager before writing. Fail-closed."""
+    try:
+        from ..security.permissions import get_permission_manager
+
+        pm = get_permission_manager()
+    except Exception:
+        logger.exception("preference_tools: cannot resolve PermissionManager")
+        return False
+    if pm is None:
+        logger.warning("preference_tools: no PermissionManager — denying write")
+        return False
+    resource = f"preferences:{_resolve_user_id(context)}:{key}"
+    try:
+        return bool(
+            pm.check_permission(
+                tool_name="remember_preference",
+                resource=resource,
+                action="write",
+                context={"key": key},
+            )
+        )
+    except Exception:
+        logger.exception("preference_tools: PermissionManager raised — denying")
+        return False
+
+
+# ── Tool definitions ─────────────────────────────────────────────────────
+
+
+class RememberPreferenceTool(Tool):
+    """Persist a user preference (key + value)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="remember_preference",
+                description=(
+                    "Store a user preference as a key-value pair. "
+                    "Preferences persist across sessions in "
+                    "~/.deile/preferences.json. Use this when the user says "
+                    "'remember that I prefer…', 'save this setting…', or "
+                    "'always do X for me'. "
+                    "⚠️ NEVER store secrets, tokens, passwords, API keys "
+                    "or PII. This is for preferences only, NOT secrets. "
+                    "Keys must be snake_case (a-z, 0-9, _, .) starting "
+                    "with a letter, max 128 chars. Values must be string, "
+                    "number, boolean, or null, max 4096 chars."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "description": (
+                                "Preference key in snake_case with optional "
+                                "dot-namespace (e.g. 'subagents.mode', "
+                                "'ui.theme'). Must match [a-z][a-z0-9_.]{0,127}."
+                            ),
+                        },
+                        "value": {
+                            "type": "string",
+                            "description": (
+                                "Value to store. Pass booleans and numbers "
+                                "as their string representation (e.g. 'true', "
+                                "'42'). Max 4096 chars."
+                            ),
+                        },
+                    },
+                    "required": ["key", "value"],
+                },
+                required=["key", "value"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+        self._store = PreferenceStore()
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        key = context.parsed_args.get("key")
+        value = context.parsed_args.get("value")
+
+        if not key or not isinstance(key, str):
+            return ToolResult.error_result(
+                message="remember_preference requires a non-empty `key` argument."
+            )
+        if value is None:
+            return ToolResult.error_result(
+                message="remember_preference requires a `value` argument."
+            )
+
+        user_id = _resolve_user_id(context)
+
+        # Coerce booleans and numbers
+        coerced_value = _coerce_value(value)
+
+        # Validate
+        from ..preferences.store import _validate_key, _validate_value
+
+        try:
+            _validate_key(key)
+            _validate_value(coerced_value)
+        except ValueError as exc:
+            return ToolResult.error_result(message=str(exc))
+
+        if not _check_write_permission(context, key):
+            return ToolResult.error_result(
+                message=(
+                    "Permission denied: preference writes are not enabled. "
+                    "Ask the operator to add a 'preferences_write' rule in "
+                    "config/permissions.yaml."
+                ),
+                error_code="PERMISSION_DENIED",
+            )
+
+        try:
+            self._store.store(user_id, key, coerced_value)
+        except Exception as exc:
+            return ToolResult.error_result(
+                message=f"Failed to store preference '{key}': {exc}"
+            )
+
+        return ToolResult.success_result(
+            data={"key": key, "value": coerced_value},
+            message=f"Preference '{key}' stored successfully.",
+        )
+
+
+class ListPreferencesTool(Tool):
+    """List all preferences for the current user, optionally filtered."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="list_preferences",
+                description=(
+                    "List all stored preferences for the current user. "
+                    "Pass an optional `prefix` to filter by key prefix "
+                    "(e.g. 'subagents' returns 'subagents.mode', "
+                    "'subagents.count', etc.). Returns a dict of key-value "
+                    "pairs."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "prefix": {
+                            "type": "string",
+                            "description": (
+                                "Optional key prefix to filter results "
+                                "(e.g. 'ui', 'subagents')."
+                            ),
+                        },
+                    },
+                },
+                security_level=SecurityLevel.SAFE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+        self._store = PreferenceStore()
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        user_id = _resolve_user_id(context)
+        prefix = context.parsed_args.get("prefix")
+
+        try:
+            all_prefs = self._store.get_all(user_id)
+        except Exception as exc:
+            return ToolResult.error_result(
+                message=f"Failed to read preferences: {exc}"
+            )
+
+        if prefix and isinstance(prefix, str):
+            filtered: Dict[str, Any] = {}
+            for k, v in all_prefs.items():
+                if k.startswith(prefix):
+                    filtered[k] = v
+            all_prefs = filtered
+
+        if not all_prefs:
+            return ToolResult.success_result(
+                data={"preferences": {}},
+                message="No preferences stored yet.",
+            )
+
+        lines = "\n".join(f"  {k}: {v!r}" for k, v in sorted(all_prefs.items()))
+        return ToolResult.success_result(
+            data={"preferences": all_prefs},
+            message=f"Preferences:\n{lines}",
+        )
+
+
+class ForgetPreferenceTool(Tool):
+    """Remove a user preference by key. Idempotent."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="forget_preference",
+                description=(
+                    "Delete a stored preference by key. Idempotent — "
+                    "removing a key that doesn't exist succeeds silently. "
+                    "Use this when the user says 'forget that I said…', "
+                    "'remove the preference…', or 'stop always doing X'."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "description": "Preference key to remove.",
+                        },
+                    },
+                    "required": ["key"],
+                },
+                required=["key"],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.SYSTEM,
+            )
+        )
+        self._store = PreferenceStore()
+
+    async def execute(self, context: ToolContext) -> ToolResult:
+        key = context.parsed_args.get("key")
+        if not key or not isinstance(key, str):
+            return ToolResult.error_result(
+                message="forget_preference requires a non-empty `key` argument."
+            )
+
+        user_id = _resolve_user_id(context)
+
+        if not _check_write_permission(context, key):
+            return ToolResult.error_result(
+                message=(
+                    "Permission denied: preference writes are not enabled. "
+                    "Ask the operator to add a 'preferences_write' rule in "
+                    "config/permissions.yaml."
+                ),
+                error_code="PERMISSION_DENIED",
+            )
+
+        try:
+            existed = self._store.delete(user_id, key)
+        except Exception as exc:
+            return ToolResult.error_result(
+                message=f"Failed to delete preference '{key}': {exc}"
+            )
+
+        if existed:
+            return ToolResult.success_result(
+                data={"key": key, "deleted": True},
+                message=f"Preference '{key}' removed.",
+            )
+        return ToolResult.success_result(
+            data={"key": key, "deleted": False},
+            message=f"Preference '{key}' did not exist (no-op).",
+        )
+
+
+# ── Value coercion ───────────────────────────────────────────────────────
+
+
+def _coerce_value(raw: str) -> Any:
+    """Try to infer the intended type of *raw* (a string from LLM output).
+
+    - ``"true"`` / ``"false"`` → bool
+    - integer/float strings → number
+    - ``"null"`` / ``"none"`` → None
+    - anything else stays as string
+    """
+    if not isinstance(raw, str):
+        return raw
+    lowered = raw.strip().lower()
+    if lowered in ("true", "false"):
+        return lowered == "true"
+    if lowered in ("null", "none"):
+        return None
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        pass
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        pass
+    return raw


### PR DESCRIPTION
## Summary

Implements the backend persistence layer for user preferences (`deile/preferences/`) and three native function-calling tools — `remember_preference`, `list_preferences`, `forget_preference` — that DEILE can invoke directly, eliminating manual workarounds (editing CLAUDE.md, shelling out to deile memory).

## What was done

### PreferenceStore (`deile/preferences/store.py`)
- Per-user key-value store backed by `~/.deile/preferences.json`
- Atomic writes via deterministic temp file + `os.replace` (avoids `mkstemp` inode exhaustion on tmpfs containers)
- File locking (`fcntl.flock`) for concurrent writer safety
- Read-after-lock reads from file path (not stale fd) for correctness
- Validation: keys must match `^[a-z][a-z0-9_.]{0,127}$`, values: string/number/boolean/null, max 4096 chars

### Three Native Tools (`deile/tools/preference_tools.py`)
| Tool | Category | Security | Description |
|---|---|---|---|
| `remember_preference` | SYSTEM | MODERATE | Persist key-value with type coercion; PermissionManager-gated |
| `list_preferences` | SYSTEM | SAFE | List all or filter by prefix |
| `forget_preference` | SYSTEM | MODERATE | Idempotent deletion; PermissionManager-gated |

### Registration
- Added `deile.tools.preference_tools` to `DEFAULT_TOOL_PACKAGES` in `deile/tools/discovery.py`
- All three tools auto-discovered and available via function calling

### Tests
- **64 tests total** — 34 for PreferenceStore CRUD/concurrency/recovery, 24 for the three tools, 1 for tool discovery/registration
- All 64 pass. No regressions in broader `deile/tests/tools/`, `deile/tests/cli/`, `deile/tests/core/` (720/724 pass; 4 pre-existing unrelated failures in messaging approval tests)

## Key design decisions
1. **Deterministic temp file** (`.preferences.tmp`) instead of `mkstemp` — avoids inode exhaustion on 64MB tmpfs containers
2. **Read from file path after flock** — stale fd after `os.replace` would cause concurrent thread data loss
3. **PermissionManager fail-closed** — write tools check permissions before touching disk

Closes #340

---
By [DEILE-One](mailto:deile@deile.info)