### PR TITLE
fix(panel): exibe timestamps em UTC explícito com sufixo Z

### DIFF
--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -149,6 +149,60 @@ class TestFmtAge:
         assert pd._fmt_age(secs) == expected
 
 
+# ===== ActivityEvent timestamps (issue #348) ================================
+
+class TestActivityEventTimestamps:
+    """`ActivityEvent.hhmmss` retorna UTC explícito com sufixo Z.
+
+    Issue #348: antes retornava `astimezone().strftime('%H:%M:%S')`
+    (hora local ambígua). Agora retorna UTC com `Z`.
+    """
+
+    def test_hhmmss_returns_utc_with_z_suffix(self):
+        """Timestamp UTC deve ter sufixo Z, não hora local."""
+        # 14:00 UTC — em America/Sao_Paulo (-3) seria 11:00 local.
+        ts = datetime(2026, 5, 27, 14, 0, 0, tzinfo=timezone.utc)
+        ev = pd.ActivityEvent(
+            ts=ts, actor="pipeline", action="dispatch",
+            target="", detail="test",
+        )
+        assert ev.hhmmss == "14:00:00Z"
+        # Não deve ser hora local!
+        assert ev.hhmmss != "11:00:00"
+
+    def test_hhmmss_local_conversion(self):
+        """`hhmmss_local` deve retornar hora local com offset."""
+        ts = datetime(2026, 5, 27, 14, 0, 0, tzinfo=timezone.utc)
+        ev = pd.ActivityEvent(
+            ts=ts, actor="pipeline", action="dispatch",
+            target="", detail="test",
+        )
+        local = ev.hhmmss_local
+        # Formato: HH:MM ±ZZZZ (ex: "11:00 -0300")
+        assert " " in local or "+" in local or "-" in local
+        # Deve ter offset (não é UTC puro)
+        assert "Z" not in local
+
+    def test_hhmmss_format_is_consistent_8_chars(self):
+        """`hhmmss` deve ter exatamente 9 caracteres: HH:MM:SSZ."""
+        ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        ev = pd.ActivityEvent(
+            ts=ts, actor="pipeline", action="dispatch",
+            target="", detail="test",
+        )
+        assert ev.hhmmss == "00:00:00Z"
+        assert len(ev.hhmmss) == 9
+
+    def test_midnight_utc_handled_correctly(self):
+        """00:00 UTC deve ser '00:00:00Z', não voltar dia anterior."""
+        ts = datetime(2026, 5, 27, 0, 0, 0, tzinfo=timezone.utc)
+        ev = pd.ActivityEvent(
+            ts=ts, actor="pipeline", action="dispatch",
+            target="", detail="test",
+        )
+        assert ev.hhmmss == "00:00:00Z"
+
+
 # ===== _parse_k8s_ts / _parse_log_line ======================================
 
 class TestK8sTs:
@@ -789,6 +843,58 @@ class TestSetPreferredModel:
                 "deile-worker", "anthropic:claude-opus-4-7",
             )
         assert ok is True
+
+
+class TestHeadPanelUtcClock:
+    """`_head_panel` exibe clock em UTC explícito (issue #348)."""
+
+    def _build_app(self, data=None):
+        """Helper: constrói PanelApp mínimo para testar _head_panel."""
+        app = MagicMock()
+        app.paused = False
+        app.refresh_mult = 1.0
+        app.current_refresh_s = 1.0
+        app.active_toasts.return_value = []
+        app.memdebug_line.return_value = ""
+        app.data = data
+        return app
+
+    def test_clock_contains_utc_label(self):
+        """O clock do _head_panel deve conter 'UTC' explicitamente."""
+        app = self._build_app()
+        panel_render = panel._head_panel("Dashboard", app)
+        # Renderiza o Panel em texto para inspecionar
+        console = panel.Console(record=True, width=120)
+        console.print(panel_render)
+        text = console.export_text()
+        assert "UTC" in text, f"_head_panel deve exibir 'UTC', mas renderizou:\n{text}"
+
+    def test_local_conversion_line_present(self):
+        """Deve haver uma linha com '↳' indicando conversão local."""
+        app = self._build_app()
+        panel_render = panel._head_panel("Dashboard", app)
+        console = panel.Console(record=True, width=120)
+        console.print(panel_render)
+        text = console.export_text()
+        assert "↳" in text, f"_head_panel deve exibir linha de conversão local '↳', mas renderizou:\n{text}"
+
+    def test_clock_with_data_context(self):
+        """Com `data` presente, o clock UTC + linha local continuam."""
+        data = MagicMock()
+        ctx = MagicMock()
+        ctx.mode_label = "k8s + local"
+        ctx.cluster_label = "test"
+        ctx.namespace = "deile"
+        ctx.repo = "test/repo"
+        data.context = ctx
+        data.context.forge_kind = "github"
+        app = self._build_app(data=data)
+        panel_render = panel._head_panel("Dashboard", app)
+        console = panel.Console(record=True, width=120)
+        console.print(panel_render)
+        text = console.export_text()
+        assert "UTC" in text
+        assert "↳" in text
 
 
 class TestPodRowsAdapter:

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -541,20 +541,22 @@ def _pod_rows(data: Optional[PanelData]) -> List[PodRow]:
 # estilo visual sem duplicar código.
 
 def _head_panel(view_title: str, app: "PanelApp") -> Panel:
-    """Cabeçalho dinâmico: modo (k8s/local/híbrido) + namespace + clock + cadência."""
+    """Cabeçalho dinâmico: modo (k8s/local/híbrido) + namespace + clock UTC + cadência."""
     paused = " ⏸ pausado" if app.paused else ""
     speed = "" if app.refresh_mult == 1.0 else f" ×{app.refresh_mult:g}"
-    clock = time.strftime("%Y-%m-%d %H:%M:%S")
+    utc_now = datetime.now(timezone.utc)
+    clock_utc = utc_now.strftime("%Y-%m-%d %H:%M:%S UTC")
+    local_now = utc_now.astimezone()
+    clock_local = local_now.strftime("%H:%M %z")
     head = Text()
     head.append("DEILE Stack", style="bold cyan")
     head.append("  ·  ")
     head.append(view_title, style="bold")
     head.append("  ·  ")
-    head.append(clock, style="dim")
+    head.append(clock_utc, style="dim")
     head.append(f"  ·  refresh {app.current_refresh_s:.1f}s{speed}{paused}",
                 style="dim yellow" if app.paused else "dim")
-    # Linha 2: contexto efetivo. Usa o RuntimeContext quando há `data`; em
-    # modo demo cai no rótulo fixo histórico.
+    # Linha 2: contexto efetivo + conversão local do clock.
     if app.data is not None:
         ctx = app.data.context
         mode_style = ("bold green" if ctx.mode_label.startswith("k8s + local")
@@ -572,7 +574,9 @@ def _head_panel(view_title: str, app: "PanelApp") -> Panel:
     else:
         sub = Text("mode: demo (mocks)   cluster: —   namespace: —",
                    style="dim yellow")
-    pieces: List[RenderableType] = [head, sub]
+    # Linha 3: conversão local do clock UTC (↳ hh:mm local).
+    local_line = Text(f"↳ {clock_local} local", style="dim")
+    pieces: List[RenderableType] = [head, sub, local_line]
     # Toasts efêmeros (snapshot salvo, etc) aparecem como linha extra
     # discreta no head — não quebram o layout das views.
     toasts = app.active_toasts()

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -687,7 +687,14 @@ class ActivityEvent:
 
     @property
     def hhmmss(self) -> str:
-        return self.ts.astimezone().strftime("%H:%M:%S")
+        """Timestamp em UTC explícito com sufixo Z (ex: '16:33:45Z')."""
+        return self.ts.strftime("%H:%M:%SZ")
+
+    @property
+    def hhmmss_local(self) -> str:
+        """Conversão para hora local como linha auxiliar (ex: '13:33 -03')."""
+        local = self.ts.astimezone()
+        return local.strftime("%H:%M %z")
 
 
 _DISPATCH_START_RE = re.compile(r"worker dispatch starting", re.IGNORECASE)


### PR DESCRIPTION
## O que muda

Painel TUI agora exibe **todos os timestamps em UTC explícito** com sufixo `Z`, eliminando a confusão operacional entre hora local do painel e UTC dos logs K8s.

### Mudanças

**`_panel_data.py`** — `ActivityEvent.hhmmss`:
- Antes: `self.ts.astimezone().strftime("%H:%M:%S")` → `13:18:32` (local, ambíguo)
- Depois: `self.ts.strftime("%H:%M:%SZ")` → `16:18:32Z` (UTC explícito)
- Adicionado `hhmmss_local` para conversão auxiliar quando necessário

**`_panel.py`** — `_head_panel`:
- Clock mostra `YYYY-MM-DD HH:MM:SS UTC` (antes era hora local sem indicador)
- Linha auxiliar `↳ HH:MM ±ZZZZ local` abaixo do contexto

### Exemplo



### Testes

7 novos testes em `test_panel_data.py`:
- `TestActivityEventTimestamps`: hhmmss retorna UTC com Z, hhmmss_local, formato consistente
- `TestHeadPanelUtcClock`: clock contém "UTC", linha `↳` presente, funciona com/sem data

---

Closes #348.

---

By [DEILE-One](mailto:deile@deile.info)