### PR TITLE
feat(357): /settings slash command suite (set, get, list, unset, where)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@
 # Versão: fase 3 (#309)
 #
 # Nota: variáveis marcadas com [DEPRECATED] ainda funcionam mas devem ser
-# migradas para ~/.deile/settings.json. Use `/settings set <chave> <valor>`
-# no CLI do DEILE para migrar.
+# migradas para ~/.deile/settings.json via `/settings set <chave> <valor>`.
+# Exemplo: /settings set model.preferred anthropic:claude-sonnet-4-6
 # ============================================================================
 
 # ----------------------------------------------------------------------------
@@ -30,8 +30,8 @@ GOOGLE_API_KEY=
 
 # Modelo preferido global — formato "provider:modelo" (ex: anthropic:claude-sonnet-4-6).
 # Pode ser sobrescrito por stage via DEILE_PIPELINE_MODEL_<STAGE>.
-# Migrar para settings.json: /settings set model.preferred anthropic:claude-sonnet-4-6
 # [DEPRECATED → settings.json: model.preferred]
+# Exemplo: /settings set model.preferred anthropic:claude-sonnet-4-6
 # DEILE_PREFERRED_MODEL=anthropic:claude-sonnet-4-6
 
 # Modelo usado pela ferramenta de visão (análise de imagens).

--- a/deile/commands/builtin/settings_command.py
+++ b/deile/commands/builtin/settings_command.py
@@ -134,20 +134,13 @@ def _coerce_value(key_path: str, raw: str) -> Any:
     return raw
 
 
-def _determine_origin(mgr: Any, key_path: str) -> str:
-    """Return the layer name ('env', 'project', 'user', 'default') that wins."""
-    from deile.config.settings import _JSON_ONLY_FIELD_MAP, _OVERRIDE_HANDLERS
+def _json_layer_origin(mgr: Any, key_path: str) -> str:
+    """Return the JSON layer ('project', 'user', 'default') that wins.
 
-    field_name = None
-    if key_path in _OVERRIDE_HANDLERS:
-        field_name = _OVERRIDE_HANDLERS[key_path][0]
-    elif key_path in _JSON_ONLY_FIELD_MAP:
-        field_name = _JSON_ONLY_FIELD_MAP[key_path]
-
-    env_var = _env_var_for_key(key_path)
-    if env_var and os.environ.get(env_var):
-        return "env"
-
+    This mirrors the resolution order used by :meth:`SettingsManager.get_setting`
+    (deep-merge: project overrides user). Env vars are NOT considered here —
+    use :func:`_resolve_effective` for the full picture including env overrides.
+    """
     proj_data = mgr.get_layer("project")
     proj_found, _ = _resolve_dotted_in_dict(proj_data, key_path)
     if proj_found:
@@ -159,6 +152,48 @@ def _determine_origin(mgr: Any, key_path: str) -> str:
         return "user"
 
     return "default"
+
+
+def _resolve_effective(mgr: Any, key_path: str) -> tuple[Any, str]:
+    """Return (effective_value, origin_layer) for *key_path*.
+
+    Resolution order (matches :class:`~deile.config.settings.Settings`):
+    1. Env var override (if set) → origin ``"env"``
+    2. Project JSON layer        → origin ``"project"``
+    3. User/global JSON layer    → origin ``"user"``
+    4. Dataclass default         → origin ``"default"``
+    5. Not set                   → origin ``"not set"``
+
+    The value for ``"env"`` origin is the raw env-var string (coerced via
+    the same converter used by the Settings dataclass). For JSON layers
+    the value comes from :meth:`SettingsManager.get_setting`.
+    """
+    from deile.config.settings import _OVERRIDE_HANDLERS
+
+    # 1. Env var override
+    env_var = _env_var_for_key(key_path)
+    if env_var:
+        raw = os.environ.get(env_var)
+        if raw is not None and raw != "":
+            # Coerce through the same converter used by Settings
+            if key_path in _OVERRIDE_HANDLERS:
+                _field_name, converter = _OVERRIDE_HANDLERS[key_path]
+                try:
+                    return converter(raw), "env"
+                except (ValueError, TypeError):
+                    pass
+            return raw, "env"
+
+    # 2-4. JSON layers + dataclass default
+    effective = mgr.get_setting(key_path)
+    if effective is not None:
+        return effective, _json_layer_origin(mgr, key_path)
+
+    default = _default_value(key_path)
+    if default is not None:
+        return default, "default"
+
+    return None, "not set"
 
 
 def _check_project_trust(mgr: Any) -> Optional[str]:
@@ -289,17 +324,7 @@ class SettingsCommand(DirectCommand):
             return CommandResult.error_result("Usage: /settings get <key>")
 
         mgr = SettingsManager()
-
-        effective = mgr.get_setting(key)
-        if effective is None:
-            default = _default_value(key)
-            if default is not None:
-                effective = default
-                origin = "default"
-            else:
-                origin = "not set"
-        else:
-            origin = _determine_origin(mgr, key)
+        effective, origin = _resolve_effective(mgr, key)
 
         table = Table(show_header=False, box=None, padding=(0, 1))
         table.add_column("Field", style="cyan")
@@ -328,14 +353,10 @@ class SettingsCommand(DirectCommand):
         table.add_column("Origin", style="dim")
 
         for key in all_keys:
-            effective = mgr.get_setting(key)
-            if effective is None:
-                default = _default_value(key)
-                value_str = _truncate(default) if default is not None else "(not set)"
-                origin = "default" if default is not None else "—"
-            else:
-                value_str = _truncate(effective)
-                origin = _determine_origin(mgr, key)
+            effective, origin = _resolve_effective(mgr, key)
+            value_str = _truncate(effective) if effective is not None else "(not set)"
+            if effective is None and origin == "not set":
+                origin = "—"
             table.add_row(key, value_str, origin)
 
         return CommandResult.success_result(table, "rich")
@@ -391,14 +412,23 @@ class SettingsCommand(DirectCommand):
         proj_found, proj_val = _resolve_dotted_in_dict(project_data, key)
 
         env_var = _env_var_for_key(key)
-        env_val = os.environ.get(env_var) if env_var else None
+        env_val_raw = os.environ.get(env_var) if env_var else None
+        # Coerce env value to match the resolved effective value
+        env_val: Any = None
+        env_has_value = False
+        if env_val_raw is not None and env_val_raw != "":
+            from deile.config.settings import _OVERRIDE_HANDLERS
+            env_has_value = True
+            if key in _OVERRIDE_HANDLERS:
+                _field_name, converter = _OVERRIDE_HANDLERS[key]
+                try:
+                    env_val = converter(env_val_raw)
+                except (ValueError, TypeError):
+                    env_val = env_val_raw
+            else:
+                env_val = env_val_raw
 
-        effective = mgr.get_setting(key)
-        if effective is None and default_val is not None:
-            effective = default_val
-        origin = _determine_origin(mgr, key)
-        if effective is None:
-            origin = "not set"
+        effective, origin = _resolve_effective(mgr, key)
 
         table = Table(title=f"Settings layers for: {key}", show_lines=True)
         table.add_column("Layer", style="cyan")
@@ -427,13 +457,22 @@ class SettingsCommand(DirectCommand):
             str(project_path),
             _wins("project"),
         )
-        env_display = env_var if env_var else "(no env var for this key)"
-        table.add_row(
-            "env",
-            _truncate(env_val) if env_val else "— (not set)",
-            env_display,
-            _wins("env"),
-        )
+        if env_has_value:
+            env_display = env_var if env_var else "(no env var for this key)"
+            table.add_row(
+                "env",
+                _truncate(env_val),
+                env_display,
+                _wins("env"),
+            )
+        else:
+            env_display = env_var if env_var else "(no env var for this key)"
+            table.add_row(
+                "env",
+                "— (not set)",
+                env_display,
+                _wins("env"),
+            )
 
         summary = (
             f"\nEffective value: [bold]{_truncate(effective) if effective is not None else '(not set)'}[/bold]"

--- a/deile/commands/builtin/settings_command.py
+++ b/deile/commands/builtin/settings_command.py
@@ -1,0 +1,479 @@
+"""Settings command — read/write ~/.deile/settings.json via slash commands.
+
+Subcommands:
+    /settings set <key> <value> [--scope=user|project]
+    /settings get <key>
+    /settings list [<prefix>]          aliases: ls
+    /settings unset <key> [--scope=user|project]  aliases: rm
+    /settings where <key>
+
+Scope aliases: ``user`` maps to ``global`` (SettingsManager), ``project``
+maps to ``project``. Default scope for writes is ``user`` (global).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from rich.table import Table
+
+from ..base import CommandContext, CommandResult, DirectCommand
+from ..settings_manager import SettingsManager
+
+_SCOPE_MAP = {"user": "global", "global": "global", "project": "project"}
+
+
+def _parse_scope_flag(rest: str) -> tuple[str, str]:
+    """Extract ``--scope=<s>`` from *rest*. Returns (cleaned_rest, scope)."""
+    scope = "global"
+    parts = rest.split()
+    kept = []
+    for tok in parts:
+        if tok.startswith("--scope="):
+            raw = tok[len("--scope="):].strip().lower()
+            scope = _SCOPE_MAP.get(raw, "global")
+        else:
+            kept.append(tok)
+    return " ".join(kept), scope
+
+
+def _truncate(value: Any, max_len: int = 80) -> str:
+    s = repr(value) if not isinstance(value, str) else value
+    return s[:max_len] + "…" if len(s) > max_len else s
+
+
+def _all_known_keys() -> list[str]:
+    """Return sorted list of all known settings dot-paths."""
+    from deile.config.settings import _JSON_ONLY_FIELD_MAP, _OVERRIDE_HANDLERS
+    keys = set(_OVERRIDE_HANDLERS.keys()) | set(_JSON_ONLY_FIELD_MAP.keys())
+    return sorted(keys)
+
+
+def _default_value(key_path: str) -> Any:
+    """Return the dataclass default for *key_path*, or None if unknown."""
+    from deile.config.settings import _JSON_ONLY_FIELD_MAP, _OVERRIDE_HANDLERS, Settings
+
+    field_name = None
+    if key_path in _OVERRIDE_HANDLERS:
+        field_name = _OVERRIDE_HANDLERS[key_path][0]
+    elif key_path in _JSON_ONLY_FIELD_MAP:
+        field_name = _JSON_ONLY_FIELD_MAP[key_path]
+
+    if field_name is None:
+        return None
+
+    for f in dataclasses.fields(Settings):
+        if f.name == field_name:
+            if f.default is not dataclasses.MISSING:
+                return f.default
+            if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+                return f.default_factory()  # type: ignore[misc]
+            return None
+    return None
+
+
+def _resolve_dotted_in_dict(data: dict, key_path: str) -> tuple[bool, Any]:
+    node: Any = data
+    for part in key_path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False, None
+        node = node[part]
+    return True, node
+
+
+def _env_var_for_key(key_path: str) -> Optional[str]:
+    """Return the env var name that overrides *key_path*, if any."""
+    from deile.config.settings import _ENV_OVERRIDES, _JSON_ONLY_FIELD_MAP, _OVERRIDE_HANDLERS
+
+    field_name = None
+    if key_path in _OVERRIDE_HANDLERS:
+        field_name = _OVERRIDE_HANDLERS[key_path][0]
+    elif key_path in _JSON_ONLY_FIELD_MAP:
+        field_name = _JSON_ONLY_FIELD_MAP[key_path]
+
+    if field_name is None:
+        return None
+
+    for env_var, attr, _conv in _ENV_OVERRIDES:
+        if attr == field_name:
+            return env_var
+    return None
+
+
+def _coerce_value(key_path: str, raw: str) -> Any:
+    """Coerce *raw* string to the appropriate Python type for *key_path*.
+
+    Looks up the converter from ``_OVERRIDE_HANDLERS`` and applies it.
+    Falls back to a best-effort heuristic (bool → int → float → str).
+    """
+    from deile.config.settings import _OVERRIDE_HANDLERS
+
+    if key_path in _OVERRIDE_HANDLERS:
+        _field_name, converter = _OVERRIDE_HANDLERS[key_path]
+        try:
+            return converter(raw)
+        except (ValueError, TypeError):
+            pass
+
+    lower = raw.lower().strip()
+    if lower in ("true", "yes", "on"):
+        return True
+    if lower in ("false", "no", "off"):
+        return False
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    return raw
+
+
+def _determine_origin(mgr: Any, key_path: str) -> str:
+    """Return the layer name ('env', 'project', 'user', 'default') that wins."""
+    from deile.config.settings import _JSON_ONLY_FIELD_MAP, _OVERRIDE_HANDLERS
+
+    field_name = None
+    if key_path in _OVERRIDE_HANDLERS:
+        field_name = _OVERRIDE_HANDLERS[key_path][0]
+    elif key_path in _JSON_ONLY_FIELD_MAP:
+        field_name = _JSON_ONLY_FIELD_MAP[key_path]
+
+    env_var = _env_var_for_key(key_path)
+    if env_var and os.environ.get(env_var):
+        return "env"
+
+    proj_data = mgr.get_layer("project")
+    proj_found, _ = _resolve_dotted_in_dict(proj_data, key_path)
+    if proj_found:
+        return "project"
+
+    user_data = mgr.get_layer("global")
+    user_found, _ = _resolve_dotted_in_dict(user_data, key_path)
+    if user_found:
+        return "user"
+
+    return "default"
+
+
+def _check_project_trust(mgr: Any) -> Optional[str]:
+    """Return an error string if cwd is not in the project layer allowlist."""
+    from deile.config.settings import get_settings
+
+    settings = get_settings()
+    cwd = str(Path.cwd().resolve())
+    dirs = [str(Path(d).resolve()) for d in (settings.trust_project_layer_dirs or [])]
+    if cwd not in dirs:
+        return (
+            f"Project scope is not trusted for the current directory ({cwd}).\n"
+            "To enable it, run:\n"
+            f"  /settings set trust.project_layer_dirs [\"{cwd}\"]"
+        )
+    return None
+
+
+class SettingsCommand(DirectCommand):
+    """Manage ~/.deile/settings.json via slash commands."""
+
+    cli_flag = "--settings"
+    cli_takes_arg = True
+    cli_arg_metavar = "SUBCOMMAND [ARGS]"
+    cli_help = (
+        "Read/write ~/.deile/settings.json "
+        "(e.g. --settings 'set pipeline.poll_interval 120')."
+    )
+    cli_requires_provider = False
+
+    def __init__(self):
+        from ...config.manager import CommandConfig
+        super().__init__(CommandConfig(
+            name="settings",
+            description=(
+                "Read and write ~/.deile/settings.json — "
+                "set, get, list, unset, where."
+            ),
+            aliases=["settings"],
+        ))
+        self.config.aliases = ["settings"]
+
+    @property
+    def name(self) -> str:
+        return "settings"
+
+    @property
+    def aliases(self) -> list:
+        return []
+
+    async def execute(self, context: CommandContext) -> CommandResult:
+        args = (getattr(context, "args", "") or "").strip()
+        if not args:
+            return CommandResult.success_result(self._help_text(), "text")
+
+        parts = args.split(maxsplit=1)
+        subcommand = parts[0].lower()
+        rest = parts[1].strip() if len(parts) > 1 else ""
+
+        if subcommand in ("ls",):
+            subcommand = "list"
+        elif subcommand in ("rm",):
+            subcommand = "unset"
+
+        if subcommand == "set":
+            return await self._cmd_set(rest)
+        if subcommand == "get":
+            return await self._cmd_get(rest)
+        if subcommand == "list":
+            return await self._cmd_list(rest)
+        if subcommand == "unset":
+            return await self._cmd_unset(rest)
+        if subcommand == "where":
+            return await self._cmd_where(rest)
+        if subcommand in ("help", "--help", "-h"):
+            return CommandResult.success_result(self._help_text(), "text")
+
+        return CommandResult.error_result(
+            f"Unknown subcommand: {subcommand!r}. "
+            "Use: set, get, list (ls), unset (rm), where, or --help."
+        )
+
+    # ------------------------------------------------------------------
+    # Subcommands
+    # ------------------------------------------------------------------
+
+    async def _cmd_set(self, rest: str) -> CommandResult:
+        rest, scope = _parse_scope_flag(rest)
+        parts = rest.split(maxsplit=1)
+        if len(parts) < 2:
+            return CommandResult.error_result(
+                "Usage: /settings set <key> <value> [--scope=user|project]\n"
+                "Example: /settings set pipeline.poll_interval 120"
+            )
+        key, raw_value = parts[0], parts[1]
+
+        value = _coerce_value(key, raw_value)
+
+        mgr = SettingsManager()
+
+        # Project scope requires trust opt-in — check before writing.
+        if scope == "project":
+            err = _check_project_trust(mgr)
+            if err:
+                return CommandResult.error_result(err)
+
+        try:
+            ok = mgr.set_setting(key, value, scope=scope)
+        except ValueError as exc:
+            return CommandResult.error_result(f"Cannot set {key!r}: {exc}")
+        except Exception as exc:
+            return CommandResult.error_result(f"Failed to write settings: {exc}")
+
+        if ok:
+            scope_label = "user (~/.deile/settings.json)" if scope == "global" else "project (.deile/settings.json)"
+            return CommandResult.success_result(
+                f"Set {key} = {_truncate(value)} in {scope_label}",
+                "text",
+            )
+        return CommandResult.error_result(
+            f"Could not set {key!r}. "
+            "Possible reasons: key looks like a secret, permission denied, or type mismatch."
+        )
+
+    async def _cmd_get(self, rest: str) -> CommandResult:
+        key = rest.strip()
+        if not key:
+            return CommandResult.error_result("Usage: /settings get <key>")
+
+        mgr = SettingsManager()
+
+        effective = mgr.get_setting(key)
+        if effective is None:
+            default = _default_value(key)
+            if default is not None:
+                effective = default
+                origin = "default"
+            else:
+                origin = "not set"
+        else:
+            origin = _determine_origin(mgr, key)
+
+        table = Table(show_header=False, box=None, padding=(0, 1))
+        table.add_column("Field", style="cyan")
+        table.add_column("Value")
+        table.add_row("key", key)
+        table.add_row("value", str(effective) if effective is not None else "(not set)")
+        table.add_row("origin", origin)
+        return CommandResult.success_result(table, "rich")
+
+    async def _cmd_list(self, rest: str) -> CommandResult:
+        prefix = rest.strip()
+
+        mgr = SettingsManager()
+
+        all_keys = _all_known_keys()
+        if prefix:
+            all_keys = [k for k in all_keys if k.startswith(prefix)]
+
+        if not all_keys:
+            msg = f"No settings found matching prefix {prefix!r}." if prefix else "No settings found."
+            return CommandResult.success_result(msg, "text")
+
+        table = Table(title="Settings", show_lines=False)
+        table.add_column("Key", style="cyan")
+        table.add_column("Value", style="green")
+        table.add_column("Origin", style="dim")
+
+        for key in all_keys:
+            effective = mgr.get_setting(key)
+            if effective is None:
+                default = _default_value(key)
+                value_str = _truncate(default) if default is not None else "(not set)"
+                origin = "default" if default is not None else "—"
+            else:
+                value_str = _truncate(effective)
+                origin = _determine_origin(mgr, key)
+            table.add_row(key, value_str, origin)
+
+        return CommandResult.success_result(table, "rich")
+
+    async def _cmd_unset(self, rest: str) -> CommandResult:
+        rest, scope = _parse_scope_flag(rest)
+        key = rest.strip()
+        if not key:
+            return CommandResult.error_result(
+                "Usage: /settings unset <key> [--scope=user|project]"
+            )
+
+        mgr = SettingsManager()
+
+        if scope == "project":
+            err = _check_project_trust(mgr)
+            if err:
+                return CommandResult.error_result(err)
+
+        try:
+            ok = mgr.unset_setting(key, scope=scope)
+        except ValueError as exc:
+            return CommandResult.error_result(f"Cannot unset {key!r}: {exc}")
+        except Exception as exc:
+            return CommandResult.error_result(f"Failed to unset setting: {exc}")
+
+        if ok:
+            scope_label = "user" if scope == "global" else "project"
+            return CommandResult.success_result(
+                f"Removed {key!r} from {scope_label} settings. "
+                "Next read will return the layer below or the default.",
+                "text",
+            )
+        return CommandResult.error_result(
+            f"Could not unset {key!r}. Possible reasons: key looks like a secret or permission denied."
+        )
+
+    async def _cmd_where(self, rest: str) -> CommandResult:
+        key = rest.strip()
+        if not key:
+            return CommandResult.error_result("Usage: /settings where <key>")
+
+        mgr = SettingsManager()
+
+        default_val = _default_value(key)
+        user_path = mgr.global_settings_path
+        project_path = mgr.project_settings_path
+
+        user_data = mgr.get_layer("global")
+        project_data = mgr.get_layer("project")
+
+        user_found, user_val = _resolve_dotted_in_dict(user_data, key)
+        proj_found, proj_val = _resolve_dotted_in_dict(project_data, key)
+
+        env_var = _env_var_for_key(key)
+        env_val = os.environ.get(env_var) if env_var else None
+
+        effective = mgr.get_setting(key)
+        if effective is None and default_val is not None:
+            effective = default_val
+        origin = _determine_origin(mgr, key)
+        if effective is None:
+            origin = "not set"
+
+        table = Table(title=f"Settings layers for: {key}", show_lines=True)
+        table.add_column("Layer", style="cyan")
+        table.add_column("Value", style="green")
+        table.add_column("Source", style="dim")
+        table.add_column("Wins?")
+
+        def _wins(layer: str) -> str:
+            return "[bold green]← wins[/bold green]" if origin == layer else ""
+
+        table.add_row(
+            "default",
+            _truncate(default_val) if default_val is not None else "—",
+            "(dataclass default)",
+            _wins("default"),
+        )
+        table.add_row(
+            "user",
+            _truncate(user_val) if user_found else "— (not set)",
+            str(user_path),
+            _wins("user"),
+        )
+        table.add_row(
+            "project",
+            _truncate(proj_val) if proj_found else "— (not set)",
+            str(project_path),
+            _wins("project"),
+        )
+        env_display = env_var if env_var else "(no env var for this key)"
+        table.add_row(
+            "env",
+            _truncate(env_val) if env_val else "— (not set)",
+            env_display,
+            _wins("env"),
+        )
+
+        summary = (
+            f"\nEffective value: [bold]{_truncate(effective) if effective is not None else '(not set)'}[/bold]"
+            f"  (origin: {origin})"
+        )
+        from rich.console import Group
+        from rich.text import Text
+        content = Group(table, Text.from_markup(summary))
+        return CommandResult.success_result(content, "rich")
+
+    # ------------------------------------------------------------------
+    # Help
+    # ------------------------------------------------------------------
+
+    def _help_text(self) -> str:
+        return """\
+Manage ~/.deile/settings.json — layered settings for DEILE.
+
+Usage:
+  /settings set <key> <value> [--scope=user|project]
+      Write a value. Default scope: user (~/.deile/settings.json).
+      Example: /settings set pipeline.poll_interval 120
+
+  /settings get <key>
+      Show the effective value and its origin layer.
+      Example: /settings get pipeline.poll_interval
+
+  /settings list [<prefix>]         (alias: ls)
+      List all settings, optionally filtered by prefix.
+      Example: /settings list pipeline
+
+  /settings unset <key> [--scope=user|project]   (alias: rm)
+      Remove a key from the specified scope (falls back to lower layer).
+      Example: /settings unset pipeline.poll_interval
+
+  /settings where <key>
+      Show each layer's value and which one wins.
+      Example: /settings where pipeline.poll_interval
+
+Notes:
+  • Keys matching secret patterns (token, key, secret, password, api_) are blocked.
+  • Project scope requires opt-in via trust.project_layer_dirs in ~/.deile/settings.json.
+  • Type coercion is automatic: "true"/"false" → bool, numeric strings → int/float."""

--- a/deile/commands/settings_manager.py
+++ b/deile/commands/settings_manager.py
@@ -734,3 +734,96 @@ class SettingsManager:
                 },
             )
         return saved
+
+    def unset_setting(self, key_path: str, scope: str = GLOBAL) -> bool:
+        """Remove *key_path* from *scope*'s settings file.
+
+        The key is deleted from the innermost nested dict it lives in.
+        After deletion, if the parent dict becomes empty it is left in place
+        (pruning empty dicts is deliberately avoided to keep the file stable).
+
+        Refuses keys that look like secrets (same blocklist as
+        :meth:`set_setting`). Goes through the same permission / audit
+        pipeline. Invalidates the singleton after a successful write.
+
+        Args:
+            key_path: Dotted key, e.g. ``"logging.level"``.
+            scope:    ``"global"`` (default) or ``"project"``.
+
+        Returns:
+            ``True`` if the key was removed (or was already absent);
+            ``False`` on I/O error, secret refusal, or permission denial.
+        """
+        from deile.config.settings import reset_settings
+
+        self._validate_scope(scope)
+        parts = self._split_key_path(key_path)
+
+        if _is_secret_key(key_path):
+            logger.error(
+                "unset_setting: refusing to operate on potential secret key %r",
+                key_path,
+            )
+            _emit_settings_audit(
+                scope=scope,
+                resource_detail=key_path,
+                action="delete",
+                result="refused_secret",
+                details={"key_path": key_path, "scope": scope, "reason": "secret_pattern"},
+            )
+            return False
+
+        if not _check_settings_write_permission(scope, key_path):
+            _emit_settings_audit(
+                scope=scope,
+                resource_detail=key_path,
+                action="delete",
+                result="denied",
+                details={"key_path": key_path, "scope": scope, "reason": "permission_denied"},
+            )
+            logger.warning(
+                "unset_setting: permission denied for %r in %s scope", key_path, scope
+            )
+            return False
+
+        if scope == GLOBAL:
+            self._ensure_global_dir()
+        path = self._settings_path(scope)
+
+        with _file_lock:
+            data = self._load(path)
+            node: Any = data
+            for part in parts[:-1]:
+                if not isinstance(node, dict) or part not in node:
+                    # Key already absent — treat as success.
+                    _emit_settings_audit(
+                        scope=scope,
+                        resource_detail=key_path,
+                        action="delete",
+                        result="allowed",
+                        details={"key_path": key_path, "scope": scope, "was_present": False},
+                    )
+                    return True
+                node = node[part]
+            if not isinstance(node, dict) or parts[-1] not in node:
+                _emit_settings_audit(
+                    scope=scope,
+                    resource_detail=key_path,
+                    action="delete",
+                    result="allowed",
+                    details={"key_path": key_path, "scope": scope, "was_present": False},
+                )
+                return True
+            del node[parts[-1]]
+            result = self._save(path, data)
+
+        if result:
+            reset_settings()
+            _emit_settings_audit(
+                scope=scope,
+                resource_detail=key_path,
+                action="delete",
+                result="allowed",
+                details={"key_path": key_path, "scope": scope, "was_present": True},
+            )
+        return result

--- a/deile/tests/commands/test_settings_command.py
+++ b/deile/tests/commands/test_settings_command.py
@@ -1,0 +1,422 @@
+"""Tests: /settings slash command suite (issue #357).
+
+Covers set, get, list, unset, where subcommands plus aliases (ls, rm)
+and the blocked-secret / project-trust flows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from deile.commands.base import CommandContext, CommandResult
+from deile.commands.builtin.settings_command import SettingsCommand
+from deile.commands.settings_manager import SettingsManager
+
+pytestmark = pytest.mark.usefixtures("allow_settings_writes")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(tmp_path: Path) -> SettingsManager:
+    return SettingsManager(
+        project_dir=tmp_path / "project",
+        user_home=tmp_path / "home",
+    )
+
+
+def _ctx(args: str = "") -> CommandContext:
+    return CommandContext(user_input=f"/settings {args}", args=args)
+
+
+async def _run(cmd: SettingsCommand, args: str) -> CommandResult:
+    return await cmd.execute(_ctx(args))
+
+
+# ---------------------------------------------------------------------------
+# Fixture: command backed by isolated SettingsManager
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cmd_with_tmp(tmp_path):
+    """Return (SettingsCommand, SettingsManager) backed by tmp_path."""
+    mgr = _make_manager(tmp_path)
+    cmd = SettingsCommand()
+    return cmd, mgr
+
+
+# ---------------------------------------------------------------------------
+# No-args / help
+# ---------------------------------------------------------------------------
+
+
+class TestHelp:
+    async def test_no_args_returns_help(self):
+        result = await _run(SettingsCommand(), "")
+        assert result.success
+        assert "set" in result.content
+        assert "get" in result.content
+        assert "list" in result.content
+        assert "unset" in result.content
+        assert "where" in result.content
+
+    async def test_unknown_subcommand_returns_error(self):
+        result = await _run(SettingsCommand(), "foobar")
+        assert not result.success
+        assert "Unknown subcommand" in result.content
+
+    async def test_help_flag(self):
+        result = await _run(SettingsCommand(), "--help")
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# /settings set
+# ---------------------------------------------------------------------------
+
+
+class TestSet:
+    async def test_set_writes_value(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "set pipeline.poll_interval 120")
+        assert result.success, result.content
+        assert mgr.get_setting("pipeline.poll_interval") == 120
+
+    async def test_set_coerces_bool(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "set ui.streaming_enabled true")
+        assert result.success, result.content
+        assert mgr.get_setting("ui.streaming_enabled") is True
+
+    async def test_set_missing_value_returns_error(self):
+        result = await _run(SettingsCommand(), "set pipeline.poll_interval")
+        assert not result.success
+        assert "Usage" in result.content
+
+    async def test_set_missing_key_and_value_returns_error(self):
+        result = await _run(SettingsCommand(), "set")
+        assert not result.success
+
+    async def test_set_blocked_secret_key(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "set ANTHROPIC_API_KEY sk-test-abc")
+        assert not result.success
+
+    async def test_set_project_scope_without_trust_returns_error(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "set pipeline.poll_interval 60 --scope=project")
+        assert not result.success
+        assert "trust" in result.content.lower() or "not trusted" in result.content.lower()
+
+    async def test_set_scope_user_alias(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "set pipeline.poll_interval 99 --scope=user")
+        assert result.success, result.content
+        assert mgr.get_setting("pipeline.poll_interval") == 99
+
+
+# ---------------------------------------------------------------------------
+# /settings get
+# ---------------------------------------------------------------------------
+
+
+class TestGet:
+    async def test_get_returns_set_value(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        mgr.set_setting("pipeline.poll_interval", 77)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "get pipeline.poll_interval")
+        assert result.success
+        # content is a Rich Table — check it serialises to something containing 77
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        c = Console(file=buf, width=120)
+        c.print(result.content)
+        text = buf.getvalue()
+        assert "77" in text
+
+    async def test_get_unknown_key_shows_not_set(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "get totally.unknown.key.xyz")
+        assert result.success
+
+    async def test_get_missing_key_returns_error(self):
+        result = await _run(SettingsCommand(), "get")
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# /settings list
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    async def test_list_returns_table(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "list")
+        assert result.success
+
+    async def test_list_pipeline_prefix_filters(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "list pipeline")
+        assert result.success
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        c = Console(file=buf, width=200)
+        c.print(result.content)
+        text = buf.getvalue()
+        assert "pipeline" in text
+
+    async def test_list_alias_ls(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "ls pipeline")
+        assert result.success
+
+    async def test_list_nonexistent_prefix(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "list zzznonexistent")
+        assert result.success
+        assert "No settings" in result.content
+
+    async def test_list_shows_pipeline_keys(self, tmp_path):
+        """pipeline.poll_interval must appear in list output."""
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "list pipeline")
+        assert result.success
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        c = Console(file=buf, width=200)
+        c.print(result.content)
+        text = buf.getvalue()
+        assert "pipeline.poll_interval" in text
+
+
+# ---------------------------------------------------------------------------
+# /settings unset
+# ---------------------------------------------------------------------------
+
+
+class TestUnset:
+    async def test_unset_removes_key(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        mgr.set_setting("pipeline.poll_interval", 55)
+        assert mgr.get_setting("pipeline.poll_interval") == 55
+
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "unset pipeline.poll_interval")
+        assert result.success, result.content
+        assert mgr.get_setting("pipeline.poll_interval") is None
+
+    async def test_unset_absent_key_is_success(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "unset pipeline.poll_interval")
+        assert result.success
+
+    async def test_unset_alias_rm(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        mgr.set_setting("pipeline.poll_interval", 42)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "rm pipeline.poll_interval")
+        assert result.success
+        assert mgr.get_setting("pipeline.poll_interval") is None
+
+    async def test_unset_missing_key_returns_error(self):
+        result = await _run(SettingsCommand(), "unset")
+        assert not result.success
+
+    async def test_unset_blocked_secret_key(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "unset ANTHROPIC_API_KEY")
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# /settings where
+# ---------------------------------------------------------------------------
+
+
+class TestWhere:
+    async def test_where_shows_all_layers(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        mgr.set_setting("pipeline.poll_interval", 120)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "where pipeline.poll_interval")
+        assert result.success
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        c = Console(file=buf, width=200)
+        c.print(result.content)
+        text = buf.getvalue()
+        assert "default" in text
+        assert "user" in text
+        assert "project" in text
+        assert "env" in text
+
+    async def test_where_shows_winning_layer(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        mgr.set_setting("pipeline.poll_interval", 120)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "where pipeline.poll_interval")
+        assert result.success
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        c = Console(file=buf, width=200)
+        c.print(result.content)
+        text = buf.getvalue()
+        assert "wins" in text.lower() or "←" in text or "120" in text
+
+    async def test_where_missing_key_returns_error(self):
+        result = await _run(SettingsCommand(), "where")
+        assert not result.success
+
+    async def test_where_env_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DEILE_PREFERRED_MODEL", "anthropic:claude-sonnet-4-6")
+        mgr = _make_manager(tmp_path)
+        cmd = SettingsCommand()
+        with patch(
+            "deile.commands.builtin.settings_command.SettingsManager",
+            return_value=mgr,
+        ):
+            result = await _run(cmd, "where model.preferred")
+        assert result.success
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        c = Console(file=buf, width=200)
+        c.print(result.content)
+        text = buf.getvalue()
+        assert "DEILE_PREFERRED_MODEL" in text
+
+
+# ---------------------------------------------------------------------------
+# SettingsManager.unset_setting (unit tests for the new method)
+# ---------------------------------------------------------------------------
+
+
+class TestUnsetSettingMethod:
+    def test_unset_removes_nested_key(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        mgr.set_setting("pipeline.poll_interval", 99)
+        assert mgr.get_setting("pipeline.poll_interval") == 99
+        result = mgr.unset_setting("pipeline.poll_interval")
+        assert result is True
+        assert mgr.get_setting("pipeline.poll_interval") is None
+
+    def test_unset_absent_key_returns_true(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        result = mgr.unset_setting("pipeline.poll_interval")
+        assert result is True
+
+    def test_unset_secret_key_returns_false(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        result = mgr.unset_setting("ANTHROPIC_API_KEY")
+        assert result is False
+
+    def test_unset_invalid_scope_raises(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        with pytest.raises(ValueError, match="Invalid scope"):
+            mgr.unset_setting("pipeline.poll_interval", scope="badscope")
+
+    def test_unset_top_level_key(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        mgr.set_setting("debug", True)
+        result = mgr.unset_setting("debug")
+        assert result is True
+        assert mgr.get_setting("debug") is None


### PR DESCRIPTION
## Summary

- Implements `/settings set <key> <value> [--scope=user|project]` — writes to `~/.deile/settings.json` with type coercion, secret-key blocklist, permission gate, and audit logging
- Implements `/settings get <key>` — shows effective value + origin layer
- Implements `/settings list [<prefix>]` (alias `ls`) — lists all known settings with values and origins
- Implements `/settings unset <key> [--scope=user|project]` (alias `rm`) — removes a key from specified scope
- Implements `/settings where <key>` — shows per-layer breakdown (default → user → project → env) with which layer wins
- Adds `SettingsManager.unset_setting()` with the same security pipeline as `set_setting`
- Updates `.env.example` to use concrete examples instead of generic "Migrar para settings.json" guidance

## Test plan

- [ ] 32 new tests in `deile/tests/commands/test_settings_command.py` — all pass
- [ ] All 150 settings-related tests pass (`test_settings_command`, `test_settings_manager`, `test_settings_manager_audit`, `test_settings_layered`)
- [ ] Full suite: 1383 passed, 1 skipped, 1 flaky timing test (pre-existing in `test_dispatch_matrix_view.py`, passes in isolation)

Closes #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)