### PR TITLE
fix: forge-agnosticism + cleanup deferred from PR #352 (issue #353)

### DIFF
--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -48,6 +48,7 @@ from deile.orchestration.pipeline.dispatch_resolver import (
 from deile.orchestration.pipeline.labels import (issue_type_from_labels,
                                                  persona_for_type,
                                                  template_for_type)
+from deile.orchestration.pipeline.constants import resolve_forge_repo
 from deile.orchestration.pipeline.model_resolver import resolve_stage_model
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -931,7 +932,7 @@ class WorkerImplementer(PipelineImplementer):
             try:
                 proc = await _aio.create_subprocess_exec(
                     "gh", "api",
-                    f"repos/elimarcavalli/deile/issues/{pr_number}/comments",
+                    f"repos/{resolve_forge_repo()}/issues/{pr_number}/comments",
                     "--paginate",
                     "-q",
                     f'.[] | select(.created_at > "{since_iso}") | '

--- a/deile/ui/panel/observability/__init__.py
+++ b/deile/ui/panel/observability/__init__.py
@@ -12,11 +12,14 @@ Public entrypoints:
 * :class:`ClaudeJsonlParser` — incremental parser for
   ``~/.claude/projects/<workspace-hash>/<session-uuid>.jsonl`` produced by
   the Claude CLI.
-* :class:`ClusterObservabilityClient` — thin HTTP client that fan-outs to
-  the pipeline status server and the claude-worker session endpoints.
-* :class:`ClusterStatusScreen`, :class:`LiveSessionScreen`,
-  :class:`HistoryScreen` — Rich-based renderers consumed by the panel main
-  loop.
+
+For the HTTP client and screen renderers, see the sibling modules:
+
+* :mod:`deile.ui.panel.observability.client` —
+  :class:`ClusterObservabilityClient` (thin HTTP client).
+* :mod:`deile.ui.panel.observability.screens` —
+  :class:`ClusterStatusScreen`, :class:`LiveSessionScreen`,
+  :class:`HistoryScreen` (Rich-based renderers).
 """
 
 from deile.ui.panel.observability.jsonl_parser import (  # noqa: F401

--- a/deile/ui/panel/observability/screens.py
+++ b/deile/ui/panel/observability/screens.py
@@ -293,7 +293,7 @@ class LiveSessionScreen:
             else:
                 preview = _truncate(turn.get("content") or turn.get("summary") or "", 70)
             table.add_row(
-                _fmt_ts(turn.get("ts") if isinstance(turn.get("ts"), (int, float)) else None) or "",
+                _fmt_ts(turn.get("ts") if isinstance(turn.get("ts"), (int, float)) else None),
                 f"{marker} {role or '?'}",
                 preview,
             )

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -1175,10 +1175,9 @@ async def resume_info_handler(request: web.Request) -> web.Response:
 # --------------------------------------------------------------------------- #
 
 
-#: Environment variable names whose VALUE must never leave the cluster.  We
-#: redact them in :func:`sessions_command_handler` so the operator can see
-#: *which* knobs were active without exposing the secret string itself.
-_REDACTED_ENV_PATTERNS = (
+#: Environment variable name patterns that SHOULD be redacted even when the
+#: value itself doesn't match a known secret pattern (defense-in-depth).
+_REDACTED_KEY_PATTERNS = (
     re.compile(r".*_API_KEY$", re.IGNORECASE),
     re.compile(r".*_TOKEN$", re.IGNORECASE),
     re.compile(r".*_SECRET$", re.IGNORECASE),
@@ -1189,18 +1188,37 @@ _REDACTED_ENV_PATTERNS = (
 
 
 def _redact_env(env: dict) -> dict:
-    """Return a copy of ``env`` with sensitive values replaced by ``***``.
+    """Return a copy of ``env`` with sensitive values redacted.
 
-    Match by *key* against :data:`_REDACTED_ENV_PATTERNS` (any pattern hit
-    redacts the value).  Non-string values are coerced to ``str`` for the
-    comparison but the resulting dict still uses strings only — JSON-safe.
+    Two-layer defense:
+
+    1. **Key-based** — any env-var whose *name* matches
+       :data:`_REDACTED_KEY_PATTERNS` (``*_API_KEY``, ``*_TOKEN``, etc.)
+       is redacted unconditionally.
+    2. **Value-based** — uses
+       :class:`deile.security.secrets_scanner.SecretsScanner.redact_text`
+       as the single source of truth for detecting secret patterns in the
+       value itself (e.g. GitHub tokens, AWS keys, private keys).
+
+    A key hit OR a value hit replaces the entry with ``***``.
+    Non-string values are coerced to ``str``.
     """
+    from deile.security.secrets_scanner import SecretsScanner
+
+    scanner = SecretsScanner()
     out = {}
     for key, value in env.items():
         if not isinstance(key, str):
             continue
-        redacted = any(pat.search(key) for pat in _REDACTED_ENV_PATTERNS)
-        out[key] = "***" if redacted else (value if isinstance(value, str) else str(value))
+        str_value = value if isinstance(value, str) else str(value)
+        # Layer 1: key-name match
+        key_sensitive = any(pat.search(key) for pat in _REDACTED_KEY_PATTERNS)
+        if key_sensitive:
+            out[key] = "***"
+            continue
+        # Layer 2: value-content scan via SecretsScanner
+        redacted_value, _matches = scanner.redact_text(str_value)
+        out[key] = "***" if redacted_value != str_value else str_value
     return out
 
 


### PR DESCRIPTION
## Summary

Implements issue #353 covering two groups of deferred work from PR #352 review:

### Part 1 — [BUG] Forge-agnosticism broken (implementer.py:896)
- Replaced hardcoded `repos/elimarcavalli/deile/...` with `resolve_forge_repo()` call
- Audit confirms this was the **only** remaining hardcoded owner/repo in production code
- `constants.PIPELINE_DEFAULT_REPO` is the allowed default fallback

### Part 2.2 — Dead-code `or ""` in screens.py:296
- `_fmt_ts()` always returns a string (never None/empty), so the `or ""` was dead code — removed

### Part 2.3 — Docstring inconsistency in `__init__.py`
- Updated docstring to reflect actual exports: only `ClaudeJsonlParser` (and turn types) are exported
- `ClusterObservabilityClient` and screen renderers are documented as sibling-module references

### Part 2.4 — Env-var redaction via SecretsScanner
- Replaced inline `_REDACTED_ENV_PATTERNS` regex with two-layer defence:
  1. Key-name matching (preserving existing behaviour for `*_API_KEY`, `*_TOKEN`, etc.)
  2. Value-content scanning via `SecretsScanner.redact_text` (single source of truth)

### Test results
```
deile/tests/orchestration/pipeline/test_implementer.py ..............  [22%]
deile/tests/orchestration/pipeline/test_implementer_per_stage_model.py ....... [29%]
deile/tests/infrastructure/test_claude_worker_server.py ....................................... [90%]
deile/tests/ui/test_observability_screens.py .......... [100%]
101 passed in 1.27s
```

Closes #353.

---
By [DEILE-One](mailto:deile@deile.info)