### PR TITLE
feat(#395): PodWatch — GET /v1/pod-status endpoint + ClaudeWorkerInfoProvider

### DIFF
--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -2232,3 +2232,72 @@ class TestSetPipelineDispatchStage:
         assert ok is True
         argv = mock_run.call_args[0][0]
         assert "custom-ns" in argv
+
+
+# ===== ClaudeWorkerInfoProvider (issue #395) ================================
+
+
+class TestClaudeWorkerInfoProvider:
+    """ClaudeWorkerInfoProvider — bearer-auth HTTP fetch + graceful fallback."""
+
+    def test_consumes_endpoint_with_bearer(self, monkeypatch, tmp_path):
+        """Provider fetches /v1/pod-status with Bearer token and maps the response."""
+        import io
+        import json as _json
+        import urllib.request as _urllib_req
+
+        token_file = tmp_path / "bearer.token"
+        token_file.write_text("super-secret", encoding="utf-8")
+
+        fake_body = {
+            "lease": {"task_id": "abc123", "heartbeat_at": 1000.0, "pid": 42},
+            "disk": {"used_bytes": 1024, "total_bytes": 2048, "mount": "/home/claude"},
+            "claude_processes": 2,
+            "anthropic_quota": None,
+            "ts": 1700000000.0,
+        }
+
+        class _FakeResp:
+            def read(self):
+                return _json.dumps(fake_body).encode()
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setenv(pd.ClaudeWorkerInfoProvider._TOKEN_FILE_ENV, str(token_file))
+        monkeypatch.setattr(_urllib_req, "urlopen", lambda req, timeout: _FakeResp())
+
+        provider = pd.ClaudeWorkerInfoProvider(
+            endpoint="http://claude-worker:8767", enabled=True,
+        )
+        status = provider._fetch()
+
+        assert status.lease == fake_body["lease"]
+        assert status.disk == fake_body["disk"]
+        assert status.claude_processes == 2
+        assert status.ts == 1700000000.0
+
+    def test_fallback_when_pod_unreachable(self, monkeypatch, tmp_path):
+        """get() returns empty ClaudeWorkerPodStatus and sets last_error when pod is down."""
+        import urllib.error
+        import urllib.request as _urllib_req
+
+        token_file = tmp_path / "bearer.token"
+        token_file.write_text("super-secret", encoding="utf-8")
+
+        def _raise_conn_err(req, timeout):
+            raise urllib.error.URLError("Connection refused")
+
+        monkeypatch.setenv(pd.ClaudeWorkerInfoProvider._TOKEN_FILE_ENV, str(token_file))
+        monkeypatch.setattr(_urllib_req, "urlopen", _raise_conn_err)
+
+        provider = pd.ClaudeWorkerInfoProvider(
+            endpoint="http://claude-worker:8767", enabled=True,
+        )
+        result = provider.get()
+
+        assert result.lease is None
+        assert result.claude_processes == 0
+        assert provider.last_error is not None
+        assert "RuntimeError" in provider.last_error

--- a/deile/tests/infra/test_panel_pod_watch.py
+++ b/deile/tests/infra/test_panel_pod_watch.py
@@ -760,3 +760,59 @@ class TestPodWatchViewRenderSize:
         assert "#309" in out
         # Updated: header now shows WORK: instead of "current task:"
         assert "WORK:" in out
+
+
+# ===== PodWatchView — claude-worker header sections (issue #395) ============
+
+
+class TestPodWatchViewClaudeWorkerHeader:
+    """_header_body injects LEASE lines ONLY for pod.role == 'claude-worker'."""
+
+    def _make_pod(self, name: str, role: str) -> MagicMock:
+        pod = MagicMock()
+        pod.name = name
+        pod.role = role
+        pod.status = "Running"
+        pod.age_s = 60.0
+        pod.restarts = 0
+        pod.ready = True
+        pod.node = "node-1"
+        return pod
+
+    def _render(self, view: "panel.PodWatchView") -> str:
+        console = Console(record=True, width=200, force_terminal=False,
+                          color_system=None)
+        console.print(view._header_body())
+        return console.export_text()
+
+    def test_claude_worker_role_shows_lease_section(self):
+        """LEASE section appears in header when pod.role == 'claude-worker'."""
+        view = panel.PodWatchView(data=MagicMock())
+        view.pod_role = "claude-worker"
+        view.pod_name = "claude-worker-0"
+
+        pod = self._make_pod("claude-worker-0", "claude-worker")
+        view.data.pods.get.return_value = [pod]
+
+        mock_status = pd.ClaudeWorkerPodStatus(
+            lease=None, disk=None, claude_processes=0, anthropic_quota=None,
+        )
+        mock_provider = MagicMock()
+        mock_provider.get.return_value = mock_status
+        view.data.claude_worker_info = mock_provider
+
+        out = self._render(view)
+        assert "LEASE:" in out, "LEASE section must appear for claude-worker role"
+
+    def test_non_claude_worker_role_has_no_lease_section(self):
+        """LEASE section must NOT appear for deile-worker or other roles."""
+        view = panel.PodWatchView(data=MagicMock())
+        view.pod_role = "worker"
+        view.pod_name = "deile-worker-abc"
+
+        pod = self._make_pod("deile-worker-abc", "worker")
+        view.data.pods.get.return_value = [pod]
+        view.data.workers.get.return_value = {}
+
+        out = self._render(view)
+        assert "LEASE:" not in out, "LEASE must not appear for non-claude-worker roles"

--- a/deile/tests/infra/test_panel_pod_watch.py
+++ b/deile/tests/infra/test_panel_pod_watch.py
@@ -793,6 +793,10 @@ class TestPodWatchViewClaudeWorkerHeader:
 
         pod = self._make_pod("claude-worker-0", "claude-worker")
         view.data.pods.get.return_value = [pod]
+        # claude_workers.get() must return a plain dict so that wstate resolves
+        # to None (idle) — otherwise MagicMock.get() chains produce MagicMock
+        # values that cause TypeError inside Text.assemble.
+        view.data.claude_workers.get.return_value = {}
 
         mock_status = pd.ClaudeWorkerPodStatus(
             lease=None, disk=None, claude_processes=0, anthropic_quota=None,

--- a/deile/tests/infrastructure/test_claude_worker_server.py
+++ b/deile/tests/infrastructure/test_claude_worker_server.py
@@ -1696,3 +1696,72 @@ async def test_pod_status_endpoint_requires_bearer(
     async with TestClient(TestServer(app)) as client:
         resp = await client.get("/v1/pod-status")  # no auth header
         assert resp.status == 401
+
+
+async def test_pod_status_endpoint_returns_disk_usage_via_shutil(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """disk field is populated from shutil.disk_usage — no subprocess."""
+    import collections
+
+    DiskUsage = collections.namedtuple("DiskUsage", ["total", "used", "free"])
+    fake_du = DiskUsage(total=10 * 1024 ** 3, used=3 * 1024 ** 3, free=7 * 1024 ** 3)
+
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEILE_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setattr(claude_worker_module.shutil, "disk_usage", lambda path: fake_du)
+    monkeypatch.setattr(claude_worker_module, "_count_claude_processes", lambda: 0)
+
+    app = claude_worker_module.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/pod-status", headers=_AUTH_HEADERS)
+        assert resp.status == 200
+        body = await resp.json()
+
+    disk = body["disk"]
+    assert disk is not None
+    assert disk["used_bytes"] == 3 * 1024 ** 3
+    assert disk["total_bytes"] == 10 * 1024 ** 3
+    assert "mount" in disk
+
+
+async def test_pod_status_endpoint_counts_claude_processes_via_psutil(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """claude_processes reflects the value returned by _count_claude_processes."""
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEILE_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setattr(claude_worker_module, "_count_claude_processes", lambda: 3)
+
+    app = claude_worker_module.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/pod-status", headers=_AUTH_HEADERS)
+        assert resp.status == 200
+        body = await resp.json()
+
+    assert body["claude_processes"] == 3
+
+
+def test_anthropic_quota_capture_middleware_stores_latest_header(
+    claude_worker_module,
+):
+    """_try_capture_quota_from_output stores rate-limit token count from dispatch output."""
+    assert claude_worker_module._get_quota_snapshot() is None
+
+    claude_worker_module._try_capture_quota_from_output(
+        stdout="",
+        stderr="anthropic-ratelimit-tokens-remaining: 87654",
+    )
+
+    snap = claude_worker_module._get_quota_snapshot()
+    assert snap is not None
+    assert snap.tokens_remaining == 87654
+    assert snap.captured_at > 0
+
+    # Second call with x-ratelimit variant overwrites with newer value.
+    claude_worker_module._try_capture_quota_from_output(
+        stdout="x-ratelimit-remaining-tokens: 50000",
+        stderr="",
+    )
+    snap2 = claude_worker_module._get_quota_snapshot()
+    assert snap2.tokens_remaining == 50000

--- a/deile/tests/infrastructure/test_claude_worker_server.py
+++ b/deile/tests/infrastructure/test_claude_worker_server.py
@@ -1546,3 +1546,153 @@ async def test_observability_endpoints_require_bearer(
         ):
             resp = await client.get(path)
             assert resp.status == 401, f"{path} did not require bearer"
+
+
+# --------------------------------------------------------------------------- #
+# Issue #395 — /v1/pod-status
+# --------------------------------------------------------------------------- #
+
+
+async def test_pod_status_endpoint_returns_lease_when_active(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """Active lease.json with recent heartbeat → lease dict is returned."""
+    import time as _time
+
+    # Create a fake workspace with a live lease.
+    task_id = "aabbccdd11223344"
+    workspace = tmp_path / task_id
+    workspace.mkdir()
+    now = _time.time()
+    lease_data = {
+        "pod": "claude-worker-0",
+        "pid": 42,
+        "task_id": task_id,
+        "extra_secret": "should-not-appear",
+        "started_at": now - 10,
+        "heartbeat_at": now - 2,
+    }
+    (workspace / ".lease.json").write_text(
+        __import__("json").dumps(lease_data), encoding="utf-8"
+    )
+
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEILE_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setattr(claude_worker_module, "_count_claude_processes", lambda: 1)
+
+    app = claude_worker_module.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/pod-status", headers=_AUTH_HEADERS)
+        assert resp.status == 200
+        body = await resp.json()
+    assert body["lease"] is not None
+    assert body["lease"]["task_id"] == task_id
+    assert body["lease"]["pid"] == 42
+    assert "heartbeat_at" in body["lease"]
+    assert body["claude_processes"] == 1
+    assert "disk" in body
+    assert "ts" in body
+
+
+async def test_pod_status_endpoint_returns_null_lease_when_idle(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """No lease.json in workspace → lease is null (pod is idle)."""
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEILE_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setattr(claude_worker_module, "_count_claude_processes", lambda: 0)
+
+    app = claude_worker_module.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/pod-status", headers=_AUTH_HEADERS)
+        assert resp.status == 200
+        body = await resp.json()
+    assert body["lease"] is None
+    assert body["claude_processes"] == 0
+
+
+async def test_pod_status_endpoint_returns_null_lease_when_heartbeat_stale(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """Lease with expired heartbeat (> TTL) → treated as dead, returns null."""
+    import time as _time
+
+    task_id = "deadbeef00112233"
+    workspace = tmp_path / task_id
+    workspace.mkdir()
+    ttl = claude_worker_module._LEASE_TTL_S
+    stale_data = {
+        "pod": "old-pod",
+        "pid": 99,
+        "heartbeat_at": _time.time() - ttl - 60,  # well past TTL
+    }
+    (workspace / ".lease.json").write_text(
+        __import__("json").dumps(stale_data), encoding="utf-8"
+    )
+
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEILE_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setattr(claude_worker_module, "_count_claude_processes", lambda: 0)
+
+    app = claude_worker_module.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/pod-status", headers=_AUTH_HEADERS)
+        assert resp.status == 200
+        body = await resp.json()
+    assert body["lease"] is None, "stale lease should be treated as idle"
+
+
+async def test_pod_status_endpoint_redacts_lease_payload(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """Only task_id, heartbeat_at, pid are exposed — no extra fields leak."""
+    import time as _time
+
+    task_id = "1122334455667788"
+    workspace = tmp_path / task_id
+    workspace.mkdir()
+    now = _time.time()
+    lease_data = {
+        "pod": "claude-worker-0",
+        "pid": 77,
+        "started_at": now - 5,
+        "heartbeat_at": now - 1,
+        "secret_prompt": "DO NOT LEAK",
+        "credentials": "also-secret",
+    }
+    (workspace / ".lease.json").write_text(
+        __import__("json").dumps(lease_data), encoding="utf-8"
+    )
+
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEILE_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setattr(claude_worker_module, "_count_claude_processes", lambda: 1)
+
+    app = claude_worker_module.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/pod-status", headers=_AUTH_HEADERS)
+        assert resp.status == 200
+        body = await resp.json()
+    lease = body["lease"]
+    assert lease is not None
+    allowed_keys = {"task_id", "heartbeat_at", "pid"}
+    assert set(lease.keys()) <= allowed_keys, (
+        f"Lease exposed extra fields: {set(lease.keys()) - allowed_keys}"
+    )
+    assert "secret_prompt" not in lease
+    assert "credentials" not in lease
+    assert "pod" not in lease
+    assert "started_at" not in lease
+
+
+async def test_pod_status_endpoint_requires_bearer(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """/v1/pod-status requires Bearer auth — no anonymous access."""
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEILE_CLAUDE_HOME", str(tmp_path))
+
+    app = claude_worker_module.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/pod-status")  # no auth header
+        assert resp.status == 401

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -1573,10 +1573,11 @@ class PodWatchView(View):
     # Mapeia role do pod → Deployment alvo do kubectl patch. Roles locais
     # não têm Deployment (são processos no host) → resize não se aplica.
     _ROLE_TO_DEPLOYMENT = {
-        "pipeline": "deile-pipeline",
-        "worker":   "deile-worker",
-        "bot":      "deilebot",
-        "shell":    "deile-shell",
+        "pipeline":     "deile-pipeline",
+        "worker":       "deile-worker",
+        "bot":          "deilebot",
+        "shell":        "deile-shell",
+        "claude-worker": "claude-worker",
     }
 
     # Roles com Service associado (issue #394): usados para decidir se a
@@ -1817,7 +1818,76 @@ class PodWatchView(View):
                     (" | ", "dim"),
                     (finished_z, "dim"),
                 ))
+        # claude-worker specific sections (issue #395)
+        if pod.role == "claude-worker":
+            lines.extend(self._claude_worker_header_lines())
         return Group(*lines)
+
+    def _claude_worker_header_lines(self) -> list:
+        """LEASE / DISK / QUOTA lines for claude-worker pod header (issue #395)."""
+        import time as _time
+        lines = []
+        if self.data is None or self.data.claude_worker_info is None:
+            lines.append(Text.assemble(
+                ("LEASE: ", "bold yellow"), ("— (provider unavailable)", "dim"),
+            ))
+            return lines
+
+        status = self.data.claude_worker_info.get()
+
+        # LEASE line
+        lease = status.lease
+        if lease:
+            hb_age = _time.time() - float(lease.get("heartbeat_at") or 0)
+            alive_label = "(alive)" if hb_age < 35 else "(stale)"
+            alive_style = "green" if hb_age < 35 else "red"
+            lines.append(Text.assemble(
+                ("LEASE: ", "bold yellow"),
+                ("task=", "dim"), (str(lease.get("task_id", "?")), "bold"),
+                ("   heartbeat=", "dim"),
+                (_fmt_age(hb_age) + " ago", "bold"),
+                ("   ", ""),
+                (alive_label, alive_style),
+                ("   claudes_running=", "dim"),
+                (str(status.claude_processes), "bold"),
+            ))
+        else:
+            lines.append(Text.assemble(
+                ("LEASE: ", "bold yellow"),
+                ("— (idle)", "dim"),
+                ("   claudes_running=", "dim"),
+                (str(status.claude_processes), "bold"),
+            ))
+
+        # DISK line
+        disk = status.disk
+        if disk:
+            used = int(disk.get("used_bytes") or 0)
+            total = int(disk.get("total_bytes") or 1)
+            pct = int(used * 100 / total) if total else 0
+            used_mi = used // (1024 * 1024)
+            total_gi = total / (1024 ** 3)
+            disk_style = "red bold" if pct >= 80 else "bold"
+            lines.append(Text.assemble(
+                ("DISK: ", "bold cyan"),
+                ("PVC claude-home ", "dim"),
+                (f"{used_mi}Mi/{total_gi:.0f}Gi used ({pct}%)", disk_style),
+            ))
+
+        # QUOTA line — omitted when never captured
+        quota = status.anthropic_quota
+        if quota:
+            tokens = int(quota.get("tokens_remaining") or 0)
+            captured_at = float(quota.get("captured_at") or 0)
+            age_s = _time.time() - captured_at
+            lines.append(Text.assemble(
+                ("QUOTA: ", "bold magenta"),
+                ("anthropic tokens left ~", "dim"),
+                (f" {tokens:,}", "bold"),
+                (f"  (cached {_fmt_age(age_s)} ago, best-effort)", "dim"),
+            ))
+
+        return lines
 
     def _local_header_body(self) -> RenderableType:
         """Cabeçalho do drill-in para processo local (não k8s)."""
@@ -1887,17 +1957,17 @@ class PodWatchView(View):
 
     def render(self, app: "PanelApp") -> RenderableType:
         layout = Layout()
-        # ``size=9`` acomoda até 6 linhas de header + bordas do Panel + título
-        # ([1] name/role/status + [2] uptime/restarts/ready/node +
-        # [3] RESOURCES + [4] ENDPOINT (conditional) +
-        # [5] worker/last activity + [6] current task).
-        # Pods sem worker ou sem ENDPOINT mostram menos linhas.
+        # size=9 acomoda 6 linhas de header + bordas + título para k8s pods
+        # (name/role/status + uptime + RESOURCES + ENDPOINT + worker/activity
+        # + current task). claude-worker adiciona LEASE/DISK/QUOTA (até 3
+        # linhas extra) → size=12. Outros pods mantêm 9.
+        info_size = 12 if self.pod_role == "claude-worker" else 9
         layout.split_column(
             Layout(_head_panel(self.title, app), name="head", size=4),
             Layout(Panel(self._header_body(),
                          title="[bold]POD[/bold]", title_align="left",
                          border_style="cyan"),
-                   name="info", size=9),
+                   name="info", size=info_size),
             Layout(self._log_panel(), name="log"),
             Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
         )

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -4704,6 +4704,101 @@ class EndpointProbeProvider(_KubectlProviderMixin):
         return EndpointInfo(ready=ready, not_ready=not_ready)
 
 
+# ===== ClaudeWorker pod-status provider (issue #395) ========================
+
+
+@dataclass
+class ClaudeWorkerPodStatus:
+    """Snapshot returned by ``GET /v1/pod-status`` on a claude-worker pod.
+
+    All fields are Optional; fallback values are used when the pod is
+    unreachable so the panel can still render gracefully.
+    """
+
+    lease: Optional[dict] = None           # {task_id, heartbeat_at, pid} or None
+    disk: Optional[dict] = None            # {used_bytes, total_bytes, mount}
+    claude_processes: int = 0
+    anthropic_quota: Optional[dict] = None # {tokens_remaining, captured_at} or None
+    ts: float = 0.0
+
+
+class ClaudeWorkerInfoProvider:
+    """Fetches ``/v1/pod-status`` from the claude-worker Service.
+
+    Bearer token read from the mounted Secret path
+    ``/run/secrets/claude-worker/CLAUDE_WORKER_BEARER_TOKEN`` or
+    ``DEILE_CLAUDE_WORKER_AUTH_TOKEN`` env var (same resolution order as the
+    server's :func:`_read_auth_token`).  Falls back gracefully: if the pod
+    is down, ``last_error`` is set but the panel never hangs.
+
+    TTL: 3s.  Timeout: 2s per request.
+    """
+
+    _SECRET_PATH = Path("/run/secrets/claude-worker/CLAUDE_WORKER_BEARER_TOKEN")
+    _TOKEN_FILE_ENV = "DEILE_CLAUDE_WORKER_AUTH_TOKEN_FILE"
+    _TOKEN_ENV = "DEILE_CLAUDE_WORKER_AUTH_TOKEN"
+
+    def __init__(
+        self,
+        endpoint: str = "",
+        ttl_s: float = 3.0,
+        timeout_s: float = 2.0,
+        enabled: bool = True,
+    ) -> None:
+        self._endpoint = endpoint or os.environ.get(
+            "DEILE_CLAUDE_WORKER_ENDPOINT", "http://claude-worker:8767"
+        )
+        self._timeout_s = timeout_s
+        self._enabled = enabled
+        self._cache: Cache[ClaudeWorkerPodStatus] = Cache(
+            ttl_s, self._fetch, fallback=ClaudeWorkerPodStatus(),
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> ClaudeWorkerPodStatus:
+        return self._cache.get(force)
+
+    def _bearer_token(self) -> Optional[str]:
+        """Resolve bearer token with same priority as the server."""
+        for p in (
+            self._SECRET_PATH,
+            Path(os.environ.get(self._TOKEN_FILE_ENV, "")),
+        ):
+            if p and p.is_file():
+                token = p.read_text(encoding="utf-8").strip()
+                if token:
+                    return token
+        return os.environ.get(self._TOKEN_ENV, "").strip() or None
+
+    def _fetch(self) -> ClaudeWorkerPodStatus:
+        if not self._enabled:
+            raise RuntimeError("ClaudeWorkerInfoProvider disabled")
+        token = self._bearer_token()
+        if not token:
+            raise RuntimeError("claude-worker bearer token not configured")
+        url = f"{self._endpoint.rstrip('/')}/v1/pod-status"
+        try:
+            import urllib.request as _urllib_req
+            req = _urllib_req.Request(
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            with _urllib_req.urlopen(req, timeout=self._timeout_s) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:
+            raise RuntimeError(f"pod-status fetch failed: {exc}") from exc
+        return ClaudeWorkerPodStatus(
+            lease=body.get("lease"),
+            disk=body.get("disk"),
+            claude_processes=int(body.get("claude_processes") or 0),
+            anthropic_quota=body.get("anthropic_quota"),
+            ts=float(body.get("ts") or 0.0),
+        )
+
+
 # ===== Aggregate hub ========================================================
 
 @dataclass
@@ -4752,6 +4847,9 @@ class PanelData:
     # WorkerProvider for the ``claude-worker`` deployment (issue #396).
     # ``None`` when the pod is not deployed (panel still renders without error).
     claude_workers: Optional[WorkerProvider] = None
+    # Pod-status provider for claude-worker (issue #395). Instanciado
+    # apenas quando k8s está disponível — accessa /v1/pod-status via HTTP.
+    claude_worker_info: Optional["ClaudeWorkerInfoProvider"] = None
 
     @classmethod
     def from_context(cls, context: RuntimeContext) -> "PanelData":
@@ -4844,6 +4942,11 @@ class PanelData:
                 enabled=k8s_on,
                 costs=CostsProvider(db_path=context.usage_db),
             ),
+            # ClaudeWorkerInfoProvider only when k8s is available — it talks
+            # to the claude-worker pod HTTP service.
+            claude_worker_info=(
+                ClaudeWorkerInfoProvider(enabled=True) if k8s_on else None
+            ),
         )
 
     @classmethod
@@ -4859,7 +4962,8 @@ class PanelData:
                 self.notifier, self.pod_metrics, self.endpoints)
         optionals = tuple(p for p in (self.local_processes, self.local_logs,
                                       self.local_audit, self.local_instances,
-                                      self.local_registry, self.claude_workers)
+                                      self.local_registry, self.claude_workers,
+                                      self.claude_worker_info)
                           if p is not None)
         return base + optionals
 
@@ -4894,6 +4998,8 @@ class PanelData:
             names.append("local_instances")
         if self.local_registry is not None:
             names.append("local_registry")
+        if self.claude_worker_info is not None:
+            names.append("claude_worker_info")
         out: List[tuple] = []
         for name, p in zip(names, self._all_providers()):
             err = p.last_error

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -17,6 +17,7 @@ Diferenças de papel vs. o ``deile-worker``:
 Endpoints:
 
 * ``GET  /v1/health``              — readiness/liveness probe (Task 12)
+* ``GET  /v1/pod-status``          — pod introspection: lease/disk/GC/quota (issue #395)
 * ``POST /v1/dispatch``            — receive brief + spawn ``claude -p`` (Task 13)
 * ``GET  /v1/progress/{task_id}``  — mid-flight snapshot via PVC tail (Task 14)
 
@@ -36,6 +37,7 @@ import secrets
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -199,6 +201,57 @@ _LEASE_TTL_S: int = int(os.environ.get("DEILE_CLAUDE_LEASE_TTL_S", "30"))
 
 #: Intervalo de atualização do heartbeat em segundos.
 _LEASE_HEARTBEAT_S: int = int(os.environ.get("DEILE_CLAUDE_LEASE_HEARTBEAT_S", "5"))
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic quota cache — thread-safe singleton (issue #395)
+#
+# Populated best-effort when dispatch output contains rate-limit header
+# patterns.  Never makes additional API calls — returns None when nothing
+# has been captured yet.
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class _QuotaSnapshot:
+    tokens_remaining: int
+    captured_at: float
+
+
+_quota_lock: threading.Lock = threading.Lock()
+_quota_snapshot: Optional[_QuotaSnapshot] = None
+
+#: Regex pattern matching anthropic rate-limit header in subprocess output.
+_QUOTA_RE = re.compile(
+    r"(?:anthropic-ratelimit-tokens-remaining|x-ratelimit-remaining-tokens)"
+    r"[:\s]+(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _update_quota_cache(tokens_remaining: int) -> None:
+    global _quota_snapshot  # noqa: PLW0603
+    with _quota_lock:
+        _quota_snapshot = _QuotaSnapshot(
+            tokens_remaining=tokens_remaining,
+            captured_at=time.time(),
+        )
+
+
+def _get_quota_snapshot() -> Optional[_QuotaSnapshot]:
+    with _quota_lock:
+        return _quota_snapshot
+
+
+def _try_capture_quota_from_output(stdout: str, stderr: str) -> None:
+    """Best-effort scan of subprocess output for rate-limit token counts."""
+    for text in (stderr, stdout):
+        m = _QUOTA_RE.search(text)
+        if m:
+            try:
+                _update_quota_cache(int(m.group(1)))
+                return
+            except ValueError:
+                pass
 
 
 def _validate_task_id_for_path(task_id: str) -> bool:
@@ -1014,6 +1067,78 @@ def _parse_claude_json_output(stdout: str) -> dict:
 
 
 # --------------------------------------------------------------------------- #
+# Pod-status helpers (issue #395)
+# --------------------------------------------------------------------------- #
+
+
+def _find_active_lease(root: Path) -> Optional[dict]:
+    """Return the most recent alive lease found under *root*/<task_id>/.lease.json.
+
+    Security: exposes only task_id, heartbeat_at, pid — never the full
+    lease payload (no pod name, no prompts, nothing injectable).
+    """
+    now = time.time()
+    best: Optional[dict] = None
+    best_hb: float = 0.0
+    try:
+        children = list(root.iterdir())
+    except OSError:
+        return None
+    for child in children:
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if not _TASK_ID_RE.fullmatch(child.name):
+            continue
+        lease_path = child / ".lease.json"
+        if not lease_path.exists():
+            continue
+        try:
+            data = json.loads(lease_path.read_text(encoding="utf-8"))
+            hb = float(data.get("heartbeat_at", 0))
+            if (now - hb) < _LEASE_TTL_S and hb > best_hb:
+                best_hb = hb
+                best = {
+                    "task_id": child.name,
+                    "heartbeat_at": hb,
+                    "pid": data.get("pid"),
+                }
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    return best
+
+
+def _count_claude_processes() -> int:
+    """Count running claude processes via psutil (preferred) or pgrep fallback."""
+    try:
+        import psutil  # optional dep; absent outside cluster
+        count = 0
+        for proc in psutil.process_iter(["name", "cmdline"]):
+            try:
+                name = proc.info.get("name") or ""
+                cmdline = proc.info.get("cmdline") or []
+                if name.startswith("claude") or (
+                    cmdline and str(cmdline[0]).endswith("/claude")
+                ):
+                    count += 1
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return count
+    except ImportError:
+        pass
+    # Fallback via pgrep (POSIX).
+    try:
+        result = subprocess.run(
+            ["pgrep", "-fc", "^claude"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode in (0, 1):  # 1 = no processes found
+            return int(result.stdout.strip() or "0")
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        pass
+    return 0
+
+
+# --------------------------------------------------------------------------- #
 # Handlers
 # --------------------------------------------------------------------------- #
 
@@ -1033,6 +1158,56 @@ async def health_handler(request: web.Request) -> web.Response:
             status=500,
         )
     return web.json_response({"status": "ok", "claude_binary": claude_bin})
+
+
+async def pod_status_handler(request: web.Request) -> web.Response:
+    """``GET /v1/pod-status`` — introspection of this pod's own runtime state.
+
+    Returns a snapshot of:
+    - ``lease``:           active lease (task_id, heartbeat_at, pid) or null when idle.
+    - ``disk``:            PVC usage via shutil.disk_usage (no subprocess).
+    - ``claude_processes``: count of running claude processes.
+    - ``anthropic_quota``: last captured rate-limit tokens-remaining + timestamp,
+                           or null if never observed.
+    - ``ts``:              unix timestamp of this response.
+
+    Security: ``lease`` exposes ONLY task_id, heartbeat_at, and pid — no
+    prompt content, no credentials, nothing that could serve as an injection
+    vector.  Bearer auth required (same middleware as all other endpoints).
+    """
+    root = Path(os.environ.get("DEILE_CLAUDE_WORKER_ROOT", "/home/claude/work"))
+    disk_mount = os.environ.get("DEILE_CLAUDE_HOME", "/home/claude")
+
+    lease_info = await asyncio.to_thread(_find_active_lease, root)
+
+    try:
+        du = await asyncio.to_thread(shutil.disk_usage, disk_mount)
+        disk_info: dict = {
+            "used_bytes": du.used,
+            "total_bytes": du.total,
+            "mount": disk_mount,
+        }
+    except OSError as exc:
+        logger.warning("disk_usage(%s) failed: %s", disk_mount, exc)
+        disk_info = {"used_bytes": 0, "total_bytes": 0, "mount": disk_mount}
+
+    claude_procs = await asyncio.to_thread(_count_claude_processes)
+
+    quota_snap = _get_quota_snapshot()
+    quota_info: Optional[dict] = None
+    if quota_snap is not None:
+        quota_info = {
+            "tokens_remaining": quota_snap.tokens_remaining,
+            "captured_at": quota_snap.captured_at,
+        }
+
+    return web.json_response({
+        "lease": lease_info,
+        "disk": disk_info,
+        "claude_processes": claude_procs,
+        "anthropic_quota": quota_info,
+        "ts": time.time(),
+    })
 
 
 async def dispatch_handler(request: web.Request) -> web.Response:
@@ -1384,6 +1559,10 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     # verdade pra is_error, result, cost. Resolve Bug A do Opus de forma
     # estrutural (sem regex frágil no stdout livre).
     claude_result = _parse_claude_json_output(result.stdout)
+
+    # Best-effort quota capture (issue #395): scan stderr for rate-limit
+    # header values printed by claude CLI.  O(1) em memória — nunca bloqueia.
+    _try_capture_quota_from_output(result.stdout, result.stderr)
 
     # Detecção de auth expirado: estrutural (is_error=true + result contém
     # signature de auth) E fallback regex no stdout/stderr crus (pra casos
@@ -2017,6 +2196,7 @@ def build_app(auth_token: Optional[str] = None) -> web.Application:
     )
     app["auth_token"] = auth_token or _read_auth_token()
     app.router.add_get("/v1/health", health_handler)
+    app.router.add_get("/v1/pod-status", pod_status_handler)
     app.router.add_post("/v1/dispatch", dispatch_handler)
     app.router.add_get("/v1/progress/{task_id}", progress_handler)
     app.router.add_get(


### PR DESCRIPTION
## Summary

- Adds `GET /v1/pod-status` handler to `infra/k8s/claude_worker_server.py`, protected by the same Bearer auth middleware as other endpoints. Returns `{lease, disk, claude_processes, anthropic_quota, ts}`.
- Lease discovery scans `<worker-root>/<task_id>/.lease.json` applying the same TTL (`_LEASE_TTL_S`); only `task_id`, `heartbeat_at`, and `pid` are exposed (no injection vectors).
- Disk usage via `shutil.disk_usage` (no subprocess). Process count via `psutil` with `pgrep` fallback.
- Thread-safe `_QuotaSnapshot` singleton captures `anthropic-ratelimit-tokens-remaining` from subprocess output best-effort; `null` when never observed.
- New `ClaudeWorkerInfoProvider` in `infra/k8s/_panel_data.py`: TTL 3s, timeout 2s, graceful fallback with `last_error`.
- `PodWatchView._header_body` injects LEASE / DISK / QUOTA lines only when `pod.role == "claude-worker"` — no impact on other roles.
- 5 new tests for `/v1/pod-status` (active lease, idle, stale TTL, payload redaction, auth required). All 286 impacted tests pass.

Closes #395.