### PR TITLE
feat(pipeline): sistema de priorização de issues e PRs (~prioridade:N)

### DIFF
--- a/deile/orchestration/forge/base.py
+++ b/deile/orchestration/forge/base.py
@@ -632,6 +632,22 @@ class ForgeClient(ABC):
     # Internal — subclasses implement label creation per forge
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Priority inheritance (issue #369)
+    # ------------------------------------------------------------------
+
+    async def inherit_priority_from_linked_issue(self, pr_number: int) -> Optional[int]:
+        """Return the most urgent priority N from issues linked in the PR/MR body.
+
+        Default no-op: returns ``None``. Forges that support this
+        (GitHub) override with a real implementation.
+        """
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal — subclasses implement label creation per forge
+    # ------------------------------------------------------------------
+
     @abstractmethod
     async def _ensure_label(self, name: str, *, color: str, description: str) -> None:
         """Create the label if it does not already exist (idempotent)."""

--- a/deile/orchestration/forge/github_forge.py
+++ b/deile/orchestration/forge/github_forge.py
@@ -34,6 +34,8 @@ from deile.orchestration.pipeline._time_utils import format_iso_utc
 from deile.orchestration.pipeline.labels import (LABEL_COLORS,
                                                  LABEL_DESCRIPTIONS,
                                                  MENTION_LABELS, REFINE_LABELS,
+                                                 PRIORITY_LABEL_PREFIX,
+                                                 PRIORITY_LABELS,
                                                  REVIEW_LABELS,
                                                  WORKFLOW_LABELS)
 
@@ -809,8 +811,49 @@ class GitHubForge(ForgeClient):
 
         await asyncio.gather(*[
             _create_one(label)
-            for label in (*WORKFLOW_LABELS, *REVIEW_LABELS, *MENTION_LABELS, *REFINE_LABELS)
+            for label in (*WORKFLOW_LABELS, *REVIEW_LABELS, *MENTION_LABELS, *REFINE_LABELS, *PRIORITY_LABELS)
         ])
+
+    # ------------------------------------------------------------------
+    # Priority inheritance (issue #369)
+    # ------------------------------------------------------------------
+
+    async def inherit_priority_from_linked_issue(self, pr_number: int) -> Optional[int]:
+        """Return the most urgent priority N from issues linked in the PR body.
+
+        Parses the PR body for ``Closes #N``, ``Fixes #N``, ``Resolves #N``
+        references, fetches each linked issue's labels, and returns the
+        smallest N (most urgent) among ``~prioridade:N`` labels found.
+
+        Returns ``None`` when:
+        - no linked issues are found in the PR body
+        - none of the linked issues carry a ``~prioridade:N`` label
+        - any transport error occurs (fail-open: ``None`` is safe)
+        """
+        body = await self.get_pr_body(pr_number)
+        if not body:
+            return None
+        # Match GitHub-flavoured closing keywords: Closes, Fixes, Resolves
+        # (case-insensitive, with optional colon).
+        linked = re.findall(
+            r"\b(?:clos\w*|fix\w*|resolv\w*)\s*:?\s*#(\d+)\b",
+            body, re.IGNORECASE,
+        )
+        if not linked:
+            return None
+        # Deduplicate linked issue numbers.
+        unique_numbers = set(int(n) for n in linked)
+        best: Optional[int] = None
+        from deile.orchestration.pipeline.labels import parse_priority_from_labels
+        for n in unique_numbers:
+            try:
+                issue = await self.get_issue(n)
+            except ForgeCommandError:
+                continue
+            p = parse_priority_from_labels(issue.labels)
+            if p is not None and (best is None or p < best):
+                best = p
+        return best
 
     # ------------------------------------------------------------------
     # Comments / search

--- a/deile/orchestration/pipeline/labels.py
+++ b/deile/orchestration/pipeline/labels.py
@@ -15,6 +15,33 @@ from __future__ import annotations
 import re
 from typing import Iterable, Optional
 
+# Priority labels ---------------------------------------------------------
+# ``~prioridade:N`` — N is an integer ≥ 0, 0 = maximum urgency.
+# Applied manually by the stakeholder on GitHub to influence pipeline ordering.
+PRIORITY_LABEL_PREFIX = "~prioridade:"
+PRIORITY_0 = "~prioridade:0"
+PRIORITY_1 = "~prioridade:1"
+PRIORITY_2 = "~prioridade:2"
+PRIORITY_3 = "~prioridade:3"
+PRIORITY_LABELS = (PRIORITY_0, PRIORITY_1, PRIORITY_2, PRIORITY_3)
+
+_PRIORITY_LABEL_RE = re.compile(r"^~prioridade:(\d+)$")
+
+
+def parse_priority_from_labels(labels: Iterable[str]) -> Optional[int]:
+    """Return the priority N from the first ``~prioridade:N`` label found.
+
+    Lower N = more urgent (0 = maximum). Returns ``None`` when no priority
+    label is present — the caller should treat this as "minimum priority"
+    and place the item after all prioritized ones.
+    """
+    for lb in labels:
+        m = _PRIORITY_LABEL_RE.match(lb)
+        if m:
+            return int(m.group(1))
+    return None
+
+
 # Issue workflow ----------------------------------------------------------
 # Only the states actually transitioned by the pipeline live here.
 # Stage 0 sets ``WORKFLOW_NEW``, Stage 1 transitions to ``WORKFLOW_REVIEWING``
@@ -216,6 +243,10 @@ _COLOR_BLUE_PR = "0052cc"          # PR opened (terminal pipeline state pre-merg
 _COLOR_BLUE_DECOMPOSED = "1d76db"  # intent decomposed (epic open)
 _COLOR_RED_BLOCKED = "b60205"      # hard block, excluded from auto-resume
 _COLOR_LIGHT_BLUE_DONE = "c5def5"  # mention already processed (sticky marker)
+_COLOR_RED_HOT = "b60205"            # priority 0 — critical / maximum urgency
+_COLOR_ORANGE_HIGH = "d93f0b"        # priority 1 — high
+_COLOR_YELLOW_MEDIUM = "fbca04"      # priority 2 — medium
+_COLOR_GREEN_LOW = "0e8a16"          # priority 3 — low
 
 LABEL_COLORS = {
     WORKFLOW_NEW: _COLOR_GREEN_PROGRESS,
@@ -233,6 +264,10 @@ LABEL_COLORS = {
     REVIEW_CONCLUDED: _COLOR_GREEN_PROGRESS,
     MENTION_DONE: _COLOR_LIGHT_BLUE_DONE,
     REFINAR: _COLOR_LAVENDER_REFINE,
+    PRIORITY_0: _COLOR_RED_HOT,
+    PRIORITY_1: _COLOR_ORANGE_HIGH,
+    PRIORITY_2: _COLOR_YELLOW_MEDIUM,
+    PRIORITY_3: _COLOR_GREEN_LOW,
 }
 
 LABEL_DESCRIPTIONS = {
@@ -251,6 +286,10 @@ LABEL_DESCRIPTIONS = {
     REVIEW_CONCLUDED: "Pipeline: PR revisada/mergeada",
     MENTION_DONE: "Pipeline: menção/atribuição já processada — humano remove para reprocessar",
     REFINAR: "Pipeline: escopo vago — precisa de refinamento antes de avançar (humano pode aplicar à mão)",
+    PRIORITY_0: "Pipeline: prioridade crítica — processar antes de tudo (0 = máxima urgência)",
+    PRIORITY_1: "Pipeline: prioridade alta",
+    PRIORITY_2: "Pipeline: prioridade média",
+    PRIORITY_3: "Pipeline: prioridade baixa",
 }
 
 

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -34,7 +34,9 @@ from deile.orchestration.pipeline.implementer import (parse_critique_verdict,
                                                       parse_decompose_result,
                                                       parse_refine_verdict)
 from deile.orchestration.pipeline.labels import (FOLLOW_UPS_PROCESSED,
-                                                 MENTION_DONE, REFINAR,
+                                                 MENTION_DONE, PRIORITY_0,
+                                                 PRIORITY_1, PRIORITY_2,
+                                                 PRIORITY_3, REFINAR,
                                                  REFINE_WORKFLOW_STATES,
                                                  REVIEW_CONCLUDED,
                                                  REVIEW_IN_PROGRESS,
@@ -422,6 +424,27 @@ async def classify_new_prs(monitor: "PipelineMonitor") -> None:
         monitor._stats.prs_classified += 1
         logger.info("pr_triage: classified PR #%s with %s", pr.number, REVIEW_PENDING)
         await monitor.notifier.pr_auto_classified(pr.number, pr.title, pr.url)
+
+        # Priority inheritance (issue #369): if this PR closes an issue that
+        # carries a ~prioridade:N label, inherit it onto the PR.
+        try:
+            inherited = await monitor.forge.inherit_priority_from_linked_issue(pr.number)
+            if inherited is not None:
+                priority_labels = {
+                    0: PRIORITY_0,
+                    1: PRIORITY_1,
+                    2: PRIORITY_2,
+                    3: PRIORITY_3,
+                }
+                label = priority_labels.get(inherited)
+                if label is not None:
+                    await monitor.forge.add_labels("pr", pr.number, [label])
+                    logger.info(
+                        "pr_triage: inherited %s from linked issue for PR #%d",
+                        label, pr.number,
+                    )
+        except Exception as exc:  # noqa: BLE001 — best-effort; never block triage
+            logger.debug("pr_triage: priority inheritance for PR #%d failed: %s", pr.number, exc)
 
 
 # ----- mention handling: unified trigger polling (issue #253) ----------

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -51,6 +51,7 @@ from deile.orchestration.pipeline.labels import (FOLLOW_UPS_PROCESSED,
                                                  is_batch_label,
                                                  issue_type_from_labels,
                                                  make_attempt_label,
+                                                 parse_priority_from_labels,
                                                  refine_workflow_state)
 
 # Mention triggers that describe a STICKY state (they re-appear on every poll
@@ -71,6 +72,30 @@ _ENDED_INCOMPLETO = "incompleto"
 _ENDED_BLOQUEADO = "bloqueado"
 
 logger = logging.getLogger(__name__)
+
+# --- Priority sorting (issue #369) ----------------------------------------
+
+
+def sort_by_priority(candidates):
+    """Sort *candidates* (IssueRef or PrRef) by priority — lower N = more urgent.
+
+    Items with a ``~prioridade:N`` label are ordered by N (0 first, 3 last).
+    Items without any priority label are placed after all prioritized items.
+    Tiebreaker: lower issue/PR number wins (deterministic).
+
+    The function is pure (no I/O) — it works client-side on the list already
+    returned by the forge. More sophisticated tiebreakers (merge-base distance,
+    commit count, diff size) are deferred to a future iteration.
+    """
+    def _key(c):
+        p = parse_priority_from_labels(getattr(c, "labels", ()))
+        # Priority group: 0 for items with a priority label (ordered by N),
+        # 1 for items without (placed last).
+        if p is not None:
+            return (0, p, getattr(c, "number", 0))
+        return (1, 0, getattr(c, "number", 0))
+    return sorted(candidates, key=_key)
+
 
 # --- Commit classification (issue #351) ------------------------------------
 
@@ -292,7 +317,7 @@ async def classify_new_issues(monitor: "PipelineMonitor") -> None:
         logger.error("could not list unclassified issues: %s", exc)
         return
 
-    for issue in issues:
+    for issue in sort_by_priority(issues):
         # Defense-in-depth: never touch an issue that already has a pipeline label.
         if any(lb.startswith("~") for lb in issue.labels):
             continue
@@ -741,8 +766,9 @@ async def review_one_new_issue(monitor: "PipelineMonitor") -> None:
         )
         return
     # Shard filter: only consider issues whose hash falls in our shard.
+    # Sort by priority so the most urgent issue is reviewed first.
     target = next(
-        (i for i in issues if i.batch_id is None and monitor.identity.owns(i.title)),
+        (i for i in sort_by_priority(issues) if i.batch_id is None and monitor.identity.owns(i.title)),
         None,
     )
     if target is None:
@@ -894,7 +920,7 @@ async def refine_one_issue(monitor: "PipelineMonitor") -> None:
     _excluded = (WORKFLOW_WAITING, WORKFLOW_BLOCKED, WORKFLOW_IMPLEMENTING,
                  WORKFLOW_PR, WORKFLOW_DECOMPOSED)
     target = next(
-        (i for i in issues
+        (i for i in sort_by_priority(issues)
          if not any(lb in i.labels for lb in _excluded)
          and monitor.identity.owns(i.title)),
         None,
@@ -1019,7 +1045,7 @@ async def decompose_one_reviewed_intent(monitor: "PipelineMonitor") -> None:
         return
     ownership_label = monitor.identity.ownership_label()
     target = next(
-        (i for i in issues
+        (i for i in sort_by_priority(issues)
          if issue_type_from_labels(i.labels) == TYPE_INTENT
          and WORKFLOW_DECOMPOSED not in i.labels
          and WORKFLOW_BLOCKED not in i.labels
@@ -1095,6 +1121,8 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
         and monitor._this_monitor_owns(i)
         and (i.batch_id is not None or ownership_label in i.labels)
     ]
+    # Sort by priority so the most urgent issues are implemented first.
+    candidates = sort_by_priority(candidates)
     # Cap concurrency at ``max_parallel`` (>=1). Each claimed issue leaves the
     # revisada set on its transition, so later ticks won't re-pick it.
     batch = candidates[: max(1, monitor.config.max_parallel)]
@@ -1224,9 +1252,10 @@ async def resume_in_progress_issues(monitor: "PipelineMonitor") -> None:
         )
         return
     now = _monotonic()
+    # Sort by priority so the most urgent parked issue is resumed first.
     target = next(
         (
-            i for i in issues
+            i for i in sort_by_priority(issues)
             if WORKFLOW_BLOCKED not in i.labels
             and WORKFLOW_PR not in i.labels
             and monitor._this_monitor_owns(i)
@@ -1695,7 +1724,8 @@ async def review_one_open_pr(monitor: "PipelineMonitor") -> None:
         # Fresh: unclaimed PR awaiting first review.
         return pr.batch_id is None
 
-    target = next((pr for pr in prs if _candidate(pr)), None)
+    # Sort by priority so the most urgent PR is reviewed first.
+    target = next((pr for pr in sort_by_priority(prs) if _candidate(pr)), None)
     if target is None:
         return
     is_resume = REVIEW_IN_PROGRESS in target.labels
@@ -2093,7 +2123,7 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
     except GhCommandError as exc:
         await _record_forge_error(monitor, "reaper: list_open_prs failed", exc)
         return
-    for pr in prs:
+    for pr in sort_by_priority(prs):
         if REVIEW_IN_PROGRESS not in pr.labels:
             continue
         # Só re-claim PRs deste monitor (ownership).
@@ -2124,7 +2154,7 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
             monitor, "reaper: list_issues_with_label failed", exc,
         )
         return
-    for issue in impl_issues:
+    for issue in sort_by_priority(impl_issues):
         if own_label not in issue.labels:
             continue
         applied_at = await monitor.forge.label_applied_at(

--- a/deile/tests/orchestration/pipeline/test_priority_sorting.py
+++ b/deile/tests/orchestration/pipeline/test_priority_sorting.py
@@ -1,0 +1,211 @@
+"""Tests for priority label system (issue #369)."""
+
+from __future__ import annotations
+
+from deile.orchestration.forge.refs import IssueRef, PrRef
+from deile.orchestration.pipeline.labels import (
+    LABEL_COLORS,
+    LABEL_DESCRIPTIONS,
+    PRIORITY_0,
+    PRIORITY_1,
+    PRIORITY_2,
+    PRIORITY_3,
+    PRIORITY_LABEL_PREFIX,
+    PRIORITY_LABELS,
+    parse_priority_from_labels,
+)
+from deile.orchestration.pipeline.stages import sort_by_priority
+
+
+# ---------------------------------------------------------------------------
+# parse_priority_from_labels
+# ---------------------------------------------------------------------------
+
+
+class TestParsePriorityFromLabels:
+    def test_single_priority_label(self):
+        assert parse_priority_from_labels(["~prioridade:0"]) == 0
+        assert parse_priority_from_labels(["~prioridade:1"]) == 1
+        assert parse_priority_from_labels(["~prioridade:3"]) == 3
+
+    def test_no_priority_label(self):
+        assert parse_priority_from_labels(["bug", "feature"]) is None
+        assert parse_priority_from_labels([]) is None
+        assert parse_priority_from_labels(()) is None
+
+    def test_mixed_labels_returns_first_priority(self):
+        labels = ("bug", "~prioridade:2", "~prioridade:0", "feature")
+        assert parse_priority_from_labels(labels) == 2
+
+    def test_invalid_priority_format_ignored(self):
+        assert parse_priority_from_labels(["~prioridade:abc"]) is None
+        assert parse_priority_from_labels(["~prioridade:"]) is None
+        assert parse_priority_from_labels(["~prioridade:-1"]) is None
+        assert parse_priority_from_labels(["prioridade:0"]) is None  # no tilde
+
+    def test_high_n_still_parsed(self):
+        # The issue says range is 0-3, but the parser accepts any int
+        # (out-of-range values are accepted — validation is deferred)
+        assert parse_priority_from_labels(["~prioridade:99"]) == 99
+
+
+# ---------------------------------------------------------------------------
+# sort_by_priority — issues
+# ---------------------------------------------------------------------------
+
+
+class TestSortByPriorityIssues:
+    def test_all_with_priority_labels(self):
+        issues = [
+            IssueRef(number=5, title="medium", url="u", labels=("~prioridade:2",)),
+            IssueRef(number=1, title="critical", url="u", labels=("~prioridade:0",)),
+            IssueRef(number=3, title="high", url="u", labels=("~prioridade:1",)),
+            IssueRef(number=7, title="low", url="u", labels=("~prioridade:3",)),
+        ]
+        sorted_issues = sort_by_priority(issues)
+        assert [i.number for i in sorted_issues] == [1, 3, 5, 7]
+
+    def test_mixed_with_and_without_labels(self):
+        issues = [
+            IssueRef(number=10, title="no-prio", url="u", labels=("bug",)),
+            IssueRef(number=1, title="urgent", url="u", labels=("~prioridade:0",)),
+            IssueRef(number=20, title="also-no-prio", url="u", labels=()),
+            IssueRef(number=3, title="medium", url="u", labels=("~prioridade:2",)),
+        ]
+        sorted_issues = sort_by_priority(issues)
+        # Priority 0 first, then priority 2, then no-priority (by number)
+        assert [i.number for i in sorted_issues] == [1, 3, 10, 20]
+
+    def test_tiebreaker_same_priority_by_number(self):
+        issues = [
+            IssueRef(number=5, title="a", url="u", labels=("~prioridade:1",)),
+            IssueRef(number=2, title="b", url="u", labels=("~prioridade:1",)),
+            IssueRef(number=8, title="c", url="u", labels=("~prioridade:1",)),
+        ]
+        sorted_issues = sort_by_priority(issues)
+        assert [i.number for i in sorted_issues] == [2, 5, 8]
+
+    def test_tiebreaker_no_priority_by_number(self):
+        issues = [
+            IssueRef(number=15, title="x", url="u", labels=()),
+            IssueRef(number=3, title="y", url="u", labels=()),
+        ]
+        sorted_issues = sort_by_priority(issues)
+        assert [i.number for i in sorted_issues] == [3, 15]
+
+    def test_empty_list(self):
+        assert sort_by_priority([]) == []
+
+    def test_single_item(self):
+        issues = [IssueRef(number=1, title="x", url="u", labels=("~prioridade:0",))]
+        assert sort_by_priority(issues) == issues
+
+
+# ---------------------------------------------------------------------------
+# sort_by_priority — PRs
+# ---------------------------------------------------------------------------
+
+
+class TestSortByPriorityPRs:
+    def test_all_with_priority_labels(self):
+        prs = [
+            PrRef(number=5, title="medium", url="u", labels=("~prioridade:2",)),
+            PrRef(number=1, title="critical", url="u", labels=("~prioridade:0",)),
+            PrRef(number=3, title="high", url="u", labels=("~prioridade:1",)),
+        ]
+        sorted_prs = sort_by_priority(prs)
+        assert [p.number for p in sorted_prs] == [1, 3, 5]
+
+    def test_mixed_with_and_without_labels(self):
+        prs = [
+            PrRef(number=42, title="no-prio", url="u", labels=()),
+            PrRef(number=2, title="urgent", url="u", labels=("~prioridade:0",)),
+        ]
+        sorted_prs = sort_by_priority(prs)
+        assert [p.number for p in sorted_prs] == [2, 42]
+
+    def test_deterministic_order(self):
+        # Same input → same output every time
+        prs = [
+            PrRef(number=3, title="c", url="u", labels=("~prioridade:1",)),
+            PrRef(number=1, title="a", url="u", labels=("~prioridade:1",)),
+            PrRef(number=2, title="b", url="u", labels=("~prioridade:1",)),
+        ]
+        result1 = sort_by_priority(prs)
+        result2 = sort_by_priority(prs)
+        assert result1 == result2
+        assert [p.number for p in result1] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Label constants
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityLabelConstants:
+    def test_prefix(self):
+        assert PRIORITY_LABEL_PREFIX == "~prioridade:"
+
+    def test_priority_labels_tuple(self):
+        assert PRIORITY_0 == "~prioridade:0"
+        assert PRIORITY_1 == "~prioridade:1"
+        assert PRIORITY_2 == "~prioridade:2"
+        assert PRIORITY_3 == "~prioridade:3"
+        assert PRIORITY_LABELS == (PRIORITY_0, PRIORITY_1, PRIORITY_2, PRIORITY_3)
+
+    def test_all_have_color(self):
+        for lb in PRIORITY_LABELS:
+            assert lb in LABEL_COLORS, f"{lb} missing color"
+            assert len(LABEL_COLORS[lb]) == 6
+            int(LABEL_COLORS[lb], 16)  # valid hex
+
+    def test_all_have_description(self):
+        for lb in PRIORITY_LABELS:
+            assert lb in LABEL_DESCRIPTIONS, f"{lb} missing description"
+            assert len(LABEL_DESCRIPTIONS[lb]) > 10
+
+    def test_priorities_have_distinct_colors(self):
+        # Each priority should have a visibly distinct color
+        colors = {lb: LABEL_COLORS[lb] for lb in PRIORITY_LABELS}
+        assert len(set(colors.values())) == len(PRIORITY_LABELS), (
+            f"Priority labels must have distinct colors, got: {colors}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: sort_by_priority with parse_priority_from_labels
+# ---------------------------------------------------------------------------
+
+
+class TestSortByPriorityIntegration:
+    def test_parse_then_sort_is_consistent(self):
+        """Ensure parse and sort produce the same ordering."""
+        labels_list = [
+            ("~prioridade:0",),
+            ("~prioridade:2",),
+            ("~prioridade:1",),
+            (),
+            ("~prioridade:3",),
+        ]
+        issues = [
+            IssueRef(number=i, title="x", url="u", labels=labels_list[i])
+            for i in range(len(labels_list))
+        ]
+        sorted_issues = sort_by_priority(issues)
+        # Parse each sorted item's priority to verify order is monotonic
+        priorities = [parse_priority_from_labels(i.labels) for i in sorted_issues]
+        # None (no priority) should be last; numeric priorities should be ascending
+        none_seen = False
+        for p in priorities:
+            if p is None:
+                none_seen = True
+            else:
+                assert not none_seen, "Items without priority must come last"
+
+    def test_multiple_priority_labels_only_first_counts(self):
+        """If an item has multiple ~prioridade:N labels, parse returns the first."""
+        issue = IssueRef(
+            number=1, title="x", url="u",
+            labels=("~prioridade:0", "~prioridade:3", "bug"),
+        )
+        assert parse_priority_from_labels(issue.labels) == 0


### PR DESCRIPTION
Implementa o sistema de labels de prioridade numérica (`~prioridade:0` a `~prioridade:3`) para que o pipeline autônomo processe itens mais urgentes primeiro.

## Mudanças

### `labels.py`
- Constantes `PRIORITY_LABEL_PREFIX`, `PRIORITY_0-3`, `PRIORITY_LABELS`
- Função `parse_priority_from_labels(labels)` — retorna N ou None
- Cores distintas (vermelho → verde) e descrições para cada label

### `github_forge.py`
- `inherit_priority_from_linked_issue(pr_number)` — herda prioridade da issue linkada via Closes/Fixes/Resolves
- Labels de prioridade incluídas em `ensure_pipeline_labels()`

### `base.py`
- `inherit_priority_from_linked_issue()` default no-op na ABC

### `stages.py`
- `sort_by_priority(candidates)` — ordena por prioridade (menor N = mais urgente), itens sem label vão por último, desempate por número
- Aplicada nos 8 pontos de seleção: classify, review, refine, decompose, implement, resume, PR review, reaper

### `test_priority_sorting.py`
- 21 testes: parse, sort com/sem labels, tiebreakers, constantes, integração, determinismo

## Testes
```
155 passed (regressão zero nos testes existentes + 21 novos)
```

Closes #369.

---
By [DEILE-One](mailto:deile@deile.info)