### PR TITLE
feat(pipeline): tick-summary INFO log com contadores por tick (fix #349)

### DIFF
--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -49,6 +49,9 @@ from deile.orchestration.pipeline.lockfile import release as release_lock
 from deile.orchestration.pipeline.notifier import DiscordNotifier
 from deile.orchestration.pipeline.resume_state import ResumeTracker
 from deile.orchestration.pipeline.scheduler import PendingRun, ScheduleStore
+from deile.orchestration.pipeline.labels import (WORKFLOW_IMPLEMENTING,
+                                                 WORKFLOW_NEW,
+                                                 WORKFLOW_REVIEWED)
 from deile.orchestration.pipeline.stages import (_extract_pr_url,
                                                  _render_follow_up_report)
 from deile.orchestration.pipeline.worktree_manager import WorktreeManager
@@ -587,6 +590,9 @@ class PipelineMonitor:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("reaper failed (non-fatal): %s", exc)
 
+        # Snapshot stats for per-tick delta computation (issue #349).
+        snap = self._stats_snapshot()
+
         # When a schedule file exists with at least one entry, the schedule
         # is authoritative: each tick runs only the actions whose cron
         # window opened since the previous tick. Without a schedule, fall
@@ -618,10 +624,24 @@ class PipelineMonitor:
                 scheduled_actions = {e.action for e in schedule.recurring if e.enabled}
                 await self._dispatch_stages(skip=scheduled_actions)
             self._publish_status_state(_status_state, tick_started)
+            await self._log_tick_summary(tick_started, snap)
             return
 
         await self._dispatch_stages()
         self._publish_status_state(_status_state, tick_started)
+        await self._log_tick_summary(tick_started, snap)
+
+    def _stats_snapshot(self) -> dict:
+        """Return a shallow copy of per-tick-relevant counters for delta
+        computation at end-of-tick (issue #349)."""
+        s = self._stats
+        return {
+            "issues_classified": s.issues_classified,
+            "prs_classified": s.prs_classified,
+            "issues_reviewed": s.issues_reviewed,
+            "issues_implemented": s.issues_implemented,
+            "prs_reviewed": s.prs_reviewed,
+        }
 
     def _publish_status_state(self, state, tick_started: float) -> None:
         """Best-effort: publica métricas + ledger snapshot pro pipeline_status_server.
@@ -650,6 +670,71 @@ class PipelineMonitor:
                     pass
         except Exception as exc:  # noqa: BLE001
             logger.debug("publish_status_state non-fatal: %s", exc)
+
+    async def _log_tick_summary(self, tick_started: float, snap: dict) -> None:
+        """Log a lightweight INFO summary at the end of each tick (issue #349).
+
+        Computes per-tick deltas from a pre-stage :meth:`_stats_snapshot` so the
+        operator can distinguish "idle" from "stuck" even when every stage is a
+        no-op.  Backlog counts are best-effort (forge errors are swallowed).
+        """
+        import time as _time
+        elapsed = _time.monotonic() - tick_started
+        s = self._stats
+
+        classified_n = (
+            (s.issues_classified - snap["issues_classified"])
+            + (s.prs_classified - snap["prs_classified"])
+        )
+        reviewed_n = s.issues_reviewed - snap["issues_reviewed"]
+        implemented_n = s.issues_implemented - snap["issues_implemented"]
+        dispatched_n = s.prs_reviewed - snap["prs_reviewed"]
+
+        # Best-effort backlog: count issues in the active pipeline queue +
+        # open PRs.  `-1` sentinel means "unavailable" (forge error).
+        backlog_issues = -1
+        backlog_prs = -1
+        try:
+            active_labels = (
+                WORKFLOW_NEW, WORKFLOW_REVIEWED, WORKFLOW_IMPLEMENTING,
+            )
+            seen: set[int] = set()
+            for label in active_labels:
+                try:
+                    items = await self.forge.list_issues_with_label(label, limit=200)
+                    for item in items:
+                        seen.add(item.number)
+                except Exception as _inner_exc:  # noqa: BLE001
+                    logger.debug(
+                        "_log_tick_summary: list_issues(%s) failed: %s",
+                        label, _inner_exc,
+                    )
+            backlog_issues = len(seen)
+        except Exception as _outer_exc:  # noqa: BLE001
+            logger.debug(
+                "_log_tick_summary: backlog issues query failed: %s", _outer_exc,
+            )
+        try:
+            prs = await self.forge.list_open_prs(limit=200)
+            backlog_prs = len(prs)
+        except Exception as _exc:  # noqa: BLE001
+            logger.debug("_log_tick_summary: list_open_prs failed: %s", _exc)
+
+        if backlog_issues >= 0 and backlog_prs >= 0:
+            logger.info(
+                "tick #%d done in %.2fs: classified=%d reviewed=%d "
+                "implemented=%d dispatched=%d "
+                "backlog={issues:%d prs:%d}",
+                s.ticks, elapsed, classified_n, reviewed_n,
+                implemented_n, dispatched_n, backlog_issues, backlog_prs,
+            )
+        else:
+            logger.info(
+                "tick #%d done in %.2fs: classified=%d reviewed=%d "
+                "implemented=%d dispatched=%d backlog=unavailable",
+                s.ticks, elapsed, classified_n, reviewed_n,
+                implemented_n, dispatched_n,
+            )
 
     async def _dispatch_stages(self, skip: set[str] | None = None) -> None:
         """Run the per-tick stage sequence.

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -727,3 +727,160 @@ def test_publish_status_state_integrates_with_real_state(monkeypatch):
     assert snap["errors_total"] == 1
     assert snap["last_tick_at"] is not None
     assert snap["last_tick_duration_seconds"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Tick-summary INFO log (issue #349)
+# ---------------------------------------------------------------------------
+
+import logging  # noqa: E402
+
+
+class TestTickSummary:
+    """Issue #349: verify the INFO-level tick-summary log fires at the end of
+    every tick with correct per-tick deltas."""
+
+    async def test_idle_tick_logs_summary_with_zeros(self, caplog):
+        """A tick with no work must still emit a summary (all-zero counters)."""
+        monitor, _ = _make_monitor()
+        monitor.config.enable_classify = False
+        with caplog.at_level(logging.INFO, logger="deile.orchestration.pipeline.monitor"):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1, f"expected 1 tick-summary record, got {len(records)}"
+        msg = records[0].message
+        assert "tick #1 done in" in msg
+        assert "classified=0 reviewed=0 implemented=0 dispatched=0" in msg
+        assert "backlog=" in msg
+
+    async def test_tick_summary_reflects_classify_delta(self, caplog):
+        """Classifying one issue must show classified=1 in the summary."""
+        new_issue = IssueRef(number=1, title="t", url="u",
+                             labels=("bug",))
+        monitor, _ = _make_monitor()
+        monitor.config.enable_classify = True
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        monitor.github.list_unclassified_issues = AsyncMock(
+            return_value=[new_issue],
+        )
+        with caplog.at_level(logging.INFO, logger="deile.orchestration.pipeline.monitor"):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1
+        msg = records[0].message
+        assert "classified=1" in msg, f"expected classified=1, got: {msg}"
+
+    async def test_tick_summary_reflects_review_delta(self, caplog):
+        """Reviewing one issue must show reviewed=1 in the summary."""
+        new_issue = IssueRef(number=1, title="t", url="u",
+                             labels=(WORKFLOW_NEW,))
+        monitor, _ = _make_monitor(issues_new=[new_issue])
+        with caplog.at_level(logging.INFO, logger="deile.orchestration.pipeline.monitor"):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1
+        msg = records[0].message
+        assert "reviewed=1" in msg, f"expected reviewed=1, got: {msg}"
+
+    async def test_tick_summary_reflects_implement_delta(self, caplog):
+        """Implementing one issue must show implemented=1 in the summary."""
+        rev = IssueRef(
+            number=2, title="impl me", url="u",
+            labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
+        )
+        monitor, _ = _make_monitor(
+            issues_reviewed=[rev],
+            claude_stdout="Done. https://github.com/owner/name/pull/3",
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        with caplog.at_level(logging.INFO, logger="deile.orchestration.pipeline.monitor"):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1
+        msg = records[0].message
+        assert "implemented=1" in msg, f"expected implemented=1, got: {msg}"
+
+    async def test_tick_summary_reflects_dispatched_delta(self, caplog):
+        """Reviewing a PR must show dispatched=1 in the summary."""
+        pr = PrRef(number=10, title="prt", url="https://x/pull/10",
+                   labels=(REVIEW_PENDING,), head_ref="auto/issue-2")
+        monitor, _ = _make_monitor(prs=[pr], claude_stdout="merged.")
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        with caplog.at_level(logging.INFO, logger="deile.orchestration.pipeline.monitor"):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1
+        msg = records[0].message
+        assert "dispatched=1" in msg, f"expected dispatched=1, got: {msg}"
+
+    async def test_tick_summary_backlog_unavailable_on_forge_error(self, caplog):
+        """When forge.list_issues_with_label raises, the summary must show
+        backlog=unavailable instead of crashing the tick."""
+        monitor, _ = _make_monitor()
+        # Disable ALL stages so only the tick-summary log's own forge calls fail.
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.enable_refinement_gate = False
+        monitor.config.enable_resume = False
+        monitor.config.reaper_stale_seconds = 0
+        # Make the forge's backlog query itself raise.
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=Exception("gh api down"),
+        )
+        monitor.github.list_open_prs = AsyncMock(
+            side_effect=Exception("gh api down"),
+        )
+        with caplog.at_level(logging.INFO, logger="deile.orchestration.pipeline.monitor"):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1
+        msg = records[0].message
+        assert "backlog=unavailable" in msg, (
+            f"expected backlog=unavailable when forge fails, got: {msg}"
+        )
+
+    async def test_tick_summary_includes_backlog_counts(self, caplog):
+        """When forge responds, the summary must include backlog issue/PR counts."""
+        monitor, _ = _make_monitor()
+        # Disable all stages so only the tick-summary calls the forge for backlog.
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_implement = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.enable_refinement_gate = False
+        monitor.config.enable_resume = False
+        monitor.config.reaper_stale_seconds = 0
+        # Override with a forge that returns known backlog counts.
+        monitor.forge.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: {
+                WORKFLOW_NEW: [IssueRef(number=1, title="a", url="u", labels=(WORKFLOW_NEW,))],
+                WORKFLOW_REVIEWED: [],
+                WORKFLOW_IMPLEMENTING: [
+                    IssueRef(number=2, title="b", url="u", labels=(WORKFLOW_IMPLEMENTING,)),
+                    IssueRef(number=3, title="c", url="u", labels=(WORKFLOW_IMPLEMENTING,)),
+                ],
+            }.get(label, []),
+        )
+        monitor.forge.list_open_prs = AsyncMock(
+            return_value=[
+                PrRef(number=10, title="p", url="u", labels=(), head_ref="x"),
+            ],
+        )
+        with caplog.at_level(logging.INFO, logger="deile.orchestration.pipeline.monitor"):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1
+        msg = records[0].message
+        assert "backlog={issues:3 prs:1}" in msg, (
+            f"expected backlog={{issues:3 prs:1}}, got: {msg}"
+        )


### PR DESCRIPTION
## O que muda

Adiciona `_log_tick_summary()` ao `PipelineMonitor` que loga um resumo INFO ao final de **todo tick** com:

- **Contadores per-tick**: `classified`, `reviewed`, `implemented`, `dispatched`
- **Backlog best-effort**: issues ativas na fila do pipeline + PRs abertas
- **Tempo decorrido** e **número do tick**

## Por que

Pipeline em `INFO` level só logava eventos. Quando um tick passava sem trabalho elegível, o pipeline ficava **literalmente silencioso por horas**. Operador interpretava silêncio = travado.

Agora todo tick produz uma linha:

```
tick #42 done in 0.05s: classified=0 reviewed=0 implemented=0 dispatched=0 backlog={issues:3 prs:1}
```

Com isso, o operador distingue "pipeline idle" (linha sai todo minuto) de "pipeline travado" (sem linhas).

## Testes

- 7 novos testes em `TestTickSummary` cobrindo: tick ocioso, deltas de classify/review/implement/dispatch, backlog com contagens reais, e fallback `backlog=unavailable` quando o forge falha
- 336 testes de pipeline existentes passam sem regressão

---

Closes #349.

By [DEILE-One](mailto:deile@deile.info)