### PR TITLE
feat(pipeline): PVC para DispatchLedger sobreviver a rollouts (issue #350)

### DIFF
--- a/infra/k8s/deploy.py
+++ b/infra/k8s/deploy.py
@@ -121,6 +121,7 @@ class DeploymentProfile:
             "47-deile-runtime-config.yaml",
             "41-worker-pvc.yaml",
             "45-deile-worker-deployment.yaml",
+            "46b-deile-pipeline-pvc.yaml",
             "46-deile-pipeline-deployment.yaml",
         )
         if self.name == "pipeline-only":
@@ -140,6 +141,7 @@ class DeploymentProfile:
             "35-deile-interactive.yaml",
             "41-worker-pvc.yaml",
             "45-deile-worker-deployment.yaml",
+            "46b-deile-pipeline-pvc.yaml",
             "46-deile-pipeline-deployment.yaml",
         )
 
@@ -1600,6 +1602,7 @@ def do_create_namespace(cfg: CreateNamespaceConfig) -> int:
         "19-bot-data-pvc.yaml",
         "20-bot-deployment.yaml", "35-deile-interactive.yaml",
         "41-worker-pvc.yaml", "45-deile-worker-deployment.yaml",
+        "46b-deile-pipeline-pvc.yaml",
         "46-deile-pipeline-deployment.yaml",
     )
     for manifest in manifests_order:

--- a/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
+++ b/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
@@ -174,6 +174,10 @@ spec:
             - { name: status-bearer,  mountPath: /run/secrets/pipeline-status, readOnly: true }
             - { name: home,           mountPath: /home/deile }
             - { name: tmp,            mountPath: /tmp }
+            # Issue #350 — PVC para o DispatchLedger sobreviver a rollouts.
+            # Montado em subpath de /home/deile: o emptyDir "home" cobre a
+            # raiz (repo clone) e o PVC overlay cobre .deile/pipeline/ (ledger).
+            - { name: pipeline-ledger, mountPath: /home/deile/.deile/pipeline }
             # settings.json layered (issue #111). Apontado pelo env var
             # DEILE_SETTINGS_FILE para evitar collision com ~/.deile/ writable.
             - name: runtime-config
@@ -202,6 +206,10 @@ spec:
         - { name: status-bearer, secret: { secretName: pipeline-status-bearer, defaultMode: 288, optional: true } }
         - { name: home,          emptyDir: { sizeLimit: "256Mi" } }
         - { name: tmp,           emptyDir: { medium: Memory, sizeLimit: "64Mi" } }
+        # Issue #350 — PVC de 1Gi pra persistir o DispatchLedger entre
+        # restarts/rollouts. O path ~/.deile/pipeline/dispatches.json
+        # resolve naturalmente pra este mount sem alterar dispatch_ledger.py.
+        - { name: pipeline-ledger, persistentVolumeClaim: { claimName: deile-pipeline-ledger } }
         - name: runtime-config
           configMap:
             name: deile-runtime-config

--- a/infra/k8s/manifests/46b-deile-pipeline-pvc.yaml
+++ b/infra/k8s/manifests/46b-deile-pipeline-pvc.yaml
@@ -1,0 +1,31 @@
+# PVC for the pipeline DispatchLedger — makes dispatches.json survive
+# Deployment rollouts/restarts (issue #350).
+#
+# Currently /home/deile is an emptyDir (lost on pod restart). This PVC is
+# mounted at /home/deile/.deile/pipeline/ — a subpath that overlays the
+# emptyDir parent — so the ledger file survives while the repo clone at
+# the root of /home/deile continues using emptyDir (no conflict between
+# initContainer bootstrap-repo and the PVC).
+#
+# 1Gi is generous: the ledger JSON file is ~4KiB even with hundreds of
+# dispatches. Single-writer (pipeline runs 1 replica, Recreate strategy).
+#
+# Usage:
+#   kubectl apply -f infra/k8s/manifests/46b-deile-pipeline-pvc.yaml
+#   kubectl rollout restart deployment/deile-pipeline -n deile
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deile-pipeline-ledger
+  namespace: deile
+  labels:
+    app: deile-pipeline
+    role: deile
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName omitted → cluster default (local-path on k3s/Rancher Desktop).
+  # Override explicitly if your cluster has multiple storage classes.


### PR DESCRIPTION
## Resumo

Adiciona um PersistentVolumeClaim de 1Gi (`deile-pipeline-ledger`) montado em `/home/deile/.deile/pipeline/` no Deployment do pipeline, para que o arquivo `dispatches.json` do DispatchLedger sobreviva a restarts/rollouts.

## Mudanças

- **Novo manifesto:** `infra/k8s/manifests/46b-deile-pipeline-pvc.yaml` — PVC RWO, 1Gi, StorageClass default do cluster.
- **Deployment editado:** `infra/k8s/manifests/46-deile-pipeline-deployment.yaml` — adicionado volume `pipeline-ledger` (PVC) e volumeMount no container `pipeline` em `/home/deile/.deile/pipeline`.

## O que NÃO muda

- **Nenhuma alteração no `dispatch_ledger.py`** — o path default `~/.deile/pipeline/dispatches.json` resolve naturalmente para o PVC montado, e o `mkdir -p` em `_flush()` cria os diretórios pais automaticamente no primeiro uso.
- **initContainer `bootstrap-repo` não é afetado** — o PVC é montado em subpath (`/home/deile/.deile/pipeline/`), sem conflito com o `emptyDir` que cobre a raiz `/home/deile` para o clone do repo.
- **Nenhuma regressão no reaper** (`~attempt:N`) — mecanismo independente, permanece como safety net.

## Design

| Decisão | Motivo |
|---|---|
| PVC de 1Gi, RWO | Single-writer (1 réplica, Recreate), ledger JSON tem ~4KiB mesmo com centenas de dispatches |
| Subpath mount | `/home/deile` (raiz) segue `emptyDir` para o clone do repo; `/home/deile/.deile/pipeline/` overlay com PVC |
| Sem storageClassName explícito | Usa default do cluster (local-path no k3s/Rancher Desktop) |

## Testes

- 15/15 testes de unidade do `DispatchLedger` passam (sem alterações de código).
- Teste funcional (pós-merge): criar dispatch pendente, `kubectl rollout restart`, verificar resume em vez de fresh — requer cluster real.

---

Closes #350.

---  
By [DEILE-One](mailto:deile@deile.info)