### PR TITLE
feat(tui): sort por atividade recente + indicador Last activity no rodapé

### DIFF
--- a/deile/tests/infra/test_panel_sort_activity.py
+++ b/deile/tests/infra/test_panel_sort_activity.py
@@ -1,0 +1,476 @@
+"""Tests for issue #393: sort by recent activity + last-activity footer indicator.
+
+Coverage:
+  1. ``_pod_rows`` sort_mode="recent" — rows ordered by age_s asc; "—" last.
+  2. ``_pod_rows`` sort_mode="number" — rows ordered by pod name asc.
+  3. ``_pod_rows`` sort_mode="status" — Running first.
+  4. ``IssuesPRsView._rows`` sort_mode="recent" — most-recent updated_at first; None last.
+  5. ``IssuesPRsView._rows`` sort_mode="number" — ascending by issue number.
+  6. ``IssuesPRsView._rows`` sort_mode="status" — ordered by workflow priority.
+  7. Hotkey ``[s]`` on DashboardView cycles recent → number → status → recent.
+  8. Hotkey ``[s]`` on IssuesPRsView cycles independently; resets cursor.
+  9. ``DashboardView.HOTKEYS`` reflects current sort_mode.
+  10. ``IssuesPRsView.HOTKEYS`` reflects current sort_mode.
+  11. ``_last_activity_caption`` returns None when data is None.
+  12. ``_last_activity_caption`` returns None when no events.
+  13. ``_last_activity_caption`` returns caption for most-recent event.
+  14. ``_footer_panel`` without last_activity renders one line.
+  15. ``_footer_panel`` with last_activity renders two lines (hotkeys + indicator).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel  # noqa: E402
+import _panel_data as pd  # noqa: E402
+
+from rich.console import Console  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_activity_event(age_s: float, target: str = "#1",
+                          action: str = "dispatch",
+                          detail: str = "") -> "pd.ActivityEvent":
+    ts = _utc_now() - timedelta(seconds=age_s)
+    return pd.ActivityEvent(ts=ts, actor="pipeline", action=action,
+                             target=target, detail=detail)
+
+
+def _make_pipeline_state(events: list) -> "pd.PipelineState":
+    ps = pd.PipelineState()
+    ps.events = events
+    return ps
+
+
+def _fake_data(pipeline_events=None, local_events=None):
+    """Build a minimal PanelData-like mock."""
+    data = MagicMock()
+    ps = _make_pipeline_state(pipeline_events or [])
+    data.pipeline.get.return_value = ps
+    if local_events is not None:
+        ls = pd.LocalLogsState()
+        ls.events = local_events
+        data.local_logs.get.return_value = ls
+    else:
+        data.local_logs = None
+    return data
+
+
+def _make_pod_row(name: str, status: str = "Running",
+                  last_activity: str = "1s ago",
+                  age_s_for_sort: float = 1.0) -> "panel.PodRow":
+    return panel.PodRow(icon="●", name=name, role="other", status=status,
+                        age="1s", restarts="0",
+                        last_activity=last_activity, doing_now="—", busy=False)
+
+
+def _make_issue(number: int, updated_at=None, workflow: str = "nova",
+                is_pr: bool = False) -> "pd.GitHubIssue":
+    return pd.GitHubIssue(
+        number=number,
+        title=f"issue {number}",
+        is_pr=is_pr,
+        state="open",
+        labels=[f"~workflow:{workflow}"] if workflow else [],
+        assignees=[],
+        updated_at=updated_at,
+        url=f"https://github.com/x/y/issues/{number}",
+        workflow=workflow,
+        review="",
+        blocked=False,
+    )
+
+
+class _FakeGitHubProvider:
+    def __init__(self, issues, prs):
+        self._snap = pd.GitHubSnapshot(issues=issues, prs=prs)
+
+    def get(self, force=False):
+        return self._snap
+
+
+class _FakePanelData:
+    def __init__(self, issues, prs, pipeline_events=None, local_events=None):
+        self.github = _FakeGitHubProvider(issues, prs)
+        ps = _make_pipeline_state(pipeline_events or [])
+        self.pipeline = MagicMock()
+        self.pipeline.get.return_value = ps
+        if local_events is not None:
+            ls = pd.LocalLogsState()
+            ls.events = local_events
+            self.local_logs = MagicMock()
+            self.local_logs.get.return_value = ls
+        else:
+            self.local_logs = None
+
+
+# ---------------------------------------------------------------------------
+# _pod_rows sorting
+# ---------------------------------------------------------------------------
+
+class TestPodRowsSort:
+    def _make_data_with_pods(self, pod_specs):
+        """pod_specs: list of (name, role, last_activity_s)
+        last_activity_s: seconds since last activity (None → no activity).
+        """
+        data = MagicMock()
+        pods = []
+        workers = {}
+        now = _utc_now()
+        for name, role, age_s in pod_specs:
+            p = MagicMock()
+            p.name = name
+            p.role = role
+            p.status = "Running"
+            p.ready = True
+            p.restarts = 0
+            p.age_s = 100.0
+            pods.append(p)
+            if role == "worker":
+                ws = pd.WorkerState(pod_name=name)
+                # last_activity_s is computed from last_substantive_ts.
+                if age_s is not None:
+                    ws.last_substantive_ts = now - timedelta(seconds=age_s)
+                ws.busy = False
+                ws.last_substantive_body = ""
+                workers[name] = ws
+        data.pods.get.return_value = pods
+        data.workers.get.return_value = workers
+        # Use MagicMock for PipelineState since last_action_age_s is a computed property.
+        ps = MagicMock()
+        ps.last_action_age_s = None
+        ps.last_action_summary = ""
+        ps.events = []
+        data.pipeline.get.return_value = ps
+        return data
+
+    def test_sort_recent_orders_by_age_asc(self):
+        # worker-b was active 2s ago, worker-a was active 10s ago → b first
+        data = self._make_data_with_pods([
+            ("worker-a", "worker", 10.0),
+            ("worker-b", "worker", 2.0),
+        ])
+        rows = panel._pod_rows(data, sort_mode="recent")
+        names = [r.name for r in rows]
+        assert names.index("worker-b") < names.index("worker-a")
+
+    def test_sort_recent_puts_dash_last(self):
+        # "other" role has no activity → goes to end
+        data = self._make_data_with_pods([
+            ("bot", "other", None),
+            ("worker-a", "worker", 5.0),
+        ])
+        rows = panel._pod_rows(data, sort_mode="recent")
+        assert rows[-1].name == "bot"
+
+    def test_sort_number_orders_by_name_alpha(self):
+        data = self._make_data_with_pods([
+            ("worker-z", "worker", 1.0),
+            ("worker-a", "worker", 100.0),
+        ])
+        rows = panel._pod_rows(data, sort_mode="number")
+        assert rows[0].name == "worker-a"
+        assert rows[1].name == "worker-z"
+
+    def test_sort_status_running_first(self):
+        data = MagicMock()
+        pods = []
+        p_nr = MagicMock()
+        p_nr.name = "not-ready-pod"
+        p_nr.role = "other"
+        p_nr.status = "Running"
+        p_nr.ready = False  # → NotReady
+        p_nr.restarts = 0
+        p_nr.age_s = 10.0
+        p_r = MagicMock()
+        p_r.name = "running-pod"
+        p_r.role = "other"
+        p_r.status = "Running"
+        p_r.ready = True
+        p_r.restarts = 0
+        p_r.age_s = 10.0
+        pods = [p_nr, p_r]
+        data.pods.get.return_value = pods
+        data.workers.get.return_value = {}
+        data.pipeline.get.return_value = pd.PipelineState()
+        rows = panel._pod_rows(data, sort_mode="status")
+        assert rows[0].name == "running-pod"
+
+    def test_default_sort_mode_is_recent(self):
+        # Calling without sort_mode should default to "recent"
+        data = self._make_data_with_pods([
+            ("worker-a", "worker", 10.0),
+            ("worker-b", "worker", 2.0),
+        ])
+        rows_default = panel._pod_rows(data)
+        rows_recent = panel._pod_rows(data, sort_mode="recent")
+        assert [r.name for r in rows_default] == [r.name for r in rows_recent]
+
+
+# ---------------------------------------------------------------------------
+# IssuesPRsView._rows sorting
+# ---------------------------------------------------------------------------
+
+class TestIssuesPRsViewSort:
+    def test_sort_recent_most_recent_first(self):
+        now = _utc_now()
+        old = _make_issue(1, updated_at=now - timedelta(hours=2))
+        new = _make_issue(2, updated_at=now - timedelta(seconds=30))
+        view = panel.IssuesPRsView(data=_FakePanelData([old, new], []))
+        view.sort_mode = "recent"
+        issues, _ = view._rows()
+        assert issues[0].number == 2
+        assert issues[1].number == 1
+
+    def test_sort_recent_none_updated_at_goes_last(self):
+        now = _utc_now()
+        has_date = _make_issue(1, updated_at=now - timedelta(hours=1))
+        no_date = _make_issue(2, updated_at=None)
+        view = panel.IssuesPRsView(data=_FakePanelData([has_date, no_date], []))
+        view.sort_mode = "recent"
+        issues, _ = view._rows()
+        assert issues[-1].number == 2
+
+    def test_sort_number_ascending(self):
+        now = _utc_now()
+        i5 = _make_issue(5, updated_at=now)
+        i2 = _make_issue(2, updated_at=now)
+        i9 = _make_issue(9, updated_at=now)
+        view = panel.IssuesPRsView(data=_FakePanelData([i5, i2, i9], []))
+        view.sort_mode = "number"
+        issues, _ = view._rows()
+        assert [it.number for it in issues] == [2, 5, 9]
+
+    def test_sort_status_by_workflow_priority(self):
+        # em_implementacao (0) should come before nova (4)
+        i_nova = _make_issue(1, workflow="nova")
+        i_impl = _make_issue(2, workflow="em_implementacao")
+        view = panel.IssuesPRsView(data=_FakePanelData([i_nova, i_impl], []))
+        view.sort_mode = "status"
+        issues, _ = view._rows()
+        assert issues[0].number == 2  # em_implementacao first
+
+    def test_sort_is_independent_per_view_instance(self):
+        # Two views with different sort_modes must not interfere.
+        now = _utc_now()
+        issues = [_make_issue(3, updated_at=now - timedelta(hours=1)),
+                  _make_issue(1, updated_at=now - timedelta(seconds=10))]
+        data = _FakePanelData(issues, [])
+        view_recent = panel.IssuesPRsView(data=data)
+        view_recent.sort_mode = "recent"
+        view_number = panel.IssuesPRsView(data=data)
+        view_number.sort_mode = "number"
+        recent_issues, _ = view_recent._rows()
+        number_issues, _ = view_number._rows()
+        assert recent_issues[0].number == 1   # most recent first
+        assert number_issues[0].number == 1   # lowest number first (also 1 here)
+        # Make it unambiguous: recent sort returns #1 first, number sort returns #1 first too.
+        # Redo with clearer numbers.
+        issues2 = [_make_issue(10, updated_at=now - timedelta(hours=1)),
+                   _make_issue(2, updated_at=now - timedelta(seconds=10))]
+        data2 = _FakePanelData(issues2, [])
+        vr = panel.IssuesPRsView(data=data2)
+        vr.sort_mode = "recent"
+        vn = panel.IssuesPRsView(data=data2)
+        vn.sort_mode = "number"
+        ri, _ = vr._rows()
+        ni, _ = vn._rows()
+        assert ri[0].number == 2   # most recent (10 here = 2s old)
+        assert ni[0].number == 2   # lowest number
+
+    def test_prs_sorted_independently_from_issues(self):
+        # PRs should also be sorted by sort_mode, not just issues.
+        now = _utc_now()
+        pr_old = _make_issue(100, updated_at=now - timedelta(hours=5), is_pr=True)
+        pr_new = _make_issue(200, updated_at=now - timedelta(seconds=5), is_pr=True)
+        view = panel.IssuesPRsView(data=_FakePanelData([], [pr_old, pr_new]))
+        view.sort_mode = "recent"
+        _, prs = view._rows()
+        assert prs[0].number == 200
+
+
+# ---------------------------------------------------------------------------
+# Hotkey [s] cycling
+# ---------------------------------------------------------------------------
+
+class TestSortHotkey:
+    def test_dashboard_s_cycles_recent_number_status(self):
+        view = panel.DashboardView(data=None)
+        assert view.sort_mode == "recent"
+        view.handle_key("s", MagicMock())
+        assert view.sort_mode == "number"
+        view.handle_key("s", MagicMock())
+        assert view.sort_mode == "status"
+        view.handle_key("s", MagicMock())
+        assert view.sort_mode == "recent"
+
+    def test_issues_prs_s_cycles_independently(self):
+        view = panel.IssuesPRsView(data=None)
+        assert view.sort_mode == "recent"
+        view.handle_key("s", MagicMock())
+        assert view.sort_mode == "number"
+        view.handle_key("s", MagicMock())
+        assert view.sort_mode == "status"
+        view.handle_key("s", MagicMock())
+        assert view.sort_mode == "recent"
+
+    def test_issues_prs_s_resets_cursor(self):
+        now = _utc_now()
+        issues = [_make_issue(i, updated_at=now) for i in range(5)]
+        view = panel.IssuesPRsView(data=_FakePanelData(issues, []))
+        view.cursor = 3
+        view.handle_key("s", MagicMock())
+        assert view.cursor == 0
+
+    def test_dashboard_s_returns_refresh(self):
+        view = panel.DashboardView(data=None)
+        result = view.handle_key("s", MagicMock())
+        assert result.kind == panel.Action.REFRESH
+
+    def test_issues_prs_s_returns_refresh(self):
+        view = panel.IssuesPRsView(data=None)
+        result = view.handle_key("s", MagicMock())
+        assert result.kind == panel.Action.REFRESH
+
+    def test_two_views_cycle_independently(self):
+        d = panel.DashboardView(data=None)
+        i = panel.IssuesPRsView(data=None)
+        d.handle_key("s", MagicMock())  # d → number
+        # i should still be at recent
+        assert i.sort_mode == "recent"
+        assert d.sort_mode == "number"
+
+
+# ---------------------------------------------------------------------------
+# HOTKEYS property
+# ---------------------------------------------------------------------------
+
+class TestHotkeysProperty:
+    def test_dashboard_hotkeys_reflects_sort_mode_recent(self):
+        view = panel.DashboardView(data=None)
+        assert "[s]ort:recent" in view.HOTKEYS
+
+    def test_dashboard_hotkeys_reflects_sort_mode_number(self):
+        view = panel.DashboardView(data=None)
+        view.sort_mode = "number"
+        assert "[s]ort:number" in view.HOTKEYS
+
+    def test_dashboard_hotkeys_reflects_sort_mode_status(self):
+        view = panel.DashboardView(data=None)
+        view.sort_mode = "status"
+        assert "[s]ort:status" in view.HOTKEYS
+
+    def test_issues_prs_hotkeys_reflects_sort_mode(self):
+        view = panel.IssuesPRsView(data=None)
+        assert "[s]ort:recent" in view.HOTKEYS
+        view.sort_mode = "number"
+        assert "[s]ort:number" in view.HOTKEYS
+
+
+# ---------------------------------------------------------------------------
+# _last_activity_caption
+# ---------------------------------------------------------------------------
+
+class TestLastActivityCaption:
+    def test_returns_none_when_data_is_none(self):
+        assert panel._last_activity_caption(None) is None
+
+    def test_returns_none_when_no_events(self):
+        data = _fake_data(pipeline_events=[])
+        assert panel._last_activity_caption(data) is None
+
+    def test_returns_caption_for_most_recent_event(self):
+        ev_old = _make_activity_event(age_s=100, target="#1")
+        ev_new = _make_activity_event(age_s=5, target="#360", detail="em_pr")
+        data = _fake_data(pipeline_events=[ev_old, ev_new])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "#360" in caption
+        assert "em_pr" in caption
+
+    def test_caption_contains_age(self):
+        ev = _make_activity_event(age_s=23, target="#100")
+        data = _fake_data(pipeline_events=[ev])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "ago" in caption
+
+    def test_combines_pipeline_and_local_events(self):
+        ev_pipeline = _make_activity_event(age_s=60, target="#1")
+        ev_local = _make_activity_event(age_s=5, target="#latest")
+        data = _fake_data(pipeline_events=[ev_pipeline],
+                          local_events=[ev_local])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "#latest" in caption
+
+    def test_uses_action_when_detail_empty(self):
+        ev = pd.ActivityEvent(
+            ts=_utc_now() - timedelta(seconds=10),
+            actor="pipeline", action="dispatch",
+            target="#99", detail="",
+        )
+        data = _fake_data(pipeline_events=[ev])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "dispatch" in caption
+
+    def test_falls_back_to_actor_when_target_empty(self):
+        ev = pd.ActivityEvent(
+            ts=_utc_now() - timedelta(seconds=10),
+            actor="local", action="startup",
+            target="", detail="",
+        )
+        data = _fake_data(pipeline_events=[ev])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "local" in caption
+
+
+# ---------------------------------------------------------------------------
+# _footer_panel with last_activity
+# ---------------------------------------------------------------------------
+
+class TestFooterPanel:
+    def _render_footer(self, hotkeys: str, last_activity=None) -> str:
+        footer = panel._footer_panel(hotkeys, last_activity)
+        console = Console(record=True, width=200, force_terminal=False,
+                          color_system=None)
+        console.print(footer)
+        return console.export_text()
+
+    def test_footer_without_last_activity_shows_hotkeys(self):
+        out = self._render_footer("[q]uit")
+        assert "[q]uit" in out
+
+    def test_footer_without_last_activity_no_last_activity_line(self):
+        out = self._render_footer("[q]uit")
+        assert "Last activity:" not in out
+
+    def test_footer_with_last_activity_shows_both_lines(self):
+        out = self._render_footer("[q]uit", "23s ago — #360 → em_pr")
+        assert "[q]uit" in out
+        assert "Last activity:" in out
+        assert "#360" in out
+
+    def test_footer_with_none_last_activity_same_as_without(self):
+        out_none = self._render_footer("[q]uit", None)
+        out_empty = self._render_footer("[q]uit")
+        assert out_none == out_empty

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -103,6 +103,22 @@ _SHORT_LABELS = {
 # mais antigos são apagados para o diretório não crescer indefinidamente.
 _SNAPSHOT_RETAIN = 50
 
+# Ordem de prioridade dos estados de workflow para sort_mode="status".
+# Valores menores aparecem primeiro; estados ausentes ficam por último (99).
+_SORT_WORKFLOW_ORDER: Dict[str, int] = {
+    "em_implementacao": 0,
+    "em_revisao": 1,
+    "revisada": 2,
+    "em_pr": 3,
+    "nova": 4,
+    "em_refinamento": 5,
+    "em_arquitetura": 6,
+    "decomposta": 7,
+    "aguardando_stakeholder": 8,
+    "bloqueada": 9,
+}
+_SORT_MODES = ("recent", "number", "status")
+
 
 # ===== key reader ===========================================================
 
@@ -417,6 +433,27 @@ def _activity_from_data(data: Optional[PanelData], limit: int = 8) -> List[Activ
     return rows
 
 
+def _last_activity_caption(data: Optional[PanelData]) -> Optional[str]:
+    """Retorna string legível do evento mais recente, ex: '23s ago — #360 → em_pr'.
+
+    Combina eventos do pipeline e locais (mesma fonte de `_activity_from_data`).
+    Retorna None quando não há eventos para não poluir o rodapé.
+    """
+    if data is None:
+        return None
+    pool: List[Any] = list(data.pipeline.get().events)
+    if data.local_logs is not None:
+        pool.extend(data.local_logs.get().events)
+    if not pool:
+        return None
+    ev = max(pool, key=lambda e: e.ts)
+    age_s = (datetime.now(timezone.utc) - ev.ts).total_seconds()
+    label = ev.detail[:40] if ev.detail else ev.action
+    if ev.target:
+        return f"{_fmt_age(age_s)} ago — {ev.target} → {label}"
+    return f"{_fmt_age(age_s)} ago — {ev.actor} {label}"
+
+
 # ===== pod adapter para a tabela ============================================
 
 @dataclass
@@ -491,7 +528,7 @@ def _local_process_rows(data: Optional[PanelData]) -> List[PodRow]:
     return rows
 
 
-def _pod_rows(data: Optional[PanelData]) -> List[PodRow]:
+def _pod_rows(data: Optional[PanelData], sort_mode: str = "recent") -> List[PodRow]:
     """Converte o estado dos providers em linhas da tabela de pods."""
     if data is None:
         return [
@@ -501,24 +538,26 @@ def _pod_rows(data: Optional[PanelData]) -> List[PodRow]:
         ]
     workers = data.workers.get()
     ps = data.pipeline.get()
-    rows: List[PodRow] = []
+    # Pares (age_s para sort, row) — age_s None significa "sem dado" (vai pro fim).
+    pairs: List[Any] = []
     for p in data.pods.get():
         # Last-activity humano por role.
         if p.role == "worker":
             ws = workers.get(p.name)
-            last = _fmt_age(ws.last_activity_s) + " ago" if ws else "—"
+            age_s: Optional[float] = ws.last_activity_s if ws else None
+            last = _fmt_age(age_s) + " ago" if ws else "—"
             doing = ws.last_substantive_body[:32] if ws and ws.last_substantive_body \
                 else ("ocupado" if ws and ws.busy else "idle")
             busy = bool(ws and ws.busy)
             icon = "⚡" if busy else "●"
         elif p.role == "pipeline":
-            last = (_fmt_age(ps.last_action_age_s) + " ago"
-                    if ps.last_action_age_s is not None else "—")
+            age_s = ps.last_action_age_s
+            last = (_fmt_age(age_s) + " ago" if age_s is not None else "—")
             doing = ps.last_action_summary[:48] or "idle"
-            busy = (ps.last_action_age_s is not None
-                    and ps.last_action_age_s < 60)
+            busy = (age_s is not None and age_s < 60)
             icon = "⚡" if busy else "●"
         else:
+            age_s = None
             last = "—"
             doing = "—"
             busy = False
@@ -528,13 +567,25 @@ def _pod_rows(data: Optional[PanelData]) -> List[PodRow]:
         if p.status == "Running" and not p.ready:
             ready_label = "NotReady"
 
-        rows.append(PodRow(
+        row = PodRow(
             icon=icon, name=p.name, role=p.role,
             status=ready_label, age=_fmt_age(p.age_s),
             restarts=str(p.restarts), last_activity=last,
             doing_now=doing, busy=busy,
-        ))
-    return rows
+        )
+        pairs.append((age_s, row))
+
+    if sort_mode == "recent":
+        # Menor age_s = mais recente; None vai pro fim.
+        pairs.sort(key=lambda t: (t[0] is None, t[0] or 0.0))
+    elif sort_mode == "number":
+        pairs.sort(key=lambda t: t[1].name)
+    elif sort_mode == "status":
+        # Running primeiro; demais por nome como desempate.
+        _pri = {"Running": 0, "NotReady": 1}
+        pairs.sort(key=lambda t: (_pri.get(t[1].status, 2), t[1].name))
+
+    return [row for _, row in pairs]
 
 
 # ===== renderers reaproveitáveis ============================================
@@ -594,9 +645,16 @@ def _head_panel(view_title: str, app: "PanelApp") -> Panel:
     return Panel(Group(*pieces), border_style="cyan", box=box.HEAVY)
 
 
-def _footer_panel(hotkeys: str) -> Panel:
-    """Rodapé com a linha de hotkeys da view ativa."""
-    return Panel(Text(hotkeys, style="dim"), border_style="dim", box=box.SIMPLE)
+def _footer_panel(hotkeys: str, last_activity: Optional[str] = None) -> Panel:
+    """Rodapé com a linha de hotkeys e, opcionalmente, o indicador de última atividade."""
+    if last_activity:
+        content: Any = Group(
+            Text(hotkeys, style="dim"),
+            Text(f"Last activity: {last_activity}", style="dim"),
+        )
+    else:
+        content = Text(hotkeys, style="dim")
+    return Panel(content, border_style="dim", box=box.SIMPLE)
 
 
 # ===== views ================================================================
@@ -614,14 +672,17 @@ class DashboardView(View):
     title = "Dashboard"
     refresh_s = 1.0    # render é ~3ms; conteúdo refresca conforme TTL do provider
 
-    HOTKEYS = (
-        "[1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  "
-        "[5]Tokens  [n]otifier  [a]ctions  [m]odel/runtime  "
-        "[d]ispatch (workers & models)  [?]help  [q]uit"
-    )
-
     def __init__(self, data: Optional[PanelData] = None):
         self.data = data
+        self.sort_mode: str = "recent"
+
+    @property
+    def HOTKEYS(self) -> str:
+        return (
+            "[1]Pod watch  [2]Pipeline  [3]Issues/PRs  [4]Logs split  "
+            "[5]Tokens  [n]otifier  [a]ctions  [m]odel/runtime  "
+            f"[d]ispatch (workers & models)  [s]ort:{self.sort_mode}  [?]help  [q]uit"
+        )
 
     def render(self, app: "PanelApp") -> RenderableType:
         layout = Layout()
@@ -645,11 +706,13 @@ class DashboardView(View):
             ))
         else:
             children.append(Layout(self._pods_panel(), name="pods", size=10))
+        last_act = _last_activity_caption(self.data)
         children.extend([
             Layout(name="middle", size=8),
             Layout(self._activity_panel(), name="activity"),
             Layout(name="bottom", size=5),
-            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+            Layout(_footer_panel(self.HOTKEYS, last_act), name="footer",
+                   size=4 if last_act else 3),
         ])
         layout.split_column(*children)
         if has_locals and k8s_on:
@@ -670,7 +733,7 @@ class DashboardView(View):
     # --- panels ---
 
     def _pods_panel(self) -> Panel:
-        rows = _pod_rows(self.data)
+        rows = _pod_rows(self.data, sort_mode=self.sort_mode)
         tbl = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
         tbl.add_column(" ", width=2, no_wrap=True)
         tbl.add_column("pod", style="bold")
@@ -894,6 +957,10 @@ class DashboardView(View):
         }
         if key in nav:
             return ActionResult.nav(nav[key])
+        if key == "s":
+            idx = _SORT_MODES.index(self.sort_mode)
+            self.sort_mode = _SORT_MODES[(idx + 1) % len(_SORT_MODES)]
+            return ActionResult.refresh()
         if key == "?":
             return ActionResult.nav("help")
         return ActionResult()
@@ -1958,6 +2025,7 @@ class PipelineTimelineView(View):
             Text(("├" + "─" * (self.HIST_BUCKETS - 2) + "┤"), style="dim"),
             Text(f"{'-24h':<{self.HIST_BUCKETS - 4}}now", style="dim"),
         )
+        last_act = _last_activity_caption(self.data)
         layout = Layout()
         layout.split_column(
             Layout(_head_panel(self.title, app), name="head", size=4),
@@ -1966,7 +2034,8 @@ class PipelineTimelineView(View):
                          title="[bold]EVENTS (mais recentes em cima)[/bold]",
                          title_align="left", border_style="green"),
                    name="events"),
-            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+            Layout(_footer_panel(self.HOTKEYS, last_act), name="footer",
+                   size=4 if last_act else 3),
         )
         layout["middle"].split_row(
             Layout(Panel(Group(*stats_lines),
@@ -1996,15 +2065,21 @@ class IssuesPRsView(View):
     title = "Issues & PRs"
     refresh_s = 1.0
 
-    HOTKEYS = ("[a] all   [i] só issues   [p] só PRs   [b] só bloqueadas   "
-               "[m] minhas   [↑/↓] navega   [enter] abrir URL   [esc] volta")
-
     def __init__(self, data: Optional[PanelData] = None):
         self.data = data
         self.filter: str = "all"
         self.cursor: int = 0
+        self.sort_mode: str = "recent"
         # Sem nome hardcoded: tenta env GH_USER → `gh api user` → vazio.
         self.my_login: str = self._resolve_login()
+
+    @property
+    def HOTKEYS(self) -> str:
+        return (
+            f"[a] all   [i] só issues   [p] só PRs   [b] só bloqueadas   "
+            f"[m] minhas   [s]ort:{self.sort_mode}   [↑/↓] navega   "
+            f"[enter] abrir URL   [esc] volta"
+        )
 
     @staticmethod
     def _resolve_login() -> str:
@@ -2029,7 +2104,8 @@ class IssuesPRsView(View):
         if self.data is None:
             return [], []
         snap = self.data.github.get()
-        issues, prs = snap.issues, snap.prs
+        issues: List[Any] = list(snap.issues)
+        prs: List[Any] = list(snap.prs)
         if self.filter == "i":
             prs = []
         elif self.filter == "p":
@@ -2040,6 +2116,20 @@ class IssuesPRsView(View):
         elif self.filter == "m":
             issues = [it for it in issues if self.my_login in it.assignees]
             prs = [pr for pr in prs if self.my_login in pr.assignees]
+        # Aplica sort_mode (estado local da view — não global).
+        if self.sort_mode == "recent":
+            # updated_at desc; None vai pro fim.
+            _key_r = lambda it: (it.updated_at is None,  # noqa: E731
+                                 -(it.updated_at.timestamp() if it.updated_at else 0))
+            issues.sort(key=_key_r)
+            prs.sort(key=_key_r)
+        elif self.sort_mode == "number":
+            issues.sort(key=lambda it: it.number)
+            prs.sort(key=lambda it: it.number)
+        elif self.sort_mode == "status":
+            _key_s = lambda it: _SORT_WORKFLOW_ORDER.get(it.workflow or "", 99)  # noqa: E731
+            issues.sort(key=_key_s)
+            prs.sort(key=_key_s)
         return issues, prs
 
     def _flat(self):
@@ -2100,13 +2190,15 @@ class IssuesPRsView(View):
             ),
             border_style="dim",
         )
+        last_act = _last_activity_caption(self.data)
         layout = Layout()
         layout.split_column(
             Layout(_head_panel(self.title, app), name="head", size=4),
             Layout(filter_panel, name="filter", size=3),
             Layout(self._build_table(issues, "Issues"), name="issues"),
             Layout(self._build_table(prs, "PRs"), name="prs"),
-            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+            Layout(_footer_panel(self.HOTKEYS, last_act), name="footer",
+                   size=4 if last_act else 3),
         )
         return layout
 
@@ -2114,6 +2206,11 @@ class IssuesPRsView(View):
         flat = self._flat()
         if key in ("a", "i", "p", "b", "m"):
             self.filter = key
+            self.cursor = 0
+            return ActionResult.refresh()
+        if key == "s":
+            idx = _SORT_MODES.index(self.sort_mode)
+            self.sort_mode = _SORT_MODES[(idx + 1) % len(_SORT_MODES)]
             self.cursor = 0
             return ActionResult.refresh()
         n = len(flat)


### PR DESCRIPTION
## Summary

- **Sort default por atividade recente** (`sort_mode="recent"`) em `_pod_rows` e `IssuesPRsView._rows`: rows/items com `last == "—"` ou `updated_at is None` vão para o fim.
- **Hotkey `[s]`** em `DashboardView` e `IssuesPRsView` cicla `recent → number → status → recent` (estado local por view, não global).
- **`HOTKEYS` como property** em ambas as views, refletindo o modo atual (ex: `[s]ort:recent`).
- **`_last_activity_caption(data)`** — novo utilitário que combina eventos do pipeline + locais e retorna a caption do evento mais recente (ex: `23s ago — #360 → em_pr`).
- **`_footer_panel`** estendido com `last_activity: Optional[str]` opcional; renderiza segunda linha `Last activity: …` quando fornecido.
- **`DashboardView`, `IssuesPRsView`, `PipelineTimelineView`** passam `_last_activity_caption` ao rodapé com tamanho dinâmico (4 com indicador, 3 sem).
- **32 novos testes** em `deile/tests/infra/test_panel_sort_activity.py` cobrindo todos os casos.

## Test plan

- [x] `python3 -m pytest deile/tests/infra/test_panel_sort_activity.py -p no:cov -q` — 32 passed
- [x] `python3 -m pytest deile/tests/infra/ -p no:cov -q` — 788 passed, 0 failures
- [x] Nenhuma regressão nos testes de panel existentes

Closes #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)