### PR TITLE
fix(tests): unset DEILE_SETTINGS_FILE env var in layered settings tests

### DIFF
--- a/deile/tests/config/test_settings_json_loading.py
+++ b/deile/tests/config/test_settings_json_loading.py
@@ -235,6 +235,7 @@ class TestApplyEnvOverrides:
 
 class TestBuildSettings:
     def test_default_values_when_no_files(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         proj = tmp_path / "project"
         proj.mkdir(exist_ok=True)
         monkeypatch.setattr("deile.config.settings.Path.home", lambda: tmp_path / "home")
@@ -249,6 +250,7 @@ class TestBuildSettings:
         reset_settings()
 
     def test_global_json_applied(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         proj = tmp_path / "project"
         proj.mkdir(parents=True)
@@ -264,6 +266,7 @@ class TestBuildSettings:
         reset_settings()
 
     def test_project_json_overrides_global(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         proj = tmp_path / "project"
         proj.mkdir(parents=True)
@@ -279,6 +282,7 @@ class TestBuildSettings:
         reset_settings()
 
     def test_env_var_overrides_json(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         """Current (non-deprecated) env vars win over JSON settings.
 
         Uses DEILE_FORGE_REPO (a current knob) to verify the env-override layer
@@ -301,6 +305,7 @@ class TestBuildSettings:
         reset_settings()
 
     def test_deprecated_env_var_does_not_override_json(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         """Deprecated env vars are silently ignored — JSON layer wins (issue #309)."""
         proj = tmp_path / "project"
         proj.mkdir(parents=True)
@@ -319,6 +324,7 @@ class TestBuildSettings:
         reset_settings()
 
     def test_reset_clears_singleton(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         monkeypatch.setattr("deile.config.settings.Path.home", lambda: tmp_path / "home")
         monkeypatch.chdir(tmp_path)
         reset_settings()

--- a/deile/tests/test_settings_layered.py
+++ b/deile/tests/test_settings_layered.py
@@ -159,6 +159,7 @@ class TestGetSettingsLayered:
         assert s.log_level == LogLevel.DEBUG  # dataclass default
 
     def test_user_layer_applied(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         (home / ".deile").mkdir(parents=True)
         (home / ".deile" / "settings.json").write_text(
@@ -189,6 +190,7 @@ class TestGetSettingsLayered:
         assert s.streaming_enabled is True            # inherited from user
 
     def test_legacy_fallback_when_no_new_layers(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         legacy = tmp_path / "config"
         legacy.mkdir()
         legacy_file = legacy / "settings.json"
@@ -215,6 +217,7 @@ class TestGetSettingsLayered:
         assert any("legacy" in r.getMessage() for r in records)
 
     def test_new_layers_take_precedence_over_legacy(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         legacy = tmp_path / "config"
         legacy.mkdir()
         (legacy / "settings.json").write_text(
@@ -306,6 +309,7 @@ class TestSettingsFileOverride:
     def test_project_layer_skipped_when_same_file_as_global(
         self, monkeypatch, tmp_path, caplog,
     ):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         """HOME == cwd → o mesmo JSON é detectado e o project layer é pulado.
 
         Cenário comum em containers (``workingDir: /home/deile`` com

--- a/deile/tests/test_settings_layered_trust.py
+++ b/deile/tests/test_settings_layered_trust.py
@@ -80,6 +80,7 @@ class TestProjectLayerTrust:
     def test_project_layer_ignored_when_not_allowlisted_and_policy_deny(
         self, monkeypatch, tmp_path
     ):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         _write_user_settings(
             home,
@@ -105,6 +106,7 @@ class TestProjectLayerTrust:
         assert any("ignoring project layer" in r.getMessage() for r in records)
 
     def test_project_layer_applied_when_allowlisted(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         project = tmp_path / "project"
         project.mkdir(parents=True, exist_ok=True)
@@ -131,6 +133,7 @@ class TestProjectLayerTrust:
     def test_default_policy_auto_applies_with_warning(
         self, monkeypatch, tmp_path
     ):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         # No explicit trust config => defaults: dirs=[], default='auto'.
         _write_user_settings(home, {"logging": {"level": "INFO"}})
@@ -151,6 +154,7 @@ class TestProjectLayerTrust:
         )
 
     def test_no_warning_when_allowlisted(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         project = tmp_path / "project"
         project.mkdir(parents=True, exist_ok=True)
@@ -177,6 +181,7 @@ class TestProjectLayerTrust:
         )
 
     def test_no_project_file_no_warning(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         home = tmp_path / "home"
         _write_user_settings(home, {})
         project = tmp_path / "project"
@@ -194,6 +199,7 @@ class TestProjectLayerTrust:
     def test_get_settings_threaded_through_layered_loader(
         self, monkeypatch, tmp_path
     ):
+        monkeypatch.delenv("DEILE_SETTINGS_FILE", raising=False)
         """Smoke test that get_settings() uses the new gate."""
         home = tmp_path / "home"
         _write_user_settings(


### PR DESCRIPTION
## Problema

Os testes de configuração em camadas (layered settings) falhavam no ambiente k8s porque a env var `DEILE_SETTINGS_FILE=/etc/deile/settings.json` (ConfigMap mount) toma precedência sobre `Path.home()` em `_resolve_global_settings_path()`. Os testes criam `~/.deile/settings.json` sintético e fazem monkeypatch de `Path.home()`, mas o loader ignorava o monkeypatch porque a env var tem prioridade.

## Solução

Adiciona `monkeypatch.delenv(DEILE_SETTINGS_FILE, raising=False)` em todos os testes que criam um `~/.deile/settings.json` sintético e esperam que ele seja carregado via `Path.home()`.

### Arquivos alterados

| Arquivo | Testes afetados |
|---|---|
| `deile/tests/test_settings_layered.py` | 4 (`test_user_layer_applied`, `test_legacy_fallback_when_no_new_layers`, `test_new_layers_take_precedence_over_legacy`, `test_project_layer_skipped_when_same_file_as_global`) |
| `deile/tests/test_settings_layered_trust.py` | 6 (todos os testes de `TestProjectLayerTrust`) |
| `deile/tests/config/test_settings_json_loading.py` | 6 (todos os testes de `TestBuildSettings`) |

## Prova

```
$ python -m pytest deile/tests/test_settings_layered.py deile/tests/test_settings_layered_trust.py deile/tests/config/test_settings_json_loading.py -v
80 passed in 1.07s
```

---

By [DEILE-One](mailto:deile@deile.info)