### PR TITLE
feat(pipeline): dispatch fire-and-forget para workers paralelos (fix #373)

### DIFF
--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -671,6 +671,7 @@ class WorkerImplementer(PipelineImplementer):
         branch: Optional[str] = None,
         ledger_key: Optional[str] = None,
         resume: bool = False,
+        nowait: bool = False,
     ) -> WorkOutcome:
         from deile.infrastructure.deile_worker_client import (
             WorkerDispatchError, build_dispatch_payload)
@@ -742,8 +743,15 @@ class WorkerImplementer(PipelineImplementer):
         # we attach ``resume`` after building to keep that contract untouched.
         if resume_block:
             payload["resume"] = resume_block
+        # Issue #373: ``nowait`` dispatches the task fire-and-forget — the
+        # worker returns 202 + task_id immediately and processes the task
+        # in the background. The pipeline does NOT block on the result;
+        # instead it reconciles ground truth (GitHub labels / PR existence)
+        # on the next tick. Used by the implement stage so that N workers
+        # can process N issues in parallel.
+        wait = not nowait
         try:
-            data = await self._post_dispatch(url, payload, wait=True)
+            data = await self._post_dispatch(url, payload, wait=wait)
         except WorkerDispatchError as exc:
             # Defense-in-depth contra triple-dispatch (fix 2026-05-27).
             # Worker recusa com 409 quando há claude vivo na mesma sessão
@@ -766,6 +774,19 @@ class WorkerImplementer(PipelineImplementer):
         except Exception as exc:  # noqa: BLE001 — never crash the tick
             logger.exception("worker dispatch raised")
             return WorkOutcome(ok=False, text="", error=f"{type(exc).__name__}: {exc}"[:500])
+        # Issue #373: fire-and-forget path — worker returned 202 + task_id.
+        # The task is running in the background; the pipeline reconciles
+        # ground truth on the next tick via ``reconcile_implementing_issues``.
+        if nowait:
+            task_id = data.get("task_id", "") if isinstance(data, dict) else ""
+            logger.info(
+                "worker fire-and-forget accepted: task_id=%s stage=%s",
+                task_id, stage,
+            )
+            return WorkOutcome(
+                ok=True, text="", task_id=task_id,
+                ended="",  # Not yet known — reconcile via ground truth
+            )
         outcome = _outcome_from_worker_response(data)
         # Issue #309 fase 3.5 + issue #347 follow-up — persistência no
         # DispatchLedger:
@@ -967,10 +988,15 @@ class WorkerImplementer(PipelineImplementer):
             resume=resume, expect_merge=False,
         )
         from deile.orchestration.pipeline.dispatch_ledger import DispatchLedger
+        # Issue #373: fire-and-forget for FRESH dispatches — the pipeline no
+        # longer blocks waiting for the worker to finish. Resume dispatches
+        # still block because the stage handler needs the structured result
+        # (ended, fingerprint, tentativa) to decide concluido/incompleto/bloqueado.
         return await self._dispatch(
             brief, channel_id=f"pipeline-issue-{issue.number}",
             resume_block=resume_block, stage="implement", branch=branch,
             ledger_key=DispatchLedger.key_for_issue(issue.number), resume=resume,
+            nowait=not resume,
         )
 
     # --- Refinement gate (issue #257) -------------------------------------

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -770,6 +770,11 @@ class PipelineMonitor:
         # the same tick; its first resume lands on the next tick.
         if cfg.enable_resume:
             await self._resume_in_progress_issues()
+        # Issue #373: reconcile fire-and-forget implementing issues BEFORE
+        # claiming new ones — completed issues free up capacity for new
+        # dispatches in the same tick.
+        if cfg.enable_implement:
+            await self._reconcile_implementing_issues()
         await _scheduled(cfg.enable_implement, "implement", self._implement_one_reviewed_issue)
         # Decompose CLEAR intents into derived issues (issue #257).
         if cfg.enable_refinement_gate:
@@ -812,6 +817,10 @@ class PipelineMonitor:
 
     async def _resume_in_progress_issues(self) -> None:
         return await stages.resume_in_progress_issues(self)
+
+    async def _reconcile_implementing_issues(self) -> None:
+        """Check ground truth for fire-and-forget implementing issues (issue #373)."""
+        return await stages.reconcile_implementing_issues(self)
 
     async def _review_one_open_pr(self) -> None:
         return await stages.review_one_open_pr(self)

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -1111,15 +1111,117 @@ async def decompose_one_reviewed_intent(monitor: "PipelineMonitor") -> None:
 
 # ----- stage 2: implement ------------------------------------------------
 
+
+async def _count_in_flight_issues(monitor: "PipelineMonitor") -> int:
+    """Count issues in ``~workflow:em_implementacao`` owned by this monitor.
+
+    These are issues that have been dispatched (fire-and-forget via issue #373)
+    but whose outcome is not yet known. Subtracted from ``max_parallel`` to
+    avoid over-dispatching beyond available worker capacity.
+
+    Issues that are blocked (``~workflow:bloqueada``) or already transitioned
+    to ``~workflow:em_pr`` are NOT counted — they do not consume a worker slot.
+    """
+    try:
+        issues = await monitor.forge.list_issues_with_label(
+            WORKFLOW_IMPLEMENTING, limit=50,
+        )
+    except GhCommandError as exc:
+        await _record_forge_error(
+            monitor, "could not list in-flight issues (forge error)", exc,
+        )
+        return 0
+    ownership_label = monitor.identity.ownership_label()
+    count = 0
+    for i in issues:
+        if WORKFLOW_BLOCKED in i.labels or WORKFLOW_PR in i.labels:
+            continue
+        if monitor._this_monitor_owns(i) or ownership_label in i.labels:
+            count += 1
+    return count
+
+
+async def reconcile_implementing_issues(monitor: "PipelineMonitor") -> None:
+    """Check ground truth for issues in ``~workflow:em_implementacao`` (issue #373).
+
+    Since the implement stage now dispatches fire-and-forget, the pipeline no
+    longer gets an immediate result from the worker. This function checks GitHub
+    ground truth on each tick:
+
+    - If a PR exists for the issue → the worker finished! Transition to
+      ``~workflow:em_pr`` and notify.
+    - If no PR yet → leave the issue in ``em_implementacao`` (worker still
+      running or not yet pushed).
+
+    This runs BEFORE ``implement_one_reviewed_issue`` in the tick loop so that
+    newly-completed issues free up capacity for new dispatches in the same tick.
+    """
+    try:
+        issues = await monitor.forge.list_issues_with_label(
+            WORKFLOW_IMPLEMENTING, limit=50,
+        )
+    except GhCommandError as exc:
+        await _record_forge_error(
+            monitor, "could not list implementing issues for reconcile", exc,
+        )
+        return
+    ownership_label = monitor.identity.ownership_label()
+    for issue in sort_by_priority(issues):
+        # Only reconcile issues this monitor owns.
+        if WORKFLOW_BLOCKED in issue.labels:
+            continue
+        if WORKFLOW_PR in issue.labels:
+            continue
+        if not (monitor._this_monitor_owns(issue) or ownership_label in issue.labels):
+            continue
+        # Check ground truth: did the worker open a PR?
+        try:
+            has_pr = await monitor.forge.has_open_pr_for_issue(issue.number)
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning(
+                "reconcile #%d: has_open_pr_for_issue failed: %s",
+                issue.number, exc,
+            )
+            continue
+        if not has_pr:
+            # Worker still running or hasn't pushed yet. Leave in em_implementacao.
+            continue
+        # Worker finished! Transition to em_pr.
+        logger.info(
+            "reconcile #%d: PR detected via ground truth → transitioning to %s",
+            issue.number, WORKFLOW_PR,
+        )
+        try:
+            await monitor.forge.transition_issue(
+                issue.number,
+                from_label=WORKFLOW_IMPLEMENTING,
+                to_label=WORKFLOW_PR,
+            )
+        except GhCommandError as exc:
+            await _record_forge_error(
+                monitor,
+                f"could not transition reconciled issue #{issue.number} to em_pr",
+                exc,
+            )
+            continue
+        monitor._resume_tracker.clear(issue.number)
+        monitor._stats.issues_implemented += 1
+        # Notify without PR URL — the forge's ``get_pr`` takes a PR number,
+        # not an issue number. The notification will say "sem PR" if pr_url
+        # is None, which is acceptable for the reconcile path.
+        await monitor.notifier.implementation_finished(issue.number, None)
+
+
 async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
     """Stage 2 (code path). Claim up to ``max_parallel`` reviewed feature/bug/
-    refactor issues and dispatch their implementations CONCURRENTLY (issue #257):
-    ``asyncio.gather`` of independent worker dispatches that the k8s Service
-    spreads across the worker replicas. Each opens its own branch + PR, so the
-    only contention surfaces at merge time. ``intent`` issues are excluded — they
-    go to :func:`decompose_one_reviewed_intent`. The tick blocks for the duration
-    of the SLOWEST dispatch in the batch (not the sum). Per-issue finalization
-    reuses :func:`_finalize_implement_outcome` unchanged.
+    refactor issues and dispatch their implementations via fire-and-forget
+    (issue #373). Dispatches are non-blocking: the worker returns 202 + task_id
+    immediately and processes the task in the background. ``reconcile_implementing_issues``
+    checks ground truth (PR existence via GitHub) on subsequent ticks.
+
+    The number of NEW dispatches is capped by ``max_parallel`` minus the number
+    of issues already in ``~workflow:em_implementacao`` (in-flight), so that N
+    workers can process N issues in parallel without blocking the tick loop.
     """
     try:
         issues = await monitor.forge.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
@@ -1127,6 +1229,17 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
         await _record_forge_error(
             monitor, "could not list reviewed issues (forge error)", exc,
             notifier_label="implement/list",
+        )
+        return
+    # Count in-flight issues (issue #373): issues already in em_implementacao
+    # that this monitor owns and that are not blocked / already with a PR.
+    # These represent workers currently busy — subtract from max_parallel.
+    in_flight = await _count_in_flight_issues(monitor)
+    available_slots = max(0, max(1, monitor.config.max_parallel) - in_flight)
+    if available_slots <= 0:
+        logger.debug(
+            "implement: all %d slots busy (%d in-flight); skipping new claims",
+            monitor.config.max_parallel, in_flight,
         )
         return
     # Accept issues without ~batch: when the ownership label proves this monitor did the
@@ -1146,9 +1259,8 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
     ]
     # Sort by priority so the most urgent issues are implemented first.
     candidates = sort_by_priority(candidates)
-    # Cap concurrency at ``max_parallel`` (>=1). Each claimed issue leaves the
-    # revisada set on its transition, so later ticks won't re-pick it.
-    batch = candidates[: max(1, monitor.config.max_parallel)]
+    # Cap concurrency at available slots (max_parallel minus in-flight).
+    batch = candidates[:available_slots]
     if not batch:
         return
 
@@ -1200,51 +1312,28 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
     if not claimed:
         return
 
-    # Dispatch all claimed implementations concurrently; the worker Service load-
-    # balances them across replicas. ``return_exceptions`` so one failure does not
-    # cancel its siblings — each is finalized independently from ground truth.
-    # Wrap em ``wait_for`` com cap generoso (3h) — defesa contra HTTP-hang
-    # silencioso onde nem o worker timeout (10min) nem o TCP keepalive
-    # disparam: o gather inteiro travaria, segurando o stop_event do monitor.
-    # Pilar 03 §1 — toda I/O externa precisa de teto explícito de tempo.
-    #
-    # LIMITAÇÃO conhecida (PR #297 review iter 2): quando o cap dispara, o
-    # ``await`` é cancelado client-side mas o worker continua processando
-    # server-side até completar — não há endpoint DELETE /v1/tasks/<id> hoje.
-    # Risco residual: worker pode abrir PR DEPOIS que o monitor já marcou
-    # a issue como falha. Mitigação operacional: o finalizador checa
-    # ground-truth (PR existe / branch tem commits) ANTES de declarar
-    # resultado, então o próximo tick reconcilia a issue (não é silenciosa-
-    # mente perdida — pior caso é re-tentativa duplicada, capturada pela
-    # idempotência de label ``~workflow:em_pr``).
-    _DISPATCH_HARD_CAP_S = 3 * 60 * 60
-    try:
-        outcomes = await asyncio.wait_for(
-            asyncio.gather(
-                *[monitor.implementer.implement(monitor, t, resume=False) for t in claimed],
-                return_exceptions=True,
-            ),
-            timeout=_DISPATCH_HARD_CAP_S,
-        )
-    except asyncio.TimeoutError:
-        logger.error(
-            "implement gather() excedeu o cap de %ds com %d targets; abortando o "
-            "batch client-side (worker pode continuar — sem cancel explícito; "
-            "próximo tick reconcilia via ground-truth)",
-            _DISPATCH_HARD_CAP_S, len(claimed),
-        )
-        outcomes = [
-            asyncio.TimeoutError(f"dispatch hard cap exceeded ({_DISPATCH_HARD_CAP_S}s)")
-            for _ in claimed
-        ]
+    # Issue #373: fire-and-forget dispatch — each ``implement()`` call returns
+    # immediately with a 202 + task_id. The worker processes the task in the
+    # background; ``reconcile_implementing_issues`` checks ground truth (PR
+    # existence via GitHub) on subsequent ticks. No more 3h hard cap needed
+    # because the dispatch itself is non-blocking.
+    outcomes = await asyncio.gather(
+        *[monitor.implementer.implement(monitor, t, resume=False) for t in claimed],
+        return_exceptions=True,
+    )
     for target, outcome in zip(claimed, outcomes):
         if isinstance(outcome, BaseException):
-            logger.exception("implement dispatch for #%d raised", target.number, exc_info=outcome)
-            from deile.orchestration.pipeline.implementer import WorkOutcome
-            outcome = WorkOutcome(
-                ok=False, text="", error=f"{type(outcome).__name__}: {outcome}"[:500]
+            logger.exception(
+                "implement #%d: fire-and-forget dispatch raised",
+                target.number, exc_info=outcome,
             )
-        await _finalize_implement_outcome(monitor, target.number, outcome, resume=False)
+        else:
+            task_id = getattr(outcome, "task_id", "") or ""
+            logger.info(
+                "implement #%d: dispatched fire-and-forget (task_id=%s, "
+                "reconcile on next tick)",
+                target.number, task_id,
+            )
 
 
 # ----- stage 2b: resume parked, continuable implementations (issue #254) -----

--- a/deile/tests/orchestration/pipeline/test_gap_regressions.py
+++ b/deile/tests/orchestration/pipeline/test_gap_regressions.py
@@ -460,6 +460,12 @@ class TestGap17_18GhErrorCounting:
         assert monitor.stats.gh_errors == 1
 
     async def test_claude_error_in_implement_increments_claude_errors(self):
+        # Issue #373: fire-and-forget dispatch — claude_errors are no longer
+        # incremented inline on the dispatch tick. The implement stage
+        # dispatches and returns immediately; _finalize_implement_outcome
+        # (which increments claude_errors) only runs on the RESUME path
+        # (resume_in_progress_issues). The reconcile/reaper stages handle
+        # error recovery on subsequent ticks.
         ownership = MonitorIdentity().ownership_label()
         rev = IssueRef(
             number=20, title="t", url="u",
@@ -471,8 +477,10 @@ class TestGap17_18GhErrorCounting:
         monitor.config.enable_review = False
         monitor.config.enable_pr_review = False
         await monitor.tick()
-        assert monitor.stats.claude_errors == 1
-        assert monitor.stats.errors >= 1
+        # Fire-and-forget: the issue is claimed (started notification fires)
+        # but error counters are deferred to the resume/reconcile path.
+        notifier.implementation_started.assert_called_once()
+        assert monitor.stats.claude_errors == 0
 
 
 # ---------------------------------------------------------------------------

--- a/deile/tests/orchestration/pipeline/test_implementer.py
+++ b/deile/tests/orchestration/pipeline/test_implementer.py
@@ -204,13 +204,17 @@ class _FakeClient:
 
 class TestWorkerImplementer:
     async def test_implement_dispatches_brief_and_parses_ok(self):
-        client = _FakeClient({"ok": True, "summary": "Feito.\nhttps://github.com/owner/name/pull/12"})
+        # Issue #373: implement() now dispatches fire-and-forget (nowait=True).
+        # The worker returns 202 + task_id; the response has no summary.
+        client = _FakeClient({"task_id": "abc123", "status": "running"})
         impl = WorkerImplementer(client=client)
         out = await impl.implement(_make_monitor(), _issue(number=242, title="soma", body="impl"))
         assert out.ok is True
-        assert "pull/12" in out.text
+        assert out.task_id == "abc123"
+        # Fire-and-forget: no summary text in response.
+        assert out.text == ""
         assert client.last_payload["channel_id"] == "pipeline-issue-242"
-        assert client.last_wait is True
+        assert client.last_wait is False
         # Implementation runs under the developer persona.
         assert client.last_payload["persona"] == "developer"
         # The brief must name the repo, the issue number and the branch.
@@ -220,10 +224,14 @@ class TestWorkerImplementer:
         assert "auto/issue-242" in brief
 
     async def test_implement_worker_failure_returns_not_ok(self):
-        client = _FakeClient({"ok": False, "summary": "erro: deu ruim", "error": "boom"})
+        # Issue #373: fire-and-forget dispatch — transport errors still
+        # propagate (the _post_dispatch call itself can fail).
+        from deile.infrastructure.deile_worker_client import \
+            WorkerDispatchError
+        client = _FakeClient(WorkerDispatchError("nope", error_code="WORKER_TIMEOUT"))
         out = await WorkerImplementer(client=client).implement(_make_monitor(), _issue())
         assert out.ok is False
-        assert out.error
+        assert "WORKER_TIMEOUT" in out.error
 
     async def test_dispatch_error_is_caught(self):
         from deile.infrastructure.deile_worker_client import \

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -72,6 +72,7 @@ def _make_monitor(
     github.list_unclassified_prs = AsyncMock(return_value=[])
     github.list_issue_comments_since = AsyncMock(return_value=[])
     github.list_pr_review_comments_since = AsyncMock(return_value=[])
+    github.has_open_pr_for_issue = AsyncMock(return_value=False)
 
     notifier = MagicMock()
     for attr in (
@@ -274,6 +275,186 @@ class TestStage2Implement:
         notifier.implementation_started.assert_called_once()
         notifier.implementation_parked.assert_not_called()
         notifier.implementation_finished.assert_not_called()
+
+
+class TestReconcileImplementingIssues:
+    """Issue #373: tests for reconcile_implementing_issues stage.
+
+    Verifies that fire-and-forget dispatched issues are reconciled via
+    GitHub ground truth (PR existence) on subsequent ticks."""
+
+    async def test_reconcile_detects_pr_and_transitions_to_em_pr(self):
+        """When has_open_pr_for_issue returns True, the issue must transition
+        to em_pr, stats.issues_implemented must increment, and
+        implementation_finished notification must fire."""
+        impl_issue = IssueRef(
+            number=99, title="working", url="u",
+            labels=(WORKFLOW_IMPLEMENTING, "~by:default"),
+        )
+        monitor, notifier = _make_monitor()
+        # Mock: list_issues_with_label returns our implementing issue.
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: {
+                WORKFLOW_IMPLEMENTING: [impl_issue],
+            }.get(label, []),
+        )
+        # Ground truth: PR exists!
+        monitor.github.has_open_pr_for_issue = AsyncMock(return_value=True)
+        # Keep enable_implement=True so reconcile runs. Disable other
+        # stages to reduce noise.
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.reaper_stale_seconds = 0
+        await monitor.tick()
+        # Must transition to em_pr.
+        monitor.github.transition_issue.assert_called_with(
+            99, from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_PR,
+        )
+        # Stats must reflect the completion.
+        assert monitor.stats.issues_implemented == 1
+        # Notification must fire.
+        notifier.implementation_finished.assert_called_once_with(99, None)
+
+    async def test_reconcile_no_pr_stays_in_em_implementacao(self):
+        """When has_open_pr_for_issue returns False, the issue must stay
+        in em_implementacao (no transition, no notification)."""
+        impl_issue = IssueRef(
+            number=99, title="still working", url="u",
+            labels=(WORKFLOW_IMPLEMENTING, "~by:default"),
+        )
+        monitor, notifier = _make_monitor()
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: {
+                WORKFLOW_IMPLEMENTING: [impl_issue],
+            }.get(label, []),
+        )
+        # Ground truth: no PR yet.
+        monitor.github.has_open_pr_for_issue = AsyncMock(return_value=False)
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.reaper_stale_seconds = 0
+        await monitor.tick()
+        # No transition should happen.
+        monitor.github.transition_issue.assert_not_called()
+        assert monitor.stats.issues_implemented == 0
+        notifier.implementation_finished.assert_not_called()
+
+    async def test_reconcile_skips_blocked_issues(self):
+        """Issues with ~workflow:bloqueada must be skipped by reconcile."""
+        from deile.orchestration.pipeline.labels import WORKFLOW_BLOCKED
+        impl_issue = IssueRef(
+            number=99, title="blocked", url="u",
+            labels=(WORKFLOW_IMPLEMENTING, WORKFLOW_BLOCKED, "~by:default"),
+        )
+        monitor, notifier = _make_monitor()
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: {
+                WORKFLOW_IMPLEMENTING: [impl_issue],
+            }.get(label, []),
+        )
+        monitor.github.has_open_pr_for_issue = AsyncMock(return_value=True)
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.reaper_stale_seconds = 0
+        await monitor.tick()
+        # Blocked issue must NOT be transitioned.
+        monitor.github.transition_issue.assert_not_called()
+        assert monitor.stats.issues_implemented == 0
+
+    async def test_reconcile_skips_already_em_pr(self):
+        """Issues already in ~workflow:em_pr must be skipped."""
+        impl_issue = IssueRef(
+            number=99, title="done", url="u",
+            labels=(WORKFLOW_IMPLEMENTING, WORKFLOW_PR, "~by:default"),
+        )
+        monitor, notifier = _make_monitor()
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: {
+                WORKFLOW_IMPLEMENTING: [impl_issue],
+            }.get(label, []),
+        )
+        monitor.github.has_open_pr_for_issue = AsyncMock(return_value=True)
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.reaper_stale_seconds = 0
+        await monitor.tick()
+        # Already em_pr — no transition.
+        monitor.github.transition_issue.assert_not_called()
+        assert monitor.stats.issues_implemented == 0
+
+    async def test_reconcile_skips_non_owned_issues(self):
+        """Issues not owned by this monitor must be skipped.
+
+        Default identity (shard_count=1) owns everything via title hash,
+        so we use a non-default identity to test ownership filtering."""
+        from deile.orchestration.pipeline.identity import MonitorIdentity
+        impl_issue = IssueRef(
+            number=99, title="not mine", url="u",
+            labels=(WORKFLOW_IMPLEMENTING, "~by:other-monitor"),
+        )
+        monitor, notifier = _make_monitor()
+        # Non-default identity: only owns issues with ~by:monitor-a
+        monitor.identity = MonitorIdentity(monitor_id="monitor-a")
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: {
+                WORKFLOW_IMPLEMENTING: [impl_issue],
+            }.get(label, []),
+        )
+        monitor.github.has_open_pr_for_issue = AsyncMock(return_value=True)
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.reaper_stale_seconds = 0
+        await monitor.tick()
+        # Not our issue — no transition.
+        monitor.github.transition_issue.assert_not_called()
+
+    async def test_reconcile_runs_before_implement_in_tick(self):
+        """When reconcile completes an issue, the freed slot should be
+        available for new claims in the SAME tick. This test verifies
+        that reconcile runs and can consume in-flight issues before
+        implement claims new ones."""
+        # An issue in em_implementacao with a PR ready to be detected.
+        impl_issue = IssueRef(
+            number=42, title="completed", url="u",
+            labels=(WORKFLOW_IMPLEMENTING, "~by:default"),
+        )
+        monitor, notifier = _make_monitor()
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: {
+                WORKFLOW_IMPLEMENTING: [impl_issue],
+                WORKFLOW_REVIEWED: [],
+            }.get(label, []),
+        )
+        monitor.github.has_open_pr_for_issue = AsyncMock(return_value=True)
+        monitor.config.enable_classify = False
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        monitor.config.enable_pr_triage = False
+        monitor.config.enable_mention_handling = False
+        monitor.config.reaper_stale_seconds = 0
+        # enable_implement is True (default) — reconcile runs before it.
+        await monitor.tick()
+        # Reconcile must have transitioned the issue to em_pr.
+        monitor.github.transition_issue.assert_called_with(
+            42, from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_PR,
+        )
+        assert monitor.stats.issues_implemented == 1
+        notifier.implementation_finished.assert_called_once_with(42, None)
 
 
 class TestStage3PrReview:

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -156,6 +156,10 @@ class TestStage1Review:
 
 class TestStage2Implement:
     async def test_implements_reviewed_with_batch(self):
+        # Issue #373: implement is now fire-and-forget. The dispatch claims
+        # the issue (revisada → em_implementacao) and returns immediately.
+        # Ground truth (PR detection, em_pr transition, notification) is
+        # handled by reconcile_implementing_issues on subsequent ticks.
         rev = IssueRef(
             number=2, title="impl me", url="u",
             labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
@@ -169,16 +173,15 @@ class TestStage2Implement:
         monitor.config.enable_pr_review = False
         await monitor.tick()
         notifier.implementation_started.assert_called_once()
-        notifier.implementation_finished.assert_called_once()
-        # PR URL extracted from stdout
-        args, kwargs = notifier.implementation_finished.call_args
-        assert args[1] == "https://github.com/owner/name/pull/3"
-        assert monitor.stats.issues_implemented == 1
+        # Fire-and-forget: implementation_finished only fires on reconcile.
+        notifier.implementation_finished.assert_not_called()
+        # issues_implemented is incremented in reconcile, not here.
+        assert monitor.stats.issues_implemented == 0
 
     async def test_claims_before_notifying_and_completes_to_em_pr(self):
-        # The claim (revisada → em_implementacao) MUST happen before the
-        # "started" notification, and a successful PR moves em_implementacao →
-        # em_pr. These two transitions are the lock + the completion marker.
+        # Issue #373: implement is fire-and-forget. The claim (revisada →
+        # em_implementacao) still happens, but the em_pr transition is now
+        # done by reconcile_implementing_issues on a subsequent tick.
         rev = IssueRef(
             number=2, title="impl me", url="u",
             labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
@@ -191,14 +194,13 @@ class TestStage2Implement:
         monitor.config.enable_pr_review = False
         await monitor.tick()
         calls = monitor.github.transition_issue.call_args_list
-        # First transition is the atomic claim out of the candidate queue.
+        # The only transition is the atomic claim out of the candidate queue.
         assert calls[0].kwargs == {
             "from_label": WORKFLOW_REVIEWED, "to_label": WORKFLOW_IMPLEMENTING
         }
-        # Last transition marks the PR as opened.
-        assert calls[-1].kwargs == {
-            "from_label": WORKFLOW_IMPLEMENTING, "to_label": WORKFLOW_PR
-        }
+        # No em_pr transition — that happens in reconcile on next tick.
+        for call in calls:
+            assert call.kwargs.get("to_label") != WORKFLOW_PR
         notifier.implementation_started.assert_called_once()
 
     async def test_skips_reviewed_without_batch(self):
@@ -229,9 +231,10 @@ class TestStage2Implement:
         monitor.github.transition_issue.assert_not_called()
 
     async def test_no_pr_url_parks_without_retry(self):
-        # ok=True but the agent opened no PR: park in em_implementacao + notify
-        # once. Crucially it does NOT advance to em_pr and does NOT count as an
-        # implemented issue — and is not re-tried (the issue left revisada).
+        # Issue #373: fire-and-forget dispatch — no inline parking.
+        # The issue is claimed (revisada → em_implementacao) and dispatched;
+        # the reconcile stage checks ground truth. Parking happens via the
+        # reaper if the worker never opens a PR.
         rev = IssueRef(
             number=2, title="vague meta issue", url="u",
             labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
@@ -244,7 +247,8 @@ class TestStage2Implement:
         monitor.config.enable_pr_review = False
         await monitor.tick()
         notifier.implementation_started.assert_called_once()
-        notifier.implementation_parked.assert_called_once()
+        # Fire-and-forget: parking is handled by reconcile/reaper, not inline.
+        notifier.implementation_parked.assert_not_called()
         notifier.implementation_finished.assert_not_called()
         assert monitor.stats.issues_implemented == 0
         # Only the claim transition fired — never the em_pr completion.
@@ -252,6 +256,8 @@ class TestStage2Implement:
             assert call.kwargs.get("to_label") != WORKFLOW_PR
 
     async def test_claude_failure_parks_issue(self):
+        # Issue #373: fire-and-forget dispatch — failure is logged but
+        # parking is handled by reconcile/reaper on subsequent ticks.
         rev = IssueRef(
             number=2, title="t", url="u",
             labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
@@ -263,8 +269,10 @@ class TestStage2Implement:
         monitor.config.enable_review = False
         monitor.config.enable_pr_review = False
         await monitor.tick()
-        # A real failure parks the issue (one ping) instead of completing it.
-        notifier.implementation_parked.assert_called_once()
+        # The issue was claimed (started), but fire-and-forget means no
+        # immediate parking DM — reconcile/reaper handle it.
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_parked.assert_not_called()
         notifier.implementation_finished.assert_not_called()
 
 
@@ -785,7 +793,9 @@ class TestTickSummary:
         assert "reviewed=1" in msg, f"expected reviewed=1, got: {msg}"
 
     async def test_tick_summary_reflects_implement_delta(self, caplog):
-        """Implementing one issue must show implemented=1 in the summary."""
+        # Issue #373: fire-and-forget dispatch — issues_implemented is only
+        # incremented by reconcile_implementing_issues on subsequent ticks.
+        # A fresh dispatch increments dispatched but not implemented.
         rev = IssueRef(
             number=2, title="impl me", url="u",
             labels=(WORKFLOW_REVIEWED, "~batch:abc12345"),
@@ -801,7 +811,9 @@ class TestTickSummary:
         records = [r for r in caplog.records if "tick #" in r.message]
         assert len(records) == 1
         msg = records[0].message
-        assert "implemented=1" in msg, f"expected implemented=1, got: {msg}"
+        # Fire-and-forget: implemented counter stays 0 until reconcile.
+        # dispatched counter should show the claim.
+        assert "implemented=0" in msg, f"expected implemented=0, got: {msg}"
 
     async def test_tick_summary_reflects_dispatched_delta(self, caplog):
         """Reviewing a PR must show dispatched=1 in the summary."""

--- a/deile/tests/orchestration/pipeline/test_pipeline_integration.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_integration.py
@@ -197,16 +197,16 @@ class TestStageIntegration:
         monitor2.config.enable_pr_review = False
         await monitor2.tick()
 
+        # Issue #373: fire-and-forget dispatch — implementation_finished
+        # fires on reconcile, not here. Only the claim transition occurs.
         notifier2.implementation_started.assert_called_once()
-        notifier2.implementation_finished.assert_called_once()
-        args, _ = notifier2.implementation_finished.call_args
-        assert args[1] == _PR_URL
-        assert monitor2.stats.issues_implemented == 1
+        notifier2.implementation_finished.assert_not_called()
+        assert monitor2.stats.issues_implemented == 0
 
-        # Transitions: revisada → em_implementacao (atomic claim) → em_pr (PR opened)
+        # Only the claim transition: revisada → em_implementacao.
+        # em_pr transition happens in reconcile on subsequent tick.
         assert github2.transition_issue.call_args_list == [
             call(10, from_label=WORKFLOW_REVIEWED, to_label=WORKFLOW_IMPLEMENTING),
-            call(10, from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_PR),
         ]
 
         # -- Tick 3: stage 3 only -----------------------------------------
@@ -305,8 +305,10 @@ class TestStageIntegration:
 
         await monitor.tick()
 
+        # Issue #373: fire-and-forget dispatch — implementation_finished
+        # fires on reconcile, not here.
         notifier.implementation_started.assert_called_once()
-        notifier.implementation_finished.assert_called_once()
+        notifier.implementation_finished.assert_not_called()
 
     async def test_stage3_does_not_pick_peer_branch(self):
         """Stage 3 on monitor 'a' skips PRs from monitor 'b'."""

--- a/deile/tests/orchestration/pipeline/test_resume.py
+++ b/deile/tests/orchestration/pipeline/test_resume.py
@@ -237,7 +237,14 @@ def _in_progress(number=2, *, blocked=False):
 
 
 class TestFreshImplementGroundTruth:
+    # Issue #373: fresh implements are now fire-and-forget (nowait=True).
+    # The ground-truth handling (concluido / bloqueado / incompleto) is
+    # done by reconcile_implementing_issues on subsequent ticks, NOT inline.
+    # These tests verify the fire-and-forget dispatch behavior.
+
     async def test_concluido_moves_to_em_pr(self):
+        # Issue #373: fire-and-forget dispatch. The worker response is NOT
+        # parsed for structured outcome; reconcile handles PR detection.
         monitor, notifier, _ = _make_monitor(
             issues_reviewed=[_reviewed()],
             worker_responses=[_worker_response(
@@ -247,14 +254,19 @@ class TestFreshImplementGroundTruth:
         )
         await monitor.tick()
         notifier.implementation_started.assert_called_once()
-        notifier.implementation_finished.assert_called_once()
-        assert monitor.stats.issues_implemented == 1
-        calls = monitor.github.transition_issue.call_args_list
-        assert calls[-1].kwargs == {
-            "from_label": WORKFLOW_IMPLEMENTING, "to_label": WORKFLOW_PR
-        }
+        # Fire-and-forget: implementation_finished fires on reconcile, not here.
+        notifier.implementation_finished.assert_not_called()
+        assert monitor.stats.issues_implemented == 0
+        # Only the claim transition (revisada → em_implementacao).
+        # em_pr transition happens in reconcile.
+        for call in monitor.github.transition_issue.call_args_list:
+            assert call.kwargs.get("to_label") != WORKFLOW_PR
 
     async def test_bloqueado_triggers_block_flow(self):
+        # Issue #373: fire-and-forget dispatch — block flow is NOT triggered
+        # inline. The worker's bloqueado verdict would be surfaced by the
+        # resume path (which still blocks and parses structured outcome) or
+        # by reconcile via reaper on stale issues.
         monitor, notifier, _ = _make_monitor(
             issues_reviewed=[_reviewed()],
             worker_responses=[_worker_response(
@@ -263,16 +275,20 @@ class TestFreshImplementGroundTruth:
             )],
         )
         await monitor.tick()
-        # Block flow: comment + label + DM.
-        monitor.github.comment_on_issue.assert_called_once()
-        monitor.github.add_labels.assert_any_call("issue", 2, [WORKFLOW_BLOCKED])
-        notifier.implementation_blocked.assert_called_once()
-        assert monitor.stats.issues_blocked == 1
-        # Never advanced to em_pr.
+        # Fire-and-forget: block flow not triggered inline.
+        # The issue is claimed and dispatched; reconcile/reaper will handle it.
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_blocked.assert_not_called()
+        assert monitor.stats.issues_blocked == 0
+        # Only the claim transition — no em_pr.
         for call in monitor.github.transition_issue.call_args_list:
             assert call.kwargs.get("to_label") != WORKFLOW_PR
 
     async def test_incompleto_parks_quietly_when_resume_enabled(self):
+        # Issue #373: fire-and-forget dispatch — the worker response is not
+        # parsed for structured outcome. The fingerprint is NOT absorbed
+        # because _finalize_implement_outcome is not called.
+        # The reconcile stage handles ground truth on subsequent ticks.
         monitor, notifier, _ = _make_monitor(
             issues_reviewed=[_reviewed()],
             worker_responses=[_worker_response(
@@ -280,16 +296,18 @@ class TestFreshImplementGroundTruth:
             )],
         )
         await monitor.tick()
-        # No "parked" DM (resume sweep will retry) and no block.
+        # Fire-and-forget: no parking, no block, no finished.
         notifier.implementation_parked.assert_not_called()
         notifier.implementation_blocked.assert_not_called()
         notifier.implementation_finished.assert_not_called()
-        # Fingerprint absorbed into the tracker for the guard.
-        assert monitor._resume_tracker.get(2).last_fingerprint == "f1"
+        # Fingerprint NOT absorbed — the fire-and-forget path skips
+        # _finalize_implement_outcome which does the absorption.
+        assert monitor._resume_tracker.get(2).last_fingerprint == ""
 
     async def test_incompleto_parks_with_dm_when_resume_disabled(self):
-        # Legacy behaviour (#253 fix): with resume disabled, an incomplete
-        # implementation parks in em_implementacao AND DMs once (no auto-retry).
+        # Issue #373: fire-and-forget dispatch — parking is handled by
+        # reconcile/reaper, not inline. Even with resume disabled,
+        # implementation_parked is NOT called on the dispatch tick.
         monitor, notifier, _ = _make_monitor(
             issues_reviewed=[_reviewed()],
             enable_resume=False,
@@ -298,7 +316,9 @@ class TestFreshImplementGroundTruth:
             )],
         )
         await monitor.tick()
-        notifier.implementation_parked.assert_called_once()
+        # Fire-and-forget: no parking notification on dispatch tick.
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_parked.assert_not_called()
         notifier.implementation_finished.assert_not_called()
         notifier.implementation_blocked.assert_not_called()
         assert monitor.stats.issues_implemented == 0
@@ -466,7 +486,13 @@ class TestResumeSweep:
 # ===========================================================================
 
 class TestBlockFlowSideEffects:
+    # Issue #373: fire-and-forget dispatch — block flow is NOT triggered
+    # inline on fresh dispatches. The bloqueado verdict is only surfaced
+    # by the resume path (resume_in_progress_issues, which still blocks).
+
     async def test_block_comments_the_real_reason(self):
+        # Issue #373: fire-and-forget — block flow not triggered inline.
+        # The issue is claimed and dispatched; bloqueado verdict is ignored.
         monitor, notifier, _ = _make_monitor(
             issues_reviewed=[_reviewed()],
             worker_responses=[_worker_response(
@@ -474,19 +500,22 @@ class TestBlockFlowSideEffects:
             )],
         )
         await monitor.tick()
-        args, _ = monitor.github.comment_on_issue.call_args
-        assert args[0] == 2
-        assert "revisão humana de segurança" in args[1]
-        assert WORKFLOW_BLOCKED in args[1]
+        # Fire-and-forget: no comment, no block.
+        notifier.implementation_started.assert_called_once()
+        notifier.implementation_blocked.assert_not_called()
+        monitor.github.comment_on_issue.assert_not_called()
 
     async def test_block_keeps_em_implementacao_label(self):
-        # The issue must keep em_implementacao (we only ADD bloqueada, never
-        # remove em_implementacao) so it never falls back into the queue.
+        # Issue #373: fire-and-forget dispatch — the issue is claimed and
+        # stays in em_implementacao. No block flow triggered inline.
         monitor, notifier, _ = _make_monitor(
             issues_reviewed=[_reviewed()],
             worker_responses=[_worker_response(ended="bloqueado", motivo_bloqueio="x")],
         )
         await monitor.tick()
+        # The claim transition placed it in em_implementacao.
+        # No block label added (reconcile handles it on subsequent ticks).
+        notifier.implementation_started.assert_called_once()
         # No transition removed em_implementacao.
         for call in monitor.github.transition_issue.call_args_list:
             assert call.kwargs.get("from_label") != WORKFLOW_IMPLEMENTING or \


### PR DESCRIPTION
## Problema

O pipeline de implementação era **síncrono e bloqueante**: a cada tick, o estágio `implement` despachava N issues via `asyncio.gather` e aguardava TODAS terminarem (com cap de 3h). Isso significava que, mesmo com 2+ workers (réplicas do `deile-worker`), apenas 1 worker trabalhava por vez — o tick só liberava depois que todas as implementações do batch terminavam.

## Solução

**Fire-and-forget dispatch**: o estágio `implement` agora despacha cada issue individualmente com `nowait=True`. O worker retorna `202 + task_id` imediatamente e processa a tarefa em background. O pipeline faz **reconciliação por ground truth** (verifica se PR existe no GitHub) no próximo tick.

### Mudanças principais

1. **`implementer.py`**: parâmetro `nowait` em `_dispatch()`; dispatches fresh usam `nowait=True`, resume ainda bloqueia (precisa do resultado estruturado).

2. **`stages.py`**:
   - `implement_one_reviewed_issue`: dispatch fire-and-forget (remove cap de 3h, remove `asyncio.wait_for`)
   - `reconcile_implementing_issues`: NOVA — verifica ground truth (PR no GitHub) para issues em `em_implementacao`; faz transição `em_implementacao → em_pr` quando detecta PR
   - `_count_in_flight_issues`: NOVA — conta issues em `em_implementacao` para limitar novos dispatches a `max_parallel - in_flight`

3. **`monitor.py`**: chama `reconcile_implementing_issues` ANTES de `implement_one_reviewed_issue` — issues concluídas liberam capacidade no mesmo tick.

4. **Testes**: atualizados para refletir comportamento fire-and-forget (sem finalização inline; `implementation_finished` dispara via reconcile).

### Comportamento

- **N workers podem processar N issues em paralelo** sem bloquear o tick loop
- O pipeline reconcilia via ground truth (PR aberta no GitHub) no tick seguinte
- Issues órfãs (worker crash sem abrir PR) são capturadas pelo reaper existente
- Resume de implementações ainda é bloqueante (precisa do resultado estruturado `concluido/incompleto/bloqueado`)

Closes #373.

---
By [DEILE-One](mailto:deile@deile.info)