### PR TITLE
feat(#394): PodWatch RESOURCES header — mem/cpu, OOM history, endpoint status

### DIFF
--- a/deile/tests/infrastructure/test_pod_watch_resources.py
+++ b/deile/tests/infrastructure/test_pod_watch_resources.py
@@ -1,0 +1,478 @@
+"""Tests para PodWatch RESOURCES header — issue #394.
+
+Cobre:
+- PodMetricsProvider: parse de `kubectl top pod`, degradação sem metrics-server
+- PodsProvider: extração de OOM history e resource limits
+- EndpointProbeProvider: mapeamento de pods para services
+- PodWatchView: renderização das linhas RESOURCES e ENDPOINT
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixture: carrega _panel_data dinamicamente (mesmo padrão do
+# test_claude_worker_server.py).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def panel_data_mod():
+    repo_root = Path(__file__).resolve().parents[3]
+    mod_path = repo_root / "infra" / "k8s" / "_panel_data.py"
+    spec = importlib.util.spec_from_file_location("_panel_data_under_test", str(mod_path))
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_panel_data_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def panel_mod(panel_data_mod):
+    """Carrega _panel.py com _panel_data já no sys.modules."""
+    repo_root = Path(__file__).resolve().parents[3]
+    infra_k8s = str(repo_root / "infra" / "k8s")
+    # _panel.py importa `_panel_data` e `_panel_demo` por nome curto —
+    # precisamos que infra/k8s esteja no sys.path para que os módulos
+    # sejam encontrados no import normal.
+    if infra_k8s not in sys.path:
+        sys.path.insert(0, infra_k8s)
+    # Inject our dynamically loaded panel_data_mod for the duration of
+    # exec_module, then restore the previous value so other test modules
+    # that use 'from _panel_data import ...' inline don't get confused.
+    prev_panel_data = sys.modules.get("_panel_data")
+    sys.modules["_panel_data"] = panel_data_mod
+    mod_path = repo_root / "infra" / "k8s" / "_panel.py"
+    spec = importlib.util.spec_from_file_location("_panel_under_test", str(mod_path))
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_panel_under_test"] = mod
+    spec.loader.exec_module(mod)
+    # Restore so other tests' `from _panel_data import X` get the real module.
+    if prev_panel_data is None:
+        sys.modules.pop("_panel_data", None)
+    else:
+        sys.modules["_panel_data"] = prev_panel_data
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pod_item(name="deile-worker-abc", app="deile-worker",
+              phase="Running", node="node1",
+              container_statuses=None, containers=None):
+    cs = container_statuses or [{"ready": True, "restartCount": 0}]
+    c = containers or [{}]
+    return {
+        "metadata": {
+            "name": name,
+            "labels": {"app": app},
+        },
+        "spec": {
+            "nodeName": node,
+            "containers": c,
+        },
+        "status": {
+            "phase": phase,
+            "startTime": "2026-01-01T00:00:00Z",
+            "containerStatuses": cs,
+        },
+    }
+
+
+def _get_pods_json(*items):
+    return json.dumps({"items": list(items)})
+
+
+def _get_endpoints_json(*items):
+    return json.dumps({"items": list(items)})
+
+
+def _kubectl_top_output(*rows):
+    return "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# PodMetricsProvider
+# ---------------------------------------------------------------------------
+
+def test_pod_metrics_provider_parses_kubectl_top_output(panel_data_mod):
+    pmp = panel_data_mod.PodMetricsProvider(enabled=True)
+    pmp._kubectl = "/usr/bin/kubectl"
+
+    top_text = _kubectl_top_output(
+        "deile-worker-abc   230m   412Mi",
+        "deile-pipeline-xyz  50m   128Mi",
+    )
+
+    with patch.object(panel_data_mod, "_capture_text", return_value=top_text):
+        result = pmp._fetch()
+
+    assert "deile-worker-abc" in result
+    cpu_mc, mem_b = result["deile-worker-abc"]
+    assert cpu_mc == 230
+    assert mem_b == 412 * 1024 ** 2
+
+    assert "deile-pipeline-xyz" in result
+    cpu_mc2, mem_b2 = result["deile-pipeline-xyz"]
+    assert cpu_mc2 == 50
+    assert mem_b2 == 128 * 1024 ** 2
+
+
+def test_pod_metrics_provider_degrades_gracefully_when_metrics_server_absent(panel_data_mod):
+    """Quando `kubectl top` falha (exit≠0 → _capture_text devolve None),
+    a exceção é capturada pelo Cache e o provider retorna {}."""
+    pmp = panel_data_mod.PodMetricsProvider(enabled=True)
+    pmp._kubectl = "/usr/bin/kubectl"
+
+    with patch.object(panel_data_mod, "_capture_text", return_value=None):
+        with pytest.raises(RuntimeError, match="kubectl top pod falhou"):
+            pmp._fetch()
+
+    # Via cache (fallback): não lança
+    result = pmp.get()   # cold-start: chama _fetch → captura → retorna {}
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# PodsProvider — OOM history
+# ---------------------------------------------------------------------------
+
+def test_pods_provider_extracts_oom_killed_from_last_state(panel_data_mod):
+    oom_cs = [
+        {
+            "ready": True,
+            "restartCount": 3,
+            "lastState": {
+                "terminated": {
+                    "reason": "OOMKilled",
+                    "finishedAt": "2026-05-01T10:00:00Z",
+                },
+            },
+            "state": {"running": {}},
+        }
+    ]
+    item = _pod_item(container_statuses=oom_cs)
+    pods_json = _get_pods_json(item)
+
+    provider = panel_data_mod.PodsProvider(enabled=True)
+    provider._kubectl = "/usr/bin/kubectl"
+
+    with patch.object(panel_data_mod, "_capture_json",
+                      return_value=json.loads(pods_json)):
+        pods = provider._fetch()
+
+    assert len(pods) == 1
+    pod = pods[0]
+    assert pod.oom_killed_count == 1
+    assert pod.last_oom_at is not None
+    assert pod.last_oom_at.year == 2026
+
+
+def test_pods_provider_no_oom_when_clean(panel_data_mod):
+    item = _pod_item(container_statuses=[{"ready": True, "restartCount": 0}])
+    provider = panel_data_mod.PodsProvider(enabled=True)
+    provider._kubectl = "/usr/bin/kubectl"
+
+    with patch.object(panel_data_mod, "_capture_json",
+                      return_value={"items": [item]}):
+        pods = provider._fetch()
+
+    assert pods[0].oom_killed_count == 0
+    assert pods[0].last_oom_at is None
+
+
+# ---------------------------------------------------------------------------
+# PodsProvider — resource limits
+# ---------------------------------------------------------------------------
+
+def test_pods_provider_extracts_resource_limits(panel_data_mod):
+    containers = [
+        {
+            "name": "app",
+            "resources": {
+                "limits": {"cpu": "2", "memory": "6Gi"},
+            },
+        }
+    ]
+    item = _pod_item(containers=containers)
+    provider = panel_data_mod.PodsProvider(enabled=True)
+    provider._kubectl = "/usr/bin/kubectl"
+
+    with patch.object(panel_data_mod, "_capture_json",
+                      return_value={"items": [item]}):
+        pods = provider._fetch()
+
+    pod = pods[0]
+    assert pod.cpu_limit_millicores == 2000
+    assert pod.mem_limit_bytes == 6 * 1024 ** 3
+
+
+def test_pods_provider_no_limits_when_unset(panel_data_mod):
+    item = _pod_item(containers=[{"name": "app", "resources": {}}])
+    provider = panel_data_mod.PodsProvider(enabled=True)
+    provider._kubectl = "/usr/bin/kubectl"
+
+    with patch.object(panel_data_mod, "_capture_json",
+                      return_value={"items": [item]}):
+        pods = provider._fetch()
+
+    pod = pods[0]
+    assert pod.cpu_limit_millicores is None
+    assert pod.mem_limit_bytes is None
+
+
+# ---------------------------------------------------------------------------
+# EndpointProbeProvider
+# ---------------------------------------------------------------------------
+
+def test_endpoint_probe_provider_maps_pods_to_services(panel_data_mod):
+    ep_item = {
+        "metadata": {"name": "deile-worker"},
+        "subsets": [
+            {
+                "addresses": [
+                    {
+                        "ip": "10.0.0.1",
+                        "targetRef": {"kind": "Pod", "name": "deile-worker-abc"},
+                    },
+                    {
+                        "ip": "10.0.0.2",
+                        "targetRef": {"kind": "Pod", "name": "deile-worker-xyz"},
+                    },
+                ],
+            }
+        ],
+    }
+    ep_json = {"items": [ep_item]}
+
+    provider = panel_data_mod.EndpointProbeProvider(enabled=True)
+    provider._kubectl = "/usr/bin/kubectl"
+
+    with patch.object(panel_data_mod, "_capture_json", return_value=ep_json):
+        result = provider._fetch()
+
+    assert "deile-worker" in result.ready
+    assert "deile-worker-abc" in result.ready["deile-worker"]
+    assert "deile-worker-xyz" in result.ready["deile-worker"]
+
+
+def test_endpoint_probe_provider_empty_when_no_subsets(panel_data_mod):
+    ep_item = {"metadata": {"name": "deile-worker"}, "subsets": []}
+    provider = panel_data_mod.EndpointProbeProvider(enabled=True)
+    provider._kubectl = "/usr/bin/kubectl"
+
+    with patch.object(panel_data_mod, "_capture_json",
+                      return_value={"items": [ep_item]}):
+        result = provider._fetch()
+
+    assert result.ready.get("deile-worker", set()) == set()
+
+
+# ---------------------------------------------------------------------------
+# PodWatchView — RESOURCES line rendering
+# ---------------------------------------------------------------------------
+
+def _make_pod(panel_data_mod, name="deile-worker-abc", role="worker",
+              cpu_mc=230, mem_b=412*1024**2,
+              cpu_lim=2000, mem_lim=6*1024**3,
+              oom_count=0, last_oom_at=None):
+    pod = panel_data_mod.PodInfo(
+        name=name,
+        role=role,
+        status="Running",
+        ready=True,
+        restarts=0,
+        age_s=3600.0,
+        started_at=None,
+        node="node1",
+        oom_killed_count=oom_count,
+        last_oom_at=last_oom_at,
+        cpu_limit_millicores=cpu_lim,
+        mem_limit_bytes=mem_lim,
+        cpu_millicores=cpu_mc,
+        mem_bytes=mem_b,
+    )
+    return pod
+
+
+def _make_panel_data_mock(panel_data_mod, pod, metrics_map=None, endpoints_map=None):
+    """Constrói um PanelData mock com pods, pod_metrics e endpoints."""
+    mock_data = MagicMock()
+    mock_data.pods.get.return_value = [pod]
+    mock_data.workers.get.return_value = {}
+
+    metrics = metrics_map if metrics_map is not None else {
+        pod.name: (pod.cpu_millicores, pod.mem_bytes)
+    }
+    mock_data.pod_metrics.get.return_value = metrics
+
+    if endpoints_map is not None:
+        ep = panel_data_mod.EndpointInfo(ready=endpoints_map, not_ready={})
+    else:
+        ep = panel_data_mod.EndpointInfo(
+            ready={"deile-worker": {pod.name}}, not_ready={}
+        )
+    mock_data.endpoints.get.return_value = ep
+    return mock_data
+
+
+def test_pod_watch_view_renders_resources_line(panel_mod, panel_data_mod):
+    pod = _make_pod(panel_data_mod)
+    mock_data = _make_panel_data_mock(panel_data_mod, pod)
+
+    view = panel_mod.PodWatchView(data=mock_data)
+    view.pod_name = pod.name
+    view.pod_role = pod.role
+
+    renderable = view._header_body()
+    from rich.console import Console
+    console = Console(width=200)
+    with console.capture() as cap:
+        console.print(renderable)
+    text = cap.get()
+
+    assert "RESOURCES" in text
+    assert "mem" in text
+    assert "cpu" in text
+    assert "no OOM history" in text
+
+
+def test_pod_watch_view_renders_oom_history_in_red(panel_mod, panel_data_mod):
+    last_oom = datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc)
+    pod = _make_pod(panel_data_mod, oom_count=3, last_oom_at=last_oom)
+    mock_data = _make_panel_data_mock(panel_data_mod, pod)
+
+    view = panel_mod.PodWatchView(data=mock_data)
+    view.pod_name = pod.name
+    view.pod_role = pod.role
+
+    renderable = view._header_body()
+    from rich.console import Console
+    console = Console(width=200)
+    with console.capture() as cap:
+        console.print(renderable)
+    text = cap.get()
+
+    assert "OOM" in text
+    assert "×3" in text
+
+
+def test_pod_watch_view_renders_endpoint_not_ready(panel_mod, panel_data_mod):
+    pod = _make_pod(panel_data_mod, role="worker")
+    # pod NOT in endpoint ready set
+    mock_data = _make_panel_data_mock(
+        panel_data_mod, pod,
+        endpoints_map={"deile-worker": set()},
+    )
+
+    view = panel_mod.PodWatchView(data=mock_data)
+    view.pod_name = pod.name
+    view.pod_role = pod.role
+
+    renderable = view._header_body()
+    from rich.console import Console
+    console = Console(width=200)
+    with console.capture() as cap:
+        console.print(renderable)
+    text = cap.get()
+
+    assert "ENDPOINT" in text
+    assert "NOT in Service" in text
+
+
+def test_pod_watch_view_omits_endpoint_line_when_pod_in_endpoints(panel_mod, panel_data_mod):
+    pod = _make_pod(panel_data_mod, role="worker")
+    mock_data = _make_panel_data_mock(
+        panel_data_mod, pod,
+        endpoints_map={"deile-worker": {pod.name}},
+    )
+
+    view = panel_mod.PodWatchView(data=mock_data)
+    view.pod_name = pod.name
+    view.pod_role = pod.role
+
+    renderable = view._header_body()
+    from rich.console import Console
+    console = Console(width=200)
+    with console.capture() as cap:
+        console.print(renderable)
+    text = cap.get()
+
+    assert "ENDPOINT" not in text
+
+
+def test_pod_watch_view_omits_endpoint_line_for_pipeline(panel_mod, panel_data_mod):
+    pod = _make_pod(panel_data_mod, role="pipeline", name="deile-pipeline-abc")
+    mock_data = _make_panel_data_mock(panel_data_mod, pod, endpoints_map={})
+
+    view = panel_mod.PodWatchView(data=mock_data)
+    view.pod_name = pod.name
+    view.pod_role = pod.role
+
+    renderable = view._header_body()
+    from rich.console import Console
+    console = Console(width=200)
+    with console.capture() as cap:
+        console.print(renderable)
+    text = cap.get()
+
+    assert "ENDPOINT" not in text
+
+
+def test_pod_watch_view_shows_dim_metrics_when_kubectl_top_unavailable(panel_mod, panel_data_mod):
+    """Quando metrics-server ausente (metrics_map vazio), mostra '?' sem crashar."""
+    pod = _make_pod(panel_data_mod, cpu_mc=None, mem_b=None)
+    # metrics_map empty → no data for this pod
+    mock_data = _make_panel_data_mock(panel_data_mod, pod, metrics_map={})
+
+    view = panel_mod.PodWatchView(data=mock_data)
+    view.pod_name = pod.name
+    view.pod_role = pod.role
+
+    renderable = view._header_body()
+    from rich.console import Console
+    console = Console(width=200)
+    with console.capture() as cap:
+        console.print(renderable)
+    text = cap.get()
+
+    assert "RESOURCES" in text
+    assert "?" in text
+
+
+# ---------------------------------------------------------------------------
+# Helper function unit tests
+# ---------------------------------------------------------------------------
+
+def test_parse_cpu(panel_data_mod):
+    assert panel_data_mod._parse_cpu("230m") == 230
+    assert panel_data_mod._parse_cpu("2") == 2000
+    assert panel_data_mod._parse_cpu("0.5") == 500
+    assert panel_data_mod._parse_cpu("") is None
+    assert panel_data_mod._parse_cpu("badval") is None
+
+
+def test_parse_mem(panel_data_mod):
+    assert panel_data_mod._parse_mem("412Mi") == 412 * 1024 ** 2
+    assert panel_data_mod._parse_mem("6Gi") == 6 * 1024 ** 3
+    assert panel_data_mod._parse_mem("1024Ki") == 1024 * 1024
+    assert panel_data_mod._parse_mem("1024") == 1024
+    assert panel_data_mod._parse_mem("") is None
+
+
+def test_pct(panel_data_mod):
+    assert panel_data_mod._pct(50, 100) == pytest.approx(50.0)
+    assert panel_data_mod._pct(None, 100) is None
+    assert panel_data_mod._pct(50, 0) is None
+    assert panel_data_mod._pct(50, None) is None

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -59,6 +59,8 @@ import _panel_demo as demo  # noqa: E402
 from _panel_data import \
     NS as _NS_DEFAULT  # noqa: F401  # PR #315 — multi-namespace
 from _panel_data import _fmt_age  # noqa: F401
+from _panel_data import _fmt_cpu_display, _fmt_mem_display, _pct  # noqa: F401
+from _panel_data import EndpointInfo  # noqa: F401
 from _panel_data import kubectl_bin  # noqa: F401
 from _panel_data import BackgroundRefresher, PanelData  # noqa: F401
 from _panel_data import \
@@ -1577,6 +1579,14 @@ class PodWatchView(View):
         "shell":    "deile-shell",
     }
 
+    # Roles com Service associado (issue #394): usados para decidir se a
+    # linha ENDPOINT deve aparecer no header.  Roles ausentes (pipeline,
+    # shell) não têm Service → linha omitida.
+    _ROLE_TO_SERVICE = {
+        "worker": "deile-worker",
+        "bot":    "deilebot",
+    }
+
     def __init__(self, data: Optional[PanelData] = None):
         self.data = data
         self.pod_name: str = ""
@@ -1641,6 +1651,11 @@ class PodWatchView(View):
             return Text(f"pod `{self.pod_name}` não encontrado.", style="red")
         wstate = self.data.workers.get().get(self.pod_name) \
             if self.pod_role == "worker" else None
+        # Fetch live metrics (graceful: empty dict when metrics-server absent).
+        _raw_metrics = self.data.pod_metrics.get() if hasattr(self.data, "pod_metrics") else {}
+        metrics_map = _raw_metrics if isinstance(_raw_metrics, dict) else {}
+        live_cpu, live_mem = metrics_map.get(pod.name, (None, None))
+
         lines = [
             Text.assemble(
                 ("name: ", "dim"), (pod.name, "bold"),
@@ -1659,6 +1674,67 @@ class PodWatchView(View):
                 ("   node: ", "dim"), (pod.node or "?", "dim"),
             ),
         ]
+
+        # RESOURCES line (issue #394) — shown for all k8s pods.
+        # Extract typed fields defensively: tests may use MagicMock for pod.
+        _mem_lim = pod.mem_limit_bytes if isinstance(pod.mem_limit_bytes, int) else None
+        _cpu_lim = pod.cpu_limit_millicores if isinstance(pod.cpu_limit_millicores, int) else None
+        _oom_count = pod.oom_killed_count if isinstance(pod.oom_killed_count, int) else 0
+        _last_oom = pod.last_oom_at if isinstance(pod.last_oom_at, datetime) else None
+
+        mem_pct = _pct(live_mem, _mem_lim)
+        cpu_pct = _pct(live_cpu, _cpu_lim)
+
+        def _resource_style(pct: Optional[float]) -> str:
+            if pct is None:
+                return "bold green"
+            if pct >= 85:
+                return "bold red"
+            if pct >= 60:
+                return "bold yellow"
+            return "bold green"
+
+        mem_used_str = _fmt_mem_display(live_mem)
+        mem_lim_str = _fmt_mem_display(_mem_lim)
+        cpu_used_str = _fmt_cpu_display(live_cpu)
+        cpu_lim_str = _fmt_cpu_display(_cpu_lim)
+        mem_pct_str = f" ({mem_pct:.1f}%)" if mem_pct is not None else ""
+        cpu_pct_str = f" ({cpu_pct:.1f}%)" if cpu_pct is not None else ""
+        mem_style = _resource_style(mem_pct) if live_mem is not None else "dim"
+        cpu_style = _resource_style(cpu_pct) if live_cpu is not None else "dim"
+
+        oom_style = "bold red" if _oom_count > 0 else "dim green"
+        if _oom_count > 0 and _last_oom is not None:
+            now_utc = datetime.now(timezone.utc)
+            oom_ago_s = (now_utc - _last_oom).total_seconds()
+            oom_str = (f"last OOM {_fmt_age(oom_ago_s)} ago "
+                       f"(×{_oom_count})")
+        elif _oom_count > 0:
+            oom_str = f"×{_oom_count} OOM"
+        else:
+            oom_str = "★ no OOM history"
+
+        lines.append(Text.assemble(
+            ("RESOURCES: ", "dim"),
+            ("mem ", "dim"),
+            (f"{mem_used_str}/{mem_lim_str}{mem_pct_str}", mem_style),
+            ("  cpu ", "dim"),
+            (f"{cpu_used_str}/{cpu_lim_str}{cpu_pct_str}", cpu_style),
+            ("   ", ""),
+            (oom_str, oom_style),
+        ))
+
+        # ENDPOINT line: only for pods with an associated Service.
+        svc_name = self._ROLE_TO_SERVICE.get(pod.role)
+        if svc_name is not None and hasattr(self.data, "endpoints"):
+            ep_info = self.data.endpoints.get()
+            if isinstance(ep_info, EndpointInfo) and not ep_info.is_ready(svc_name, pod.name):
+                lines.append(Text.assemble(
+                    ("ENDPOINT: ", "dim"),
+                    (f"NOT in Service endpoints "
+                     f"(kubectl get endpoints {svc_name})", "bold red"),
+                ))
+
         if wstate is not None:
             lines.append(Text.assemble(
                 ("worker: ", "dim"),
@@ -1774,17 +1850,17 @@ class PodWatchView(View):
 
     def render(self, app: "PanelApp") -> RenderableType:
         layout = Layout()
-        # ``size=7`` acomoda 4 linhas de header + bordas do Panel + título
-        # ([1] name/role/status + [2] uptime/restarts/ready/node + [3]
-        # worker/last activity + [4] current task — issue #309 fase 2).
-        # Workers idle ou pods não-worker mostram menos linhas; o Panel
-        # auto-encolhe sem corte porque o size é teto, não piso.
+        # ``size=9`` acomoda até 6 linhas de header + bordas do Panel + título
+        # ([1] name/role/status + [2] uptime/restarts/ready/node +
+        # [3] RESOURCES + [4] ENDPOINT (conditional) +
+        # [5] worker/last activity + [6] current task).
+        # Pods sem worker ou sem ENDPOINT mostram menos linhas.
         layout.split_column(
             Layout(_head_panel(self.title, app), name="head", size=4),
             Layout(Panel(self._header_body(),
                          title="[bold]POD[/bold]", title_align="left",
                          border_style="cyan"),
-                   name="info", size=7),
+                   name="info", size=9),
             Layout(self._log_panel(), name="log"),
             Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
         )

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -48,7 +48,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Optional, Set, Tuple, TypeVar
 
 T = TypeVar("T")
 
@@ -592,6 +592,72 @@ def _fmt_age(seconds: Optional[float]) -> str:
     return f"{s // 86400}d"
 
 
+# ===== Resource / metrics helpers ==========================================
+
+_MEM_SUFFIXES: Dict[str, int] = {
+    "Ki": 1024,
+    "Mi": 1024 ** 2,
+    "Gi": 1024 ** 3,
+    "Ti": 1024 ** 4,
+    "K":  1000,
+    "M":  1000 ** 2,
+    "G":  1000 ** 3,
+}
+
+
+def _parse_cpu(s: str) -> Optional[int]:
+    """'230m' → 230 (millicores); '2' → 2000."""
+    if not s:
+        return None
+    if s.endswith("m"):
+        try:
+            return int(s[:-1])
+        except ValueError:
+            return None
+    try:
+        return int(float(s) * 1000)
+    except ValueError:
+        return None
+
+
+def _parse_mem(s: str) -> Optional[int]:
+    """'412Mi' → bytes.  Supports Ki/Mi/Gi/Ti and K/M/G."""
+    if not s:
+        return None
+    for suffix, mult in _MEM_SUFFIXES.items():
+        if s.endswith(suffix):
+            try:
+                return int(s[: -len(suffix)]) * mult
+            except ValueError:
+                return None
+    try:
+        return int(s)
+    except ValueError:
+        return None
+
+
+def _fmt_mem_display(b: Optional[int]) -> str:
+    if not isinstance(b, int):
+        return "?"
+    if b >= 1024 ** 3:
+        return f"{b / 1024 ** 3:.1f}Gi"
+    if b >= 1024 ** 2:
+        return f"{b // 1024 ** 2}Mi"
+    if b >= 1024:
+        return f"{b // 1024}Ki"
+    return f"{b}B"
+
+
+def _fmt_cpu_display(mc: Optional[int]) -> str:
+    return "?" if not isinstance(mc, int) else f"{mc}m"
+
+
+def _pct(used: Optional[int], limit: Optional[int]) -> Optional[float]:
+    if not isinstance(used, int) or not isinstance(limit, int) or limit == 0:
+        return None
+    return used / limit * 100
+
+
 # ===== Pods provider ========================================================
 
 @dataclass
@@ -604,6 +670,15 @@ class PodInfo:
     age_s: float
     started_at: Optional[datetime]
     node: str = ""
+    # OOM history (populated from containerStatuses[].lastState.terminated)
+    oom_killed_count: int = 0
+    last_oom_at: Optional[datetime] = None
+    # Resource limits from spec.containers[].resources.limits (aggregated)
+    cpu_limit_millicores: Optional[int] = None
+    mem_limit_bytes: Optional[int] = None
+    # Live usage from kubectl top pod (injected by PodMetricsProvider)
+    cpu_millicores: Optional[int] = None
+    mem_bytes: Optional[int] = None
 
 
 _ROLE_BY_APP = {
@@ -658,6 +733,36 @@ class PodsProvider(_KubectlProviderMixin):
             restarts = sum(cs.get("restartCount", 0) for cs in container_statuses)
             started_at = _parse_k8s_ts(status.get("startTime"))
             age_s = (now - started_at).total_seconds() if started_at else 0.0
+
+            # OOM history: aggregate across all containers.
+            oom_count = 0
+            last_oom: Optional[datetime] = None
+            for cs in container_statuses:
+                for state_block in (
+                    cs.get("lastState", {}).get("terminated", {}),
+                    cs.get("state", {}).get("terminated", {}),
+                ):
+                    if state_block.get("reason") == "OOMKilled":
+                        oom_count += 1
+                        fin = _parse_k8s_ts(state_block.get("finishedAt"))
+                        if fin is not None and (
+                            last_oom is None or fin > last_oom
+                        ):
+                            last_oom = fin
+
+            # Resource limits: aggregate across all containers.
+            containers = item.get("spec", {}).get("containers", []) or []
+            cpu_limit_total = 0
+            mem_limit_total = 0
+            for c in containers:
+                lims = c.get("resources", {}).get("limits", {})
+                cpu_val = _parse_cpu(lims.get("cpu", ""))
+                mem_val = _parse_mem(lims.get("memory", ""))
+                if cpu_val is not None:
+                    cpu_limit_total += cpu_val
+                if mem_val is not None:
+                    mem_limit_total += mem_val
+
             rows.append(PodInfo(
                 name=meta.get("name", "?"),
                 role=role,
@@ -667,6 +772,10 @@ class PodsProvider(_KubectlProviderMixin):
                 age_s=age_s,
                 started_at=started_at,
                 node=item.get("spec", {}).get("nodeName", ""),
+                oom_killed_count=oom_count,
+                last_oom_at=last_oom,
+                cpu_limit_millicores=cpu_limit_total if cpu_limit_total else None,
+                mem_limit_bytes=mem_limit_total if mem_limit_total else None,
             ))
         # Ordem estável: pipeline > worker > bot > shell > outros, por nome.
         order = {"pipeline": 0, "worker": 1, "bot": 2, "shell": 3, "other": 4}
@@ -4364,6 +4473,144 @@ class LocalRegistryProvider:
                                 instances=len(raw_entries))
 
 
+# ===== Pod metrics provider (kubectl top pod) ================================
+
+class PodMetricsProvider(_KubectlProviderMixin):
+    """Live CPU/memory usage per pod via `kubectl top pod`.
+
+    TTL 5s — metrics-server scrape interval is 15s; no benefit from more
+    frequent polling. Returns Dict[pod_name, (cpu_m, mem_b)]. Fails
+    gracefully when metrics-server is absent (callers show dim '?').
+    """
+
+    def __init__(self, ttl_s: float = 5.0, namespace: str = NS,
+                 enabled: bool = True):
+        self._kubectl = kubectl_bin()
+        self._namespace = namespace
+        self._enabled = enabled
+        self._cache: Cache[Dict[str, tuple]] = Cache(
+            ttl_s, self._fetch, fallback={},
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> Dict[str, tuple]:
+        return self._cache.get(force)
+
+    def _fetch(self) -> Dict[str, tuple]:
+        self._check_enabled()
+        self._resolve_kubectl()
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        out = _capture_text(
+            [self._kubectl, "-n", self._namespace, "top", "pod", "--no-headers"],
+            timeout=8.0,
+        )
+        if out is None:
+            raise RuntimeError("kubectl top pod falhou (metrics-server ausente?)")
+        return self._parse_top_output(out)
+
+    @staticmethod
+    def _parse_top_output(text: str) -> Dict[str, tuple]:
+        result: Dict[str, tuple] = {}
+        for line in text.splitlines():
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            name, cpu_s, mem_s = parts[0], parts[1], parts[2]
+            result[name] = (_parse_cpu(cpu_s), _parse_mem(mem_s))
+        return result
+
+
+# ===== Endpoint probe provider (kubectl get endpoints) =======================
+
+@dataclass
+class EndpointInfo:
+    """Ready/not-ready pod names per Service in the namespace."""
+    ready: Dict[str, set]       # service_name -> set of ready pod names
+    not_ready: Dict[str, set]   # service_name -> set of not-ready pod names
+
+    def service_for_pod(self, pod_name: str) -> Optional[str]:
+        """Service name if pod appears in any endpoint subset, else None."""
+        for svc, pods in self.ready.items():
+            if pod_name in pods:
+                return svc
+        for svc, pods in self.not_ready.items():
+            if pod_name in pods:
+                return svc
+        return None
+
+    def is_ready(self, service: str, pod_name: str) -> bool:
+        return pod_name in self.ready.get(service, set())
+
+    @staticmethod
+    def empty() -> "EndpointInfo":
+        return EndpointInfo(ready={}, not_ready={})
+
+
+class EndpointProbeProvider(_KubectlProviderMixin):
+    """Single `kubectl get endpoints -o json` -> EndpointInfo (TTL 3s).
+
+    Builds ready/not-ready pod-name sets per Service. Pods that don't
+    appear in any endpoint (e.g. deile-pipeline) return None from
+    service_for_pod — the view omits the ENDPOINT line for them.
+    """
+
+    def __init__(self, ttl_s: float = 3.0, namespace: str = NS,
+                 enabled: bool = True):
+        self._kubectl = kubectl_bin()
+        self._namespace = namespace
+        self._enabled = enabled
+        self._cache: Cache[EndpointInfo] = Cache(
+            ttl_s, self._fetch, fallback=EndpointInfo.empty(),
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> EndpointInfo:
+        return self._cache.get(force)
+
+    def _fetch(self) -> EndpointInfo:
+        self._check_enabled()
+        self._resolve_kubectl()
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        data = _capture_json(
+            [self._kubectl, "-n", self._namespace, "get", "endpoints", "-o", "json"],
+            timeout=5.0,
+        )
+        if data is None:
+            raise RuntimeError("kubectl get endpoints falhou")
+        return self._parse_endpoints(data)
+
+    @staticmethod
+    def _parse_endpoints(data: Any) -> EndpointInfo:
+        ready: Dict[str, set] = {}
+        not_ready: Dict[str, set] = {}
+        for item in data.get("items", []):
+            svc = item.get("metadata", {}).get("name", "")
+            if not svc:
+                continue
+            for subset in (item.get("subsets") or []):
+                for addr in (subset.get("addresses") or []):
+                    ref = addr.get("targetRef", {})
+                    if ref.get("kind") == "Pod":
+                        pod = ref.get("name", "")
+                        if pod:
+                            ready.setdefault(svc, set()).add(pod)
+                for addr in (subset.get("notReadyAddresses") or []):
+                    ref = addr.get("targetRef", {})
+                    if ref.get("kind") == "Pod":
+                        pod = ref.get("name", "")
+                        if pod:
+                            not_ready.setdefault(svc, set()).add(pod)
+        return EndpointInfo(ready=ready, not_ready=not_ready)
+
+
 # ===== Aggregate hub ========================================================
 
 @dataclass
@@ -4394,6 +4641,9 @@ class PanelData:
     # ``DispatchMatrixView`` (hotkey [d]). TTL 3s.
     stage_dispatch: "StageDispatchProvider"
     notifier: NotifierProvider
+    # PodWatch RESOURCES header (issue #394).
+    pod_metrics: PodMetricsProvider
+    endpoints: EndpointProbeProvider
     local_processes: Optional[LocalProcessesProvider] = None
     local_logs: Optional[LocalLogsProvider] = None
     local_audit: Optional[LocalAuditProvider] = None
@@ -4482,6 +4732,10 @@ class PanelData:
             notifier=NotifierProvider(namespace=context.namespace,
                                       deploy=context.bot_deploy,
                                       enabled=k8s_on),
+            pod_metrics=PodMetricsProvider(namespace=context.namespace,
+                                           enabled=k8s_on),
+            endpoints=EndpointProbeProvider(namespace=context.namespace,
+                                            enabled=k8s_on),
             local_processes=local_procs,
             local_logs=local_logs,
             local_audit=local_audit,
@@ -4499,7 +4753,7 @@ class PanelData:
         base = (self.pods, self.pipeline, self.workers, self.github,
                 self.costs, self.models, self.current_model,
                 self.stage_models, self.dispatch_mode, self.stage_dispatch,
-                self.notifier)
+                self.notifier, self.pod_metrics, self.endpoints)
         locals_ = tuple(p for p in (self.local_processes, self.local_logs,
                                     self.local_audit, self.local_instances,
                                     self.local_registry)
@@ -4525,7 +4779,8 @@ class PanelData:
         """
         names = ["pods", "pipeline", "workers", "github", "costs",
                  "models", "current_model", "stage_models",
-                 "dispatch_mode", "stage_dispatch", "notifier"]
+                 "dispatch_mode", "stage_dispatch", "notifier",
+                 "pod_metrics", "endpoints"]
         if self.local_processes is not None:
             names.append("local_processes")
         if self.local_logs is not None:
@@ -4542,8 +4797,10 @@ class PanelData:
             if not err:
                 continue
             # "k8s desabilitado" e "kubectl não encontrado" são esperados —
-            # não viram alerta.
-            if "k8s desabilitado" in err or "kubectl não encontrado" in err:
+            # não viram alerta. "kubectl top pod falhou" indica metrics-server
+            # ausente — também esperado em clusters sem metrics-server.
+            if ("k8s desabilitado" in err or "kubectl não encontrado" in err
+                    or "kubectl top pod falhou" in err):
                 continue
             out.append((name, err))
         return out


### PR DESCRIPTION
## Summary

- Adds `RESOURCES` line to `PodWatchView._header_body` for all k8s pods: live mem/CPU vs limits with color-coded thresholds (green/yellow/red at 60%/85%), OOM killed count + timestamp, and conditional `ENDPOINT` line when pod is absent from its Service's ready endpoints
- New `PodMetricsProvider` in `_panel_data.py`: `kubectl top pod --no-headers` with TTL 5s, graceful fallback to `{}` when metrics-server absent
- New `EndpointProbeProvider` + `EndpointInfo` dataclass: single `kubectl get endpoints -o json` with TTL 3s, tracking ready/not-ready pod sets per Service
- `PodInfo` gains `oom_killed_count`, `last_oom_at`, `cpu_limit_millicores`, `mem_limit_bytes` populated by `PodsProvider` from `containerStatuses[].lastState.terminated` and `spec.containers[].resources.limits`
- `PanelData` wired with both new providers; error suppression extended for `kubectl top pod falhou` (metrics-server absent is expected)
- Layout size `info` raised from 7→9 to accommodate the additional lines
- Defensive `isinstance` guards in helper functions and view code prevent `TypeError` when `pod` is a `MagicMock` in existing tests

## Test plan

- [x] 17 new tests in `deile/tests/infrastructure/test_pod_watch_resources.py` covering all new providers, OOM extraction, resource limits, and view rendering
- [x] All pre-existing `deile/tests/infra/test_panel_pod_watch.py` tests pass (67/67 together with new tests)
- [x] 6 pre-existing failures in `test_dispatch_matrix_*` and `test_panel_cost_cap.py` are unrelated to this PR (verified on main)

Closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)