### PR TITLE
perf(pipeline): share one ~workflow:revisada fetch across implement + decompose (PR #380 follow-up)

### DIFF
--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -775,10 +775,32 @@ class PipelineMonitor:
         # dispatches in the same tick.
         if cfg.enable_implement:
             await self._reconcile_implementing_issues()
-        await _scheduled(cfg.enable_implement, "implement", self._implement_one_reviewed_issue)
+        # PR #380 follow-up (non-blocking review suggestion): fetch the
+        # ``~workflow:revisada`` snapshot ONCE and ensure ownership ONCE, then
+        # share it with both the implement and decompose stages — halving the
+        # per-tick reviewed-list forge calls (each stage used to fetch + ensure
+        # independently). The two stages target disjoint issue types (implement
+        # → non-intent, decompose → intent), so a shared snapshot is safe.
+        #
+        # Two views preserve the exact prior pickup timing: implement gets the
+        # PRE-ensure snapshot (it always filtered its own un-ensured fetch, so an
+        # orphan code issue is adopted next tick); decompose gets the POST-ensure
+        # snapshot (it used to re-fetch a fresh one carrying the label, so an
+        # orphan intent is decomposed the same tick). On a forge error both are
+        # None and each stage falls back to its own self-contained fetch.
+        # ``implement`` only consumes the shared snapshot in legacy (non-schedule)
+        # mode; when run via the scheduler it is invoked by name with no args and
+        # fetches its own (unchanged).
+        reviewed_pre = reviewed_post = None
+        if (cfg.enable_implement and "implement" not in skip) or cfg.enable_refinement_gate:
+            reviewed_pre, reviewed_post = await stages.fetch_reviewed_and_ensure_ownership(self)
+        await _scheduled(
+            cfg.enable_implement, "implement",
+            lambda: self._implement_one_reviewed_issue(reviewed_pre),
+        )
         # Decompose CLEAR intents into derived issues (issue #257).
         if cfg.enable_refinement_gate:
-            await self._decompose_one_reviewed_intent()
+            await self._decompose_one_reviewed_intent(reviewed_post)
         await _scheduled(cfg.enable_pr_review, "pr_review", self._review_one_open_pr)
         if cfg.enable_pr_triage:
             await self._classify_new_prs()
@@ -809,11 +831,11 @@ class PipelineMonitor:
     async def _refine_one_issue(self) -> None:
         return await stages.refine_one_issue(self)
 
-    async def _decompose_one_reviewed_intent(self) -> None:
-        return await stages.decompose_one_reviewed_intent(self)
+    async def _decompose_one_reviewed_intent(self, issues=None) -> None:
+        return await stages.decompose_one_reviewed_intent(self, issues)
 
-    async def _implement_one_reviewed_issue(self) -> None:
-        return await stages.implement_one_reviewed_issue(self)
+    async def _implement_one_reviewed_issue(self, issues=None) -> None:
+        return await stages.implement_one_reviewed_issue(self, issues)
 
     async def _resume_in_progress_issues(self) -> None:
         return await stages.resume_in_progress_issues(self)

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -22,9 +22,10 @@ import logging
 import re
 import time
 import warnings
-from typing import TYPE_CHECKING, Optional
+from dataclasses import replace
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from deile.orchestration.forge import (CommentRef, GhCommandError,
+from deile.orchestration.forge import (CommentRef, GhCommandError, IssueRef,
                                        MentionTrigger, declared_hosts,
                                        find_last_pr_url)
 from deile.orchestration.pipeline._time_utils import now_utc
@@ -1052,13 +1053,32 @@ async def _block_refinement(monitor: "PipelineMonitor", issue, reason: str) -> N
     await _block(monitor, "issue", number, short, comment=comment)
 
 
-async def _ensure_ownership_label(monitor: "PipelineMonitor", issues) -> None:
+async def _ensure_ownership_label(
+    monitor: "PipelineMonitor", issues: List["IssueRef"]
+) -> List["IssueRef"]:
     """Issue #375: auto-add ownership label to reviewed issues that this monitor
     owns (via ``_this_monitor_owns``) but that lack both ``~batch:`` and the
     ``~by:*`` label. Without this, issues manually promoted to
     ``~workflow:revisada`` (by removing ``~workflow:bloqueada`` outside the
-    classification flow) are silently ignored."""
+    classification flow) are silently ignored.
+
+    Returns a **new** snapshot list with the freshly-added ownership label
+    reflected in memory for any issue it fixes (``IssueRef`` is frozen, so a new
+    one is built via :func:`dataclasses.replace`). The input list is left
+    untouched, so the caller keeps both views:
+
+    - the **pre-ensure** input — what ``implement_one_reviewed_issue`` filters
+      on (it always filtered its own un-ensured fetch, so an orphan code issue
+      is adopted on the *next* tick), and
+    - the **post-ensure** return — what ``decompose_one_reviewed_intent``
+      filters on (it used to re-fetch a fresh snapshot that already carried the
+      label, so an orphan intent is decomposed the *same* tick).
+
+    Keeping both views lets the tick fetch the reviewed snapshot **once** (PR
+    #380 follow-up) while preserving the exact per-stage pickup timing that the
+    two independent fetches produced before."""
     ownership_label = monitor.identity.ownership_label()
+    updated: List["IssueRef"] = []
     for issue in issues:
         if (
             WORKFLOW_BLOCKED not in issue.labels
@@ -1073,30 +1093,97 @@ async def _ensure_ownership_label(monitor: "PipelineMonitor", issues) -> None:
             )
             try:
                 await monitor.forge.add_labels("issue", issue.number, [ownership_label])
+                issue = replace(issue, labels=(*issue.labels, ownership_label))
             except GhCommandError as exc:
                 logger.warning(
                     "could not add ownership label %s to #%d: %s",
                     ownership_label, issue.number, exc,
                 )
+        updated.append(issue)
+    return updated
 
 
-async def decompose_one_reviewed_intent(monitor: "PipelineMonitor") -> None:
-    """Stage 2 (intent path, issue #257): an architect decomposes a CLEAR intent
-    into independent derived issues, then the intent stays OPEN as a decomposed
-    epic (``~workflow:decomposta``)."""
-    if not monitor.config.enable_refinement_gate:
-        return
+async def fetch_reviewed_and_ensure_ownership(
+    monitor: "PipelineMonitor", *, notifier_label: str = "reviewed/list"
+) -> "Tuple[Optional[List[IssueRef]], Optional[List[IssueRef]]]":
+    """PR #380 follow-up (non-blocking review suggestion): fetch the
+    ``~workflow:revisada`` snapshot **once** per tick and ensure ownership
+    **once**, so the implement and decompose stages share a single forge list
+    call instead of each issuing their own (they target disjoint issue types —
+    non-intent vs intent — so a shared snapshot is safe).
+
+    Returns ``(pre, post)``:
+
+    - ``pre`` — the raw snapshot, before any ownership label was reflected
+      in memory. ``implement_one_reviewed_issue`` filters on this, reproducing
+      its prior behavior (it always filtered its own un-ensured fetch, so an
+      orphan code issue is adopted on the *next* tick).
+    - ``post`` — the ownership-ensured snapshot. ``decompose_one_reviewed_intent``
+      filters on this, reproducing its prior behavior (it re-fetched a fresh
+      snapshot that already carried the label, so an orphan intent is
+      decomposed the *same* tick).
+
+    Both are ``None`` on a forge error; each stage then falls back to its own
+    self-contained fetch (see :func:`_resolve_reviewed_snapshot`)."""
     try:
         issues = await monitor.forge.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
     except GhCommandError as exc:
         await _record_forge_error(
-            monitor, "could not list reviewed intents (forge error)", exc,
-            notifier_label="decompose/list",
+            monitor, "could not list reviewed issues (forge error)", exc,
+            notifier_label=notifier_label,
         )
+        return None, None
+    ensured = await _ensure_ownership_label(monitor, issues)
+    return issues, ensured
+
+
+async def _resolve_reviewed_snapshot(
+    monitor: "PipelineMonitor",
+    issues: Optional[List["IssueRef"]],
+    *,
+    notifier_label: str,
+) -> Optional[List["IssueRef"]]:
+    """Return the reviewed-issue snapshot a stage should operate on.
+
+    When ``issues`` is provided, the tick already fetched it (and ensured
+    ownership in a single shared pass) — use it as-is. When ``None`` (direct
+    invocation, tests, or fallback after a centralized fetch error), fetch the
+    snapshot and run the ownership side-effect inline, then return the **raw**
+    (pre-ensure) view — matching the prior per-stage direct-call behavior, where
+    ``_ensure_ownership_label`` updated the forge but the stage filtered its own
+    un-mutated fetch."""
+    if issues is not None:
+        return issues
+    try:
+        raw = await monitor.forge.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
+    except GhCommandError as exc:
+        await _record_forge_error(
+            monitor, "could not list reviewed issues (forge error)", exc,
+            notifier_label=notifier_label,
+        )
+        return None
+    # GitHub side-effect + audit log; the returned ensured view is discarded so
+    # the stage keeps filtering on the raw snapshot (next-tick adoption).
+    await _ensure_ownership_label(monitor, raw)
+    return raw
+
+
+async def decompose_one_reviewed_intent(
+    monitor: "PipelineMonitor", issues: Optional[List["IssueRef"]] = None
+) -> None:
+    """Stage 2 (intent path, issue #257): an architect decomposes a CLEAR intent
+    into independent derived issues, then the intent stays OPEN as a decomposed
+    epic (``~workflow:decomposta``).
+
+    ``issues`` is the shared reviewed snapshot when called from the tick (PR #380
+    follow-up); ``None`` means fetch + ensure ownership inline (direct/legacy)."""
+    if not monitor.config.enable_refinement_gate:
         return
-    # Issue #375: auto-add ownership label to orphan reviewed issues before
-    # candidate filtering (so manually-unblocked issues are not silently ignored).
-    await _ensure_ownership_label(monitor, issues)
+    issues = await _resolve_reviewed_snapshot(
+        monitor, issues, notifier_label="decompose/list"
+    )
+    if issues is None:
+        return
     ownership_label = monitor.identity.ownership_label()
     target = next(
         (i for i in sort_by_priority(issues)
@@ -1243,7 +1330,9 @@ async def reconcile_implementing_issues(monitor: "PipelineMonitor") -> None:
         await monitor.notifier.implementation_finished(issue.number, None)
 
 
-async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
+async def implement_one_reviewed_issue(
+    monitor: "PipelineMonitor", issues: Optional[List["IssueRef"]] = None
+) -> None:
     """Stage 2 (code path). Claim up to ``max_parallel`` reviewed feature/bug/
     refactor issues and dispatch their implementations via fire-and-forget
     (issue #373). Dispatches are non-blocking: the worker returns 202 + task_id
@@ -1253,14 +1342,14 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
     The number of NEW dispatches is capped by ``max_parallel`` minus the number
     of issues already in ``~workflow:em_implementacao`` (in-flight), so that N
     workers can process N issues in parallel without blocking the tick loop.
+
+    ``issues`` is the shared reviewed snapshot when called from the tick (PR #380
+    follow-up); ``None`` means fetch + ensure ownership inline (direct/legacy).
     """
-    try:
-        issues = await monitor.forge.list_issues_with_label(WORKFLOW_REVIEWED, limit=50)
-    except GhCommandError as exc:
-        await _record_forge_error(
-            monitor, "could not list reviewed issues (forge error)", exc,
-            notifier_label="implement/list",
-        )
+    issues = await _resolve_reviewed_snapshot(
+        monitor, issues, notifier_label="implement/list"
+    )
+    if issues is None:
         return
     # Count in-flight issues (issue #373): issues already in em_implementacao
     # that this monitor owns and that are not blocked / already with a PR.
@@ -1273,9 +1362,6 @@ async def implement_one_reviewed_issue(monitor: "PipelineMonitor") -> None:
             monitor.config.max_parallel, in_flight,
         )
         return
-    # Issue #375: auto-add ownership label to orphan reviewed issues before
-    # candidate filtering (so manually-unblocked issues are not silently ignored).
-    await _ensure_ownership_label(monitor, issues)
     # Accept issues without ~batch: when the ownership label proves this monitor did the
     # review (e.g. operator manually promoted to ~workflow:revisada or batch label removed).
     ownership_label = monitor.identity.ownership_label()

--- a/deile/tests/orchestration/pipeline/test_refinement_gate.py
+++ b/deile/tests/orchestration/pipeline/test_refinement_gate.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import AsyncMock, MagicMock
 
+from deile.orchestration.forge import GhCommandError
 from deile.orchestration.pipeline.github_client import IssueRef
 from deile.orchestration.pipeline.implementer import WorkerImplementer
 from deile.orchestration.pipeline.labels import (REFINAR,
@@ -309,3 +310,100 @@ class TestBriefSizeClamp:
         await monitor._review_one_new_issue()
         assert client.payloads, "critique must have dispatched"
         assert len(client.payloads[0]["brief"]) <= 8000
+
+
+# ===========================================================================
+# SHARED REVIEWED SNAPSHOT (PR #380 follow-up — non-blocking review suggestion)
+# ===========================================================================
+
+def _reviewed_list_calls(github: MagicMock) -> int:
+    """Count list_issues_with_label calls targeting ~workflow:revisada."""
+    n = 0
+    for call in github.list_issues_with_label.await_args_list:
+        label = call.args[0] if call.args else call.kwargs.get("label")
+        if label == WORKFLOW_REVIEWED:
+            n += 1
+    return n
+
+
+class TestSharedReviewedSnapshot:
+    """The implement + decompose stages share a single ~workflow:revisada fetch
+    per tick (and a single ownership-ensure pass) instead of each issuing their
+    own. Behavior is preserved via two views: implement filters the PRE-ensure
+    snapshot (orphan code adopted next tick); decompose filters the POST-ensure
+    snapshot (orphan intent decomposed same tick)."""
+
+    async def test_reviewed_listed_once_per_dispatch(self):
+        # A mix of intent + code so both stages have work to consider.
+        reviewed = [
+            _issue(80, "intent", "~batch:abc12345"),
+            _issue(81, "feature", "~batch:abc12345"),
+        ]
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: reviewed},
+            worker_responses=[_resp("DECOMPOSTO: #91"), _resp("https://github.com/owner/name/pull/191")],
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor._dispatch_stages()
+        # Was 2 (implement + decompose each fetched independently); now 1 shared.
+        assert _reviewed_list_calls(monitor.github) == 1
+
+    async def test_orphan_intent_decomposed_same_tick(self):
+        # No ~batch:, no ~by: — manually promoted to revisada. The default
+        # monitor owns everything (shard 1), so it must adopt + decompose it.
+        orphan = _issue(82, "intent")  # no batch, no ownership
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: [orphan]},
+            worker_responses=[_resp("DECOMPOSTO: #92 #93")],
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor._dispatch_stages()
+        ownership = monitor.identity.ownership_label()
+        assert ownership in _added(monitor.github, 82)  # adopted
+        # Decomposed in the SAME tick (decompose filters the post-ensure view).
+        assert (82, WORKFLOW_REVIEWED, WORKFLOW_DECOMPOSED) in _transitions(monitor.github)
+
+    async def test_orphan_code_adopted_but_not_implemented_same_tick(self):
+        # The implement path filters the PRE-ensure snapshot, so an orphan code
+        # issue is labeled now but only claimed on the NEXT tick (preserving the
+        # 1-tick latency the original two-fetch flow had).
+        orphan = _issue(83, "feature")  # no batch, no ownership
+        monitor, _, client = _make_monitor(
+            label_map={WORKFLOW_REVIEWED: [orphan]},
+        )
+        monitor.config.enable_review = False
+        monitor.config.enable_pr_review = False
+        await monitor._dispatch_stages()
+        ownership = monitor.identity.ownership_label()
+        assert ownership in _added(monitor.github, 83)  # adopted (label added)
+        # NOT claimed for implementation this tick.
+        claims = [t for t in _transitions(monitor.github)
+                  if t == (83, WORKFLOW_REVIEWED, WORKFLOW_IMPLEMENTING)]
+        assert claims == []
+        assert client.payloads == []
+
+    async def test_ensure_ownership_label_returns_view_without_mutating_input(self):
+        from deile.orchestration.pipeline.stages import _ensure_ownership_label
+        orphan = _issue(84, "feature")            # gets adopted
+        batched = _issue(85, "feature", "~batch:abc12345")  # no-op
+        monitor, _, _ = _make_monitor()
+        inp = [orphan, batched]
+        out = await _ensure_ownership_label(monitor, inp)
+        ownership = monitor.identity.ownership_label()
+        # Input list untouched (pre-ensure view stays clean for implement).
+        assert ownership not in inp[0].labels
+        # Returned view reflects the added label for the orphan only.
+        assert ownership in out[0].labels
+        assert out[1] is batched  # batched issue reused as-is (no replace)
+
+    async def test_forge_error_returns_none_pair(self):
+        monitor, _, _ = _make_monitor()
+        monitor.github.list_issues_with_label = AsyncMock(
+            side_effect=GhCommandError(("gh", "issue", "list"), 1, "", "boom")
+        )
+        from deile.orchestration.pipeline.stages import \
+            fetch_reviewed_and_ensure_ownership
+        pre, post = await fetch_reviewed_and_ensure_ownership(monitor)
+        assert pre is None and post is None


### PR DESCRIPTION
## Contexto

Implementa a **Sugestão não-bloqueante** deixada pelo @deile-one na revisão da PR #380:

> 🔧 A chamada em `decompose_one_reviewed_intent` é parcialmente redundante com a de `implement_one_reviewed_issue`... Se quiser reduzir chamadas à API, considere extrair `_ensure_ownership_label` para um único ponto no `tick()`.

## A sugestão faz sentido? Sim — com um alvo mais preciso

A sugestão literal (um único `_ensure_ownership_label` no tick) sozinha **não reduziria chamadas à API**: `_ensure_ownership_label` não faz `list` nenhum — só chama `add_labels` para órfãs (raro), e iterar in-memory é grátis. A redundância **real** por tick é que `implement_one_reviewed_issue` **e** `decompose_one_reviewed_intent` cada um disparava seu próprio `list_issues_with_label(WORKFLOW_REVIEWED)` — **duas list calls idênticas à forge a cada tick**.

## Solução

Consolidar num único `fetch_reviewed_and_ensure_ownership` em `_dispatch_stages`: busca o snapshot de `~workflow:revisada` **uma vez**, garante ownership **uma vez**, e compartilha com os dois stages. Em modo legacy (o default, sem schedule file) as list calls de revisada caem de **2 → 1 por tick**.

Os dois stages operam sobre **tipos de issue disjuntos** (implement → não-intent, decompose → intent) — exatamente a propriedade que a própria revisão identificou como a garantia anti-duplicação. Logo o snapshot compartilhado é seguro.

## Timing de pickup preservado exatamente (zero mudança de comportamento)

Para não regredir nada, mantenho **duas views** do mesmo fetch:

| Stage | View | Comportamento preservado |
|---|---|---|
| `implement` | **PRE**-ensure (raw) | sempre filtrou o próprio fetch não-mutado → issue de código órfã é adotada no **próximo** tick (a latência de 1 tick que a revisão declarou aceitável) |
| `decompose` | **POST**-ensure | re-buscava um snapshot fresco que já carregava o label → intent órfã é decomposta no **mesmo** tick |

`_ensure_ownership_label` agora retorna uma **nova** lista com o label refletido in-memory (`IssueRef` é frozen → reconstruído via `dataclasses.replace`), deixando a entrada intacta — assim as duas views coexistem a partir de um único fetch.

Os stages ganham um parâmetro opcional `issues`: `None` ⇒ caminho self-contained (fetch + ensure inline) usado por chamadas diretas, testes e **fallback em erro de forge** (resiliência: se o fetch central falha, cada stage re-busca o seu).

## "Não pegar coisas em duplicidade por workers separados"

A segurança cross-process **não muda**: PID lock, hash sharding, labels `~by:<id>` e o claim via `transition_issue` continuam idênticos. O snapshot compartilhado é **por-tick, por-processo, in-memory** — não atravessa workers.

## Modos cobertos

- **legacy (default)**: 1 fetch (era 2). ✅ otimização.
- **scheduled (implement no schedule)**: implement roda pelo scheduler (fetch próprio) + fetch compartilhado p/ decompose = 2 (igual a antes, sem regressão).
- gate desabilitado / implement desabilitado: 1 fetch ou nenhum, conforme aplicável.

## Testes

Novo `TestSharedReviewedSnapshot` em `test_refinement_gate.py`:
- `test_reviewed_listed_once_per_dispatch` — fetch único compartilhado (2 → 1)
- `test_orphan_intent_decomposed_same_tick` — intent órfã adotada + decomposta no mesmo tick (view POST)
- `test_orphan_code_adopted_but_not_implemented_same_tick` — código órfão recebe `~by:default` mas só é implementado no próximo tick (view PRE)
- `test_ensure_ownership_label_returns_view_without_mutating_input` — retorna view sem mutar a entrada
- `test_forge_error_returns_none_pair` — erro de forge → `(None, None)`

```
deile/tests/orchestration/pipeline/{test_refinement_gate,test_monitor,test_gap_regressions,
  test_concurrency,test_pr_triage,test_reaper,test_loop_guards,test_priority_sorting,
  test_bug_fixes_a_b,test_issue351_invalidation,test_pipeline_integration}.py
→ 244 passed, 2 skipped, 0 regressões
```

(As suítes `test_github_client*` falham só neste sandbox por ausência do binário `gh` — pré-existente, não relacionado a esta mudança.)

---
By [DEILE-One](mailto:deile@deile.info)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAxMpy6kTjZvVsPWFMyZDt)_