### PR TITLE
feat: DispatchMatrixView Cost cap per stage with UsageRepository/BudgetGuard integration

### DIFF
--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -16,6 +16,7 @@ import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from decimal import Decimal, InvalidOperation
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -220,6 +221,34 @@ def _to_optional_dispatcher(value: Any) -> Optional[str]:
     return stripped
 
 
+def _to_optional_positive_decimal(value: Any) -> Optional[Decimal]:
+    """Strict converter for per-stage cost cap entries (issue #392).
+
+    ``None`` and empty/whitespace string collapse to ``None`` (no cap).
+    Non-strings, strings that don't parse as decimal, or non-positive values
+    raise — ``apply_overrides`` catches and keeps the previous (default) value.
+    Strict by design: a malformed cap would silently allow unlimited spend.
+    """
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        if value <= 0:
+            raise ValueError(f"cost cap must be positive, got {value}")
+        return value
+    if not isinstance(value, (str, int, float)):
+        raise TypeError(f"expected str/numeric, got {type(value).__name__}")
+    stripped = str(value).strip()
+    if not stripped:
+        return None
+    try:
+        d = Decimal(stripped)
+    except InvalidOperation:
+        raise ValueError(f"invalid decimal {stripped!r} for cost cap")
+    if d <= 0:
+        raise ValueError(f"cost cap must be positive, got {d}")
+    return d
+
+
 # Map of nested JSON paths in ``.deile/settings.json`` to ``Settings`` flat
 # fields, with a converter for each. Unknown keys are silently ignored —
 # that's how future-compatible forward-compat works.
@@ -294,6 +323,12 @@ _OVERRIDE_HANDLERS: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
     # Global defaults for timeout and retries (issue #391).
     "pipeline.default_timeout_s_deile":  ("pipeline_deile_timeout",       _to_optional_pos_int),
     "pipeline.default_max_retries":      ("pipeline_default_max_retries",  _to_optional_nonneg_int),
+    # Per-stage cost cap (issue #392) — per-run USD ceiling; None = no cap.
+    "pipeline.cost_caps_usd.classify":   ("pipeline_cost_cap_usd_classify",   _to_optional_positive_decimal),
+    "pipeline.cost_caps_usd.refine":     ("pipeline_cost_cap_usd_refine",     _to_optional_positive_decimal),
+    "pipeline.cost_caps_usd.implement":  ("pipeline_cost_cap_usd_implement",  _to_optional_positive_decimal),
+    "pipeline.cost_caps_usd.pr_review":  ("pipeline_cost_cap_usd_pr_review",  _to_optional_positive_decimal),
+    "pipeline.cost_caps_usd.follow_ups": ("pipeline_cost_cap_usd_follow_ups", _to_optional_positive_decimal),
     # Sub-DEILEs paralelos (issue #257)
     "subagent.runner": ("subagent_runner", lambda v: str(v).strip().lower()),
     "subagent.max_parallel": ("subagent_max_parallel", _to_pos_int),
@@ -540,6 +575,15 @@ class Settings:
     # from the formerly hard-coded value of 3. None collapses to built-in 3.
     pipeline_default_max_retries: Optional[int] = None
 
+    # Per-stage cost cap (issue #392) — per-run USD ceiling.
+    # None = no cap (current behavior). Positive Decimal = hard stop.
+    # Persisted under ``pipeline.cost_caps_usd.<stage>`` in settings.json.
+    # Cluster path: DEILE_PIPELINE_COST_CAP_USD_<STAGE> env in deile-pipeline.
+    pipeline_cost_cap_usd_classify: Optional[Decimal] = None
+    pipeline_cost_cap_usd_refine: Optional[Decimal] = None
+    pipeline_cost_cap_usd_implement: Optional[Decimal] = None
+    pipeline_cost_cap_usd_pr_review: Optional[Decimal] = None
+    pipeline_cost_cap_usd_follow_ups: Optional[Decimal] = None
 
     # Sub-DEILEs paralelos em sessão CLI (issue #257)
     # `subagent_runner`        — "local" (default; in-process via asyncio.gather de

--- a/deile/orchestration/pipeline/cost_estimator.py
+++ b/deile/orchestration/pipeline/cost_estimator.py
@@ -1,0 +1,244 @@
+"""Stage cost estimator — issue #392.
+
+Estimates per-run USD cost for a given stage + model, using historical
+usage data from ``UsageRepository`` and per-token pricing from
+``model_providers.yaml``. Falls back to conservative heuristics when no
+history is available for the stage.
+
+Consumed by ``StageBudgetGuard`` in ``deile/storage/usage_repository.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Heuristic fallbacks (tokens) when UsageRepository has no history for stage
+# ---------------------------------------------------------------------------
+
+#: Conservative token-count estimates for stages with no recorded history.
+#: Tuned to be slightly above the p50 observed in production so that the cap
+#: check does not fire on normal runs — operators set caps above these.
+_FALLBACK_TOKENS: dict[str, tuple[int, int]] = {
+    # (prompt_tokens, completion_tokens)
+    "classify":   (2_000,  500),
+    "refine":     (5_000,  2_000),
+    "implement":  (30_000, 15_000),
+    "pr_review":  (20_000, 5_000),
+    "follow_ups": (5_000,  2_000),
+}
+
+# Default fallback for unknown stages (should not happen in practice).
+_DEFAULT_FALLBACK = (5_000, 2_000)
+
+# Number of recent runs to average when estimating tokens from history.
+_HISTORY_WINDOW = 10
+
+
+class PricingProvider:
+    """Resolves per-token pricing for a model slug.
+
+    Reads ``deile/config/model_providers.yaml`` and returns
+    ``(input_usd_per_token, output_usd_per_token)``.  Returns ``(0, 0)``
+    when the slug is not found — missing pricing never blocks dispatch.
+
+    Results are cached in-process (the YAML does not change at runtime).
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, tuple[Decimal, Decimal]] = {}
+        self._loaded: bool = False
+
+    def _load(self) -> dict:
+        """Parse ``model_providers.yaml`` once and return the raw dict."""
+        try:
+            import importlib.resources as pkg
+            import yaml  # type: ignore[import-untyped]
+        except ImportError:
+            return {}
+        try:
+            # The YAML lives in the ``deile.config`` package directory.
+            import deile.config as _cfg_pkg  # noqa: PLC0415
+            pkg_path = getattr(_cfg_pkg, "__path__", [None])[0]
+            if pkg_path is None:
+                return {}
+            from pathlib import Path as _Path  # noqa: PLC0415
+            yaml_file = _Path(pkg_path) / "model_providers.yaml"
+            if not yaml_file.is_file():
+                return {}
+            with open(yaml_file) as fh:
+                return yaml.safe_load(fh) or {}
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("PricingProvider: could not load model_providers.yaml: %s", exc)
+            return {}
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        data = self._load()
+        models = data.get("models", {})
+        if not isinstance(models, dict):
+            return
+        for slug, attrs in models.items():
+            if not isinstance(attrs, dict):
+                continue
+            pricing = attrs.get("pricing", {})
+            if not isinstance(pricing, dict):
+                continue
+            try:
+                inp = Decimal(str(pricing.get("input_per_token", 0) or 0))
+                out = Decimal(str(pricing.get("output_per_token", 0) or 0))
+                self._cache[str(slug)] = (inp, out)
+            except Exception:  # noqa: BLE001
+                pass
+
+    def get_pricing(self, model_slug: str) -> tuple[Decimal, Decimal]:
+        """Return ``(input_usd_per_token, output_usd_per_token)`` for *model_slug*.
+
+        Returns ``(Decimal(0), Decimal(0))`` when the slug is unknown — missing
+        pricing never blocks dispatch (cost guard stays silent).
+        """
+        self._ensure_loaded()
+        return self._cache.get(model_slug, (Decimal(0), Decimal(0)))
+
+
+# Module-level singleton — reused across calls within the same process.
+_pricing_provider: Optional[PricingProvider] = None
+
+
+def get_pricing_provider() -> PricingProvider:
+    """Return the singleton PricingProvider."""
+    global _pricing_provider
+    if _pricing_provider is None:
+        _pricing_provider = PricingProvider()
+    return _pricing_provider
+
+
+def reset_pricing_provider() -> None:
+    """Reset the singleton (test helper)."""
+    global _pricing_provider
+    _pricing_provider = None
+
+
+class StageCostEstimator:
+    """Estimates per-run USD cost for a pipeline stage.
+
+    Algorithm:
+    1. Query ``UsageRepository`` for the last ``_HISTORY_WINDOW`` records
+       of ``(model_id, stage)`` (stage encoded in session_id prefix).
+    2. Average ``prompt_tokens`` / ``completion_tokens`` from those records.
+    3. If fewer than 2 records exist, fall back to ``_FALLBACK_TOKENS``.
+    4. Multiply by the per-token price from ``PricingProvider``.
+
+    The estimate is intentionally conservative (uses average, not p50) so
+    that cost-cap checks do not block normal runs. Operators should set caps
+    above the typical run cost.
+
+    Notes:
+    - ``payload_size_tokens`` is a hint from the caller (size of the brief/
+      prompt being dispatched). When > 0 it replaces the historical
+      ``prompt_tokens`` average — useful for stages like ``implement`` where
+      the prompt size varies widely per issue.
+    - When pricing data is missing (``Decimal(0)``), the estimate is ``0``
+      and the guard never fires — absence of pricing = no enforcement.
+    """
+
+    def __init__(
+        self,
+        usage_repo: "UsageRepository",  # noqa: F821
+        pricing_provider: Optional[PricingProvider] = None,
+    ) -> None:
+        self._repo = usage_repo
+        self._pricing = pricing_provider or get_pricing_provider()
+
+    def estimate_run_cost(
+        self,
+        stage: str,
+        model_slug: str,
+        payload_size_tokens: int = 0,
+    ) -> Decimal:
+        """Return USD estimate for one run of *stage* with *model_slug*.
+
+        Args:
+            stage: canonical stage name (classify/refine/implement/
+                pr_review/follow_ups).
+            model_slug: provider:model string (e.g. ``anthropic:claude-opus-4-7``).
+            payload_size_tokens: estimated token count of the dispatch payload;
+                overrides the historical prompt-token average when > 0.
+
+        Returns:
+            Decimal USD estimate. Returns ``Decimal(0)`` when pricing is
+            unknown — callers treat 0 as "cannot estimate; skip enforcement".
+        """
+        # Resolve pricing first — if unknown, return 0 immediately.
+        input_price, output_price = self._pricing.get_pricing(model_slug)
+        if input_price == 0 and output_price == 0:
+            logger.debug(
+                "StageCostEstimator: no pricing for model %r — estimate=0",
+                model_slug,
+            )
+            return Decimal(0)
+
+        prompt_avg, completion_avg = self._average_tokens(stage, model_slug)
+
+        # Override prompt tokens from payload hint when available.
+        if payload_size_tokens > 0:
+            prompt_tokens = Decimal(payload_size_tokens)
+        else:
+            prompt_tokens = Decimal(prompt_avg)
+
+        completion_tokens = Decimal(completion_avg)
+
+        cost = prompt_tokens * input_price + completion_tokens * output_price
+        logger.debug(
+            "StageCostEstimator: stage=%s model=%s "
+            "prompt=%s completion=%s → est=$%s",
+            stage, model_slug, prompt_tokens, completion_tokens,
+            cost,
+        )
+        return cost
+
+    def _average_tokens(self, stage: str, model_slug: str) -> tuple[int, int]:
+        """Return ``(avg_prompt, avg_completion)`` from recent history.
+
+        Falls back to ``_FALLBACK_TOKENS`` when fewer than 2 records exist.
+        Stage is matched by ``session_id`` prefix ``pipeline-<stage>-``
+        (canonical format used by WorkerImplementer when building channel_id).
+        """
+        try:
+            records = self._repo.records_for_stage_model(
+                stage=stage,
+                model_id=model_slug,
+                limit=_HISTORY_WINDOW,
+            )
+        except AttributeError:
+            # UsageRepository may not have records_for_stage_model yet
+            # (e.g. old DB without the stage column); fall back gracefully.
+            records = []
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "StageCostEstimator: error fetching history for %s/%s: %s",
+                stage, model_slug, exc,
+            )
+            records = []
+
+        if len(records) < 2:
+            fallback = _FALLBACK_TOKENS.get(stage, _DEFAULT_FALLBACK)
+            logger.debug(
+                "StageCostEstimator: insufficient history for %s/%s "
+                "(%d records) — using fallback %s",
+                stage, model_slug, len(records), fallback,
+            )
+            return fallback
+
+        total_prompt = sum(getattr(r, "prompt_tokens", 0) for r in records)
+        total_completion = sum(
+            getattr(r, "completion_tokens", 0) for r in records
+        )
+        n = len(records)
+        return int(total_prompt / n), int(total_completion / n)

--- a/deile/orchestration/pipeline/dispatch_resolver.py
+++ b/deile/orchestration/pipeline/dispatch_resolver.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+from decimal import Decimal, InvalidOperation
 from typing import FrozenSet, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -285,6 +286,91 @@ def resolve_stage_max_retries(stage: str) -> int:
 
     # 4. Built-in
     return BUILT_IN_MAX_RETRIES
+
+
+def resolve_stage_cost_cap_usd(stage: str) -> Optional[Decimal]:
+    """Return per-stage cost cap in USD, or None if no cap configured.
+
+    Fallback chain (5 levels — mirrors resolve_stage_dispatcher):
+
+    1. ``DEILE_PIPELINE_COST_CAP_USD_<STAGE>`` env var — decimal string, e.g.
+       ``"5.00"``.  Invalid value → ValueError fail-fast.
+    2. ``pipeline.cost_caps_usd.<stage>`` in settings.json — graceful warn +
+       skip on invalid.
+    3. ``DEILE_PIPELINE_COST_CAP_USD`` env var (global fallback for all stages).
+       Invalid → ValueError fail-fast.
+    4. ``pipeline.cost_cap_usd`` in settings.json (global).  Graceful warn.
+    5. ``None`` — no cap (current behavior, unlimited).
+
+    Args:
+        stage: canonical stage name.
+
+    Returns:
+        Positive Decimal in USD, or None when no cap is configured.
+
+    Raises:
+        ValueError: stage is not in PIPELINE_STAGES (programming bug).
+        ValueError: an env var contains a non-positive or non-parseable value.
+    """
+    if stage not in PIPELINE_STAGES:
+        raise ValueError(
+            f"unknown stage {stage!r}; expected one of {PIPELINE_STAGES}"
+        )
+
+    def _parse_cap(raw: Optional[str], context: str, *, strict: bool) -> Optional[Decimal]:
+        if not raw or not raw.strip():
+            return None
+        stripped = raw.strip()
+        try:
+            d = Decimal(stripped)
+        except InvalidOperation as exc:
+            msg = f"invalid decimal {stripped!r} for cost cap ({context})"
+            if strict:
+                raise ValueError(msg) from exc
+            logger.warning("dispatch_resolver: %s — ignoring", msg)
+            return None
+        if d <= 0:
+            msg = f"cost cap must be positive, got {d} ({context})"
+            if strict:
+                raise ValueError(msg)
+            logger.warning("dispatch_resolver: %s — ignoring", msg)
+            return None
+        return d
+
+    # 1. Per-stage env var (fail-fast on invalid).
+    stage_env = os.environ.get(f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}")
+    cap = _parse_cap(stage_env, f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}", strict=True)
+    if cap is not None:
+        return cap
+
+    # 2. Settings per-stage (graceful).
+    from deile.config.settings import get_settings  # noqa: PLC0415 — lazy import
+    settings = get_settings()
+    settings_val = getattr(settings, f"pipeline_cost_cap_usd_{stage}", None)
+    if settings_val is not None:
+        if isinstance(settings_val, Decimal) and settings_val > 0:
+            return settings_val
+        # Non-Decimal or non-positive — log and fall through.
+        logger.warning(
+            "dispatch_resolver: invalid cost cap %r in settings.json "
+            "(pipeline.cost_caps_usd.%s) — ignoring",
+            settings_val, stage,
+        )
+
+    # 3. Global env var fallback (fail-fast on invalid).
+    global_env = os.environ.get("DEILE_PIPELINE_COST_CAP_USD")
+    cap = _parse_cap(global_env, "DEILE_PIPELINE_COST_CAP_USD", strict=True)
+    if cap is not None:
+        return cap
+
+    # 4. Global settings (graceful).
+    global_settings = getattr(settings, "pipeline_cost_cap_usd", None)
+    if global_settings is not None:
+        if isinstance(global_settings, Decimal) and global_settings > 0:
+            return global_settings
+
+    # 5. No cap.
+    return None
 
 
 def get_endpoint_for(dispatcher: str) -> str:

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -749,6 +749,59 @@ class WorkerImplementer(PipelineImplementer):
         # we attach ``resume`` after building to keep that contract untouched.
         if resume_block:
             payload["resume"] = resume_block
+        # Issue #392: per-stage cost cap check before POST.
+        # Estimate run cost from UsageRepository history + model pricing;
+        # raise StageCostCapExceeded when over the cap. None cap = pass-through.
+        if stage:
+            try:
+                from deile.orchestration.pipeline.cost_estimator import (  # noqa: PLC0415
+                    StageCostEstimator,
+                )
+                from deile.storage.usage_repository import (  # noqa: PLC0415
+                    StageBudgetGuard, StageCostCapExceeded,
+                    get_usage_repository,
+                )
+                _estimator = StageCostEstimator(
+                    usage_repo=get_usage_repository(),
+                )
+                _guard = StageBudgetGuard(_estimator)
+                # Estimate payload tokens from the brief length as a rough proxy
+                # (1 token ≈ 4 chars is a conservative heuristic).
+                _payload_tokens = max(0, len(brief) // 4)
+                _model_for_guard = preferred_model or ""
+                _guard.check_stage_run(
+                    stage=stage,
+                    model_slug=_model_for_guard,
+                    payload_size_tokens=_payload_tokens,
+                )
+            except StageCostCapExceeded as _exc:
+                # Escalate: block the dispatch and return a blocked WorkOutcome.
+                # The stage handler will see ok=False + motivo_bloqueio prefix
+                # and move the issue to ~workflow:bloqueada.
+                logger.warning(
+                    "cost-cap-exceeded: stage=%s model=%s "
+                    "estimated=$%s > cap=$%s — blocking dispatch",
+                    _exc.stage, preferred_model,
+                    _exc.estimated_usd, _exc.cap_usd,
+                )
+                return WorkOutcome(
+                    ok=False,
+                    text="",
+                    error=(
+                        f"cost-cap-exceeded: estimated USD {_exc.estimated_usd} "
+                        f"> cap USD {_exc.cap_usd} for stage {_exc.stage}"
+                    ),
+                    motivo_bloqueio=(
+                        f"cost-cap-exceeded: estimated USD {_exc.estimated_usd} "
+                        f"> cap USD {_exc.cap_usd}"
+                    ),
+                )
+            except Exception as _cap_exc:  # noqa: BLE001 — guard never crashes dispatch
+                logger.debug(
+                    "cost cap check for stage=%s failed (non-fatal): %s",
+                    stage, _cap_exc,
+                )
+
         # Issue #373: ``nowait`` dispatches the task fire-and-forget — the
         # worker returns 202 + task_id immediately and processes the task
         # in the background. The pipeline does NOT block on the result;

--- a/deile/storage/usage_repository.py
+++ b/deile/storage/usage_repository.py
@@ -7,6 +7,7 @@ import sqlite3
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
@@ -188,6 +189,63 @@ class UsageRepository:
             for r in rows
         ]
 
+    def records_for_stage_model(
+        self,
+        stage: str,
+        model_id: str,
+        limit: int = 10,
+    ) -> List[UsageRecord]:
+        """Return the most recent *limit* records for a stage + model pair.
+
+        Stage is matched by ``session_id`` prefix ``pipeline-<stage>-``
+        (the canonical format produced by ``WorkerImplementer`` when building
+        the channel_id: ``pipeline-issue-<N>`` or ``pipeline-pr-<N>`` after
+        the stage prefix).  A looser match ``pipeline-`` + stage is used so
+        both ``pipeline-issue-`` and ``pipeline-pr-`` are captured.
+
+        Returns records ordered by descending timestamp (newest first).
+        """
+        # Match session_ids that encode the stage name.  WorkerImplementer uses
+        # "pipeline-issue-<N>" / "pipeline-pr-<N>" so we search for rows whose
+        # session_id contains the stage name AND model_id matches.
+        # The LIKE pattern is intentionally broad because the stage is not
+        # stored as a separate column — this is a best-effort heuristic.
+        stage_pattern = f"%{stage}%"
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM usage_records
+                WHERE (session_id LIKE ? OR session_id LIKE ?)
+                  AND model_id = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+                """,
+                (
+                    f"pipeline-{stage}-%",
+                    stage_pattern,
+                    model_id,
+                    limit,
+                ),
+            ).fetchall()
+        return [
+            UsageRecord(
+                provider_id=r["provider_id"],
+                model_id=r["model_id"],
+                tier=r["tier"],
+                session_id=r["session_id"],
+                prompt_tokens=r["prompt_tokens"],
+                completion_tokens=r["completion_tokens"],
+                cached_tokens=r["cached_tokens"],
+                total_tokens=r["total_tokens"],
+                cost_usd=r["cost_usd"],
+                latency_ms=r["latency_ms"],
+                success=bool(r["success"]),
+                error_type=r["error_type"],
+                timestamp=r["timestamp"],
+            )
+            for r in rows
+        ]
+
 
 # ---------------------------------------------------------------------------
 # BudgetGuard
@@ -333,6 +391,103 @@ class BudgetGuard:
             "per_provider_monthly_usd": dict(self._monthly),
             "alert_threshold_pct": int(self._alert_threshold * 100),
         }
+
+
+# ---------------------------------------------------------------------------
+# Stage-level cost cap (issue #392)
+# ---------------------------------------------------------------------------
+
+
+class StageCostCapExceeded(Exception):
+    """Raised when the estimated cost of a stage run exceeds the configured cap.
+
+    Attributes:
+        stage: canonical stage name (classify/refine/implement/pr_review/follow_ups).
+        estimated_usd: estimated cost in USD as Decimal.
+        cap_usd: configured cap in USD as Decimal.
+    """
+
+    def __init__(self, stage: str, estimated_usd: Decimal, cap_usd: Decimal) -> None:
+        super().__init__(
+            f"stage '{stage}' estimated cost ${estimated_usd} exceeds cap ${cap_usd}"
+        )
+        self.stage = stage
+        self.estimated_usd = estimated_usd
+        self.cap_usd = cap_usd
+
+
+class StageBudgetGuard:
+    """Per-stage pre-dispatch cost guard (issue #392).
+
+    Checks whether the estimated cost of a single stage run would exceed the
+    per-stage cost cap resolved by ``resolve_stage_cost_cap_usd``. When the
+    cap is exceeded, raises ``StageCostCapExceeded`` so the caller can
+    escalate the issue to ``~workflow:bloqueada`` before posting the dispatch.
+
+    ``None`` cap means "no enforcement" — the check passes silently.
+    ``Decimal(0)`` estimate (unknown pricing) also passes silently.
+    """
+
+    def __init__(self, estimator: "StageCostEstimator") -> None:  # noqa: F821
+        self._estimator = estimator
+
+    def check_stage_run(
+        self,
+        stage: str,
+        model_slug: str,
+        payload_size_tokens: int = 0,
+    ) -> None:
+        """Raise StageCostCapExceeded if estimated cost > resolved cap.
+
+        Args:
+            stage: canonical stage name.
+            model_slug: provider:model slug for the dispatch.
+            payload_size_tokens: token count hint for the payload (0 = use history).
+
+        Raises:
+            StageCostCapExceeded: when estimated cost exceeds the cap.
+        """
+        # Lazy import to avoid import cycle and to allow resolve_stage_cost_cap_usd
+        # to be imported after the module is fully initialized.
+        from deile.orchestration.pipeline.dispatch_resolver import (  # noqa: PLC0415
+            resolve_stage_cost_cap_usd,
+        )
+
+        cap = resolve_stage_cost_cap_usd(stage)
+        if cap is None:
+            return  # No cap configured — pass through.
+
+        estimated = self._estimator.estimate_run_cost(
+            stage=stage,
+            model_slug=model_slug,
+            payload_size_tokens=payload_size_tokens,
+        )
+
+        if estimated == Decimal(0):
+            # Cannot estimate (pricing unknown) — pass through silently.
+            logger.debug(
+                "StageBudgetGuard: estimate=0 for stage=%s model=%s "
+                "(pricing unknown) — skipping cap check",
+                stage, model_slug,
+            )
+            return
+
+        if estimated > cap:
+            logger.warning(
+                "StageBudgetGuard: stage=%s model=%s estimated=$%s > cap=$%s "
+                "— raising StageCostCapExceeded",
+                stage, model_slug, estimated, cap,
+            )
+            raise StageCostCapExceeded(
+                stage=stage,
+                estimated_usd=estimated,
+                cap_usd=cap,
+            )
+
+        logger.debug(
+            "StageBudgetGuard: stage=%s model=%s estimated=$%s <= cap=$%s — OK",
+            stage, model_slug, estimated, cap,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/deile/tests/config/test_settings_cost_caps.py
+++ b/deile/tests/config/test_settings_cost_caps.py
@@ -1,0 +1,128 @@
+"""Unit tests for per-stage cost cap settings (issue #392).
+
+Covers:
+- Settings dataclass has cost cap fields
+- _to_optional_positive_decimal validator
+- JSON loading via override handlers (pipeline.cost_caps_usd.<stage>)
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from deile.config.settings import (
+    Settings,
+    _to_optional_positive_decimal,
+    get_settings,
+    reset_settings,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    reset_settings()
+    yield
+    reset_settings()
+
+
+class TestToOptionalPositiveDecimal:
+    def test_none_returns_none(self):
+        assert _to_optional_positive_decimal(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _to_optional_positive_decimal("") is None
+        assert _to_optional_positive_decimal("   ") is None
+
+    def test_valid_string_returns_decimal(self):
+        assert _to_optional_positive_decimal("5.00") == Decimal("5.00")
+        assert _to_optional_positive_decimal("1") == Decimal("1")
+        assert _to_optional_positive_decimal("0.50") == Decimal("0.50")
+
+    def test_valid_int_returns_decimal(self):
+        assert _to_optional_positive_decimal(5) == Decimal("5")
+
+    def test_valid_float_returns_decimal(self):
+        d = _to_optional_positive_decimal(2.5)
+        assert d > 0
+
+    def test_decimal_passthrough(self):
+        assert _to_optional_positive_decimal(Decimal("3.14")) == Decimal("3.14")
+
+    def test_zero_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            _to_optional_positive_decimal("0")
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            _to_optional_positive_decimal("-1.00")
+
+    def test_non_numeric_raises(self):
+        with pytest.raises(ValueError):
+            _to_optional_positive_decimal("abc")
+
+    def test_non_string_non_numeric_raises(self):
+        with pytest.raises(TypeError):
+            _to_optional_positive_decimal([1, 2])
+
+
+class TestSettingsCostCapFields:
+    def test_defaults_are_none(self):
+        s = Settings()
+        assert s.pipeline_cost_cap_usd_classify is None
+        assert s.pipeline_cost_cap_usd_refine is None
+        assert s.pipeline_cost_cap_usd_implement is None
+        assert s.pipeline_cost_cap_usd_pr_review is None
+        assert s.pipeline_cost_cap_usd_follow_ups is None
+
+    def test_fields_accept_decimal(self):
+        s = Settings(
+            pipeline_cost_cap_usd_implement=Decimal("5.00"),
+            pipeline_cost_cap_usd_classify=Decimal("1.50"),
+        )
+        assert s.pipeline_cost_cap_usd_implement == Decimal("5.00")
+        assert s.pipeline_cost_cap_usd_classify == Decimal("1.50")
+
+
+class TestSettingsJsonLoadingCostCap:
+    def test_json_loads_cost_caps(self):
+        """Applying cost_caps_usd overrides via apply_overrides."""
+        cfg = {
+            "pipeline": {
+                "cost_caps_usd": {
+                    "implement": "5.00",
+                    "classify": "1.00",
+                    "pr_review": "10.00",
+                }
+            }
+        }
+        s = Settings()
+        s.apply_overrides(cfg)
+
+        assert s.pipeline_cost_cap_usd_implement == Decimal("5.00")
+        assert s.pipeline_cost_cap_usd_classify == Decimal("1.00")
+        assert s.pipeline_cost_cap_usd_pr_review == Decimal("10.00")
+        # Unset stages remain None
+        assert s.pipeline_cost_cap_usd_refine is None
+        assert s.pipeline_cost_cap_usd_follow_ups is None
+
+    def test_invalid_value_is_skipped_gracefully(self):
+        """A bad value is skipped (logged as warning), default stays."""
+        cfg = {
+            "pipeline": {
+                "cost_caps_usd": {
+                    "implement": "not_a_number",
+                    "classify": "5.00",
+                }
+            }
+        }
+        s = Settings()
+        s.apply_overrides(cfg)
+
+        # Invalid value skipped → default None
+        assert s.pipeline_cost_cap_usd_implement is None
+        # Valid value applied
+        assert s.pipeline_cost_cap_usd_classify == Decimal("5.00")

--- a/deile/tests/infra/test_panel_cost_cap.py
+++ b/deile/tests/infra/test_panel_cost_cap.py
@@ -1,0 +1,344 @@
+"""Tests for per-stage cost cap panel data functions (issue #392).
+
+Covers:
+- set_stage_cost_cap_usd: stage validation, value validation, kubectl absent,
+  kubectl success, kubectl failure
+- reset_stage_cost_cap_usd: stage validation, kubectl absent, success
+- StageDispatchEntry.cost_cap_usd field present and read by StageDispatchProvider
+- DispatchMatrixView: col 2 renders cost cap, reset_current_cell col 2 calls reset
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+if str(_INFRA_K8S) not in sys.path:
+    sys.path.insert(0, str(_INFRA_K8S))
+
+import _panel_data as pd_mod  # noqa: E402
+
+
+def _deployment_env_json(envs: dict) -> dict:
+    env_list = [{"name": k, "value": v} for k, v in envs.items()]
+    return {"spec": {"template": {"spec": {"containers": [{"env": env_list}]}}}}
+
+
+# ---------------------------------------------------------------------------
+# set_stage_cost_cap_usd
+# ---------------------------------------------------------------------------
+
+
+class TestSetStageCostCapUsd:
+    def test_invalid_stage_returns_error(self):
+        ok, msg = pd_mod.set_stage_cost_cap_usd("bad_stage", "5.00")
+        assert ok is False
+        assert "inválido" in msg.lower() or "invalid" in msg.lower()
+
+    def test_invalid_value_negative(self):
+        ok, msg = pd_mod.set_stage_cost_cap_usd("implement", "-1.00")
+        assert ok is False
+
+    def test_invalid_value_non_numeric(self):
+        ok, msg = pd_mod.set_stage_cost_cap_usd("implement", "abc")
+        assert ok is False
+
+    def test_kubectl_not_found(self):
+        with patch("_panel_data.kubectl_bin", return_value=None):
+            ok, msg = pd_mod.set_stage_cost_cap_usd("implement", "5.00")
+        assert ok is False
+        assert "kubectl" in msg.lower()
+
+    def test_kubectl_success(self):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "deployment.apps/deile-pipeline env updated"
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("subprocess.run", return_value=mock_proc) as mock_run:
+            ok, msg = pd_mod.set_stage_cost_cap_usd("implement", "5.00",
+                                                     namespace="deile")
+        assert ok is True
+        assert "5.00" in msg
+        # Check env var name in argv
+        call_args = mock_run.call_args[0][0]
+        env_arg = next((a for a in call_args if "COST_CAP" in a), None)
+        assert env_arg == "DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT=5.00"
+
+    def test_kubectl_failure(self):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.stdout = ""
+        mock_proc.stderr = "Error: deployment not found"
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("subprocess.run", return_value=mock_proc):
+            ok, msg = pd_mod.set_stage_cost_cap_usd("implement", "5.00")
+        assert ok is False
+        assert "not found" in msg.lower()
+
+    def test_all_stages_accepted(self):
+        """All five canonical stages should be accepted."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "ok"
+        for stage in ("classify", "refine", "implement", "pr_review", "follow_ups"):
+            with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+                 patch("subprocess.run", return_value=mock_proc):
+                ok, _ = pd_mod.set_stage_cost_cap_usd(stage, "2.00")
+            assert ok is True, f"stage {stage!r} should be accepted"
+
+
+# ---------------------------------------------------------------------------
+# reset_stage_cost_cap_usd
+# ---------------------------------------------------------------------------
+
+
+class TestResetStageCostCapUsd:
+    def test_invalid_stage(self):
+        ok, msg = pd_mod.reset_stage_cost_cap_usd("nope")
+        assert ok is False
+
+    def test_kubectl_not_found(self):
+        with patch("_panel_data.kubectl_bin", return_value=None):
+            ok, msg = pd_mod.reset_stage_cost_cap_usd("implement")
+        assert ok is False
+
+    def test_success_uses_trailing_dash(self):
+        """Clear syntax: ``kubectl set env ... VAR-``."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "ok"
+        with patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"), \
+             patch("subprocess.run", return_value=mock_proc) as mock_run:
+            ok, msg = pd_mod.reset_stage_cost_cap_usd("implement",
+                                                       namespace="deile")
+        assert ok is True
+        call_args = mock_run.call_args[0][0]
+        # Trailing dash = unset
+        assert "DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT-" in call_args
+
+
+# ---------------------------------------------------------------------------
+# StageDispatchEntry cost_cap_usd field
+# ---------------------------------------------------------------------------
+
+
+class TestStageDispatchEntryCostCapField:
+    def test_entry_has_cost_cap_field(self):
+        entry = pd_mod.StageDispatchEntry(
+            stage="implement",
+            worker="deile-worker",
+            model=None,
+            source="default",
+            cost_cap_usd="5.00",
+        )
+        assert entry.cost_cap_usd == "5.00"
+
+    def test_entry_default_cost_cap_is_none(self):
+        entry = pd_mod.StageDispatchEntry(
+            stage="implement",
+            worker="deile-worker",
+            model=None,
+            source="default",
+        )
+        assert entry.cost_cap_usd is None
+
+
+class TestStageDispatchProviderReadsCostCap:
+    def _pipeline_env_json(self, envs: dict) -> dict:
+        return _deployment_env_json(envs)
+
+    def test_cost_cap_read_from_pipeline_env(self):
+        """Provider reads DEILE_PIPELINE_COST_CAP_USD_<STAGE> from deile-pipeline."""
+        pipeline_json = self._pipeline_env_json({
+            "DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT": "7.50",
+        })
+        worker_json = _deployment_env_json({})
+
+        def fake_capture(cmd, **kwargs):
+            if "deile-pipeline" in " ".join(cmd):
+                return pipeline_json
+            if "deile-worker" in " ".join(cmd):
+                return worker_json
+            return None
+
+        with patch("_panel_data._capture_json", side_effect=fake_capture), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            provider = pd_mod.StageDispatchProvider(enabled=True)
+            entries = provider.get_all_stages(force=True)
+
+        implement = next(e for e in entries if e.stage == "implement")
+        assert implement.cost_cap_usd == "7.50"
+        # Other stages have no cap
+        classify = next(e for e in entries if e.stage == "classify")
+        assert classify.cost_cap_usd is None
+
+    def test_no_cost_cap_env_returns_none(self):
+        """When no cost cap env is set, cost_cap_usd is None."""
+        pipeline_json = _deployment_env_json({"SOME_OTHER_VAR": "x"})
+        worker_json = _deployment_env_json({})
+
+        def fake_capture(cmd, **kwargs):
+            if "deile-pipeline" in " ".join(cmd):
+                return pipeline_json
+            if "deile-worker" in " ".join(cmd):
+                return worker_json
+            return None
+
+        with patch("_panel_data._capture_json", side_effect=fake_capture), \
+             patch("_panel_data.kubectl_bin", return_value="/fake/kubectl"):
+            provider = pd_mod.StageDispatchProvider(enabled=True)
+            entries = provider.get_all_stages(force=True)
+
+        for entry in entries:
+            assert entry.cost_cap_usd is None
+
+
+# ---------------------------------------------------------------------------
+# DispatchMatrixView – cost cap column rendering and reset
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchMatrixViewCostCapCol:
+    def _make_view(self, cost_cap_usd=None):
+        """Build a DispatchMatrixView in demo mode with a single-entry list."""
+        import _panel as panel_mod  # noqa: PLC0415
+
+        view = panel_mod.DispatchMatrixView(data=None)
+        # Override _entries() to return controllable demo data.
+        mock_entry = pd_mod.StageDispatchEntry(
+            stage="implement",
+            worker="deile-worker",
+            model=None,
+            source="default",
+            cost_cap_usd=cost_cap_usd,
+        )
+        view._entries = lambda: [mock_entry]  # type: ignore[method-assign]
+        return view
+
+    def test_column_count_includes_cost_cap(self):
+        """Rendered table has a 'Cost cap (USD/run)' column header."""
+        import _panel as panel_mod  # noqa: PLC0415
+        from rich.console import Console  # noqa: PLC0415
+
+        view = self._make_view()
+        app = MagicMock()
+
+        console = Console()
+        with console.capture() as cap:
+            console.print(view.render(app))
+        output = cap.get()
+        assert "Cost cap" in output or "cost_cap" in output.lower() or "USD/run" in output
+
+    def test_no_cap_renders_no_cap_text(self):
+        import _panel as panel_mod  # noqa: PLC0415
+        from rich.console import Console  # noqa: PLC0415
+
+        view = self._make_view(cost_cap_usd=None)
+        app = MagicMock()
+        console = Console()
+        with console.capture() as cap:
+            console.print(view.render(app))
+        output = cap.get()
+        assert "(no cap)" in output
+
+    def test_cap_value_renders_with_dollar_sign(self):
+        import _panel as panel_mod  # noqa: PLC0415
+        from rich.console import Console  # noqa: PLC0415
+
+        view = self._make_view(cost_cap_usd="5.00")
+        app = MagicMock()
+        console = Console()
+        with console.capture() as cap:
+            console.print(view.render(app))
+        output = cap.get()
+        assert "$5.00" in output
+
+    def test_cursor_col_max_is_two(self):
+        """RIGHT key can advance to col 2 but no further."""
+        import _panel as panel_mod  # noqa: PLC0415
+
+        view = self._make_view()
+        view.cursor_col = 0
+        app = MagicMock()
+
+        view.handle_key("RIGHT", app)
+        assert view.cursor_col == 1
+        view.handle_key("RIGHT", app)
+        assert view.cursor_col == 2
+        view.handle_key("RIGHT", app)  # should clamp at 2
+        assert view.cursor_col == 2
+
+    def test_reset_col_2_calls_reset_cost_cap(self):
+        """[r] on col 2 calls reset_stage_cost_cap_usd."""
+        import _panel as panel_mod  # noqa: PLC0415
+
+        view = self._make_view()
+        view.cursor_row = 0
+        view.cursor_col = 2
+
+        # Stub data with context
+        mock_data = MagicMock()
+        mock_data.context.namespace = "deile"
+        view.data = mock_data
+        view._entries = lambda: [  # type: ignore[method-assign]
+            pd_mod.StageDispatchEntry("implement", "deile-worker", None,
+                                      "default", cost_cap_usd=None)
+        ]
+        app = MagicMock()
+
+        with patch("_panel.pd_reset_stage_cost_cap_usd",
+                   return_value=(True, "ok")) as mock_reset:
+            result = view.handle_key("r", app)
+
+        mock_reset.assert_called_once_with("implement", namespace="deile")
+
+    def test_enter_col_2_opens_cost_cap_picker(self):
+        """[enter] on col 2 opens the cost_cap_usd picker modal."""
+        import _panel as panel_mod  # noqa: PLC0415
+
+        view = self._make_view(cost_cap_usd="5.00")
+        view.cursor_row = 0
+        view.cursor_col = 2
+        view.data = None  # demo mode
+        app = MagicMock()
+
+        view.handle_key("\r", app)
+        assert view.mode is not None
+        assert view.mode[0] == "cost_cap_usd"
+        assert view.mode[1] == "implement"
+
+    def test_picker_no_cap_calls_reset(self):
+        """Selecting '(no cap)' in cost_cap picker calls reset_stage_cost_cap_usd."""
+        import _panel as panel_mod  # noqa: PLC0415
+
+        view = self._make_view()
+        view.cursor_row = 0
+        view.cursor_col = 2
+        mock_data = MagicMock()
+        mock_data.context.namespace = "deile"
+        view.data = mock_data
+        view._entries = lambda: [  # type: ignore[method-assign]
+            pd_mod.StageDispatchEntry("implement", "deile-worker", None,
+                                      "default", cost_cap_usd=None)
+        ]
+        app = MagicMock()
+
+        # Open picker
+        view.handle_key("\r", app)
+        assert view.mode is not None
+        assert view.mode[0] == "cost_cap_usd"
+
+        # picker_cursor=0 → "(no cap)"
+        view.picker_cursor = 0
+
+        with patch("_panel.pd_reset_stage_cost_cap_usd",
+                   return_value=(True, "unset")) as mock_reset:
+            view.handle_key("\r", app)
+
+        mock_reset.assert_called_once_with("implement", namespace="deile")
+        assert view.mode is None  # picker closed after selection

--- a/deile/tests/orchestration/pipeline/test_cost_estimator.py
+++ b/deile/tests/orchestration/pipeline/test_cost_estimator.py
@@ -1,0 +1,178 @@
+"""Unit tests for cost_estimator.py — issue #392.
+
+Covers:
+- StageCostEstimator.estimate_run_cost with mocked history
+- Fallback heuristics when history is absent
+- PricingProvider zero-fallback when model unknown
+- payload_size_tokens override of historical prompt-token average
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from deile.orchestration.pipeline.cost_estimator import (
+    StageCostEstimator,
+    _FALLBACK_TOKENS,
+    reset_pricing_provider,
+)
+from deile.storage.usage_repository import UsageRecord
+
+
+@pytest.fixture(autouse=True)
+def _reset_pricing():
+    reset_pricing_provider()
+    yield
+    reset_pricing_provider()
+
+
+def _make_record(prompt: int, completion: int, model: str = "anthropic:claude-sonnet-4-6") -> UsageRecord:
+    return UsageRecord(
+        provider_id="anthropic",
+        model_id=model,
+        tier="high",
+        session_id="pipeline-implement-123",
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
+    )
+
+
+def _make_pricing_provider(input_price: str = "0.000003",
+                           output_price: str = "0.000015") -> MagicMock:
+    pp = MagicMock()
+    pp.get_pricing.return_value = (Decimal(input_price), Decimal(output_price))
+    return pp
+
+
+class TestStageCostEstimatorFallback:
+    """When no history exists, estimator uses fallback token counts."""
+
+    def test_no_history_uses_fallback_implement(self):
+        repo = MagicMock()
+        repo.records_for_stage_model.return_value = []
+        pp = _make_pricing_provider("0.000003", "0.000015")
+        estimator = StageCostEstimator(repo, pp)
+
+        cost = estimator.estimate_run_cost("implement", "anthropic:claude-opus-4-7")
+
+        fallback_in, fallback_out = _FALLBACK_TOKENS["implement"]
+        expected = (
+            Decimal(fallback_in) * Decimal("0.000003")
+            + Decimal(fallback_out) * Decimal("0.000015")
+        )
+        assert cost == expected
+
+    def test_no_history_uses_fallback_classify(self):
+        repo = MagicMock()
+        repo.records_for_stage_model.return_value = []
+        pp = _make_pricing_provider("0.000001", "0.000005")
+        estimator = StageCostEstimator(repo, pp)
+
+        cost = estimator.estimate_run_cost("classify", "anthropic:claude-haiku-4-5")
+
+        fallback_in, fallback_out = _FALLBACK_TOKENS["classify"]
+        expected = (
+            Decimal(fallback_in) * Decimal("0.000001")
+            + Decimal(fallback_out) * Decimal("0.000005")
+        )
+        assert cost == expected
+
+    def test_single_record_falls_back_to_heuristic(self):
+        """Fewer than 2 records → fallback (not a stable average)."""
+        repo = MagicMock()
+        repo.records_for_stage_model.return_value = [
+            _make_record(prompt=10_000, completion=5_000)
+        ]
+        pp = _make_pricing_provider("0.000003", "0.000015")
+        estimator = StageCostEstimator(repo, pp)
+
+        cost = estimator.estimate_run_cost("implement", "anthropic:claude-sonnet-4-6")
+
+        # Should use fallback (30000 in / 15000 out), not the single record.
+        fallback_in, fallback_out = _FALLBACK_TOKENS["implement"]
+        expected = (
+            Decimal(fallback_in) * Decimal("0.000003")
+            + Decimal(fallback_out) * Decimal("0.000015")
+        )
+        assert cost == expected
+
+
+class TestStageCostEstimatorHistory:
+    """When history has >= 2 records, use their average."""
+
+    def test_averages_prompt_and_completion_tokens(self):
+        repo = MagicMock()
+        repo.records_for_stage_model.return_value = [
+            _make_record(prompt=10_000, completion=4_000),
+            _make_record(prompt=6_000, completion=2_000),
+        ]
+        pp = _make_pricing_provider("0.000003", "0.000015")
+        estimator = StageCostEstimator(repo, pp)
+
+        cost = estimator.estimate_run_cost("implement", "anthropic:claude-sonnet-4-6")
+
+        avg_in = int((10_000 + 6_000) / 2)   # 8000
+        avg_out = int((4_000 + 2_000) / 2)    # 3000
+        expected = (
+            Decimal(avg_in) * Decimal("0.000003")
+            + Decimal(avg_out) * Decimal("0.000015")
+        )
+        assert cost == expected
+
+    def test_payload_size_overrides_prompt_average(self):
+        """When payload_size_tokens > 0, it replaces the historical average."""
+        repo = MagicMock()
+        repo.records_for_stage_model.return_value = [
+            _make_record(prompt=10_000, completion=4_000),
+            _make_record(prompt=10_000, completion=4_000),
+        ]
+        pp = _make_pricing_provider("0.000003", "0.000015")
+        estimator = StageCostEstimator(repo, pp)
+
+        payload_tokens = 50_000
+        cost = estimator.estimate_run_cost(
+            "implement", "anthropic:claude-sonnet-4-6",
+            payload_size_tokens=payload_tokens,
+        )
+
+        # prompt = payload_tokens, completion = average
+        expected = (
+            Decimal(payload_tokens) * Decimal("0.000003")
+            + Decimal(4_000) * Decimal("0.000015")
+        )
+        assert cost == expected
+
+
+class TestStageCostEstimatorPricingFallback:
+    """When model pricing is unknown, estimate returns 0."""
+
+    def test_unknown_model_returns_zero(self):
+        repo = MagicMock()
+        repo.records_for_stage_model.return_value = []
+        pp = _make_pricing_provider("0", "0")
+        estimator = StageCostEstimator(repo, pp)
+
+        cost = estimator.estimate_run_cost("implement", "unknown:model-xyz")
+
+        assert cost == Decimal(0)
+
+    def test_repo_error_falls_back_gracefully(self):
+        """UsageRepository raising → falls back to heuristic."""
+        repo = MagicMock()
+        repo.records_for_stage_model.side_effect = RuntimeError("db error")
+        pp = _make_pricing_provider("0.000003", "0.000015")
+        estimator = StageCostEstimator(repo, pp)
+
+        # Should not raise; falls back to heuristic.
+        cost = estimator.estimate_run_cost("implement", "anthropic:claude-opus-4-7")
+
+        fallback_in, fallback_out = _FALLBACK_TOKENS["implement"]
+        expected = (
+            Decimal(fallback_in) * Decimal("0.000003")
+            + Decimal(fallback_out) * Decimal("0.000015")
+        )
+        assert cost == expected

--- a/deile/tests/orchestration/pipeline/test_implementer_cost_cap_gating.py
+++ b/deile/tests/orchestration/pipeline/test_implementer_cost_cap_gating.py
@@ -1,0 +1,163 @@
+"""Tests for WorkerImplementer cost-cap gating (issue #392).
+
+Covers:
+- POST proceeds when no cost cap is configured (None)
+- POST is blocked and motivo_bloqueio set when estimated cost > cap
+- POST proceeds when estimated cost <= cap
+- Guard exceptions (non-StageCostCapExceeded) never crash dispatch
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.implementer import WorkerImplementer, WorkOutcome
+
+
+class _FakeClient:
+    def __init__(self, response=None):
+        self._response = response or {"task_id": "x", "status": "running"}
+        self.calls = 0
+        self.last_payload = None
+
+    async def dispatch(self, payload, *, wait):
+        self.calls += 1
+        self.last_payload = payload
+        return self._response
+
+
+def _make_monitor():
+    monitor = MagicMock()
+    monitor.config = SimpleNamespace(
+        repo="owner/repo", main_branch="main", base_repo_path=Path("/tmp/fake")
+    )
+    monitor.branch_for_issue = lambda n: f"auto/issue-{n}"
+    return monitor
+
+
+def _issue(number=1, title="t", body="brief body"):
+    return SimpleNamespace(number=number, title=title, body=body)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    from deile.orchestration.pipeline.dispatch_resolver import PIPELINE_STAGES
+    from deile.config.settings import reset_settings
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}", raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_COST_CAP_USD", raising=False)
+    reset_settings()
+    yield
+    reset_settings()
+
+
+class TestImplementerCostCapGating:
+    async def test_no_cap_dispatch_proceeds(self, monkeypatch):
+        """When no cost cap is configured, dispatch proceeds normally."""
+        client = _FakeClient()
+        impl = WorkerImplementer(client=client)
+
+        with patch(
+            "deile.storage.usage_repository.get_usage_repository",
+            return_value=MagicMock(),
+        ):
+            out = await impl.implement(_make_monitor(), _issue())
+
+        assert out.ok is True
+        assert client.calls == 1
+
+    async def test_cap_exceeded_blocks_dispatch(self, monkeypatch):
+        """When estimated cost > cap, dispatch is blocked and POST is NOT called."""
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "1.00")
+
+        client = _FakeClient()
+        impl = WorkerImplementer(client=client)
+
+        mock_estimator = MagicMock()
+        mock_estimator.estimate_run_cost.return_value = Decimal("5.00")
+
+        with patch(
+            "deile.storage.usage_repository.get_usage_repository",
+            return_value=MagicMock(),
+        ), patch(
+            "deile.orchestration.pipeline.cost_estimator.StageCostEstimator",
+            return_value=mock_estimator,
+        ):
+            out = await impl.implement(_make_monitor(), _issue())
+
+        assert out.ok is False
+        assert client.calls == 0
+        assert out.motivo_bloqueio is not None
+        assert "cost-cap-exceeded" in out.motivo_bloqueio
+
+    async def test_cap_not_exceeded_dispatch_proceeds(self, monkeypatch):
+        """When estimated cost <= cap, dispatch proceeds normally."""
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "10.00")
+
+        client = _FakeClient()
+        impl = WorkerImplementer(client=client)
+
+        mock_estimator = MagicMock()
+        mock_estimator.estimate_run_cost.return_value = Decimal("2.00")
+
+        with patch(
+            "deile.storage.usage_repository.get_usage_repository",
+            return_value=MagicMock(),
+        ), patch(
+            "deile.orchestration.pipeline.cost_estimator.StageCostEstimator",
+            return_value=mock_estimator,
+        ):
+            out = await impl.implement(_make_monitor(), _issue())
+
+        assert out.ok is True
+        assert client.calls == 1
+
+    async def test_guard_error_non_fatal_dispatch_proceeds(self, monkeypatch):
+        """A non-StageCostCapExceeded guard exception never crashes dispatch."""
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "1.00")
+
+        client = _FakeClient()
+        impl = WorkerImplementer(client=client)
+
+        mock_estimator = MagicMock()
+        mock_estimator.estimate_run_cost.side_effect = RuntimeError("db error")
+
+        with patch(
+            "deile.storage.usage_repository.get_usage_repository",
+            return_value=MagicMock(),
+        ), patch(
+            "deile.orchestration.pipeline.cost_estimator.StageCostEstimator",
+            return_value=mock_estimator,
+        ):
+            out = await impl.implement(_make_monitor(), _issue())
+
+        assert out.ok is True
+        assert client.calls == 1
+
+    async def test_blocked_outcome_has_cost_details(self, monkeypatch):
+        """Blocked WorkOutcome includes estimated and cap USD values."""
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "3.00")
+
+        client = _FakeClient()
+        impl = WorkerImplementer(client=client)
+
+        mock_estimator = MagicMock()
+        mock_estimator.estimate_run_cost.return_value = Decimal("7.50")
+
+        with patch(
+            "deile.storage.usage_repository.get_usage_repository",
+            return_value=MagicMock(),
+        ), patch(
+            "deile.orchestration.pipeline.cost_estimator.StageCostEstimator",
+            return_value=mock_estimator,
+        ):
+            out = await impl.implement(_make_monitor(), _issue())
+
+        assert out.ok is False
+        assert "7.50" in out.motivo_bloqueio
+        assert "3.00" in out.motivo_bloqueio

--- a/deile/tests/orchestration/pipeline/test_stage_budget_guard.py
+++ b/deile/tests/orchestration/pipeline/test_stage_budget_guard.py
@@ -1,0 +1,158 @@
+"""Unit tests for StageBudgetGuard + StageCostCapExceeded — issue #392.
+
+Covers:
+- check_stage_run passes when no cap configured (None)
+- check_stage_run passes when estimate <= cap
+- check_stage_run raises StageCostCapExceeded when estimate > cap
+- check_stage_run passes when estimate is 0 (unknown pricing)
+- resolve_stage_cost_cap_usd fallback chain (env var levels)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline.cost_estimator import reset_pricing_provider
+from deile.storage.usage_repository import (
+    StageBudgetGuard,
+    StageCostCapExceeded,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    """Clear env vars + reset settings singleton before each test."""
+    from deile.orchestration.pipeline.dispatch_resolver import PIPELINE_STAGES
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}",
+                          raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_COST_CAP_USD", raising=False)
+    reset_pricing_provider()
+    from deile.config.settings import reset_settings
+    reset_settings()
+    yield
+    reset_settings()
+    reset_pricing_provider()
+
+
+def _make_guard(estimated_cost: Decimal) -> StageBudgetGuard:
+    estimator = MagicMock()
+    estimator.estimate_run_cost.return_value = estimated_cost
+    return StageBudgetGuard(estimator)
+
+
+class TestStageBudgetGuardNoCap:
+    def test_no_cap_passes_silently(self, monkeypatch):
+        """When no cap is configured, check_stage_run returns without raising."""
+        guard = _make_guard(Decimal("99.99"))
+        # No env var set → no cap → passes
+        guard.check_stage_run("implement", "anthropic:claude-opus-4-7")
+
+    def test_zero_estimate_passes_even_with_cap(self, monkeypatch):
+        """Estimate of 0 (unknown pricing) passes regardless of cap."""
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "1.00")
+        guard = _make_guard(Decimal("0"))
+        # Pricing unknown → estimate 0 → no enforcement
+        guard.check_stage_run("implement", "anthropic:claude-opus-4-7")
+
+
+class TestStageBudgetGuardWithCap:
+    def test_below_cap_passes(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "5.00")
+        guard = _make_guard(Decimal("4.99"))
+        guard.check_stage_run("implement", "anthropic:claude-opus-4-7")
+
+    def test_equal_to_cap_passes(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "5.00")
+        guard = _make_guard(Decimal("5.00"))
+        guard.check_stage_run("implement", "anthropic:claude-opus-4-7")
+
+    def test_above_cap_raises(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "5.00")
+        guard = _make_guard(Decimal("5.01"))
+
+        with pytest.raises(StageCostCapExceeded) as exc_info:
+            guard.check_stage_run("implement", "anthropic:claude-opus-4-7")
+
+        exc = exc_info.value
+        assert exc.stage == "implement"
+        assert exc.estimated_usd == Decimal("5.01")
+        assert exc.cap_usd == Decimal("5.00")
+
+    def test_exception_message_contains_values(self, monkeypatch):
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_CLASSIFY", "2.00")
+        guard = _make_guard(Decimal("3.50"))
+
+        with pytest.raises(StageCostCapExceeded) as exc_info:
+            guard.check_stage_run("classify", "anthropic:claude-haiku-4-5")
+
+        assert "3.50" in str(exc_info.value)
+        assert "2.00" in str(exc_info.value)
+        assert "classify" in str(exc_info.value)
+
+
+class TestResolveStageCostCapUsd:
+    """Tests for the resolve_stage_cost_cap_usd fallback chain."""
+
+    def test_no_env_returns_none(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        assert resolve_stage_cost_cap_usd("implement") is None
+
+    def test_stage_env_var_parsed(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "7.50")
+        assert resolve_stage_cost_cap_usd("implement") == Decimal("7.50")
+
+    def test_global_env_var_fallback(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD", "3.00")
+        assert resolve_stage_cost_cap_usd("refine") == Decimal("3.00")
+
+    def test_stage_env_overrides_global(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD", "3.00")
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_REFINE", "10.00")
+        assert resolve_stage_cost_cap_usd("refine") == Decimal("10.00")
+        # implement should fall back to global
+        assert resolve_stage_cost_cap_usd("implement") == Decimal("3.00")
+
+    def test_invalid_stage_raises(self):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        with pytest.raises(ValueError, match="unknown stage"):
+            resolve_stage_cost_cap_usd("bad_stage")
+
+    def test_non_positive_env_raises(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "-1.00")
+        with pytest.raises(ValueError, match="positive"):
+            resolve_stage_cost_cap_usd("implement")
+
+    def test_non_decimal_env_raises(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "not_a_number")
+        with pytest.raises(ValueError):
+            resolve_stage_cost_cap_usd("implement")
+
+    def test_empty_string_treated_as_none(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import (
+            resolve_stage_cost_cap_usd,
+        )
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "")
+        assert resolve_stage_cost_cap_usd("implement") is None

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -76,6 +76,10 @@ from _panel_data import set_preferred_model as pd_set_preferred_model
 from _panel_data import set_stage_model as pd_set_stage_model
 from _panel_data import set_stage_timeout as pd_set_stage_timeout
 from _panel_data import set_stage_retries as pd_set_stage_retries
+from _panel_data import \
+    set_stage_cost_cap_usd as pd_set_stage_cost_cap_usd
+from _panel_data import \
+    reset_stage_cost_cap_usd as pd_reset_stage_cost_cap_usd
 from rich import box
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
@@ -3780,7 +3784,7 @@ class DispatchMatrixView(View):
         "[enter] editar   [r] reset   "
         "[L] switch claude login   [I] install   [U] uninstall   [q] back   "
         "[s]caling row: enter digita réplicas (0-10)   "
-        "colunas: 0=Worker 1=Model 2=Timeout 3=Retries"
+        "colunas: 0=Worker 1=Model 2=Timeout 3=Retries 4=Cost cap (USD/run)"
     )
 
     # Índice de row constante para a linha de scaling (após Global default).
@@ -3821,7 +3825,7 @@ class DispatchMatrixView(View):
         # cursor_row ∈ [0, N] — N inclusive corresponde à linha "Global
         # default" no fim da matriz.
         self.cursor_row: int = 0
-        # cursor_col ∈ {0, 1, 2, 3} — 0=Worker, 1=Model, 2=Timeout(s), 3=Retries.
+        # cursor_col ∈ {0, 1, 2, 3, 4} — 0=Worker, 1=Model, 2=Timeout(s), 3=Retries, 4=Cost cap (USD/run).
         # As colunas Stage e Source não são editáveis.
         self.cursor_col: int = 0
         # --- Picker modal state (Task 19). ``None`` = browsing.
@@ -3895,7 +3899,8 @@ class DispatchMatrixView(View):
         if self.data is None:
             from _panel_data import StageDispatchEntry  # noqa: PLC0415
             return [
-                StageDispatchEntry(s, "deile-worker", None, "default")
+                StageDispatchEntry(s, "deile-worker", None, "default",
+                                   cost_cap_usd=None)
                 for s in self._stages()
             ]
         return self.data.stage_dispatch.get_all_stages()
@@ -4018,6 +4023,7 @@ class DispatchMatrixView(View):
         tbl.add_column("Model")
         tbl.add_column("Timeout (s)")
         tbl.add_column("Max retries")
+        tbl.add_column("Cost cap (USD/run)")
         tbl.add_column("Source", style="dim")
 
         for i, entry in enumerate(entries):
@@ -4025,6 +4031,7 @@ class DispatchMatrixView(View):
             highlight_m = (i == self.cursor_row and self.cursor_col == 1)
             highlight_t = (i == self.cursor_row and self.cursor_col == 2)
             highlight_r = (i == self.cursor_row and self.cursor_col == 3)
+            highlight_c = (i == self.cursor_row and self.cursor_col == 4)
 
             worker_cell = (f"[reverse]{entry.worker}[/reverse]"
                            if highlight_w else entry.worker)
@@ -4037,11 +4044,15 @@ class DispatchMatrixView(View):
             retries_txt = str(entry.max_retries) if entry.max_retries is not None else "(default)"
             retries_cell = (f"[reverse]{retries_txt}[/reverse]"
                             if highlight_r else retries_txt)
+            cap_raw = getattr(entry, "cost_cap_usd", None)
+            cap_txt = (f"${cap_raw}" if cap_raw else "(no cap)")
+            cost_cap_cell = (f"[reverse]{cap_txt}[/reverse]"
+                             if highlight_c else cap_txt)
             tbl.add_row(entry.stage, worker_cell, model_cell,
-                        timeout_cell, retries_cell, entry.source)
+                        timeout_cell, retries_cell, cost_cap_cell, entry.source)
 
         # Separador visual entre stages e a linha "Global default".
-        tbl.add_row("─" * 12, "─" * 14, "─" * 28, "─" * 10, "─" * 11, "─" * 8,
+        tbl.add_row("─" * 12, "─" * 14, "─" * 28, "─" * 10, "─" * 11, "─" * 12, "─" * 8,
                     style="dim")
 
         # Linha "Global default" — ``cursor_row == len(entries)`` aponta
@@ -4068,7 +4079,7 @@ class DispatchMatrixView(View):
         if highlight_gr:
             global_r_txt = f"[reverse]{global_r_txt}[/reverse]"
         tbl.add_row("Global default", global_w_txt, global_m_txt,
-                    global_t_txt, global_r_txt, "env")
+                    global_t_txt, global_r_txt, "—", "env")
 
         # Linha "Worker Scaling" — edita réplicas de deile-worker / claude-worker
         # via prompt numérico [enter] (issue #309 fase 3 Task 4).
@@ -4083,7 +4094,7 @@ class DispatchMatrixView(View):
         if highlight_sm:
             scale_m_txt = f"[reverse]{scale_m_txt}[/reverse]"
         tbl.add_row("Worker Scaling", scale_w_txt, scale_m_txt,
-                    "", "", "kubectl")
+                    "", "", "—", "kubectl")
 
         # --- Compose: header + matrix + (picker?) + (status?) + hotkeys --
         parts: List[RenderableType] = [
@@ -4117,6 +4128,8 @@ class DispatchMatrixView(View):
             title = f"TIMEOUT (s) PARA STAGE '{stage}' (enter vazio = clear)"
         elif kind == "retries":
             title = f"MAX RETRIES PARA STAGE '{stage}' (enter vazio = clear)"
+        elif kind == "cost_cap_usd":
+            title = f"COST CAP (USD/RUN) PARA STAGE '{stage}'"
         elif kind == "global_worker":
             title = "ESCOLHA DISPATCH MODE GLOBAL (DEILE_PIPELINE_DISPATCH_MODE)"
         elif kind == "global_model":
@@ -4253,7 +4266,8 @@ class DispatchMatrixView(View):
             self.cursor_col = max(0, self.cursor_col - 1)
             return ActionResult.refresh()
         if key in ("RIGHT", "l"):
-            self.cursor_col = min(3, self.cursor_col + 1)
+            # 5 editable columns: 0=Worker, 1=Model, 2=Timeout, 3=Retries, 4=Cost cap (issues #391/#392)
+            self.cursor_col = min(4, self.cursor_col + 1)
             return ActionResult.refresh()
 
         # --- [enter]: abre picker contextual ------------------------------
@@ -4291,8 +4305,11 @@ class DispatchMatrixView(View):
                 return self._open_model_picker(entry)
             elif self.cursor_col == 2:
                 return self._open_timeout_prompt(entry)
-            else:
+            elif self.cursor_col == 3:
                 return self._open_retries_prompt(entry)
+            else:
+                # col 4 = Cost cap (issue #392)
+                return self._open_cost_cap_picker(entry)
 
         # --- [r] reset da célula corrente -------------------------------
         if key == "r":
@@ -4409,6 +4426,24 @@ class DispatchMatrixView(View):
         self.picker_cursor = 0
         return ActionResult.refresh()
 
+    def _open_cost_cap_picker(self, entry) -> ActionResult:
+        """Abre picker de cost cap (USD/run) para um stage (col 4, issue #392).
+
+        Oferece presets comuns + "(no cap)" para limpar o override.
+        O operador pode também digitar um valor decimal positivo via entrada
+        livre (``cost_cap_usd`` kind aceita qualquer decimal positivo).
+        """
+        current = getattr(entry, "cost_cap_usd", None)
+        # Common preset values + current (if set and not a preset) + "(no cap)".
+        presets = ["(no cap)", "1.00", "2.00", "5.00", "10.00", "20.00", "50.00"]
+        if current and current not in presets:
+            opts = ["(no cap)", current, *presets[1:]]
+        else:
+            opts = presets
+        self.mode = ("cost_cap_usd", entry.stage, opts)
+        self.picker_cursor = 0
+        return ActionResult.refresh()
+
     # --- [r] reset cell --------------------------------------------------
 
     def _reset_current_cell(self) -> ActionResult:
@@ -4445,8 +4480,11 @@ class DispatchMatrixView(View):
                 ok, msg = pd_clear_stage_model(stage)
             elif self.cursor_col == 2:
                 ok, msg = pd_set_stage_timeout(stage, None, namespace=ns)
-            else:
+            elif self.cursor_col == 3:
                 ok, msg = pd_set_stage_retries(stage, None, namespace=ns)
+            else:
+                # col 4 = Cost cap reset (issue #392)
+                ok, msg = pd_reset_stage_cost_cap_usd(stage, namespace=ns)
         else:  # Global default row
             if self.cursor_col == 0:
                 ok, msg = pd_clear_pipeline_dispatch_mode(namespace=ns)
@@ -5201,6 +5239,17 @@ class DispatchMatrixView(View):
                 ok, msg = pd_set_pipeline_dispatch_mode(
                     mode_for_global, namespace=ns,
                 )
+            self.last_ok = ok
+            self.last_msg = msg
+            return
+
+        # --- per-stage cost cap (issue #392) ----------------------------
+        if kind == "cost_cap_usd":
+            if selected == "(no cap)":
+                ok, msg = pd_reset_stage_cost_cap_usd(stage, namespace=ns)
+            else:
+                ok, msg = pd_set_stage_cost_cap_usd(stage, selected,
+                                                    namespace=ns)
             self.last_ok = ok
             self.last_msg = msg
             return

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -3002,6 +3002,121 @@ def set_stage_retries(
     return True, f"{env_var}={max_retries} ({msg})"
 
 
+# ===== Per-stage cost cap — issue #392 ======================================
+#
+# ``set_stage_cost_cap_usd`` / ``reset_stage_cost_cap_usd`` espelham
+# :func:`set_pipeline_dispatch_stage`: escrevem / removem a env var
+# ``DEILE_PIPELINE_COST_CAP_USD_<STAGE>`` no Deployment ``deile-pipeline``
+# via ``kubectl set env``.  O resolver (:func:`resolve_stage_cost_cap_usd`
+# em ``dispatch_resolver.py``) usa a env var como nível 1 da fallback chain.
+#
+# Deployment alvo: ``deile-pipeline`` (mesmo que as envs de dispatch e cost
+# cap são lidas pelo pipeline, não pelo worker).
+
+_COST_CAP_DEPLOYMENT = "deile-pipeline"
+
+# Regex para valor decimal positivo de USD cost cap. Aceita "5", "5.00",
+# ".50" — rejeita negativo, vazio, letras.
+_COST_CAP_RE = re.compile(r"^\d*\.?\d+$")
+
+
+def set_stage_cost_cap_usd(
+    stage: str, usd: str, *, namespace: str = NS, timeout: float = 15.0,
+) -> tuple:
+    """Pin ``DEILE_PIPELINE_COST_CAP_USD_<STAGE>=<usd>`` em ``deile-pipeline``.
+
+    Args:
+        stage: canonical stage name (classify/refine/implement/pr_review/follow_ups).
+        usd: positive decimal string, e.g. ``"5.00"``.
+        namespace: K8s namespace.
+        timeout: kubectl timeout.
+
+    Returns:
+        ``(ok: bool, msg: str)``.
+    """
+    try:
+        from deile.orchestration.pipeline.dispatch_resolver import (  # noqa: PLC0415
+            PIPELINE_STAGES)
+    except ImportError as exc:
+        return False, f"dispatch_resolver indisponível: {exc}"
+
+    if stage not in PIPELINE_STAGES:
+        allowed = ", ".join(PIPELINE_STAGES)
+        return False, f"stage inválido {stage!r} — esperado um de: {allowed}"
+
+    if not isinstance(usd, str) or not _COST_CAP_RE.match(usd.strip()):
+        return False, (
+            f"valor inválido {usd!r} — esperado decimal positivo (ex: '5.00')"
+        )
+    usd = usd.strip()
+
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+
+    env_var = f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}"
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", namespace, "set", "env",
+             f"deploy/{_COST_CAP_DEPLOYMENT}", f"{env_var}={usd}"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+
+    msg = (proc.stdout or "rollout disparado").strip()
+    return True, f"{env_var}=${usd} ({msg})"
+
+
+def reset_stage_cost_cap_usd(
+    stage: str, *, namespace: str = NS, timeout: float = 15.0,
+) -> tuple:
+    """Remove ``DEILE_PIPELINE_COST_CAP_USD_<STAGE>`` de ``deile-pipeline``.
+
+    Args:
+        stage: canonical stage name.
+        namespace: K8s namespace.
+        timeout: kubectl timeout.
+
+    Returns:
+        ``(ok: bool, msg: str)``.
+    """
+    try:
+        from deile.orchestration.pipeline.dispatch_resolver import (  # noqa: PLC0415
+            PIPELINE_STAGES)
+    except ImportError as exc:
+        return False, f"dispatch_resolver indisponível: {exc}"
+
+    if stage not in PIPELINE_STAGES:
+        allowed = ", ".join(PIPELINE_STAGES)
+        return False, f"stage inválido {stage!r} — esperado um de: {allowed}"
+
+    kubectl = kubectl_bin()
+    if kubectl is None:
+        return False, "kubectl não encontrado"
+
+    env_var = f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}"
+    try:
+        proc = subprocess.run(
+            [kubectl, "-n", namespace, "set", "env",
+             f"deploy/{_COST_CAP_DEPLOYMENT}", f"{env_var}-"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"falha ao executar kubectl: {exc}"
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "kubectl set env falhou").strip()
+        return False, err
+
+    msg = (proc.stdout or "rollout disparado").strip()
+    return True, f"{env_var} unset ({msg})"
+
+
 # ===== Stage dispatch (worker + model) consolidado — issue #309 fase 2 ======
 #
 # ``StageDispatchProvider`` unifica 3 leituras separadas em uma única view:
@@ -3045,6 +3160,9 @@ class StageDispatchEntry:
       ``None`` quando nenhum override per-stage está setado (cai no global).
     - ``max_retries`` — override de max retries para este stage, ou
       ``None`` quando nenhum override per-stage está setado (cai no global).
+    - ``cost_cap_usd`` — per-run USD ceiling from
+      ``DEILE_PIPELINE_COST_CAP_USD_<STAGE>`` env, or ``None`` if not set
+      (issue #392).
     """
 
     stage: str
@@ -3053,6 +3171,7 @@ class StageDispatchEntry:
     source: str
     timeout_s: Optional[int] = None
     max_retries: Optional[int] = None
+    cost_cap_usd: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -3167,7 +3286,8 @@ class StageDispatchProvider(_KubectlProviderMixin):
         # --local-only → cai no fallback vazio do Cache sem chamar kubectl.
         if not self._enabled:
             return [
-                StageDispatchEntry(s, _DEFAULT_WORKER, None, "default")
+                StageDispatchEntry(s, _DEFAULT_WORKER, None, "default",
+                                   cost_cap_usd=None)
                 for s in PIPELINE_STAGES
             ]
 
@@ -3192,7 +3312,8 @@ class StageDispatchProvider(_KubectlProviderMixin):
             # Pipeline absent → tudo default. Não levanta para deixar o
             # painel continuar a renderizar (cluster pode estar mid-deploy).
             return [
-                StageDispatchEntry(s, _DEFAULT_WORKER, None, "default")
+                StageDispatchEntry(s, _DEFAULT_WORKER, None, "default",
+                                   cost_cap_usd=None)
                 for s in PIPELINE_STAGES
             ]
         pipeline_env = StageModelsProvider._extract_env_map(pipeline_data)
@@ -3257,9 +3378,15 @@ class StageDispatchProvider(_KubectlProviderMixin):
                         max_retries = v
                 except (ValueError, TypeError):
                     pass
+            # Cost cap chain: per-stage env from pipeline Deployment (issue #392).
+            cost_cap_raw = pipeline_env.get(
+                f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}"
+            )
+            cost_cap_usd = (cost_cap_raw or "").strip() or None
             result.append(StageDispatchEntry(
                 stage, worker, model, source,
                 timeout_s=timeout_s, max_retries=max_retries,
+                cost_cap_usd=cost_cap_usd,
             ))
         return result
 


### PR DESCRIPTION
Adds per-stage cost cap (USD/run) column to DispatchMatrixView. Introduces StageCostEstimator, StageBudgetGuard, and hooks dispatch to block and escalate when estimated cost exceeds cap. Closes #392.