### PR TITLE
feat(#391): per-stage Timeout and Retries overrides in DispatchMatrixView

### DIFF
--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -82,32 +82,42 @@ def _mb_to_bytes(value: Any) -> int:
     return int(value) * 1024 * 1024
 
 
-def _to_optional_pos_int(value: Any) -> Optional[int]:
-    """Coerce to a positive int (> 0), or None if absent.
+def _to_optional_positive_int(value: Any) -> Optional[int]:
+    """Coerce to a positive int (> 0), or None if absent/empty.
 
     Used for per-stage timeout_s overrides: None = no override (fall
     through to global/built-in); 0 or negative = rejected.
+    Empty string is treated as absent (returns None) for env-var ergonomics.
     """
     if value is None:
         return None
     if isinstance(value, bool):
         raise TypeError("expected int, got bool")
+    if isinstance(value, str) and not value.strip():
+        return None
     iv = int(value)
     if iv <= 0:
         raise ValueError(f"value must be > 0, got {iv}")
     return iv
 
 
+# Alias kept for internal compatibility (issue #391 spec used this name).
+_to_optional_pos_int = _to_optional_positive_int
+
+
 def _to_optional_nonneg_int(value: Any) -> Optional[int]:
-    """Coerce to a non-negative int (>= 0), or None if absent.
+    """Coerce to a non-negative int (>= 0), or None if absent/empty.
 
     Used for per-stage retries overrides: None = no override; negative = rejected.
     0 is valid (means no retries).
+    Empty string is treated as absent (returns None) for env-var ergonomics.
     """
     if value is None:
         return None
     if isinstance(value, bool):
         raise TypeError("expected int, got bool")
+    if isinstance(value, str) and not value.strip():
+        return None
     iv = int(value)
     if iv < 0:
         raise ValueError(f"value must be >= 0, got {iv}")

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -82,6 +82,38 @@ def _mb_to_bytes(value: Any) -> int:
     return int(value) * 1024 * 1024
 
 
+def _to_optional_pos_int(value: Any) -> Optional[int]:
+    """Coerce to a positive int (> 0), or None if absent.
+
+    Used for per-stage timeout_s overrides: None = no override (fall
+    through to global/built-in); 0 or negative = rejected.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError("expected int, got bool")
+    iv = int(value)
+    if iv <= 0:
+        raise ValueError(f"value must be > 0, got {iv}")
+    return iv
+
+
+def _to_optional_nonneg_int(value: Any) -> Optional[int]:
+    """Coerce to a non-negative int (>= 0), or None if absent.
+
+    Used for per-stage retries overrides: None = no override; negative = rejected.
+    0 is valid (means no retries).
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError("expected int, got bool")
+    iv = int(value)
+    if iv < 0:
+        raise ValueError(f"value must be >= 0, got {iv}")
+    return iv
+
+
 def _to_nonneg_int(value: Any) -> int:
     """Coerce to a non-negative int (rejects negatives and bools).
 
@@ -237,6 +269,21 @@ _OVERRIDE_HANDLERS: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
     "pipeline.dispatchers.implement":  ("pipeline_dispatcher_implement",  _to_optional_dispatcher),
     "pipeline.dispatchers.pr_review":  ("pipeline_dispatcher_pr_review",  _to_optional_dispatcher),
     "pipeline.dispatchers.follow_ups": ("pipeline_dispatcher_follow_ups", _to_optional_dispatcher),
+    # Per-stage timeout override (issue #391) — seconds. None = no override.
+    "pipeline.timeouts_s.classify":   ("pipeline_timeout_s_classify",   _to_optional_pos_int),
+    "pipeline.timeouts_s.refine":     ("pipeline_timeout_s_refine",     _to_optional_pos_int),
+    "pipeline.timeouts_s.implement":  ("pipeline_timeout_s_implement",  _to_optional_pos_int),
+    "pipeline.timeouts_s.pr_review":  ("pipeline_timeout_s_pr_review",  _to_optional_pos_int),
+    "pipeline.timeouts_s.follow_ups": ("pipeline_timeout_s_follow_ups", _to_optional_pos_int),
+    # Per-stage max retries override (issue #391) — 0 = no retry. None = no override.
+    "pipeline.retries.classify":   ("pipeline_retries_classify",   _to_optional_nonneg_int),
+    "pipeline.retries.refine":     ("pipeline_retries_refine",     _to_optional_nonneg_int),
+    "pipeline.retries.implement":  ("pipeline_retries_implement",  _to_optional_nonneg_int),
+    "pipeline.retries.pr_review":  ("pipeline_retries_pr_review",  _to_optional_nonneg_int),
+    "pipeline.retries.follow_ups": ("pipeline_retries_follow_ups", _to_optional_nonneg_int),
+    # Global defaults for timeout and retries (issue #391).
+    "pipeline.default_timeout_s_deile":  ("pipeline_deile_timeout",       _to_optional_pos_int),
+    "pipeline.default_max_retries":      ("pipeline_default_max_retries",  _to_optional_nonneg_int),
     # Sub-DEILEs paralelos (issue #257)
     "subagent.runner": ("subagent_runner", lambda v: str(v).strip().lower()),
     "subagent.max_parallel": ("subagent_max_parallel", _to_pos_int),
@@ -452,6 +499,36 @@ class Settings:
     pipeline_dispatcher_implement: Optional[str] = None
     pipeline_dispatcher_pr_review: Optional[str] = None
     pipeline_dispatcher_follow_ups: Optional[str] = None
+
+    # Pipeline per-stage timeout override (issue #391) — CLI persistence layer.
+    # Tempo máximo de execução do dispatch (segundos) por etapa. None = sem
+    # override (cai para global deile/claude timeout ou built-in). Cluster path
+    # usa ``DEILE_PIPELINE_TIMEOUT_S_<STAGE>`` env no Deployment deile-pipeline.
+    pipeline_timeout_s_classify: Optional[int] = None
+    pipeline_timeout_s_refine: Optional[int] = None
+    pipeline_timeout_s_implement: Optional[int] = None
+    pipeline_timeout_s_pr_review: Optional[int] = None
+    pipeline_timeout_s_follow_ups: Optional[int] = None
+
+    # Pipeline per-stage max retries override (issue #391) — CLI persistence layer.
+    # Número máximo de tentativas antes de escalar para ~workflow:bloqueada.
+    # None = sem override (cai para pipeline_default_max_retries ou built-in 3).
+    # 0 = sem retry (falha imediata). Cluster path usa
+    # ``DEILE_PIPELINE_RETRIES_<STAGE>`` env no Deployment deile-pipeline.
+    pipeline_retries_classify: Optional[int] = None
+    pipeline_retries_refine: Optional[int] = None
+    pipeline_retries_implement: Optional[int] = None
+    pipeline_retries_pr_review: Optional[int] = None
+    pipeline_retries_follow_ups: Optional[int] = None
+
+    # Global default for deile-worker timeout (issue #391). Mirrors
+    # ``pipeline_claude_timeout`` (1800s) for the deile-worker path (built-in
+    # 900s). None collapses to the built-in (dispatch_resolver handles it).
+    pipeline_deile_timeout: Optional[int] = None
+
+    # Global default max retries across all stages (issue #391) — extracted
+    # from the formerly hard-coded value of 3. None collapses to built-in 3.
+    pipeline_default_max_retries: Optional[int] = None
 
     # Sub-DEILEs paralelos em sessão CLI (issue #257)
     # `subagent_runner`        — "local" (default; in-process via asyncio.gather de
@@ -1059,6 +1136,22 @@ _ENV_OVERRIDES: Tuple[Tuple[str, str, Callable[[str], Any]], ...] = (
     ("DEILE_PIPELINE_DISPATCH_IMPLEMENT",    "pipeline_dispatcher_implement",  _to_optional_dispatcher),
     ("DEILE_PIPELINE_DISPATCH_PR_REVIEW",    "pipeline_dispatcher_pr_review",  _to_optional_dispatcher),
     ("DEILE_PIPELINE_DISPATCH_FOLLOW_UPS",   "pipeline_dispatcher_follow_ups", _to_optional_dispatcher),
+    # Per-stage timeout override (issue #391) — cluster path. Set via the panel
+    # TUI on deploy/deile-pipeline. Paridade com pipeline.timeouts_s.<stage>.
+    ("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY",    "pipeline_timeout_s_classify",    _to_optional_pos_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_REFINE",      "pipeline_timeout_s_refine",      _to_optional_pos_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT",   "pipeline_timeout_s_implement",   _to_optional_pos_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW",   "pipeline_timeout_s_pr_review",   _to_optional_pos_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_FOLLOW_UPS",  "pipeline_timeout_s_follow_ups",  _to_optional_pos_int),
+    # Per-stage max retries override (issue #391) — cluster path.
+    ("DEILE_PIPELINE_RETRIES_CLASSIFY",      "pipeline_retries_classify",      _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_REFINE",        "pipeline_retries_refine",        _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_IMPLEMENT",     "pipeline_retries_implement",     _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_PR_REVIEW",     "pipeline_retries_pr_review",     _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_FOLLOW_UPS",    "pipeline_retries_follow_ups",    _to_optional_nonneg_int),
+    # Global timeout/retries defaults (issue #391).
+    ("DEILE_PIPELINE_DEILE_TIMEOUT",         "pipeline_deile_timeout",         _to_optional_pos_int),
+    ("DEILE_PIPELINE_DEFAULT_MAX_RETRIES",   "pipeline_default_max_retries",   _to_optional_nonneg_int),
 )
 
 

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -143,6 +143,44 @@ def _to_optional_model_slug(value: Any) -> Optional[str]:
     return stripped
 
 
+def _to_optional_positive_int(value: Any) -> Optional[int]:
+    """Coerce to a positive int (> 0) or None (issue #391 — per-stage timeout).
+
+    ``None`` and empty/whitespace string collapse to ``None`` (no override).
+    Non-int-convertible or non-positive values raise — ``apply_overrides``
+    catches the exception and keeps the previous (default) value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    if isinstance(value, bool):
+        raise TypeError("expected int, got bool")
+    iv = int(value)
+    if iv <= 0:
+        raise ValueError(f"value must be > 0, got {iv}")
+    return iv
+
+
+def _to_optional_nonneg_int(value: Any) -> Optional[int]:
+    """Coerce to a non-negative int (>= 0) or None (issue #391 — per-stage retries).
+
+    ``None`` and empty/whitespace string collapse to ``None`` (no override).
+    Non-int-convertible or negative values raise — ``apply_overrides``
+    catches the exception and keeps the previous (default) value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    if isinstance(value, bool):
+        raise TypeError("expected int, got bool")
+    iv = int(value)
+    if iv < 0:
+        raise ValueError(f"value must be >= 0, got {iv}")
+    return iv
+
+
 def _to_optional_dispatcher(value: Any) -> Optional[str]:
     """Strict converter for ``pipeline.dispatchers.<stage>`` entries (issue #309).
 
@@ -237,6 +275,18 @@ _OVERRIDE_HANDLERS: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
     "pipeline.dispatchers.implement":  ("pipeline_dispatcher_implement",  _to_optional_dispatcher),
     "pipeline.dispatchers.pr_review":  ("pipeline_dispatcher_pr_review",  _to_optional_dispatcher),
     "pipeline.dispatchers.follow_ups": ("pipeline_dispatcher_follow_ups", _to_optional_dispatcher),
+    # Per-stage timeout override (issue #391) — see dispatch_resolver.
+    "pipeline.timeouts_s.classify":   ("pipeline_timeout_s_classify",   _to_optional_positive_int),
+    "pipeline.timeouts_s.refine":     ("pipeline_timeout_s_refine",     _to_optional_positive_int),
+    "pipeline.timeouts_s.implement":  ("pipeline_timeout_s_implement",  _to_optional_positive_int),
+    "pipeline.timeouts_s.pr_review":  ("pipeline_timeout_s_pr_review",  _to_optional_positive_int),
+    "pipeline.timeouts_s.follow_ups": ("pipeline_timeout_s_follow_ups", _to_optional_positive_int),
+    # Per-stage retries override (issue #391) — see dispatch_resolver.
+    "pipeline.retries.classify":   ("pipeline_retries_classify",   _to_optional_nonneg_int),
+    "pipeline.retries.refine":     ("pipeline_retries_refine",     _to_optional_nonneg_int),
+    "pipeline.retries.implement":  ("pipeline_retries_implement",  _to_optional_nonneg_int),
+    "pipeline.retries.pr_review":  ("pipeline_retries_pr_review",  _to_optional_nonneg_int),
+    "pipeline.retries.follow_ups": ("pipeline_retries_follow_ups", _to_optional_nonneg_int),
     # Sub-DEILEs paralelos (issue #257)
     "subagent.runner": ("subagent_runner", lambda v: str(v).strip().lower()),
     "subagent.max_parallel": ("subagent_max_parallel", _to_pos_int),
@@ -452,6 +502,26 @@ class Settings:
     pipeline_dispatcher_implement: Optional[str] = None
     pipeline_dispatcher_pr_review: Optional[str] = None
     pipeline_dispatcher_follow_ups: Optional[str] = None
+
+    # Pipeline per-stage timeout override (issue #391) — CLI persistence layer.
+    # Overrides the global timeout (pipeline_claude_timeout for claude stages,
+    # hard-coded 900s for deile stages) for individual stages. ``None`` = use
+    # global default. Cluster path uses DEILE_PIPELINE_TIMEOUT_S_<STAGE> env.
+    pipeline_timeout_s_classify: Optional[int] = None
+    pipeline_timeout_s_refine: Optional[int] = None
+    pipeline_timeout_s_implement: Optional[int] = None
+    pipeline_timeout_s_pr_review: Optional[int] = None
+    pipeline_timeout_s_follow_ups: Optional[int] = None
+
+    # Pipeline per-stage retries override (issue #391) — CLI persistence layer.
+    # Overrides the global default max retries for individual stages.
+    # ``None`` = use global default. Cluster path uses
+    # DEILE_PIPELINE_RETRIES_<STAGE> env.
+    pipeline_retries_classify: Optional[int] = None
+    pipeline_retries_refine: Optional[int] = None
+    pipeline_retries_implement: Optional[int] = None
+    pipeline_retries_pr_review: Optional[int] = None
+    pipeline_retries_follow_ups: Optional[int] = None
 
     # Sub-DEILEs paralelos em sessão CLI (issue #257)
     # `subagent_runner`        — "local" (default; in-process via asyncio.gather de
@@ -1059,6 +1129,22 @@ _ENV_OVERRIDES: Tuple[Tuple[str, str, Callable[[str], Any]], ...] = (
     ("DEILE_PIPELINE_DISPATCH_IMPLEMENT",    "pipeline_dispatcher_implement",  _to_optional_dispatcher),
     ("DEILE_PIPELINE_DISPATCH_PR_REVIEW",    "pipeline_dispatcher_pr_review",  _to_optional_dispatcher),
     ("DEILE_PIPELINE_DISPATCH_FOLLOW_UPS",   "pipeline_dispatcher_follow_ups", _to_optional_dispatcher),
+    # Per-stage timeout override (issue #391) — cluster path. Operates em
+    # paridade com pipeline.timeouts_s.<stage> em settings.json. Validator
+    # ``_to_optional_positive_int`` rejeita valores <= 0.
+    ("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY",    "pipeline_timeout_s_classify",    _to_optional_positive_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_REFINE",      "pipeline_timeout_s_refine",      _to_optional_positive_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT",   "pipeline_timeout_s_implement",   _to_optional_positive_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW",   "pipeline_timeout_s_pr_review",   _to_optional_positive_int),
+    ("DEILE_PIPELINE_TIMEOUT_S_FOLLOW_UPS",  "pipeline_timeout_s_follow_ups",  _to_optional_positive_int),
+    # Per-stage retries override (issue #391) — cluster path. Operates em
+    # paridade com pipeline.retries.<stage> em settings.json. Validator
+    # ``_to_optional_nonneg_int`` rejeita valores negativos.
+    ("DEILE_PIPELINE_RETRIES_CLASSIFY",      "pipeline_retries_classify",      _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_REFINE",        "pipeline_retries_refine",        _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_IMPLEMENT",     "pipeline_retries_implement",     _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_PR_REVIEW",     "pipeline_retries_pr_review",     _to_optional_nonneg_int),
+    ("DEILE_PIPELINE_RETRIES_FOLLOW_UPS",    "pipeline_retries_follow_ups",    _to_optional_nonneg_int),
 )
 
 

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -281,6 +281,14 @@ def build_dispatch_payload(
     # via JSONL persistido no PVC. Pipeline resolve via DispatchLedger.
     resume_session_id: Optional[str] = None,
     prev_task_id: Optional[str] = None,
+    # --- Per-stage execution limits (issue #391) ----------------------------
+    # Opcionais e adicionados ao final — backward compat com worker antigo.
+    # ``timeout_s`` sobrescreve o DEILE_WORKER_TASK_TIMEOUT_S/
+    # DEILE_CLAUDE_WORKER_TASK_TIMEOUT_S do worker-side para ESTE dispatch.
+    # ``max_retries`` informa ao monitor loop o teto de tentativas antes de
+    # escalar para ~workflow:bloqueada.
+    timeout_s: Optional[int] = None,
+    max_retries: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Assemble the JSON body POSTed to ``POST /v1/dispatch``.
 
@@ -299,6 +307,8 @@ def build_dispatch_payload(
     no worker. São opcionais e omitidos do wire quando ``None`` — workers
     antigos que não conhecem estes campos continuam funcionando porque o
     cliente serializa via ``model_dump(exclude_none=True)``.
+
+    ``timeout_s`` / ``max_retries`` (issue #391) carregam limites por-stage.
     """
     payload: Dict[str, Any] = {
         "brief": brief,
@@ -329,6 +339,10 @@ def build_dispatch_payload(
         payload["resume_session_id"] = str(resume_session_id)
     if prev_task_id:
         payload["prev_task_id"] = str(prev_task_id)
+    if timeout_s is not None and isinstance(timeout_s, int) and timeout_s > 0:
+        payload["timeout_s"] = timeout_s
+    if max_retries is not None and isinstance(max_retries, int) and max_retries >= 0:
+        payload["max_retries"] = max_retries
     return payload
 
 

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -150,6 +150,17 @@ class DispatchPayload(BaseModel):
     # retomar — devolve 404/410/409 com error_code específico se invalido,
     # pra o pipeline fallback pra fresh dispatch.
     prev_task_id: Optional[str] = Field(default=None, max_length=16)
+    # --- Per-stage dispatch tuning (issue #391) ---------------------------------
+    # ``timeout_s``: wall-clock seconds before the worker kills the subprocess /
+    # marks the task as timed-out. When set, overrides the worker's own default
+    # ``DEILE_WORKER_TASK_TIMEOUT_S`` for THIS dispatch only. Resolved by
+    # :func:`deile.orchestration.pipeline.dispatch_resolver.resolve_stage_timeout_s`
+    # before the payload is assembled.
+    timeout_s: Optional[int] = Field(default=None, ge=1)
+    # ``max_retries``: maximum number of attempts before the pipeline escalates
+    # to ``~workflow:bloqueada``. 0 = no retry (fail immediately). Resolved by
+    # :func:`deile.orchestration.pipeline.dispatch_resolver.resolve_stage_max_retries`.
+    max_retries: Optional[int] = Field(default=None, ge=0)
 
     @field_validator("brief")
     @classmethod
@@ -281,6 +292,9 @@ def build_dispatch_payload(
     # via JSONL persistido no PVC. Pipeline resolve via DispatchLedger.
     resume_session_id: Optional[str] = None,
     prev_task_id: Optional[str] = None,
+    # --- Per-stage dispatch tuning (issue #391) -----------------------------
+    timeout_s: Optional[int] = None,
+    max_retries: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Assemble the JSON body POSTed to ``POST /v1/dispatch``.
 
@@ -329,6 +343,10 @@ def build_dispatch_payload(
         payload["resume_session_id"] = str(resume_session_id)
     if prev_task_id:
         payload["prev_task_id"] = str(prev_task_id)
+    if timeout_s is not None:
+        payload["timeout_s"] = int(timeout_s)
+    if max_retries is not None:
+        payload["max_retries"] = int(max_retries)
     return payload
 
 

--- a/deile/orchestration/pipeline/dispatch_resolver.py
+++ b/deile/orchestration/pipeline/dispatch_resolver.py
@@ -179,6 +179,104 @@ def resolve_stage_dispatcher(stage: str) -> str:
     return _DEFAULT_DISPATCHER
 
 
+# Built-in timeout defaults (seconds). ``claude-worker`` stages use
+# ``pipeline_claude_timeout`` from settings (default 1800s); ``deile-worker``
+# stages use this deile-specific default (900s). These are only consulted when
+# no per-stage or global settings override exists.
+_DEFAULT_CLAUDE_TIMEOUT_S = 1800
+_DEFAULT_DEILE_TIMEOUT_S = 900
+
+# Built-in default max retries when no override exists.
+_DEFAULT_MAX_RETRIES = 3
+
+# Stages whose default worker is claude-worker (for timeout fallback).
+_CLAUDE_DEFAULT_STAGES: frozenset = frozenset({"implement", "pr_review"})
+
+
+def resolve_stage_timeout_s(stage: str) -> int:
+    """Returns per-stage timeout in seconds, falling back to global default.
+
+    Fallback chain (high → low):
+
+    1. ``DEILE_PIPELINE_TIMEOUT_S_<STAGE>`` env var — fail-fast on invalid.
+    2. ``pipeline.timeouts_s.<stage>`` in settings.json — warn + skip on invalid.
+    3. Global default: ``pipeline_claude_timeout`` from settings for claude
+       stages (implement, pr_review); 900s for deile stages.
+    4. Built-in: 1800s for claude stages, 900s for deile stages.
+
+    Raises:
+        ValueError: stage not in :data:`PIPELINE_STAGES`.
+    """
+    if stage not in PIPELINE_STAGES:
+        raise ValueError(
+            f"unknown stage {stage!r}; expected one of {PIPELINE_STAGES}"
+        )
+
+    # 1. Per-stage env var (fail-fast)
+    raw_env = os.environ.get(f"DEILE_PIPELINE_TIMEOUT_S_{stage.upper()}")
+    if raw_env and raw_env.strip():
+        try:
+            v = int(raw_env.strip())
+            if v > 0:
+                return v
+        except (ValueError, TypeError):
+            pass
+
+    # 2. Per-stage settings.json (graceful)
+    from deile.config.settings import get_settings  # lazy
+    settings = get_settings()
+    per_stage = getattr(settings, f"pipeline_timeout_s_{stage}", None)
+    if per_stage is not None and isinstance(per_stage, int) and per_stage > 0:
+        return per_stage
+
+    # 3. Global default from settings
+    if stage in _CLAUDE_DEFAULT_STAGES:
+        global_timeout = getattr(settings, "pipeline_claude_timeout", None)
+        if global_timeout and isinstance(global_timeout, int) and global_timeout > 0:
+            return global_timeout
+        return _DEFAULT_CLAUDE_TIMEOUT_S
+    else:
+        return _DEFAULT_DEILE_TIMEOUT_S
+
+
+def resolve_stage_max_retries(stage: str) -> int:
+    """Returns per-stage max retries, falling back to global default.
+
+    Fallback chain (high → low):
+
+    1. ``DEILE_PIPELINE_RETRIES_<STAGE>`` env var — fail-fast on invalid.
+    2. ``pipeline.retries.<stage>`` in settings.json — warn + skip on invalid.
+    3. Built-in default: 3 retries.
+
+    Raises:
+        ValueError: stage not in :data:`PIPELINE_STAGES`.
+    """
+    if stage not in PIPELINE_STAGES:
+        raise ValueError(
+            f"unknown stage {stage!r}; expected one of {PIPELINE_STAGES}"
+        )
+
+    # 1. Per-stage env var (fail-fast)
+    raw_env = os.environ.get(f"DEILE_PIPELINE_RETRIES_{stage.upper()}")
+    if raw_env is not None and raw_env.strip():
+        try:
+            v = int(raw_env.strip())
+            if v >= 0:
+                return v
+        except (ValueError, TypeError):
+            pass
+
+    # 2. Per-stage settings.json (graceful)
+    from deile.config.settings import get_settings  # lazy
+    settings = get_settings()
+    per_stage = getattr(settings, f"pipeline_retries_{stage}", None)
+    if per_stage is not None and isinstance(per_stage, int) and per_stage >= 0:
+        return per_stage
+
+    # 3. Built-in default
+    return _DEFAULT_MAX_RETRIES
+
+
 def get_endpoint_for(dispatcher: str) -> str:
     """Resolve a URL HTTP do worker pod *dispatcher*.
 

--- a/deile/orchestration/pipeline/dispatch_resolver.py
+++ b/deile/orchestration/pipeline/dispatch_resolver.py
@@ -61,6 +61,17 @@ _DISPATCHER_ALIASES: dict[str, str] = {
 
 _DEFAULT_DISPATCHER = "deile-worker"
 
+#: Built-in timeout defaults (seconds) when no per-stage or global override is set.
+#: claude-worker runs ``claude -p`` subprocesses that take longer; deile-worker
+#: is in-process and faster. Mirrors ``pipeline_claude_timeout`` (1800) and
+#: the new ``pipeline_deile_timeout`` (900) defaults in Settings.
+BUILT_IN_TIMEOUT_S_CLAUDE: int = 1800
+BUILT_IN_TIMEOUT_S_DEILE: int = 900
+
+#: Built-in max retries default — formerly hard-coded in the monitor loop.
+#: Extracted here (issue #391) so it can be overridden per-stage or globally.
+BUILT_IN_MAX_RETRIES: int = 3
+
 # Default endpoints. Env vars sobrescrevem (útil pra dev local fora do cluster).
 _ENDPOINT_DEFAULTS = {
     "deile-worker": "http://deile-worker:8766",
@@ -177,6 +188,103 @@ def resolve_stage_dispatcher(stage: str) -> str:
     # 5. Hardcoded safety net (only reached if settings.pipeline_dispatch_mode
     #    is empty or an unrecognized alias — extremely unlikely in practice).
     return _DEFAULT_DISPATCHER
+
+
+def resolve_stage_timeout_s(stage: str) -> int:
+    """Returns per-stage dispatch timeout in seconds, falling back to global default.
+
+    Fallback chain (high → low priority):
+
+    1. ``DEILE_PIPELINE_TIMEOUT_S_<STAGE>`` env var — fail-fast on invalid.
+    2. ``pipeline.timeouts_s.<stage>`` in settings.json — warn + skip on invalid.
+    3. Global settings: ``pipeline_claude_timeout`` (claude-worker) or
+       ``pipeline_deile_timeout`` (deile-worker), when set.
+    4. Built-in: :data:`BUILT_IN_TIMEOUT_S_CLAUDE` / :data:`BUILT_IN_TIMEOUT_S_DEILE`.
+
+    Raises:
+        ValueError: stage not in :data:`PIPELINE_STAGES` (programming bug).
+        ValueError: env var contains a non-positive integer (fail-fast).
+    """
+    if stage not in PIPELINE_STAGES:
+        raise ValueError(
+            f"unknown stage {stage!r}; expected one of {PIPELINE_STAGES}"
+        )
+
+    # 1. Per-stage env var (fail-fast)
+    raw_env = os.environ.get(f"DEILE_PIPELINE_TIMEOUT_S_{stage.upper()}")
+    if raw_env and raw_env.strip():
+        try:
+            v = int(raw_env.strip())
+            if v <= 0:
+                raise ValueError(f"timeout must be > 0, got {v}")
+            return v
+        except ValueError:
+            raise
+
+    # 2. Per-stage settings (graceful)
+    from deile.config.settings import get_settings  # lazy: avoids import cycle
+    settings = get_settings()
+    settings_val = getattr(settings, f"pipeline_timeout_s_{stage}", None)
+    if settings_val is not None and settings_val > 0:
+        return settings_val
+
+    # 3. Global settings fallback — dispatcher-aware (claude vs deile)
+    dispatcher = resolve_stage_dispatcher(stage)
+    if dispatcher == "claude-worker":
+        global_val = settings.pipeline_claude_timeout
+        if global_val is not None and global_val > 0:
+            return global_val
+        return BUILT_IN_TIMEOUT_S_CLAUDE
+    else:
+        global_val = settings.pipeline_deile_timeout
+        if global_val is not None and global_val > 0:
+            return global_val
+        return BUILT_IN_TIMEOUT_S_DEILE
+
+
+def resolve_stage_max_retries(stage: str) -> int:
+    """Returns per-stage max retries, falling back to global default.
+
+    Fallback chain (high → low priority):
+
+    1. ``DEILE_PIPELINE_RETRIES_<STAGE>`` env var — fail-fast on invalid.
+    2. ``pipeline.retries.<stage>`` in settings.json — warn + skip on invalid.
+    3. ``pipeline.default_max_retries`` in settings.json (global default).
+    4. Built-in: :data:`BUILT_IN_MAX_RETRIES` (3).
+
+    Raises:
+        ValueError: stage not in :data:`PIPELINE_STAGES` (programming bug).
+        ValueError: env var contains a negative integer (fail-fast).
+    """
+    if stage not in PIPELINE_STAGES:
+        raise ValueError(
+            f"unknown stage {stage!r}; expected one of {PIPELINE_STAGES}"
+        )
+
+    # 1. Per-stage env var (fail-fast)
+    raw_env = os.environ.get(f"DEILE_PIPELINE_RETRIES_{stage.upper()}")
+    if raw_env is not None and raw_env.strip():
+        try:
+            v = int(raw_env.strip())
+            if v < 0:
+                raise ValueError(f"retries must be >= 0, got {v}")
+            return v
+        except ValueError:
+            raise
+
+    # 2. Per-stage settings (graceful)
+    from deile.config.settings import get_settings  # lazy: avoids import cycle
+    settings = get_settings()
+    settings_val = getattr(settings, f"pipeline_retries_{stage}", None)
+    if settings_val is not None:
+        return settings_val
+
+    # 3. Global settings default
+    if settings.pipeline_default_max_retries is not None:
+        return settings.pipeline_default_max_retries
+
+    # 4. Built-in
+    return BUILT_IN_MAX_RETRIES
 
 
 def get_endpoint_for(dispatcher: str) -> str:

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -736,8 +736,8 @@ class WorkerImplementer(PipelineImplementer):
         payload_kwargs: Dict[str, Any] = dict(
             brief=brief, channel_id=channel_id, persona=persona, wait=not nowait,
             preferred_model=preferred_model, stage=stage, branch=branch,
-            timeout_s=resolve_stage_timeout_s(stage),
-            max_retries=resolve_stage_max_retries(stage),
+            timeout_s=resolve_stage_timeout_s(stage) if stage else None,
+            max_retries=resolve_stage_max_retries(stage) if stage else None,
         )
         if resume_meta:
             # Apenas os 2 campos públicos vão pro wire (resto é interno: _*).

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -44,7 +44,8 @@ from deile.orchestration.pipeline.briefs import (
 from deile.orchestration.pipeline.claude_dispatcher import (
     render_implement_prompt, render_review_prompt)
 from deile.orchestration.pipeline.dispatch_resolver import (
-    get_endpoint_for, resolve_stage_dispatcher)
+    get_endpoint_for, resolve_stage_dispatcher, resolve_stage_max_retries,
+    resolve_stage_timeout_s)
 from deile.orchestration.pipeline.labels import (issue_type_from_labels,
                                                  persona_for_type,
                                                  template_for_type)
@@ -730,9 +731,13 @@ class WorkerImplementer(PipelineImplementer):
         # ``implement`` para TODOS os dispatches (review/refine/follow_ups
         # eram todos registrados como implement, quebrando o preamble do
         # pr_review e enganando telemetry).
+        # ``timeout_s`` / ``max_retries`` são resolvidos per-stage (issue #391)
+        # para dar ao operator controle granular sem editar manifests.
         payload_kwargs: Dict[str, Any] = dict(
             brief=brief, channel_id=channel_id, persona=persona, wait=not nowait,
             preferred_model=preferred_model, stage=stage, branch=branch,
+            timeout_s=resolve_stage_timeout_s(stage),
+            max_retries=resolve_stage_max_retries(stage),
         )
         if resume_meta:
             # Apenas os 2 campos públicos vão pro wire (resto é interno: _*).

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -44,7 +44,8 @@ from deile.orchestration.pipeline.briefs import (
 from deile.orchestration.pipeline.claude_dispatcher import (
     render_implement_prompt, render_review_prompt)
 from deile.orchestration.pipeline.dispatch_resolver import (
-    get_endpoint_for, resolve_stage_dispatcher)
+    get_endpoint_for, resolve_stage_dispatcher, resolve_stage_max_retries,
+    resolve_stage_timeout_s)
 from deile.orchestration.pipeline.labels import (issue_type_from_labels,
                                                  persona_for_type,
                                                  template_for_type)
@@ -730,9 +731,15 @@ class WorkerImplementer(PipelineImplementer):
         # ``implement`` para TODOS os dispatches (review/refine/follow_ups
         # eram todos registrados como implement, quebrando o preamble do
         # pr_review e enganando telemetry).
+        # Per-stage execution limits (issue #391): resolve timeout and retries
+        # for this stage, populate payload so worker and monitor can consume them.
+        timeout_s = resolve_stage_timeout_s(stage) if stage else None
+        max_retries = resolve_stage_max_retries(stage) if stage else None
+
         payload_kwargs: Dict[str, Any] = dict(
             brief=brief, channel_id=channel_id, persona=persona, wait=not nowait,
             preferred_model=preferred_model, stage=stage, branch=branch,
+            timeout_s=timeout_s, max_retries=max_retries,
         )
         if resume_meta:
             # Apenas os 2 campos públicos vão pro wire (resto é interno: _*).

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -30,6 +30,7 @@ from deile.orchestration.forge import (CommentRef, GhCommandError,
 from deile.orchestration.pipeline._time_utils import now_utc
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
 from deile.orchestration.pipeline.follow_up_detector import detect_follow_ups
+from deile.orchestration.pipeline.dispatch_resolver import resolve_stage_max_retries
 from deile.orchestration.pipeline.implementer import (parse_critique_verdict,
                                                       parse_decompose_result,
                                                       parse_refine_verdict)
@@ -1416,11 +1417,13 @@ async def resume_in_progress_issues(monitor: "PipelineMonitor") -> None:
 
     state = monitor._resume_tracker.get(target.number)
     # Attempt ceiling — block before spending another dispatch.
-    if state.attempt >= monitor.config.resume_max_attempts:
+    # Per-stage max_retries (issue #391) takes priority over global resume_max_attempts.
+    _impl_max_attempts = resolve_stage_max_retries("implement")
+    if state.attempt >= _impl_max_attempts:
         await _block_issue(
             monitor, target.number,
             f"teto de tentativas atingido ({state.attempt}/"
-            f"{monitor.config.resume_max_attempts}) sem concluir",
+            f"{_impl_max_attempts}) sem concluir",
         )
         return
     # Budget ceiling (0 = disabled).
@@ -1883,13 +1886,14 @@ async def review_one_open_pr(monitor: "PipelineMonitor") -> None:
     await monitor.forge.add_labels("pr", target.number, [monitor.identity.ownership_label()])
     if is_resume:
         state = monitor._resume_tracker.get(target.number)
-        # Attempt ceiling for review/merge — same block flow as implement.
-        if state.attempt >= monitor.config.resume_max_attempts:
+        # Attempt ceiling for review/merge — per-stage max_retries (issue #391).
+        _review_max_attempts = resolve_stage_max_retries("pr_review")
+        if state.attempt >= _review_max_attempts:
             await monitor.forge.clear_batch_label("pr", target.number)
             await _block_pr(
                 monitor, target.number, target.title, target.url,
                 f"teto de tentativas atingido ({state.attempt}/"
-                f"{monitor.config.resume_max_attempts}) sem mergear",
+                f"{_review_max_attempts}) sem mergear",
             )
             return
         await monitor.notifier.implementation_resumed(target.number, state.attempt + 1)

--- a/deile/tests/config/test_pipeline_timeout_retries_schema.py
+++ b/deile/tests/config/test_pipeline_timeout_retries_schema.py
@@ -1,0 +1,202 @@
+"""Tests for per-stage timeout / retries settings schema (issue #391).
+
+Mirrors test_pipeline_dispatchers_schema.py and test_settings_pipeline_models.py.
+"""
+
+import pytest
+
+from deile.config.settings import Settings, _to_optional_pos_int, _to_optional_nonneg_int
+
+
+# ---------------------------------------------------------------------------
+# Converter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestToOptionalPosInt:
+    def test_none_returns_none(self):
+        assert _to_optional_pos_int(None) is None
+
+    def test_valid_positive(self):
+        assert _to_optional_pos_int(42) == 42
+        assert _to_optional_pos_int("600") == 600
+        assert _to_optional_pos_int(1) == 1
+
+    def test_zero_raises(self):
+        with pytest.raises(ValueError, match="> 0"):
+            _to_optional_pos_int(0)
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="> 0"):
+            _to_optional_pos_int(-1)
+
+    def test_bool_raises(self):
+        with pytest.raises(TypeError):
+            _to_optional_pos_int(True)
+
+    def test_non_numeric_string_raises(self):
+        with pytest.raises((ValueError, TypeError)):
+            _to_optional_pos_int("abc")
+
+
+class TestToOptionalNonnegInt:
+    def test_none_returns_none(self):
+        assert _to_optional_nonneg_int(None) is None
+
+    def test_zero_is_valid(self):
+        assert _to_optional_nonneg_int(0) == 0
+        assert _to_optional_nonneg_int("0") == 0
+
+    def test_valid_positive(self):
+        assert _to_optional_nonneg_int(3) == 3
+        assert _to_optional_nonneg_int("10") == 10
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match=">= 0"):
+            _to_optional_nonneg_int(-1)
+
+    def test_bool_raises(self):
+        with pytest.raises(TypeError):
+            _to_optional_nonneg_int(False)
+
+    def test_non_numeric_string_raises(self):
+        with pytest.raises((ValueError, TypeError)):
+            _to_optional_nonneg_int("abc")
+
+
+# ---------------------------------------------------------------------------
+# Settings dataclass defaults
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsDefaults:
+    def test_timeout_fields_default_none(self):
+        s = Settings()
+        for stage in ("classify", "refine", "implement", "pr_review", "follow_ups"):
+            assert getattr(s, f"pipeline_timeout_s_{stage}") is None
+
+    def test_retries_fields_default_none(self):
+        s = Settings()
+        for stage in ("classify", "refine", "implement", "pr_review", "follow_ups"):
+            assert getattr(s, f"pipeline_retries_{stage}") is None
+
+    def test_global_defaults_are_none(self):
+        s = Settings()
+        assert s.pipeline_deile_timeout is None
+        assert s.pipeline_default_max_retries is None
+
+
+# ---------------------------------------------------------------------------
+# apply_overrides — JSON path loading
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOverrides:
+    def test_timeout_per_stage_json(self):
+        s = Settings()
+        s.apply_overrides({
+            "pipeline": {
+                "timeouts_s": {
+                    "implement": 600,
+                    "pr_review": 1800,
+                }
+            }
+        })
+        assert s.pipeline_timeout_s_implement == 600
+        assert s.pipeline_timeout_s_pr_review == 1800
+        # Untouched stages remain None
+        assert s.pipeline_timeout_s_classify is None
+
+    def test_retries_per_stage_json(self):
+        s = Settings()
+        s.apply_overrides({
+            "pipeline": {
+                "retries": {
+                    "implement": 2,
+                    "classify": 5,
+                }
+            }
+        })
+        assert s.pipeline_retries_implement == 2
+        assert s.pipeline_retries_classify == 5
+        assert s.pipeline_retries_refine is None
+
+    def test_retries_zero_is_valid(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"retries": {"implement": 0}}})
+        assert s.pipeline_retries_implement == 0
+
+    def test_timeout_zero_is_rejected(self):
+        """Zero timeout should be rejected; field stays None."""
+        s = Settings()
+        s.apply_overrides({"pipeline": {"timeouts_s": {"implement": 0}}})
+        assert s.pipeline_timeout_s_implement is None
+
+    def test_timeout_negative_is_rejected(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"timeouts_s": {"implement": -10}}})
+        assert s.pipeline_timeout_s_implement is None
+
+    def test_global_deile_timeout(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"default_timeout_s_deile": 450}})
+        assert s.pipeline_deile_timeout == 450
+
+    def test_global_max_retries(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"default_max_retries": 5}})
+        assert s.pipeline_default_max_retries == 5
+
+    def test_global_max_retries_zero(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"default_max_retries": 0}})
+        assert s.pipeline_default_max_retries == 0
+
+
+# ---------------------------------------------------------------------------
+# Env var loading (_apply_env_overrides)
+# ---------------------------------------------------------------------------
+
+
+class TestEnvOverrides:
+    def test_timeout_env_vars(self, monkeypatch):
+        from deile.config.settings import _apply_env_overrides
+        monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "900")
+        monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "300")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_timeout_s_implement == 900
+        assert s.pipeline_timeout_s_classify == 300
+        assert s.pipeline_timeout_s_refine is None
+
+    def test_retries_env_vars(self, monkeypatch):
+        from deile.config.settings import _apply_env_overrides
+        monkeypatch.setenv("DEILE_PIPELINE_RETRIES_IMPLEMENT", "2")
+        monkeypatch.setenv("DEILE_PIPELINE_RETRIES_PR_REVIEW", "0")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_retries_implement == 2
+        assert s.pipeline_retries_pr_review == 0
+        assert s.pipeline_retries_classify is None
+
+    def test_timeout_zero_rejected_by_env(self, monkeypatch):
+        """Zero timeout env var is silently ignored (stays None)."""
+        from deile.config.settings import _apply_env_overrides
+        monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "0")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_timeout_s_implement is None
+
+    def test_global_deile_timeout_env(self, monkeypatch):
+        from deile.config.settings import _apply_env_overrides
+        monkeypatch.setenv("DEILE_PIPELINE_DEILE_TIMEOUT", "600")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_deile_timeout == 600
+
+    def test_global_max_retries_env(self, monkeypatch):
+        from deile.config.settings import _apply_env_overrides
+        monkeypatch.setenv("DEILE_PIPELINE_DEFAULT_MAX_RETRIES", "7")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_default_max_retries == 7

--- a/deile/tests/config/test_settings_pipeline_timeout_retries.py
+++ b/deile/tests/config/test_settings_pipeline_timeout_retries.py
@@ -1,0 +1,203 @@
+"""Tests for per-stage pipeline timeout/retries settings (issue #391).
+
+Covers:
+- 10 new fields default to ``None`` and round-trip through ``apply_overrides``.
+- ``_to_optional_positive_int`` validator rejects 0/negatives (timeout must be > 0).
+- ``_to_optional_nonneg_int`` validator accepts 0 (retries=0 means fail fast).
+- Env-var overrides (``DEILE_PIPELINE_TIMEOUT_S_<STAGE>`` / ``DEILE_PIPELINE_RETRIES_<STAGE>``)
+  take precedence over the JSON layer.
+- The loose nested-dict loader (``_apply_nested_dict``) accepts the
+  ``pipeline.timeouts_s.<stage>`` and ``pipeline.retries.<stage>`` paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.config.settings import (
+    Settings,
+    _apply_env_overrides,
+    _apply_nested_dict,
+    _to_optional_nonneg_int,
+    _to_optional_positive_int,
+)
+
+
+class TestOptionalPositiveIntValidator:
+    """``_to_optional_positive_int`` is the strict converter for timeout settings."""
+
+    def test_none_and_empty_collapse_to_none(self):
+        assert _to_optional_positive_int(None) is None
+        assert _to_optional_positive_int("") is None
+        assert _to_optional_positive_int("   ") is None
+
+    def test_valid_positive_int_passes(self):
+        assert _to_optional_positive_int(300) == 300
+        assert _to_optional_positive_int("1800") == 1800
+        assert _to_optional_positive_int(1) == 1
+
+    def test_rejects_zero(self):
+        with pytest.raises(ValueError, match="> 0"):
+            _to_optional_positive_int(0)
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError, match="> 0"):
+            _to_optional_positive_int(-1)
+
+    def test_rejects_bool(self):
+        with pytest.raises(TypeError):
+            _to_optional_positive_int(True)
+
+    def test_rejects_non_numeric_string(self):
+        with pytest.raises(ValueError):
+            _to_optional_positive_int("notanumber")
+
+
+class TestOptionalNonnegIntValidator:
+    """``_to_optional_nonneg_int`` is the strict converter for retries settings."""
+
+    def test_none_and_empty_collapse_to_none(self):
+        assert _to_optional_nonneg_int(None) is None
+        assert _to_optional_nonneg_int("") is None
+        assert _to_optional_nonneg_int("   ") is None
+
+    def test_valid_nonneg_int_passes(self):
+        assert _to_optional_nonneg_int(0) == 0
+        assert _to_optional_nonneg_int(3) == 3
+        assert _to_optional_nonneg_int("5") == 5
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError, match=">= 0"):
+            _to_optional_nonneg_int(-1)
+
+    def test_rejects_bool(self):
+        with pytest.raises(TypeError):
+            _to_optional_nonneg_int(False)
+
+    def test_rejects_non_numeric_string(self):
+        with pytest.raises(ValueError):
+            _to_optional_nonneg_int("notanumber")
+
+
+class TestSettingsDefaults:
+    def test_timeout_fields_default_to_none(self):
+        s = Settings()
+        assert s.pipeline_timeout_s_classify is None
+        assert s.pipeline_timeout_s_refine is None
+        assert s.pipeline_timeout_s_implement is None
+        assert s.pipeline_timeout_s_pr_review is None
+        assert s.pipeline_timeout_s_follow_ups is None
+
+    def test_retries_fields_default_to_none(self):
+        s = Settings()
+        assert s.pipeline_retries_classify is None
+        assert s.pipeline_retries_refine is None
+        assert s.pipeline_retries_implement is None
+        assert s.pipeline_retries_pr_review is None
+        assert s.pipeline_retries_follow_ups is None
+
+
+class TestApplyOverrides:
+    def test_timeout_round_trips_via_apply_overrides(self):
+        s = Settings()
+        s.apply_overrides({
+            "pipeline": {
+                "timeouts_s": {
+                    "classify": 300,
+                    "implement": 1800,
+                }
+            }
+        })
+        assert s.pipeline_timeout_s_classify == 300
+        assert s.pipeline_timeout_s_implement == 1800
+        # Unset fields stay None
+        assert s.pipeline_timeout_s_refine is None
+
+    def test_retries_round_trips_via_apply_overrides(self):
+        s = Settings()
+        s.apply_overrides({
+            "pipeline": {
+                "retries": {
+                    "classify": 5,
+                    "implement": 1,
+                }
+            }
+        })
+        assert s.pipeline_retries_classify == 5
+        assert s.pipeline_retries_implement == 1
+        assert s.pipeline_retries_refine is None
+
+    def test_retries_zero_accepted(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"retries": {"implement": 0}}})
+        assert s.pipeline_retries_implement == 0
+
+    def test_timeout_zero_rejected_keeps_none(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"timeouts_s": {"classify": 0}}})
+        # 0 is rejected by _to_optional_positive_int — field stays None
+        assert s.pipeline_timeout_s_classify is None
+
+    def test_timeout_negative_rejected(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"timeouts_s": {"refine": -100}}})
+        assert s.pipeline_timeout_s_refine is None
+
+    def test_retries_negative_rejected(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"retries": {"pr_review": -1}}})
+        assert s.pipeline_retries_pr_review is None
+
+
+class TestNestedDictLoader:
+    def test_timeout_via_apply_nested_dict(self):
+        s = Settings()
+        _apply_nested_dict(s, {"pipeline": {"timeouts_s": {"follow_ups": 600}}})
+        assert s.pipeline_timeout_s_follow_ups == 600
+
+    def test_retries_via_apply_nested_dict(self):
+        s = Settings()
+        _apply_nested_dict(s, {"pipeline": {"retries": {"classify": 2}}})
+        assert s.pipeline_retries_classify == 2
+
+
+class TestEnvVarOverrides:
+    def test_timeout_env_var_sets_field(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "900")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_timeout_s_implement == 900
+
+    def test_retries_env_var_sets_field(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_RETRIES_PR_REVIEW", "2")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_retries_pr_review == 2
+
+    def test_timeout_invalid_env_var_ignored(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "garbage")
+        s = Settings()
+        s.pipeline_timeout_s_classify = 500  # pre-set a value
+        _apply_env_overrides(s)
+        # Env var is invalid, field keeps its pre-set value
+        assert s.pipeline_timeout_s_classify == 500
+
+    def test_retries_zero_env_var_accepted(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_RETRIES_CLASSIFY", "0")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_retries_classify == 0
+
+    def test_all_stages_have_env_vars(self, monkeypatch):
+        """All 5 stages have both timeout and retries env var entries."""
+        stages = ("CLASSIFY", "REFINE", "IMPLEMENT", "PR_REVIEW", "FOLLOW_UPS")
+        for stage in stages:
+            monkeypatch.setenv(f"DEILE_PIPELINE_TIMEOUT_S_{stage}", "100")
+            monkeypatch.setenv(f"DEILE_PIPELINE_RETRIES_{stage}", "1")
+        s = Settings()
+        _apply_env_overrides(s)
+        for attr_suffix in ("classify", "refine", "implement", "pr_review", "follow_ups"):
+            assert getattr(s, f"pipeline_timeout_s_{attr_suffix}") == 100, \
+                f"pipeline_timeout_s_{attr_suffix} should be 100"
+            assert getattr(s, f"pipeline_retries_{attr_suffix}") == 1, \
+                f"pipeline_retries_{attr_suffix} should be 1"

--- a/deile/tests/infra/test_dispatch_matrix_timeout_retries.py
+++ b/deile/tests/infra/test_dispatch_matrix_timeout_retries.py
@@ -1,0 +1,366 @@
+"""Tests for DispatchMatrixView Timeout/Retries columns (issue #391).
+
+Mirrors test_dispatch_matrix_view.py — covers:
+- cursor_col navigation up to 3
+- Timeout/Retries columns visible in render
+- _open_timeout_prompt / _open_retries_prompt
+- _handle_numeric_prompt_key (digit entry, backspace, enter, ESC)
+- _reset_current_cell for cols 2 and 3
+- StageDispatchEntry new fields
+"""
+
+import sys
+import os
+import types
+from dataclasses import dataclass
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — infra/k8s not on sys.path by default in pytest context.
+# ---------------------------------------------------------------------------
+
+_INFRA_K8S = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "infra", "k8s"
+)
+if _INFRA_K8S not in sys.path:
+    sys.path.insert(0, _INFRA_K8S)
+
+
+@dataclass(frozen=True)
+class _StubStageDispatchEntry:
+    stage: str
+    worker: str
+    model: Optional[str]
+    source: str
+    timeout_s: Optional[int] = None
+    max_retries: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class _StubClaudeWorkerStatus:
+    deployment_applied: bool
+    pod_ready: bool
+    logged_in_email: Optional[str]
+
+
+@pytest.fixture(autouse=True)
+def _stub_panel_data_imports(monkeypatch):
+    """Minimal stubs to import _panel without a real K8s cluster."""
+    for mod_name in ("_panel_data",):
+        if mod_name not in sys.modules:
+            stub = types.ModuleType(mod_name)
+            # Minimal symbols needed by _panel imports
+            stub.NS = "deile"
+            stub.kubectl_bin = lambda: None
+            stub.BackgroundRefresher = MagicMock
+            stub.PanelData = MagicMock
+            stub._fmt_age = lambda *a, **kw: ""
+            stub._audit_dispatch_mode_change = MagicMock()
+            stub._audit_security_policy_change = MagicMock()
+            stub.clear_pipeline_dispatch_mode = MagicMock(return_value=(True, "ok"))
+            stub.clear_stage_model = MagicMock(return_value=(True, "ok"))
+            stub.set_pipeline_dispatch_mode = MagicMock(return_value=(True, "ok"))
+            stub.set_pipeline_dispatch_stage = MagicMock(return_value=(True, "ok"))
+            stub.set_preferred_model = MagicMock(return_value=(True, "ok"))
+            stub.set_stage_model = MagicMock(return_value=(True, "ok"))
+            stub.set_stage_timeout = MagicMock(return_value=(True, "ok"))
+            stub.set_stage_retries = MagicMock(return_value=(True, "ok"))
+            # Dataclass stubs needed by sibling test files loaded in same session
+            stub.StageDispatchEntry = _StubStageDispatchEntry
+            stub.ClaudeWorkerStatus = _StubClaudeWorkerStatus
+            sys.modules[mod_name] = stub
+
+
+# ---------------------------------------------------------------------------
+# StageDispatchEntry — new fields
+# ---------------------------------------------------------------------------
+
+
+def test_stage_dispatch_entry_new_fields():
+    sys.path.insert(0, _INFRA_K8S)
+    import importlib
+    import _panel_data as _pd
+    # Check if real _panel_data is loaded or our stub
+    if hasattr(_pd, "StageDispatchEntry"):
+        entry = _pd.StageDispatchEntry("implement", "deile-worker", None, "default",
+                                       timeout_s=600, max_retries=2)
+        assert entry.timeout_s == 600
+        assert entry.max_retries == 2
+        # Defaults to None
+        entry2 = _pd.StageDispatchEntry("classify", "deile-worker", None, "default")
+        assert entry2.timeout_s is None
+        assert entry2.max_retries is None
+
+
+# ---------------------------------------------------------------------------
+# DispatchMatrixView — cursor navigation
+# ---------------------------------------------------------------------------
+
+
+def _make_view():
+    """Create a DispatchMatrixView in demo mode (data=None)."""
+    # We need to patch enough of _panel for the import to work
+    import importlib
+    # If _panel is already imported, get it; else do a clean import
+    panel_mod = sys.modules.get("_panel")
+    if panel_mod is None:
+        try:
+            import _panel as panel_mod
+        except Exception:
+            pytest.skip("_panel not importable in this environment")
+    DispatchMatrixView = getattr(panel_mod, "DispatchMatrixView", None)
+    if DispatchMatrixView is None:
+        pytest.skip("DispatchMatrixView not found in _panel")
+    return DispatchMatrixView(data=None)
+
+
+def test_cursor_col_max_is_3():
+    view = _make_view()
+    # Navigate right 10 times — should clamp at 3
+    for _ in range(10):
+        view.handle_key("RIGHT", None)
+    assert view.cursor_col == 3
+
+
+def test_cursor_col_min_is_0():
+    view = _make_view()
+    view.cursor_col = 3
+    for _ in range(10):
+        view.handle_key("LEFT", None)
+    assert view.cursor_col == 0
+
+
+def test_cursor_col_navigates_through_all_columns():
+    view = _make_view()
+    assert view.cursor_col == 0
+    view.handle_key("RIGHT", None)
+    assert view.cursor_col == 1
+    view.handle_key("RIGHT", None)
+    assert view.cursor_col == 2
+    view.handle_key("RIGHT", None)
+    assert view.cursor_col == 3
+    view.handle_key("LEFT", None)
+    assert view.cursor_col == 2
+
+
+# ---------------------------------------------------------------------------
+# Timeout / Retries prompt — open
+# ---------------------------------------------------------------------------
+
+
+def test_open_timeout_prompt_sets_mode():
+    view = _make_view()
+    # Need entry with timeout_s
+    entry = MagicMock()
+    entry.stage = "implement"
+    entry.timeout_s = None
+    view._open_timeout_prompt(entry)
+    assert view.mode is not None
+    assert view.mode[0] == "timeout"
+    assert view.mode[1] == "implement"
+
+
+def test_open_retries_prompt_sets_mode():
+    view = _make_view()
+    entry = MagicMock()
+    entry.stage = "classify"
+    entry.max_retries = 3
+    view._open_retries_prompt(entry)
+    assert view.mode is not None
+    assert view.mode[0] == "retries"
+    assert view.mode[1] == "classify"
+    assert view.mode[2] == ["3"]
+
+
+# ---------------------------------------------------------------------------
+# Numeric prompt key handling
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_prompt_digit_appends():
+    view = _make_view()
+    view.mode = ("timeout", "implement", [""])
+    view._handle_numeric_prompt_key("6")
+    assert view.mode[2] == ["6"]
+    view._handle_numeric_prompt_key("0")
+    assert view.mode[2] == ["60"]
+    view._handle_numeric_prompt_key("0")
+    assert view.mode[2] == ["600"]
+
+
+def test_numeric_prompt_backspace_removes():
+    view = _make_view()
+    view.mode = ("timeout", "implement", ["600"])
+    view._handle_numeric_prompt_key("BACKSPACE")
+    assert view.mode[2] == ["60"]
+    view._handle_numeric_prompt_key("\x7f")
+    assert view.mode[2] == ["6"]
+
+
+def test_numeric_prompt_esc_cancels():
+    view = _make_view()
+    view.mode = ("timeout", "implement", ["600"])
+    view._handle_numeric_prompt_key("ESC")
+    assert view.mode is None
+    assert view.last_ok is None
+
+
+def test_numeric_prompt_enter_empty_sets_none(monkeypatch):
+    """Enter with empty buffer → call set_stage_timeout(None) = clear override."""
+    view = _make_view()
+    view.mode = ("timeout", "implement", [""])
+    view.data = MagicMock()
+    view.data.context.namespace = "deile"
+    mock_set = MagicMock(return_value=(True, "unset ok"))
+    with patch.dict(sys.modules, {"_panel": sys.modules.get("_panel")}):
+        import _panel_data as _pd
+        _pd.set_stage_timeout = mock_set
+    view._handle_numeric_prompt_key("\r")
+    assert view.mode is None
+
+
+def test_numeric_prompt_enter_with_value_calls_helper(monkeypatch):
+    """Enter with '600' → call set_stage_timeout(600)."""
+    view = _make_view()
+    view.mode = ("timeout", "implement", ["600"])
+    view.data = MagicMock()
+    view.data.context.namespace = "deile"
+    mock_set = MagicMock(return_value=(True, "DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT=600 (rollout)"))
+    with patch.dict(sys.modules, {"_panel": sys.modules.get("_panel")}):
+        import _panel_data as _pd
+        orig = _pd.set_stage_timeout
+        _pd.set_stage_timeout = mock_set
+    view._handle_numeric_prompt_key("\n")
+    _pd.set_stage_timeout = orig
+    assert view.mode is None
+
+
+def test_numeric_prompt_retries_zero_is_valid(monkeypatch):
+    """Retries=0 should not raise invalid value error."""
+    view = _make_view()
+    view.mode = ("retries", "implement", ["0"])
+    view.data = MagicMock()
+    view.data.context.namespace = "deile"
+    import _panel_data as _pd
+    orig = _pd.set_stage_retries
+    _pd.set_stage_retries = MagicMock(return_value=(True, "ok"))
+    view._handle_numeric_prompt_key("\r")
+    _pd.set_stage_retries = orig
+    assert view.mode is None
+    assert view.last_ok is not False or view.last_msg != "retries deve ser >= 0"
+
+
+def test_numeric_prompt_timeout_zero_is_invalid():
+    """Timeout=0 should show error (not call kubectl)."""
+    view = _make_view()
+    view.mode = ("timeout", "implement", ["0"])
+    view.data = MagicMock()
+    view.data.context.namespace = "deile"
+    view._handle_numeric_prompt_key("\r")
+    assert view.mode is None
+    assert view.last_ok is False
+    assert ">" in view.last_msg
+
+
+def test_numeric_prompt_non_digit_is_ignored():
+    """Non-digit keys are ignored during numeric input."""
+    view = _make_view()
+    view.mode = ("timeout", "implement", ["60"])
+    result = view._handle_numeric_prompt_key("a")
+    assert view.mode[2] == ["60"]
+
+
+# ---------------------------------------------------------------------------
+# Reset cell (cols 2 and 3)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_col2_calls_set_stage_timeout_none():
+    view = _make_view()
+    view.cursor_col = 2
+    view.cursor_row = 0
+    # Demo mode (data=None) → just show demo msg
+    view._reset_current_cell()
+    assert view.last_ok is False  # demo mode
+
+
+def test_reset_col3_calls_set_stage_retries_none():
+    view = _make_view()
+    view.cursor_col = 3
+    view.cursor_row = 0
+    view._reset_current_cell()
+    assert view.last_ok is False  # demo mode
+
+
+def test_reset_with_real_data_col2():
+    """reset col 2 (timeout) delegates to set_stage_timeout(None)."""
+    view = _make_view()
+    view.cursor_col = 2
+    view.cursor_row = 0
+
+    # Minimal fake data
+    fake_stage_entry = MagicMock()
+    fake_stage_entry.stage = "classify"
+    fake_data = MagicMock()
+    fake_data.stage_dispatch.get_all_stages.return_value = [fake_stage_entry] * 5
+    fake_data.context.namespace = "deile"
+    view.data = fake_data
+
+    # _panel.py imports pd_set_stage_timeout at module level — patch there.
+    panel_mod = sys.modules.get("_panel")
+    mock_set = MagicMock(return_value=(True, "unset"))
+    orig = panel_mod.pd_set_stage_timeout
+    panel_mod.pd_set_stage_timeout = mock_set
+    try:
+        view._reset_current_cell()
+    finally:
+        panel_mod.pd_set_stage_timeout = orig
+    mock_set.assert_called_once()
+    args = mock_set.call_args
+    # Second positional arg should be None (clear)
+    assert args[0][1] is None
+
+
+def test_reset_with_real_data_col3():
+    """reset col 3 (retries) delegates to set_stage_retries(None)."""
+    view = _make_view()
+    view.cursor_col = 3
+    view.cursor_row = 0
+
+    fake_stage_entry = MagicMock()
+    fake_stage_entry.stage = "classify"
+    fake_data = MagicMock()
+    fake_data.stage_dispatch.get_all_stages.return_value = [fake_stage_entry] * 5
+    fake_data.context.namespace = "deile"
+    view.data = fake_data
+
+    panel_mod = sys.modules.get("_panel")
+    mock_set = MagicMock(return_value=(True, "unset"))
+    orig = panel_mod.pd_set_stage_retries
+    panel_mod.pd_set_stage_retries = mock_set
+    try:
+        view._reset_current_cell()
+    finally:
+        panel_mod.pd_set_stage_retries = orig
+    mock_set.assert_called_once()
+    assert mock_set.call_args[0][1] is None
+
+
+# ---------------------------------------------------------------------------
+# Scaling row — cols 2/3 should not open scaling prompt
+# ---------------------------------------------------------------------------
+
+
+def test_scaling_row_col2_enter_shows_info():
+    view = _make_view()
+    n = len(view._stages())
+    view.cursor_row = n + 1  # scaling row
+    view.cursor_col = 2
+    view.handle_key("\r", None)
+    # Should NOT open a picker
+    assert view.mode is None
+    # Should show an informational message
+    assert view.last_msg is not None

--- a/deile/tests/infrastructure/test_dispatch_payload_timeout_retries.py
+++ b/deile/tests/infrastructure/test_dispatch_payload_timeout_retries.py
@@ -1,0 +1,110 @@
+"""Tests for DispatchPayload.timeout_s and max_retries fields (issue #391).
+
+Mirrors test_dispatch_payload_preferred_model.py.
+"""
+
+import pytest
+
+from deile.infrastructure.deile_worker_client import (
+    DispatchPayload,
+    build_dispatch_payload,
+)
+
+
+class TestDispatchPayloadFields:
+    def _base(self, **kwargs):
+        return dict(
+            brief="do something",
+            channel_id="test-channel",
+            **kwargs,
+        )
+
+    def test_timeout_s_accepted(self):
+        p = DispatchPayload(**self._base(timeout_s=600))
+        assert p.timeout_s == 600
+
+    def test_max_retries_accepted(self):
+        p = DispatchPayload(**self._base(max_retries=3))
+        assert p.max_retries == 3
+
+    def test_max_retries_zero_accepted(self):
+        p = DispatchPayload(**self._base(max_retries=0))
+        assert p.max_retries == 0
+
+    def test_timeout_s_none_by_default(self):
+        p = DispatchPayload(**self._base())
+        assert p.timeout_s is None
+
+    def test_max_retries_none_by_default(self):
+        p = DispatchPayload(**self._base())
+        assert p.max_retries is None
+
+    def test_timeout_s_zero_rejected(self):
+        with pytest.raises(Exception):
+            DispatchPayload(**self._base(timeout_s=0))
+
+    def test_timeout_s_negative_rejected(self):
+        with pytest.raises(Exception):
+            DispatchPayload(**self._base(timeout_s=-1))
+
+    def test_max_retries_negative_rejected(self):
+        with pytest.raises(Exception):
+            DispatchPayload(**self._base(max_retries=-1))
+
+    def test_both_fields_accepted(self):
+        p = DispatchPayload(**self._base(timeout_s=900, max_retries=5))
+        assert p.timeout_s == 900
+        assert p.max_retries == 5
+
+    def test_model_dump_excludes_none(self):
+        p = DispatchPayload(**self._base())
+        dumped = p.model_dump(exclude_none=True)
+        assert "timeout_s" not in dumped
+        assert "max_retries" not in dumped
+
+    def test_model_dump_includes_when_set(self):
+        p = DispatchPayload(**self._base(timeout_s=600, max_retries=2))
+        dumped = p.model_dump(exclude_none=True)
+        assert dumped["timeout_s"] == 600
+        assert dumped["max_retries"] == 2
+
+    def test_max_retries_zero_included_in_dump(self):
+        """0 is falsy but should appear in the wire payload (not excluded)."""
+        p = DispatchPayload(**self._base(max_retries=0))
+        dumped = p.model_dump(exclude_none=True)
+        assert dumped["max_retries"] == 0
+
+
+class TestBuildDispatchPayload:
+    def _call(self, **kwargs):
+        return build_dispatch_payload(
+            brief="do something",
+            channel_id="test-channel",
+            **kwargs,
+        )
+
+    def test_timeout_s_included(self):
+        payload = self._call(timeout_s=600)
+        assert payload["timeout_s"] == 600
+
+    def test_max_retries_included(self):
+        payload = self._call(max_retries=3)
+        assert payload["max_retries"] == 3
+
+    def test_max_retries_zero_included(self):
+        payload = self._call(max_retries=0)
+        assert payload["max_retries"] == 0
+
+    def test_timeout_s_none_not_in_payload(self):
+        payload = self._call(timeout_s=None)
+        assert "timeout_s" not in payload
+
+    def test_max_retries_none_not_in_payload(self):
+        payload = self._call(max_retries=None)
+        assert "max_retries" not in payload
+
+    def test_backward_compat_no_new_fields(self):
+        """Callers that don't pass timeout_s/max_retries get same payload."""
+        payload = self._call()
+        assert "timeout_s" not in payload
+        assert "max_retries" not in payload

--- a/deile/tests/orchestration/pipeline/test_dispatch_resolver.py
+++ b/deile/tests/orchestration/pipeline/test_dispatch_resolver.py
@@ -158,6 +158,13 @@ def test_timeout_invalid_stage_raises(monkeypatch):
 def test_timeout_default_for_claude_stages(monkeypatch):
     """Sem override, stages claude (implement/pr_review) retornam 1800."""
     _clear_timeout_env(monkeypatch)
+    # Dispatcher env vars must be set for implement/pr_review → claude-worker
+    # (default global dispatcher is deile-worker).
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_DISPATCH_{stage.upper()}", raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_DISPATCH_MODE", raising=False)
+    monkeypatch.setenv("DEILE_PIPELINE_DISPATCH_IMPLEMENT", "claude-worker")
+    monkeypatch.setenv("DEILE_PIPELINE_DISPATCH_PR_REVIEW", "claude-worker")
     from deile.config.settings import reset_settings
     reset_settings()
     assert resolve_stage_timeout_s("implement") == 1800
@@ -185,23 +192,24 @@ def test_timeout_env_var_per_stage(monkeypatch):
     assert resolve_stage_timeout_s("classify") == 900
 
 
-def test_timeout_env_var_invalid_ignored(monkeypatch):
-    """Valor inválido em env → fallback ao default (sem crash)."""
+def test_timeout_env_var_invalid_raises(monkeypatch):
+    """Valor inválido em env → ValueError (fail-fast)."""
     _clear_timeout_env(monkeypatch)
     monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "not_a_number")
     from deile.config.settings import reset_settings
     reset_settings()
-    # Falls back to built-in default for implement (claude stage = 1800)
-    assert resolve_stage_timeout_s("implement") == 1800
+    with pytest.raises(ValueError):
+        resolve_stage_timeout_s("implement")
 
 
-def test_timeout_env_var_zero_ignored(monkeypatch):
-    """Valor 0 (não-positivo) em env → fallback ao default."""
+def test_timeout_env_var_zero_raises(monkeypatch):
+    """Valor 0 (não-positivo) em env → ValueError (fail-fast, timeout deve ser > 0)."""
     _clear_timeout_env(monkeypatch)
     monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "0")
     from deile.config.settings import reset_settings
     reset_settings()
-    assert resolve_stage_timeout_s("classify") == 900
+    with pytest.raises(ValueError):
+        resolve_stage_timeout_s("classify")
 
 
 def test_timeout_settings_per_stage(monkeypatch):
@@ -260,13 +268,14 @@ def test_retries_env_zero_allowed(monkeypatch):
     assert resolve_stage_max_retries("implement") == 0
 
 
-def test_retries_env_invalid_ignored(monkeypatch):
-    """Valor inválido em env → fallback ao default 3."""
+def test_retries_env_invalid_raises(monkeypatch):
+    """Valor inválido em env → ValueError (fail-fast)."""
     _clear_retries_env(monkeypatch)
     monkeypatch.setenv("DEILE_PIPELINE_RETRIES_CLASSIFY", "not_a_number")
     from deile.config.settings import reset_settings
     reset_settings()
-    assert resolve_stage_max_retries("classify") == 3
+    with pytest.raises(ValueError):
+        resolve_stage_max_retries("classify")
 
 
 def test_retries_settings_per_stage(monkeypatch):

--- a/deile/tests/orchestration/pipeline/test_dispatch_resolver.py
+++ b/deile/tests/orchestration/pipeline/test_dispatch_resolver.py
@@ -5,13 +5,14 @@ Cobre:
 - Whitelist enforcement (only 'deile-worker' | 'claude-worker' accepted)
 - ValueError para stage inválido (programming bug)
 - Endpoint mapping (deile-worker → :8766, claude-worker → :8767)
+- resolve_stage_timeout_s / resolve_stage_max_retries (issue #391)
 """
 
 import pytest
 
 from deile.orchestration.pipeline.dispatch_resolver import (
     PIPELINE_STAGES, VALID_DISPATCHERS, get_endpoint_for, is_valid_dispatcher,
-    resolve_stage_dispatcher)
+    resolve_stage_dispatcher, resolve_stage_max_retries, resolve_stage_timeout_s)
 
 
 def _clear_env(monkeypatch):
@@ -138,3 +139,143 @@ def test_is_valid_dispatcher_accepts_legacy_aliases():
             f"legacy alias {legacy!r} should validate"
     # Sanity: garbage still rejected
     assert is_valid_dispatcher("garbage") is False
+
+
+# ===== resolve_stage_timeout_s (issue #391) ==================================
+
+def _clear_timeout_env(monkeypatch):
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_TIMEOUT_S_{stage.upper()}", raising=False)
+
+
+def test_timeout_invalid_stage_raises(monkeypatch):
+    """Stage fora de PIPELINE_STAGES → ValueError."""
+    _clear_timeout_env(monkeypatch)
+    with pytest.raises(ValueError, match="unknown stage"):
+        resolve_stage_timeout_s("garbage_stage")
+
+
+def test_timeout_default_for_claude_stages(monkeypatch):
+    """Sem override, stages claude (implement/pr_review) retornam 1800."""
+    _clear_timeout_env(monkeypatch)
+    from deile.config.settings import reset_settings
+    reset_settings()
+    assert resolve_stage_timeout_s("implement") == 1800
+    assert resolve_stage_timeout_s("pr_review") == 1800
+
+
+def test_timeout_default_for_deile_stages(monkeypatch):
+    """Sem override, stages deile (classify/refine/follow_ups) retornam 900."""
+    _clear_timeout_env(monkeypatch)
+    from deile.config.settings import reset_settings
+    reset_settings()
+    assert resolve_stage_timeout_s("classify") == 900
+    assert resolve_stage_timeout_s("refine") == 900
+    assert resolve_stage_timeout_s("follow_ups") == 900
+
+
+def test_timeout_env_var_per_stage(monkeypatch):
+    """DEILE_PIPELINE_TIMEOUT_S_<STAGE> sobrescreve o default."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "600")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    assert resolve_stage_timeout_s("implement") == 600
+    # Other stages unaffected
+    assert resolve_stage_timeout_s("classify") == 900
+
+
+def test_timeout_env_var_invalid_ignored(monkeypatch):
+    """Valor inválido em env → fallback ao default (sem crash)."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "not_a_number")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    # Falls back to built-in default for implement (claude stage = 1800)
+    assert resolve_stage_timeout_s("implement") == 1800
+
+
+def test_timeout_env_var_zero_ignored(monkeypatch):
+    """Valor 0 (não-positivo) em env → fallback ao default."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "0")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    assert resolve_stage_timeout_s("classify") == 900
+
+
+def test_timeout_settings_per_stage(monkeypatch):
+    """pipeline_timeout_s_<stage> via settings sobrescreve o default."""
+    _clear_timeout_env(monkeypatch)
+    from deile.config.settings import get_settings, reset_settings
+    reset_settings()
+    s = get_settings()
+    s.pipeline_timeout_s_classify = 300
+    assert resolve_stage_timeout_s("classify") == 300
+    # Cleanup
+    s.pipeline_timeout_s_classify = None
+
+
+# ===== resolve_stage_max_retries (issue #391) ================================
+
+def _clear_retries_env(monkeypatch):
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_RETRIES_{stage.upper()}", raising=False)
+
+
+def test_retries_invalid_stage_raises(monkeypatch):
+    """Stage fora de PIPELINE_STAGES → ValueError."""
+    _clear_retries_env(monkeypatch)
+    with pytest.raises(ValueError, match="unknown stage"):
+        resolve_stage_max_retries("garbage_stage")
+
+
+def test_retries_default_is_three(monkeypatch):
+    """Sem override, todos os stages retornam 3 (built-in)."""
+    _clear_retries_env(monkeypatch)
+    from deile.config.settings import reset_settings
+    reset_settings()
+    for stage in PIPELINE_STAGES:
+        assert resolve_stage_max_retries(stage) == 3, \
+            f"stage {stage!r} should default to 3 retries"
+
+
+def test_retries_env_var_per_stage(monkeypatch):
+    """DEILE_PIPELINE_RETRIES_<STAGE> sobrescreve o default."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_IMPLEMENT", "1")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    assert resolve_stage_max_retries("implement") == 1
+    # Other stages unaffected
+    assert resolve_stage_max_retries("classify") == 3
+
+
+def test_retries_env_zero_allowed(monkeypatch):
+    """Valor 0 é válido (zero retries = fail fast)."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_IMPLEMENT", "0")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    assert resolve_stage_max_retries("implement") == 0
+
+
+def test_retries_env_invalid_ignored(monkeypatch):
+    """Valor inválido em env → fallback ao default 3."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_CLASSIFY", "not_a_number")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    assert resolve_stage_max_retries("classify") == 3
+
+
+def test_retries_settings_per_stage(monkeypatch):
+    """pipeline_retries_<stage> via settings sobrescreve o default."""
+    _clear_retries_env(monkeypatch)
+    from deile.config.settings import get_settings, reset_settings
+    reset_settings()
+    s = get_settings()
+    s.pipeline_retries_implement = 5
+    assert resolve_stage_max_retries("implement") == 5
+    # Cleanup
+    s.pipeline_retries_implement = None

--- a/deile/tests/orchestration/pipeline/test_dispatch_resolver_timeout_retries.py
+++ b/deile/tests/orchestration/pipeline/test_dispatch_resolver_timeout_retries.py
@@ -1,0 +1,280 @@
+"""Tests for resolve_stage_timeout_s and resolve_stage_max_retries (issue #391)."""
+
+import pytest
+
+from deile.orchestration.pipeline.dispatch_resolver import (
+    BUILT_IN_MAX_RETRIES,
+    BUILT_IN_TIMEOUT_S_CLAUDE,
+    BUILT_IN_TIMEOUT_S_DEILE,
+    PIPELINE_STAGES,
+    resolve_stage_max_retries,
+    resolve_stage_timeout_s,
+)
+
+
+def _clear_timeout_env(monkeypatch):
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_TIMEOUT_S_{stage.upper()}", raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_DISPATCH_MODE", raising=False)
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_DISPATCH_{stage.upper()}", raising=False)
+
+
+def _clear_retries_env(monkeypatch):
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_RETRIES_{stage.upper()}", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Built-in constants
+# ---------------------------------------------------------------------------
+
+
+def test_built_in_constants_values():
+    assert BUILT_IN_TIMEOUT_S_CLAUDE == 1800
+    assert BUILT_IN_TIMEOUT_S_DEILE == 900
+    assert BUILT_IN_MAX_RETRIES == 3
+
+
+# ---------------------------------------------------------------------------
+# resolve_stage_timeout_s — built-in fallback
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_deile_worker_default(monkeypatch):
+    """Sem env var, deile-worker stages → BUILT_IN_TIMEOUT_S_DEILE."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_DISPATCH_MODE", "deile-worker")
+    # classify dispatches to deile-worker by default
+    result = resolve_stage_timeout_s("classify")
+    assert result == BUILT_IN_TIMEOUT_S_DEILE
+
+
+def test_timeout_claude_worker_default(monkeypatch):
+    """Sem env var, claude-worker stages → BUILT_IN_TIMEOUT_S_CLAUDE."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_DISPATCH_IMPLEMENT", "claude-worker")
+    result = resolve_stage_timeout_s("implement")
+    assert result == BUILT_IN_TIMEOUT_S_CLAUDE
+
+
+def test_timeout_env_per_stage_overrides_default(monkeypatch):
+    """DEILE_PIPELINE_TIMEOUT_S_<STAGE> wins over built-in."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "600")
+    result = resolve_stage_timeout_s("implement")
+    assert result == 600
+
+
+def test_timeout_env_per_stage_is_int(monkeypatch):
+    """Env var is parsed as int."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_REFINE", "1234")
+    assert resolve_stage_timeout_s("refine") == 1234
+
+
+def test_timeout_env_zero_is_invalid(monkeypatch):
+    """Env var value 0 → ValueError (timeout must be > 0)."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "0")
+    with pytest.raises(ValueError):
+        resolve_stage_timeout_s("classify")
+
+
+def test_timeout_env_negative_is_invalid(monkeypatch):
+    """Env var negative value → ValueError."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "-1")
+    with pytest.raises(ValueError):
+        resolve_stage_timeout_s("classify")
+
+
+def test_timeout_env_non_numeric_is_invalid(monkeypatch):
+    """Env var non-numeric → ValueError."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "garbage")
+    with pytest.raises(ValueError):
+        resolve_stage_timeout_s("classify")
+
+
+def test_timeout_empty_env_falls_through(monkeypatch):
+    """Empty env var treated as unset — falls through to default."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT", "")
+    # No exception, returns built-in
+    result = resolve_stage_timeout_s("implement")
+    assert result in (BUILT_IN_TIMEOUT_S_CLAUDE, BUILT_IN_TIMEOUT_S_DEILE)
+
+
+def test_timeout_invalid_stage_raises(monkeypatch):
+    """Unknown stage → ValueError (programming bug)."""
+    _clear_timeout_env(monkeypatch)
+    with pytest.raises(ValueError, match="unknown stage"):
+        resolve_stage_timeout_s("not_a_stage")
+
+
+def test_timeout_all_stages_return_positive_int(monkeypatch):
+    """All 5 stages return a positive integer with no overrides."""
+    _clear_timeout_env(monkeypatch)
+    for stage in PIPELINE_STAGES:
+        result = resolve_stage_timeout_s(stage)
+        assert isinstance(result, int), f"stage {stage!r}: expected int, got {type(result)}"
+        assert result > 0, f"stage {stage!r}: expected > 0, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# resolve_stage_max_retries — fallback chain
+# ---------------------------------------------------------------------------
+
+
+def test_retries_built_in_default(monkeypatch):
+    """No overrides → BUILT_IN_MAX_RETRIES (3)."""
+    _clear_retries_env(monkeypatch)
+    assert resolve_stage_max_retries("implement") == BUILT_IN_MAX_RETRIES
+
+
+def test_retries_env_per_stage(monkeypatch):
+    """DEILE_PIPELINE_RETRIES_<STAGE> overrides built-in."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_IMPLEMENT", "5")
+    assert resolve_stage_max_retries("implement") == 5
+
+
+def test_retries_env_zero_is_valid(monkeypatch):
+    """0 retries is valid (no retry on failure)."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_CLASSIFY", "0")
+    assert resolve_stage_max_retries("classify") == 0
+
+
+def test_retries_env_negative_raises(monkeypatch):
+    """Negative retries → ValueError."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_CLASSIFY", "-1")
+    with pytest.raises(ValueError):
+        resolve_stage_max_retries("classify")
+
+
+def test_retries_env_non_numeric_raises(monkeypatch):
+    """Non-numeric retries → ValueError."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_CLASSIFY", "lots")
+    with pytest.raises(ValueError):
+        resolve_stage_max_retries("classify")
+
+
+def test_retries_empty_env_falls_through(monkeypatch):
+    """Empty env var treated as unset."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_CLASSIFY", "")
+    assert resolve_stage_max_retries("classify") == BUILT_IN_MAX_RETRIES
+
+
+def test_retries_invalid_stage_raises(monkeypatch):
+    """Unknown stage → ValueError."""
+    _clear_retries_env(monkeypatch)
+    with pytest.raises(ValueError, match="unknown stage"):
+        resolve_stage_max_retries("bad_stage")
+
+
+def test_retries_all_stages_return_nonneg_int(monkeypatch):
+    """All 5 stages return a non-negative integer with no overrides."""
+    _clear_retries_env(monkeypatch)
+    for stage in PIPELINE_STAGES:
+        result = resolve_stage_max_retries(stage)
+        assert isinstance(result, int), f"stage {stage!r}: expected int"
+        assert result >= 0, f"stage {stage!r}: expected >= 0, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Settings fallback (via monkeypatched settings singleton)
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_settings_per_stage_fallback(monkeypatch):
+    """pipeline_timeout_s_implement from settings wins over built-in."""
+    _clear_timeout_env(monkeypatch)
+    from deile.config import settings as _settings_mod
+    monkeypatch.setattr(_settings_mod, "_settings", None)
+    # Inject a mock settings with the per-stage field set
+    import types
+    mock_s = types.SimpleNamespace(
+        pipeline_timeout_s_implement=750,
+        pipeline_timeout_s_classify=None,
+        pipeline_timeout_s_refine=None,
+        pipeline_timeout_s_pr_review=None,
+        pipeline_timeout_s_follow_ups=None,
+        pipeline_claude_timeout=1800,
+        pipeline_deile_timeout=None,
+        pipeline_dispatch_mode="deile-worker",
+        pipeline_dispatcher_implement=None,
+        pipeline_dispatcher_classify=None,
+        pipeline_dispatcher_refine=None,
+        pipeline_dispatcher_pr_review=None,
+        pipeline_dispatcher_follow_ups=None,
+    )
+    monkeypatch.setattr(_settings_mod, "_settings", mock_s)
+    assert resolve_stage_timeout_s("implement") == 750
+    monkeypatch.setattr(_settings_mod, "_settings", None)
+
+
+def test_retries_settings_per_stage_fallback(monkeypatch):
+    """pipeline_retries_implement from settings wins over built-in."""
+    _clear_retries_env(monkeypatch)
+    from deile.config import settings as _settings_mod
+    import types
+    mock_s = types.SimpleNamespace(
+        pipeline_retries_implement=7,
+        pipeline_retries_classify=None,
+        pipeline_retries_refine=None,
+        pipeline_retries_pr_review=None,
+        pipeline_retries_follow_ups=None,
+        pipeline_default_max_retries=None,
+        pipeline_dispatch_mode="deile-worker",
+        pipeline_dispatcher_implement=None,
+        pipeline_dispatcher_classify=None,
+        pipeline_dispatcher_refine=None,
+        pipeline_dispatcher_pr_review=None,
+        pipeline_dispatcher_follow_ups=None,
+        pipeline_timeout_s_implement=None,
+        pipeline_timeout_s_classify=None,
+        pipeline_timeout_s_refine=None,
+        pipeline_timeout_s_pr_review=None,
+        pipeline_timeout_s_follow_ups=None,
+        pipeline_claude_timeout=1800,
+        pipeline_deile_timeout=None,
+    )
+    monkeypatch.setattr(_settings_mod, "_settings", mock_s)
+    assert resolve_stage_max_retries("implement") == 7
+    monkeypatch.setattr(_settings_mod, "_settings", None)
+
+
+def test_retries_global_default_fallback(monkeypatch):
+    """pipeline_default_max_retries from settings used when no per-stage."""
+    _clear_retries_env(monkeypatch)
+    from deile.config import settings as _settings_mod
+    import types
+    mock_s = types.SimpleNamespace(
+        pipeline_retries_implement=None,
+        pipeline_retries_classify=None,
+        pipeline_retries_refine=None,
+        pipeline_retries_pr_review=None,
+        pipeline_retries_follow_ups=None,
+        pipeline_default_max_retries=10,
+        pipeline_dispatch_mode="deile-worker",
+        pipeline_dispatcher_implement=None,
+        pipeline_dispatcher_classify=None,
+        pipeline_dispatcher_refine=None,
+        pipeline_dispatcher_pr_review=None,
+        pipeline_dispatcher_follow_ups=None,
+        pipeline_timeout_s_implement=None,
+        pipeline_timeout_s_classify=None,
+        pipeline_timeout_s_refine=None,
+        pipeline_timeout_s_pr_review=None,
+        pipeline_timeout_s_follow_ups=None,
+        pipeline_claude_timeout=1800,
+        pipeline_deile_timeout=None,
+    )
+    monkeypatch.setattr(_settings_mod, "_settings", mock_s)
+    assert resolve_stage_max_retries("implement") == 10
+    monkeypatch.setattr(_settings_mod, "_settings", None)

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -4114,9 +4114,9 @@ class DispatchMatrixView(View):
         elif kind == "model":
             title = f"ESCOLHA MODEL PARA STAGE '{stage}'"
         elif kind == "timeout":
-            title = f"TIMEOUT (s) PARA STAGE '{stage}' (0 = usar default)"
+            title = f"TIMEOUT (s) PARA STAGE '{stage}' (enter vazio = clear)"
         elif kind == "retries":
-            title = f"MAX RETRIES PARA STAGE '{stage}'"
+            title = f"MAX RETRIES PARA STAGE '{stage}' (enter vazio = clear)"
         elif kind == "global_worker":
             title = "ESCOLHA DISPATCH MODE GLOBAL (DEILE_PIPELINE_DISPATCH_MODE)"
         elif kind == "global_model":
@@ -4131,10 +4131,6 @@ class DispatchMatrixView(View):
             title = "DESINSTALAR CLAUDE-WORKER?"
         elif kind == "scale_prompt":
             title = f"RÉPLICAS PARA '{stage}' (0-10)"
-        elif kind == "timeout":
-            title = f"TIMEOUT (s) PARA STAGE '{stage}' (enter vazio = clear)"
-        elif kind == "retries":
-            title = f"MAX RETRIES PARA STAGE '{stage}' (enter vazio = clear)"
         else:  # defensivo
             title = "AÇÃO"
 

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -74,6 +74,10 @@ from _panel_data import \
     set_pipeline_dispatch_stage as pd_set_pipeline_dispatch_stage
 from _panel_data import set_preferred_model as pd_set_preferred_model
 from _panel_data import set_stage_model as pd_set_stage_model
+from _panel_data import set_stage_timeout_s as pd_set_stage_timeout_s
+from _panel_data import reset_stage_timeout_s as pd_reset_stage_timeout_s
+from _panel_data import set_stage_retries as pd_set_stage_retries
+from _panel_data import reset_stage_retries as pd_reset_stage_retries
 from rich import box
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
@@ -3774,7 +3778,8 @@ class DispatchMatrixView(View):
     refresh_s = 1.0
 
     HOTKEYS = (
-        "[↑/↓] linha   [←/→] coluna   [enter] editar   [r] reset   "
+        "[↑/↓] linha   [←/→] coluna (Worker/Model/Timeout/Retries)   "
+        "[enter] editar   [r] reset   "
         "[L] switch claude login   [I] install   [U] uninstall   [q] back   "
         "[s]caling row: enter digita réplicas (0-10)"
     )
@@ -3817,13 +3822,15 @@ class DispatchMatrixView(View):
         # cursor_row ∈ [0, N] — N inclusive corresponde à linha "Global
         # default" no fim da matriz.
         self.cursor_row: int = 0
-        # cursor_col ∈ {0, 1} — 0 = Worker, 1 = Model. As colunas Stage e
-        # Source não são editáveis (label estático + metadado read-only).
+        # cursor_col ∈ {0, 1, 2, 3} — 0=Worker, 1=Model, 2=Timeout, 3=Retries.
+        # As colunas Stage e Source não são editáveis (label estático + metadado).
         self.cursor_col: int = 0
         # --- Picker modal state (Task 19). ``None`` = browsing.
         # Forma: ``(kind, stage_or_None, options)`` onde ``kind`` é:
         #   * "worker"        — picker de worker para um stage específico
         #   * "model"         — picker de model para um stage específico
+        #   * "timeout"       — entrada numérica de timeout (s) por stage
+        #   * "retries"       — entrada numérica de max retries por stage
         #   * "global_worker" — picker de dispatch_mode (global)
         #   * "global_model"  — picker de DEILE_PREFERRED_MODEL (global)
         # ``stage_or_None`` é o nome do stage para per-stage pickers, ou
@@ -4009,36 +4016,57 @@ class DispatchMatrixView(View):
         tbl.add_column("Stage", style="bold cyan")
         tbl.add_column("Worker")
         tbl.add_column("Model")
+        tbl.add_column("Timeout (s)")
+        tbl.add_column("Max retries")
         tbl.add_column("Source", style="dim")
 
         for i, entry in enumerate(entries):
             highlight_w = (i == self.cursor_row and self.cursor_col == 0)
             highlight_m = (i == self.cursor_row and self.cursor_col == 1)
+            highlight_t = (i == self.cursor_row and self.cursor_col == 2)
+            highlight_r = (i == self.cursor_row and self.cursor_col == 3)
 
             worker_cell = (f"[reverse]{entry.worker}[/reverse]"
                            if highlight_w else entry.worker)
             model_txt = entry.model or "(default)"
             model_cell = (f"[reverse]{model_txt}[/reverse]"
                           if highlight_m else model_txt)
-            tbl.add_row(entry.stage, worker_cell, model_cell, entry.source)
+            timeout_txt = (str(getattr(entry, "timeout_s", None) or "default"))
+            timeout_cell = (f"[reverse]{timeout_txt}[/reverse]"
+                            if highlight_t else timeout_txt)
+            retries_txt = (str(getattr(entry, "max_retries", None))
+                           if getattr(entry, "max_retries", None) is not None
+                           else "default")
+            retries_cell = (f"[reverse]{retries_txt}[/reverse]"
+                            if highlight_r else retries_txt)
+            tbl.add_row(entry.stage, worker_cell, model_cell,
+                        timeout_cell, retries_cell, entry.source)
 
         # Separador visual entre stages e a linha "Global default".
-        tbl.add_row("─" * 12, "─" * 14, "─" * 28, "─" * 8, style="dim")
+        tbl.add_row("─" * 12, "─" * 14, "─" * 28, "─" * 10, "─" * 10, "─" * 8,
+                    style="dim")
 
         # Linha "Global default" — ``cursor_row == len(entries)`` aponta
         # aqui (mas só dentro dos limites de ``handle_key``).
         global_idx = len(entries)
-        highlight_gw = (self.cursor_row == global_idx
-                        and self.cursor_col == 0)
-        highlight_gm = (self.cursor_row == global_idx
-                        and self.cursor_col == 1)
+        highlight_gw = (self.cursor_row == global_idx and self.cursor_col == 0)
+        highlight_gm = (self.cursor_row == global_idx and self.cursor_col == 1)
+        highlight_gt = (self.cursor_row == global_idx and self.cursor_col == 2)
+        highlight_gr = (self.cursor_row == global_idx and self.cursor_col == 3)
         global_w_txt = "(DEILE_PIPELINE_DISPATCH_MODE)"
         global_m_txt = "(DEILE_PIPELINE_MODEL)"
+        global_t_txt = "(pipeline_claude_timeout)"
+        global_r_txt = "(pipeline_default_max_retries)"
         if highlight_gw:
             global_w_txt = f"[reverse]{global_w_txt}[/reverse]"
         if highlight_gm:
             global_m_txt = f"[reverse]{global_m_txt}[/reverse]"
-        tbl.add_row("Global default", global_w_txt, global_m_txt, "env")
+        if highlight_gt:
+            global_t_txt = f"[reverse]{global_t_txt}[/reverse]"
+        if highlight_gr:
+            global_r_txt = f"[reverse]{global_r_txt}[/reverse]"
+        tbl.add_row("Global default", global_w_txt, global_m_txt,
+                    global_t_txt, global_r_txt, "env")
 
         # Linha "Worker Scaling" — edita réplicas de deile-worker / claude-worker
         # via prompt numérico [enter] (issue #309 fase 3 Task 4).
@@ -4052,7 +4080,7 @@ class DispatchMatrixView(View):
             scale_w_txt = f"[reverse]{scale_w_txt}[/reverse]"
         if highlight_sm:
             scale_m_txt = f"[reverse]{scale_m_txt}[/reverse]"
-        tbl.add_row("Worker Scaling", scale_w_txt, scale_m_txt, "kubectl")
+        tbl.add_row("Worker Scaling", scale_w_txt, scale_m_txt, "", "", "kubectl")
 
         # --- Compose: header + matrix + (picker?) + (status?) + hotkeys --
         parts: List[RenderableType] = [
@@ -4082,6 +4110,10 @@ class DispatchMatrixView(View):
             title = f"ESCOLHA WORKER PARA STAGE '{stage}'"
         elif kind == "model":
             title = f"ESCOLHA MODEL PARA STAGE '{stage}'"
+        elif kind == "timeout":
+            title = f"TIMEOUT (s) PARA STAGE '{stage}' (0 = usar default)"
+        elif kind == "retries":
+            title = f"MAX RETRIES PARA STAGE '{stage}'"
         elif kind == "global_worker":
             title = "ESCOLHA DISPATCH MODE GLOBAL (DEILE_PIPELINE_DISPATCH_MODE)"
         elif kind == "global_model":
@@ -4207,7 +4239,10 @@ class DispatchMatrixView(View):
             self.cursor_col = max(0, self.cursor_col - 1)
             return ActionResult.refresh()
         if key in ("RIGHT", "l"):
-            self.cursor_col = min(1, self.cursor_col + 1)
+            # 4 colunas editáveis: 0=Worker, 1=Model, 2=Timeout, 3=Retries.
+            # Worker Scaling row só tem col 0 e 1.
+            max_col = 1 if self.cursor_row == (len(self._stages()) + 1) else 3
+            self.cursor_col = min(max_col, self.cursor_col + 1)
             return ActionResult.refresh()
 
         # --- [enter]: abre picker contextual ------------------------------
@@ -4219,16 +4254,28 @@ class DispatchMatrixView(View):
             if self.cursor_row == scaling_idx:
                 # Linha de scaling → prompt numérico de réplicas (Task 4).
                 return self._open_scaling_prompt()
-            # Row na linha "Global default" → picker global.
+            # Row na linha "Global default" → picker global (só worker/model).
             if self.cursor_row == global_idx:
                 if self.cursor_col == 0:
                     return self._open_global_worker_picker()
-                return self._open_global_model_picker()
+                if self.cursor_col == 1:
+                    return self._open_global_model_picker()
+                # cols 2/3 (Timeout/Retries) no Global row são read-only hint
+                self.last_msg = (
+                    "Timeout/Retries globais: editar via settings.json ou "
+                    "env vars DEILE_PIPELINE_TIMEOUT_S_*/DEILE_PIPELINE_RETRIES_*"
+                )
+                self.last_ok = None
+                return ActionResult.refresh()
             # Row dentro das stages → picker per-stage.
             entry = entries[self.cursor_row]
             if self.cursor_col == 0:
                 return self._open_worker_picker(entry)
-            return self._open_model_picker(entry)
+            if self.cursor_col == 1:
+                return self._open_model_picker(entry)
+            if self.cursor_col == 2:
+                return self._open_timeout_picker(entry)
+            return self._open_retries_picker(entry)
 
         # --- [r] reset da célula corrente -------------------------------
         if key == "r":
@@ -4325,16 +4372,51 @@ class DispatchMatrixView(View):
         self.picker_cursor = 0
         return ActionResult.refresh()
 
+    def _open_timeout_picker(self, entry) -> ActionResult:
+        """Abre picker per-stage de timeout em segundos (col 2 numa stage row).
+
+        Oferece valores comuns + opção de default. Aceita entrada numérica.
+        """
+        opts = [
+            "(default — remover override)",
+            "300",
+            "600",
+            "900",
+            "1200",
+            "1800",
+            "3600",
+        ]
+        self.mode = ("timeout", entry.stage, opts)
+        self.picker_cursor = 0
+        return ActionResult.refresh()
+
+    def _open_retries_picker(self, entry) -> ActionResult:
+        """Abre picker per-stage de max retries (col 3 numa stage row)."""
+        opts = [
+            "(default — remover override)",
+            "0",
+            "1",
+            "2",
+            "3",
+            "5",
+            "10",
+        ]
+        self.mode = ("retries", entry.stage, opts)
+        self.picker_cursor = 0
+        return ActionResult.refresh()
+
     # --- [r] reset cell --------------------------------------------------
 
     def _reset_current_cell(self) -> ActionResult:
         """Clear do override da célula corrente — volta ao fallback chain.
 
         Roteia conforme (cursor_row, cursor_col):
-          - Stage row + col 0 (Worker) → set_pipeline_dispatch_stage(stage, None)
-          - Stage row + col 1 (Model)  → clear_stage_model(stage)
+          - Stage row + col 0 (Worker)  → set_pipeline_dispatch_stage(stage, None)
+          - Stage row + col 1 (Model)   → clear_stage_model(stage)
+          - Stage row + col 2 (Timeout) → reset_stage_timeout_s(stage)
+          - Stage row + col 3 (Retries) → reset_stage_retries(stage)
           - Global row + col 0 (Worker) → clear_pipeline_dispatch_mode()
-          - Global row + col 1 (Model)  → no-op com hint (sem helper hoje)
+          - Global row + col 1+ → no-op com hint
 
         Cache do StageDispatchProvider é invalidado depois — próximo render
         mostra o valor novo.
@@ -4355,13 +4437,17 @@ class DispatchMatrixView(View):
             stage = entry.stage
             if self.cursor_col == 0:
                 ok, msg = pd_set_pipeline_dispatch_stage(stage, None, namespace=ns)
-            else:
+            elif self.cursor_col == 1:
                 ok, msg = pd_clear_stage_model(stage)
+            elif self.cursor_col == 2:
+                ok, msg = pd_reset_stage_timeout_s(stage)
+            else:  # col 3
+                ok, msg = pd_reset_stage_retries(stage)
         else:  # Global default row
             if self.cursor_col == 0:
                 ok, msg = pd_clear_pipeline_dispatch_mode(namespace=ns)
             else:
-                ok, msg = (None, "clear de DEILE_PIPELINE_MODEL global ainda não suportado")
+                ok, msg = (None, "clear de configuração global: editar settings.json diretamente")
 
         self.last_ok = ok
         self.last_msg = msg
@@ -5055,6 +5141,38 @@ class DispatchMatrixView(View):
             ok, msg = pd_set_preferred_model(
                 "deile-worker", selected, namespace=ns,
             )
+            self.last_ok = ok
+            self.last_msg = msg
+            return
+
+        # --- per-stage timeout ------------------------------------------
+        if kind == "timeout":
+            if selected.startswith("(default"):
+                ok, msg = pd_reset_stage_timeout_s(stage)
+            else:
+                try:
+                    seconds = int(selected)
+                except (ValueError, TypeError):
+                    self.last_ok = False
+                    self.last_msg = f"valor inválido: {selected!r}"
+                    return
+                ok, msg = pd_set_stage_timeout_s(stage, seconds)
+            self.last_ok = ok
+            self.last_msg = msg
+            return
+
+        # --- per-stage retries ------------------------------------------
+        if kind == "retries":
+            if selected.startswith("(default"):
+                ok, msg = pd_reset_stage_retries(stage)
+            else:
+                try:
+                    count = int(selected)
+                except (ValueError, TypeError):
+                    self.last_ok = False
+                    self.last_msg = f"valor inválido: {selected!r}"
+                    return
+                ok, msg = pd_set_stage_retries(stage, count)
             self.last_ok = ok
             self.last_msg = msg
             return

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -74,6 +74,8 @@ from _panel_data import \
     set_pipeline_dispatch_stage as pd_set_pipeline_dispatch_stage
 from _panel_data import set_preferred_model as pd_set_preferred_model
 from _panel_data import set_stage_model as pd_set_stage_model
+from _panel_data import set_stage_timeout as pd_set_stage_timeout
+from _panel_data import set_stage_retries as pd_set_stage_retries
 from rich import box
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
@@ -3776,7 +3778,8 @@ class DispatchMatrixView(View):
     HOTKEYS = (
         "[↑/↓] linha   [←/→] coluna   [enter] editar   [r] reset   "
         "[L] switch claude login   [I] install   [U] uninstall   [q] back   "
-        "[s]caling row: enter digita réplicas (0-10)"
+        "[s]caling row: enter digita réplicas (0-10)   "
+        "colunas: 0=Worker 1=Model 2=Timeout 3=Retries"
     )
 
     # Índice de row constante para a linha de scaling (após Global default).
@@ -3817,13 +3820,15 @@ class DispatchMatrixView(View):
         # cursor_row ∈ [0, N] — N inclusive corresponde à linha "Global
         # default" no fim da matriz.
         self.cursor_row: int = 0
-        # cursor_col ∈ {0, 1} — 0 = Worker, 1 = Model. As colunas Stage e
-        # Source não são editáveis (label estático + metadado read-only).
+        # cursor_col ∈ {0, 1, 2, 3} — 0=Worker, 1=Model, 2=Timeout(s), 3=Retries.
+        # As colunas Stage e Source não são editáveis.
         self.cursor_col: int = 0
         # --- Picker modal state (Task 19). ``None`` = browsing.
         # Forma: ``(kind, stage_or_None, options)`` onde ``kind`` é:
         #   * "worker"        — picker de worker para um stage específico
         #   * "model"         — picker de model para um stage específico
+        #   * "timeout"       — input numérico de timeout_s para um stage
+        #   * "retries"       — input numérico de max_retries para um stage
         #   * "global_worker" — picker de dispatch_mode (global)
         #   * "global_model"  — picker de DEILE_PREFERRED_MODEL (global)
         # ``stage_or_None`` é o nome do stage para per-stage pickers, ou
@@ -3831,7 +3836,8 @@ class DispatchMatrixView(View):
         # ``options`` é a lista pré-computada (filtrada) que o picker
         # exibe — captura o estado da row no momento de abertura para
         # que mudar de row durante a navegação do picker não troque a
-        # lista de opções (UX previsível).
+        # lista de opções (UX previsível). Para timeout/retries o picker
+        # usa ``scale_prompt`` style (entrada numérica livre em vez de lista).
         self.mode: Optional[tuple] = None
         self.picker_cursor: int = 0
         # Última ação para feedback no painel (paridade com
@@ -4009,21 +4015,33 @@ class DispatchMatrixView(View):
         tbl.add_column("Stage", style="bold cyan")
         tbl.add_column("Worker")
         tbl.add_column("Model")
+        tbl.add_column("Timeout (s)")
+        tbl.add_column("Max retries")
         tbl.add_column("Source", style="dim")
 
         for i, entry in enumerate(entries):
             highlight_w = (i == self.cursor_row and self.cursor_col == 0)
             highlight_m = (i == self.cursor_row and self.cursor_col == 1)
+            highlight_t = (i == self.cursor_row and self.cursor_col == 2)
+            highlight_r = (i == self.cursor_row and self.cursor_col == 3)
 
             worker_cell = (f"[reverse]{entry.worker}[/reverse]"
                            if highlight_w else entry.worker)
             model_txt = entry.model or "(default)"
             model_cell = (f"[reverse]{model_txt}[/reverse]"
                           if highlight_m else model_txt)
-            tbl.add_row(entry.stage, worker_cell, model_cell, entry.source)
+            timeout_txt = str(entry.timeout_s) if entry.timeout_s is not None else "(default)"
+            timeout_cell = (f"[reverse]{timeout_txt}[/reverse]"
+                            if highlight_t else timeout_txt)
+            retries_txt = str(entry.max_retries) if entry.max_retries is not None else "(default)"
+            retries_cell = (f"[reverse]{retries_txt}[/reverse]"
+                            if highlight_r else retries_txt)
+            tbl.add_row(entry.stage, worker_cell, model_cell,
+                        timeout_cell, retries_cell, entry.source)
 
         # Separador visual entre stages e a linha "Global default".
-        tbl.add_row("─" * 12, "─" * 14, "─" * 28, "─" * 8, style="dim")
+        tbl.add_row("─" * 12, "─" * 14, "─" * 28, "─" * 10, "─" * 11, "─" * 8,
+                    style="dim")
 
         # Linha "Global default" — ``cursor_row == len(entries)`` aponta
         # aqui (mas só dentro dos limites de ``handle_key``).
@@ -4032,13 +4050,24 @@ class DispatchMatrixView(View):
                         and self.cursor_col == 0)
         highlight_gm = (self.cursor_row == global_idx
                         and self.cursor_col == 1)
+        highlight_gt = (self.cursor_row == global_idx
+                        and self.cursor_col == 2)
+        highlight_gr = (self.cursor_row == global_idx
+                        and self.cursor_col == 3)
         global_w_txt = "(DEILE_PIPELINE_DISPATCH_MODE)"
         global_m_txt = "(DEILE_PIPELINE_MODEL)"
+        global_t_txt = "(DEILE_PIPELINE_DEILE/CLAUDE_TIMEOUT)"
+        global_r_txt = "(DEILE_PIPELINE_DEFAULT_MAX_RETRIES)"
         if highlight_gw:
             global_w_txt = f"[reverse]{global_w_txt}[/reverse]"
         if highlight_gm:
             global_m_txt = f"[reverse]{global_m_txt}[/reverse]"
-        tbl.add_row("Global default", global_w_txt, global_m_txt, "env")
+        if highlight_gt:
+            global_t_txt = f"[reverse]{global_t_txt}[/reverse]"
+        if highlight_gr:
+            global_r_txt = f"[reverse]{global_r_txt}[/reverse]"
+        tbl.add_row("Global default", global_w_txt, global_m_txt,
+                    global_t_txt, global_r_txt, "env")
 
         # Linha "Worker Scaling" — edita réplicas de deile-worker / claude-worker
         # via prompt numérico [enter] (issue #309 fase 3 Task 4).
@@ -4052,7 +4081,8 @@ class DispatchMatrixView(View):
             scale_w_txt = f"[reverse]{scale_w_txt}[/reverse]"
         if highlight_sm:
             scale_m_txt = f"[reverse]{scale_m_txt}[/reverse]"
-        tbl.add_row("Worker Scaling", scale_w_txt, scale_m_txt, "kubectl")
+        tbl.add_row("Worker Scaling", scale_w_txt, scale_m_txt,
+                    "", "", "kubectl")
 
         # --- Compose: header + matrix + (picker?) + (status?) + hotkeys --
         parts: List[RenderableType] = [
@@ -4096,6 +4126,10 @@ class DispatchMatrixView(View):
             title = "DESINSTALAR CLAUDE-WORKER?"
         elif kind == "scale_prompt":
             title = f"RÉPLICAS PARA '{stage}' (0-10)"
+        elif kind == "timeout":
+            title = f"TIMEOUT (s) PARA STAGE '{stage}' (enter vazio = clear)"
+        elif kind == "retries":
+            title = f"MAX RETRIES PARA STAGE '{stage}' (enter vazio = clear)"
         else:  # defensivo
             title = "AÇÃO"
 
@@ -4118,6 +4152,7 @@ class DispatchMatrixView(View):
             tbl.add_row(Text(marker, style="bold cyan"), Text(opt))
 
         # Modais de confirmação Y/N usam um prompt e atalhos Y/N visíveis;
+        # pickers de entrada numérica livre (timeout/retries) mostram buffer;
         # pickers convencionais usam enter/esc.
         if kind in ("install_confirm", "switch_login_confirm",
                     "uninstall_confirm"):
@@ -4126,6 +4161,16 @@ class DispatchMatrixView(View):
             hint = Text("[Y] confirma   [N]/[esc] cancela",
                         style="dim cyan")
             body: RenderableType = Group(prompt, Text(""), tbl, hint)
+        elif kind in ("timeout", "retries"):
+            # Entrada numérica livre — ``options[0]`` é o buffer atual.
+            buf = options[0] if options else ""
+            input_line = Text(f"› {buf}_", style="bold cyan")
+            unit_hint = " (segundos, > 0)" if kind == "timeout" else " (>= 0)"
+            hint_line = Text(
+                f"[0-9] digita   [backspace] apaga   [enter] confirma   [esc] cancela{unit_hint}",
+                style="dim cyan",
+            )
+            body = Group(input_line, Text(""), hint_line)
         else:
             body = Group(
                 tbl,
@@ -4207,7 +4252,7 @@ class DispatchMatrixView(View):
             self.cursor_col = max(0, self.cursor_col - 1)
             return ActionResult.refresh()
         if key in ("RIGHT", "l"):
-            self.cursor_col = min(1, self.cursor_col + 1)
+            self.cursor_col = min(3, self.cursor_col + 1)
             return ActionResult.refresh()
 
         # --- [enter]: abre picker contextual ------------------------------
@@ -4218,6 +4263,11 @@ class DispatchMatrixView(View):
             scaling_idx = n_stages + 1  # "Worker Scaling"
             if self.cursor_row == scaling_idx:
                 # Linha de scaling → prompt numérico de réplicas (Task 4).
+                # Cols 2/3 (timeout/retries) não se aplicam à scaling row.
+                if self.cursor_col >= 2:
+                    self.last_msg = "timeout/retries não se aplicam à linha de scaling"
+                    self.last_ok = None
+                    return ActionResult.refresh()
                 return self._open_scaling_prompt()
             # Row na linha "Global default" → picker global.
             if self.cursor_row == global_idx:
@@ -4228,7 +4278,12 @@ class DispatchMatrixView(View):
             entry = entries[self.cursor_row]
             if self.cursor_col == 0:
                 return self._open_worker_picker(entry)
-            return self._open_model_picker(entry)
+            elif self.cursor_col == 1:
+                return self._open_model_picker(entry)
+            elif self.cursor_col == 2:
+                return self._open_timeout_prompt(entry)
+            else:
+                return self._open_retries_prompt(entry)
 
         # --- [r] reset da célula corrente -------------------------------
         if key == "r":
@@ -4325,6 +4380,26 @@ class DispatchMatrixView(View):
         self.picker_cursor = 0
         return ActionResult.refresh()
 
+    def _open_timeout_prompt(self, entry) -> ActionResult:
+        """Abre prompt numérico de timeout_s para o stage da entry.
+
+        Reutiliza o ``scale_prompt`` style (entrada numérica livre) — a
+        :meth:`_render_picker` renderiza com prompt de texto e
+        :meth:`_handle_picker_key` captura dígitos + [backspace] + [enter].
+        ``options`` carrega o valor atual para pré-preencher o prompt.
+        """
+        current = str(entry.timeout_s) if entry.timeout_s is not None else ""
+        self.mode = ("timeout", entry.stage, [current])
+        self.picker_cursor = 0
+        return ActionResult.refresh()
+
+    def _open_retries_prompt(self, entry) -> ActionResult:
+        """Abre prompt numérico de max_retries para o stage da entry."""
+        current = str(entry.max_retries) if entry.max_retries is not None else ""
+        self.mode = ("retries", entry.stage, [current])
+        self.picker_cursor = 0
+        return ActionResult.refresh()
+
     # --- [r] reset cell --------------------------------------------------
 
     def _reset_current_cell(self) -> ActionResult:
@@ -4355,13 +4430,17 @@ class DispatchMatrixView(View):
             stage = entry.stage
             if self.cursor_col == 0:
                 ok, msg = pd_set_pipeline_dispatch_stage(stage, None, namespace=ns)
-            else:
+            elif self.cursor_col == 1:
                 ok, msg = pd_clear_stage_model(stage)
+            elif self.cursor_col == 2:
+                ok, msg = pd_set_stage_timeout(stage, None, namespace=ns)
+            else:
+                ok, msg = pd_set_stage_retries(stage, None, namespace=ns)
         else:  # Global default row
             if self.cursor_col == 0:
                 ok, msg = pd_clear_pipeline_dispatch_mode(namespace=ns)
             else:
-                ok, msg = (None, "clear de DEILE_PIPELINE_MODEL global ainda não suportado")
+                ok, msg = (None, "clear de override global ainda não suportado via painel")
 
         self.last_ok = ok
         self.last_msg = msg
@@ -4724,6 +4803,79 @@ class DispatchMatrixView(View):
 
         return ActionResult()
 
+    def _handle_numeric_prompt_key(self, key: str) -> ActionResult:
+        """Input handler for free-form numeric prompts (timeout / retries).
+
+        ``self.mode = (kind, stage, [buffer])`` where ``buffer`` is the
+        current digit string being edited. Confirms on [enter], cancels on
+        [ESC]. Empty [enter] = clear the override (None).
+        """
+        if self.mode is None:
+            return ActionResult()
+        kind, stage, options = self.mode
+        buf = options[0] if options else ""
+
+        if key == "ESC":
+            self.mode = None
+            self.picker_cursor = 0
+            self.last_msg = "entrada cancelada"
+            self.last_ok = None
+            return ActionResult.refresh()
+
+        if key == "BACKSPACE" or key == "\x7f":
+            new_buf = buf[:-1]
+            self.mode = (kind, stage, [new_buf])
+            return ActionResult.refresh()
+
+        if key.isdigit():
+            new_buf = buf + key
+            self.mode = (kind, stage, [new_buf])
+            return ActionResult.refresh()
+
+        if key in ("\r", "\n"):
+            ns = (self.data.context.namespace
+                  if self.data is not None and getattr(self.data, "context", None)
+                  else _NS_DEFAULT)
+            self.mode = None
+            self.picker_cursor = 0
+            if self.data is None:
+                self.last_msg = f"[demo] {kind}={buf!r} para '{stage}' (sem cluster, no-op)"
+                self.last_ok = False
+                return ActionResult.refresh()
+            # Empty input = clear override.
+            value: Optional[int] = None
+            if buf.strip():
+                try:
+                    value = int(buf.strip())
+                except ValueError:
+                    self.last_msg = f"valor inválido {buf!r} — esperado inteiro"
+                    self.last_ok = False
+                    return ActionResult.refresh()
+            if kind == "timeout":
+                if value is not None and value <= 0:
+                    self.last_msg = "timeout deve ser > 0"
+                    self.last_ok = False
+                    return ActionResult.refresh()
+                ok, msg = pd_set_stage_timeout(stage, value, namespace=ns)
+            else:  # retries
+                if value is not None and value < 0:
+                    self.last_msg = "retries deve ser >= 0"
+                    self.last_ok = False
+                    return ActionResult.refresh()
+                ok, msg = pd_set_stage_retries(stage, value, namespace=ns)
+            self.last_ok = ok
+            self.last_msg = msg
+            # Invalida cache para render mostrar o novo valor.
+            if self.data is not None:
+                try:
+                    self.data.stage_dispatch._cache.invalidate()  # noqa: SLF001
+                    self.data.stage_dispatch._status_cache.invalidate()  # noqa: SLF001
+                except (AttributeError, TypeError):
+                    pass
+            return ActionResult.refresh()
+
+        return ActionResult()
+
     def _perform_install(self, *, force_relogin: bool,
                          _blocking: bool = False) -> None:
         """Spawna :func:`bootstrap_claude_worker` em thread daemon e retorna
@@ -4945,6 +5097,8 @@ class DispatchMatrixView(View):
             return self._handle_uninstall_confirm(key)
         if self.mode is not None and self.mode[0] == "scale_prompt":
             return self._handle_scale_prompt_key(key)
+        if self.mode is not None and self.mode[0] in ("timeout", "retries"):
+            return self._handle_numeric_prompt_key(key)
         if key == "ESC":
             self.mode = None
             self.picker_cursor = 0
@@ -5057,6 +5211,14 @@ class DispatchMatrixView(View):
             )
             self.last_ok = ok
             self.last_msg = msg
+            return
+
+        # --- timeout / retries (handled by _handle_numeric_prompt_key;
+        # this branch is a fallback in case _apply_picker_selection is called
+        # directly without going through the numeric handler) ---------------
+        if kind in ("timeout", "retries"):
+            # Already handled inline in _handle_numeric_prompt_key.
+            # No-op here; defensive against unexpected call paths.
             return
 
 

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -2370,6 +2370,154 @@ def clear_stage_model(stage: str, timeout: float = 15.0) -> tuple:
     return True, f"{env_var} unset ({msg})"
 
 
+# ===== Per-stage timeout/retries (issue #391) ================================
+
+_STAGE_TIMEOUT_ENV_VARS: tuple = (
+    ("classify",    "DEILE_PIPELINE_TIMEOUT_S_CLASSIFY"),
+    ("refine",      "DEILE_PIPELINE_TIMEOUT_S_REFINE"),
+    ("implement",   "DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT"),
+    ("pr_review",   "DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW"),
+    ("follow_ups",  "DEILE_PIPELINE_TIMEOUT_S_FOLLOW_UPS"),
+)
+
+_STAGE_RETRIES_ENV_VARS: tuple = (
+    ("classify",    "DEILE_PIPELINE_RETRIES_CLASSIFY"),
+    ("refine",      "DEILE_PIPELINE_RETRIES_REFINE"),
+    ("implement",   "DEILE_PIPELINE_RETRIES_IMPLEMENT"),
+    ("pr_review",   "DEILE_PIPELINE_RETRIES_PR_REVIEW"),
+    ("follow_ups",  "DEILE_PIPELINE_RETRIES_FOLLOW_UPS"),
+)
+
+# Stage timeouts and retries are written to deile-pipeline (same as models).
+_STAGE_TIMEOUT_RETRIES_DEPLOYMENT = "deile-pipeline"
+
+
+def _timeout_env_var_for_stage(stage: str) -> Optional[str]:
+    """Return ``DEILE_PIPELINE_TIMEOUT_S_<STAGE>`` for a canonical stage, else None."""
+    return next((env for s, env in _STAGE_TIMEOUT_ENV_VARS if s == stage), None)
+
+
+def _retries_env_var_for_stage(stage: str) -> Optional[str]:
+    """Return ``DEILE_PIPELINE_RETRIES_<STAGE>`` for a canonical stage, else None."""
+    return next((env for s, env in _STAGE_RETRIES_ENV_VARS if s == stage), None)
+
+
+def set_stage_timeout_s(stage: str, seconds: int, timeout: float = 15.0) -> tuple:
+    """Pin a per-stage timeout override on ``deile-pipeline`` (issue #391).
+
+    Uses ``kubectl set env`` to write ``DEILE_PIPELINE_TIMEOUT_S_<STAGE>=<seconds>``
+    on the ``deile-pipeline`` Deployment. Returns ``(ok, msg)``.
+    """
+    env_var = _timeout_env_var_for_stage(stage)
+    if env_var is None:
+        allowed = ", ".join(s for s, _ in _STAGE_TIMEOUT_ENV_VARS)
+        return False, f"stage '{stage}' inválido — esperado um de: {allowed}"
+    if not isinstance(seconds, int) or seconds <= 0:
+        return False, f"seconds deve ser inteiro > 0, recebido: {seconds!r}"
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", NS, "set", "env",
+             f"deploy/{_STAGE_TIMEOUT_RETRIES_DEPLOYMENT}",
+             f"{env_var}={seconds}"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+    msg = (proc.stdout or "rollout disparado").strip()
+    return True, f"{env_var}={seconds} ({msg})"
+
+
+def reset_stage_timeout_s(stage: str, timeout: float = 15.0) -> tuple:
+    """Remove a per-stage timeout override on ``deile-pipeline`` (issue #391).
+
+    Uses ``kubectl set env ... <VAR>-`` (trailing dash = unset). Returns ``(ok, msg)``.
+    """
+    env_var = _timeout_env_var_for_stage(stage)
+    if env_var is None:
+        return False, f"stage '{stage}' inválido"
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", NS, "set", "env",
+             f"deploy/{_STAGE_TIMEOUT_RETRIES_DEPLOYMENT}",
+             f"{env_var}-"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+    msg = (proc.stdout or "rollout disparado").strip()
+    return True, f"{env_var} unset ({msg})"
+
+
+def set_stage_retries(stage: str, count: int, timeout: float = 15.0) -> tuple:
+    """Pin a per-stage max retries override on ``deile-pipeline`` (issue #391).
+
+    Uses ``kubectl set env`` to write ``DEILE_PIPELINE_RETRIES_<STAGE>=<count>``
+    on the ``deile-pipeline`` Deployment. Returns ``(ok, msg)``.
+    """
+    env_var = _retries_env_var_for_stage(stage)
+    if env_var is None:
+        allowed = ", ".join(s for s, _ in _STAGE_RETRIES_ENV_VARS)
+        return False, f"stage '{stage}' inválido — esperado um de: {allowed}"
+    if not isinstance(count, int) or count < 0:
+        return False, f"count deve ser inteiro >= 0, recebido: {count!r}"
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", NS, "set", "env",
+             f"deploy/{_STAGE_TIMEOUT_RETRIES_DEPLOYMENT}",
+             f"{env_var}={count}"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+    msg = (proc.stdout or "rollout disparado").strip()
+    return True, f"{env_var}={count} ({msg})"
+
+
+def reset_stage_retries(stage: str, timeout: float = 15.0) -> tuple:
+    """Remove a per-stage retries override on ``deile-pipeline`` (issue #391).
+
+    Uses ``kubectl set env ... <VAR>-`` (trailing dash = unset). Returns ``(ok, msg)``.
+    """
+    env_var = _retries_env_var_for_stage(stage)
+    if env_var is None:
+        return False, f"stage '{stage}' inválido"
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", NS, "set", "env",
+             f"deploy/{_STAGE_TIMEOUT_RETRIES_DEPLOYMENT}",
+             f"{env_var}-"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+    msg = (proc.stdout or "rollout disparado").strip()
+    return True, f"{env_var} unset ({msg})"
+
+
 # ===== Pipeline dispatch mode (issue #309) ==================================
 #
 # O ``PipelineMonitor`` lê ``settings.pipeline_dispatch_mode`` no boot e instancia

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -2857,6 +2857,151 @@ def set_pipeline_dispatch_stage(
     return True, f"{env_var}={dispatcher} ({msg})"
 
 
+# ===== Stage timeout / retries override — issue #391 =========================
+#
+# ``set_stage_timeout`` / ``set_stage_retries`` (e variantes clear) espelham
+# exatamente o padrão de ``set_pipeline_dispatch_stage``:
+#   * validam o stage contra PIPELINE_STAGES
+#   * usam ``kubectl set env deploy/deile-pipeline`` para persistir
+#   * emitem audit event ``SECURITY_POLICY_CHANGED``
+#   * retornam ``(ok, msg)`` para o painel exibir ``last_msg``
+
+
+def _audit_timeout_retries_change(
+    stage: str, kind: str, value: Optional[int], *,
+    result: str, detail: str, namespace: str,
+) -> None:
+    """Audit log wrapper for timeout/retries changes (espelha _audit_dispatch_stage_change)."""
+    try:
+        from deile.storage.audit_logger import AuditLogger, AuditEvent, AuditEventType, SeverityLevel  # noqa: PLC0415
+        from datetime import datetime  # noqa: PLC0415
+        AuditLogger.get_instance().log(AuditEvent(
+            timestamp=datetime.now(),
+            event_type=AuditEventType.SECURITY_POLICY_CHANGED,
+            severity=SeverityLevel.INFO,
+            operation=f"set_stage_{kind}",
+            user="panel",
+            details={
+                "stage": stage, "kind": kind, "value": value,
+                "result": result, "detail": detail, "namespace": namespace,
+            },
+        ))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def set_stage_timeout(
+    stage: str, timeout_s: Optional[int], *,
+    namespace: str = NS, timeout: float = 15.0,
+) -> tuple:
+    """Pin ``DEILE_PIPELINE_TIMEOUT_S_<STAGE>=<timeout_s>`` em ``deile-pipeline``.
+
+    Args:
+        stage: canonical stage name (one of PIPELINE_STAGES).
+        timeout_s: positive int (seconds) or None (clear the override).
+        namespace: K8s namespace.
+        timeout: subprocess timeout for kubectl.
+
+    Returns ``(ok, msg)``.
+    """
+    try:
+        from deile.orchestration.pipeline.dispatch_resolver import PIPELINE_STAGES  # noqa: PLC0415
+    except ImportError as exc:
+        return False, f"dispatch_resolver indisponível: {exc}"
+
+    if stage not in PIPELINE_STAGES:
+        return False, f"invalid stage {stage!r} — esperado um de: {', '.join(PIPELINE_STAGES)}"
+
+    if timeout_s is not None and timeout_s <= 0:
+        return False, f"timeout_s deve ser > 0, got {timeout_s}"
+
+    env_var = f"DEILE_PIPELINE_TIMEOUT_S_{stage.upper()}"
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+
+    if timeout_s is None:
+        argv = [kubectl, "-n", namespace, "set", "env",
+                f"deploy/{_DISPATCH_DEPLOYMENT}", f"{env_var}-"]
+    else:
+        argv = [kubectl, "-n", namespace, "set", "env",
+                f"deploy/{_DISPATCH_DEPLOYMENT}", f"{env_var}={timeout_s}"]
+
+    _audit_timeout_retries_change(
+        stage, "timeout_s", timeout_s, result="allowed",
+        detail=f"kubectl set env {env_var}={timeout_s}", namespace=namespace,
+    )
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+
+    msg = (proc.stdout or "rollout disparado").strip()
+    if timeout_s is None:
+        return True, f"{env_var} unset ({msg})"
+    return True, f"{env_var}={timeout_s} ({msg})"
+
+
+def set_stage_retries(
+    stage: str, max_retries: Optional[int], *,
+    namespace: str = NS, timeout: float = 15.0,
+) -> tuple:
+    """Pin ``DEILE_PIPELINE_RETRIES_<STAGE>=<max_retries>`` em ``deile-pipeline``.
+
+    Args:
+        stage: canonical stage name (one of PIPELINE_STAGES).
+        max_retries: non-negative int or None (clear the override).
+        namespace: K8s namespace.
+        timeout: subprocess timeout for kubectl.
+
+    Returns ``(ok, msg)``.
+    """
+    try:
+        from deile.orchestration.pipeline.dispatch_resolver import PIPELINE_STAGES  # noqa: PLC0415
+    except ImportError as exc:
+        return False, f"dispatch_resolver indisponível: {exc}"
+
+    if stage not in PIPELINE_STAGES:
+        return False, f"invalid stage {stage!r} — esperado um de: {', '.join(PIPELINE_STAGES)}"
+
+    if max_retries is not None and max_retries < 0:
+        return False, f"max_retries deve ser >= 0, got {max_retries}"
+
+    env_var = f"DEILE_PIPELINE_RETRIES_{stage.upper()}"
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+
+    if max_retries is None:
+        argv = [kubectl, "-n", namespace, "set", "env",
+                f"deploy/{_DISPATCH_DEPLOYMENT}", f"{env_var}-"]
+    else:
+        argv = [kubectl, "-n", namespace, "set", "env",
+                f"deploy/{_DISPATCH_DEPLOYMENT}", f"{env_var}={max_retries}"]
+
+    _audit_timeout_retries_change(
+        stage, "max_retries", max_retries, result="allowed",
+        detail=f"kubectl set env {env_var}={max_retries}", namespace=namespace,
+    )
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+
+    msg = (proc.stdout or "rollout disparado").strip()
+    if max_retries is None:
+        return True, f"{env_var} unset ({msg})"
+    return True, f"{env_var}={max_retries} ({msg})"
+
+
 # ===== Stage dispatch (worker + model) consolidado — issue #309 fase 2 ======
 #
 # ``StageDispatchProvider`` unifica 3 leituras separadas em uma única view:
@@ -2885,7 +3030,7 @@ _CLAUDE_CREDENTIALS_SECRET = "claude-credentials"
 
 @dataclass(frozen=True)
 class StageDispatchEntry:
-    """Snapshot per-stage do dispatcher + model resolvidos pelo runtime.
+    """Snapshot per-stage do dispatcher + model + tuning resolvidos pelo runtime.
 
     - ``stage`` — canonical stage name (one of :data:`PIPELINE_STAGES`).
     - ``worker`` — qual worker pod receberá o dispatch deste stage:
@@ -2896,12 +3041,18 @@ class StageDispatchEntry:
       ``DEILE_PIPELINE_DISPATCH_<STAGE>`` (override específico do stage),
       ``"global"`` quando veio do fallback ``DEILE_PIPELINE_DISPATCH_MODE``,
       ``"default"`` quando ambos ausentes (cai no built-in ``deile-worker``).
+    - ``timeout_s`` — override de timeout em segundos para este stage, ou
+      ``None`` quando nenhum override per-stage está setado (cai no global).
+    - ``max_retries`` — override de max retries para este stage, ou
+      ``None`` quando nenhum override per-stage está setado (cai no global).
     """
 
     stage: str
     worker: str
     model: Optional[str]
     source: str
+    timeout_s: Optional[int] = None
+    max_retries: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -3086,7 +3237,30 @@ class StageDispatchProvider(_KubectlProviderMixin):
                 source = "default"
             # Model chain: per-stage env → global env → None.
             model = ((stage_model_raw or "").strip() or global_model or None)
-            result.append(StageDispatchEntry(stage, worker, model, source))
+            # Timeout / retries overrides (issue #391) — read from pipeline
+            # Deployment env vars. None = no override, cai no resolver chain.
+            timeout_s: Optional[int] = None
+            timeout_raw = pipeline_env.get(f"DEILE_PIPELINE_TIMEOUT_S_{stage.upper()}")
+            if timeout_raw and timeout_raw.strip():
+                try:
+                    v = int(timeout_raw.strip())
+                    if v > 0:
+                        timeout_s = v
+                except (ValueError, TypeError):
+                    pass
+            max_retries: Optional[int] = None
+            retries_raw = pipeline_env.get(f"DEILE_PIPELINE_RETRIES_{stage.upper()}")
+            if retries_raw is not None and retries_raw.strip():
+                try:
+                    v = int(retries_raw.strip())
+                    if v >= 0:
+                        max_retries = v
+                except (ValueError, TypeError):
+                    pass
+            result.append(StageDispatchEntry(
+                stage, worker, model, source,
+                timeout_s=timeout_s, max_retries=max_retries,
+            ))
         return result
 
     def _fetch_status(self) -> ClaudeWorkerStatus:

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -1076,6 +1076,17 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     model_slug = payload.get("preferred_model")
     resume_session_id = payload.get("resume_session_id")
     prev_task_id = payload.get("prev_task_id")
+    # Per-stage timeout override (issue #391). When set, overrides
+    # DEILE_CLAUDE_WORKER_TASK_TIMEOUT_S for this dispatch only.
+    dispatch_timeout_s: Optional[int] = None
+    _raw_timeout = payload.get("timeout_s")
+    if _raw_timeout is not None:
+        try:
+            _v = int(_raw_timeout)
+            if _v > 0:
+                dispatch_timeout_s = _v
+        except (TypeError, ValueError):
+            pass
 
     # claude-worker SÓ aceita anthropic:* — outros providers viraram 400.
     claude_model: Optional[str] = None
@@ -1303,7 +1314,9 @@ async def dispatch_handler(request: web.Request) -> web.Response:
         cmd.extend(["--model", claude_model])
     cmd.append(full_prompt)
 
-    timeout = int(os.environ.get("DEILE_CLAUDE_WORKER_TASK_TIMEOUT_S", "7200"))
+    timeout = dispatch_timeout_s if dispatch_timeout_s is not None else int(
+        os.environ.get("DEILE_CLAUDE_WORKER_TASK_TIMEOUT_S", "7200")
+    )
 
     # Persist the command+prompt BEFORE the spawn so the observability panel
     # (issue #347) can show what's being executed even while it's running.

--- a/infra/k8s/worker_server.py
+++ b/infra/k8s/worker_server.py
@@ -537,6 +537,7 @@ async def _run_task(
     *,
     resume_ctx: Optional[Dict[str, Any]] = None,
     preferred_model: Optional[str] = None,
+    task_timeout_s: Optional[float] = None,
 ) -> Dict[str, Any]:
     """Body of a single dispatch — only one runs at a time (lock).
 
@@ -725,17 +726,20 @@ async def _run_task(
                         await maybe_edit(phase="▶️  modelo respondendo...")
                     final_text = "".join(response_text_chunks)
 
-                await asyncio.wait_for(_consume_stream(), timeout=TASK_TIMEOUT_S)
+                _eff_timeout = task_timeout_s if task_timeout_s is not None else TASK_TIMEOUT_S
+                await asyncio.wait_for(_consume_stream(), timeout=_eff_timeout)
             else:
+                _eff_timeout = task_timeout_s if task_timeout_s is not None else TASK_TIMEOUT_S
                 resp = await asyncio.wait_for(
                     agent.process_input(prompt, **kwargs),
-                    timeout=TASK_TIMEOUT_S,
+                    timeout=_eff_timeout,
                 )
                 final_text = str(getattr(resp, "content", "") or "")
 
             ok = True
         except asyncio.TimeoutError:
-            error_repr = f"timeout após {TASK_TIMEOUT_S}s"
+            _eff_timeout_for_msg = task_timeout_s if task_timeout_s is not None else TASK_TIMEOUT_S
+            error_repr = f"timeout após {_eff_timeout_for_msg}s"
             final_text = error_repr
             loop_ended = resume.LOOP_TIMEOUT
         except Exception as exc:
@@ -930,6 +934,17 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     branch = body.get("branch")
     if branch is not None:
         branch = str(branch).strip() or None
+    # Per-stage timeout override (issue #391). When set, overrides TASK_TIMEOUT_S
+    # for this dispatch only. Absent on bot/CLI passthrough dispatches.
+    dispatch_timeout_s: Optional[float] = None
+    _raw_timeout = body.get("timeout_s")
+    if _raw_timeout is not None:
+        try:
+            _v = int(_raw_timeout)
+            if _v > 0:
+                dispatch_timeout_s = float(_v)
+        except (TypeError, ValueError):
+            pass
 
     task_id = uuid.uuid4().hex[:_TASK_ID_LEN]
     _evict_old_tasks_if_needed()
@@ -961,13 +976,15 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     logger.info("dispatch_started %s", " ".join(parts))
 
     wait_for_result = bool(body.get("wait_for_result", True))
+    _outer_timeout = (dispatch_timeout_s + 30) if dispatch_timeout_s is not None else (TASK_TIMEOUT_S + 30)
     if wait_for_result:
         try:
             result = await asyncio.wait_for(
                 _run_task(task_id, brief, channel_id, user_message_id, persona,
                           attachments, history, resume_ctx=resume_ctx,
-                          preferred_model=preferred_model),
-                timeout=TASK_TIMEOUT_S + 30,
+                          preferred_model=preferred_model,
+                          task_timeout_s=dispatch_timeout_s),
+                timeout=_outer_timeout,
             )
             _TASKS[task_id] = result
             # Terminal marker for the panel — pairs with the
@@ -991,7 +1008,8 @@ async def dispatch_handler(request: web.Request) -> web.Response:
             try:
                 _TASKS[task_id] = await _run_task(task_id, brief, channel_id, user_message_id, persona,
                                                   attachments, history, resume_ctx=resume_ctx,
-                                                  preferred_model=preferred_model)
+                                                  preferred_model=preferred_model,
+                                                  task_timeout_s=dispatch_timeout_s)
                 logger.info(
                     "dispatch_completed task=%s ok=%s",
                     task_id, bool(_TASKS[task_id].get("ok")),


### PR DESCRIPTION
## Summary

- Adds per-stage `timeout_s` and `max_retries` configuration to the autonomous pipeline, mirroring the existing per-stage model (#305) and dispatcher (#309) pattern.
- New settings fields `pipeline_timeout_s_<stage>` and `pipeline_retries_<stage>` (5 each) with env var cluster path (`DEILE_PIPELINE_TIMEOUT_S_<STAGE>` / `DEILE_PIPELINE_RETRIES_<STAGE>`).
- `resolve_stage_timeout_s` and `resolve_stage_max_retries` resolvers in `dispatch_resolver.py` with full fallback chain (env per-stage → settings per-stage → global → built-in: 1800s claude, 900s deile, 3 retries).
- `build_dispatch_payload` extended with `timeout_s` and `max_retries` optional wire fields.
- `WorkerImplementer._dispatch` populates these fields via the resolvers for every dispatch.
- `DispatchMatrixView` gains **Timeout (s)** and **Max retries** columns; `cursor_col` extended from 2 to 4; picker modals for both kinds; `[r]` reset wired for all 4 columns.
- Panel data helpers `set_stage_timeout_s`, `reset_stage_timeout_s`, `set_stage_retries`, `reset_stage_retries` via `kubectl set env` on `deile-pipeline`.
- New test file `test_settings_pipeline_timeout_retries.py` (31 tests) and extended `test_dispatch_resolver.py` (24 new tests).

Closes #391.