### PR TITLE
feat(panel): enrich PodWatchView header with WORK and LAST_COMPLETED lines

### DIFF
--- a/deile/tests/infra/test_panel_pod_watch.py
+++ b/deile/tests/infra/test_panel_pod_watch.py
@@ -638,6 +638,7 @@ class TestPodWatchViewCurrentTask:
         wstate = pd.WorkerState(pod_name=view.pod_name, busy=busy,
                                 current_task=current_task)
         view.data.workers.get.return_value = {view.pod_name: wstate}
+        view.data.claude_workers = None
         return view
 
     def _render_to_text(self, view: "panel.PodWatchView") -> str:
@@ -656,9 +657,9 @@ class TestPodWatchViewCurrentTask:
         )
         view = self._setup_view_with_pod(current_task=ct, busy=True)
         out = self._render_to_text(view)
-        assert "current task:" in out
+        # Updated: header now shows WORK: instead of "current task:"
+        assert "WORK:" in out
         assert "#309" in out
-        assert "implement" in out  # stage
         assert "auto/issue-309" in out  # branch
 
     def test_busy_worker_with_pr_shows_pr_prefix(self):
@@ -669,18 +670,18 @@ class TestPodWatchViewCurrentTask:
         view = self._setup_view_with_pod(current_task=ct, busy=True)
         out = self._render_to_text(view)
         assert "PR#291" in out
-        assert "pr_review" in out
 
     def test_idle_worker_shows_dash(self):
         view = self._setup_view_with_pod(current_task=None, busy=False)
         out = self._render_to_text(view)
-        assert "current task:" in out
+        # Updated: header now shows WORK: instead of "current task:"
+        assert "WORK:" in out
         # Estado idle — não menciona um número de issue/PR
         assert "idle" in out.lower()
 
     def test_non_worker_pod_has_no_current_task_line(self):
         """Pods que não são worker (bot, pipeline, shell) não tem
-        ``wstate`` no dict de workers — a linha "current task:" NÃO
+        ``wstate`` no dict de workers — a linha WORK NÃO
         aparece (mantém compat visual com pipeline/bot/shell)."""
         view = panel.PodWatchView(data=MagicMock())
         view.pod_role = "pipeline"  # não-worker
@@ -696,8 +697,9 @@ class TestPodWatchViewCurrentTask:
         view.data.pods.get.return_value = [pod]
         # workers.get() devolve {} (sem este pod).
         view.data.workers.get.return_value = {}
+        view.data.claude_workers = None
         out = self._render_to_text(view)
-        assert "current task:" not in out
+        assert "WORK:" not in out
 
     def test_target_label_is_forge_agnostic(self):
         """O renderer não distingue GitHub de GitLab — usa o vocabulário
@@ -741,6 +743,7 @@ class TestPodWatchViewRenderSize:
             view.pod_name: pd.WorkerState(pod_name=view.pod_name,
                                           busy=True, current_task=ct),
         }
+        view.data.claude_workers = None
         app = MagicMock()
         app.pause = False  # _head_panel pode consultar
         # Mock _head_panel direto pra não depender do PanelApp completo.
@@ -755,4 +758,5 @@ class TestPodWatchViewRenderSize:
         console.print(layout)
         out = console.export_text()
         assert "#309" in out
-        assert "current task:" in out
+        # Updated: header now shows WORK: instead of "current task:"
+        assert "WORK:" in out

--- a/deile/tests/infra/test_panel_work_header.py
+++ b/deile/tests/infra/test_panel_work_header.py
@@ -1,0 +1,420 @@
+"""Testes do header WORK/LAST_COMPLETED em ``PodWatchView`` (issue #396).
+
+Cobertura:
+
+1. ``WorkerProvider._parse`` extrai ``model`` do ``dispatch_started``.
+2. ``WorkerProvider._parse`` cria ``LastCompletedTask`` ao parear
+   ``dispatch_started`` ↔ ``dispatch_completed``.
+3. ``WorkerProvider._parse`` resolve ``cost_usd`` via ``CostsProvider``
+   quando disponível; ``None`` quando DB ausente.
+4. ``WorkerProvider._parse`` mantém ``last_completed = None`` quando
+   o buffer só tem ``dispatch_started`` (sem completed).
+5. ``PodWatchView._header_body`` renderiza linha ``WORK`` com modelo.
+6. ``PodWatchView._header_body`` renderiza ``WORK: — (idle)`` quando idle.
+7. ``PodWatchView._header_body`` renderiza ``LAST_COMPLETED`` com outcome
+   colorido (green/red/dim).
+8. ``PodWatchView._header_body`` não levanta erro quando ambos são ``None``.
+9. Timestamp de ``LAST_COMPLETED`` usa formato ``Z`` (UTC explícito).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel  # noqa: E402
+import _panel_data as pd  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts(offset_s: int = 0) -> str:
+    """Timestamp string no formato ``kubectl logs --timestamps``."""
+    ts = datetime.now(timezone.utc) - timedelta(seconds=offset_s)
+    return ts.strftime("%Y-%m-%dT%H:%M:%S.000000000+00:00")
+
+
+def _build_provider(costs=None) -> pd.WorkerProvider:
+    prov = pd.WorkerProvider(ttl_s=0.0, costs=costs)
+    prov._kubectl = "kubectl"
+    return prov
+
+
+def _render(view: panel.PodWatchView) -> str:
+    """Captura o output Rich do _header_body como string plana."""
+    renderable = view._header_body()
+    console = Console(record=True, width=200, force_terminal=False,
+                      color_system=None)
+    console.print(renderable)
+    return console.export_text()
+
+
+def _worker_view(current_task=None, last_completed=None, busy: bool = False,
+                 role: str = "worker") -> panel.PodWatchView:
+    view = panel.PodWatchView(data=MagicMock())
+    view.pod_role = role
+    view.pod_name = "deile-worker-abc"
+    pod = MagicMock()
+    pod.name = view.pod_name
+    pod.role = role
+    pod.status = "Running"
+    pod.age_s = 120.0
+    pod.restarts = 0
+    pod.ready = True
+    pod.node = "node-1"
+    view.data.pods.get.return_value = [pod]
+    wstate = pd.WorkerState(
+        pod_name=view.pod_name,
+        busy=busy,
+        current_task=current_task,
+        last_completed=last_completed,
+    )
+    view.data.workers.get.return_value = {view.pod_name: wstate}
+    view.data.claude_workers = None
+    return view
+
+
+# ---------------------------------------------------------------------------
+# WorkerProvider._parse — model extraction
+# ---------------------------------------------------------------------------
+
+class TestWorkerProviderExtractsModel:
+    def test_extracts_model_from_dispatch_started(self):
+        prov = _build_provider()
+        text = (
+            f"{_ts(5)} dispatch_started task=abc123def456 "
+            f"channel=pipeline-issue-396 stage=implement issue=396 "
+            f"model=anthropic:claude-sonnet-4-6 branch=auto/issue-396"
+        )
+        state = prov._parse("w-1", text)
+        assert state.current_task is not None
+        assert state.current_task.model == "anthropic:claude-sonnet-4-6"
+
+    def test_model_none_when_absent_in_started(self):
+        prov = _build_provider()
+        text = (
+            f"{_ts(5)} dispatch_started task=abc123def456 "
+            f"channel=pipeline-issue-396 stage=implement issue=396"
+        )
+        state = prov._parse("w-1", text)
+        assert state.current_task is not None
+        assert state.current_task.model is None
+
+    def test_model_preserved_after_second_dispatch_started(self):
+        """Dois dispatch_started sobrepostos — o mais recente prevalece."""
+        prov = _build_provider()
+        text = "\n".join([
+            f"{_ts(10)} dispatch_started task=old1old1old1 "
+            f"channel=pipeline-issue-100 model=anthropic:claude-opus-4-7",
+            f"{_ts(8)} dispatch_completed task=old1old1old1 ok=True",
+            f"{_ts(5)} dispatch_started task=new1new1new1 "
+            f"channel=pipeline-issue-396 model=anthropic:claude-sonnet-4-6",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.current_task is not None
+        assert state.current_task.model == "anthropic:claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# WorkerProvider._parse — LastCompletedTask creation
+# ---------------------------------------------------------------------------
+
+class TestWorkerProviderLastCompleted:
+    def test_pairs_started_with_completed(self):
+        prov = _build_provider()
+        text = "\n".join([
+            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"channel=pipeline-issue-386 stage=pr_review issue=386 "
+            f"model=anthropic:claude-sonnet-4-6",
+            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.current_task is None  # task completed — idle now
+        assert state.last_completed is not None
+        lc = state.last_completed
+        assert lc.task_id == "aabbccdd1122"
+        assert lc.channel_id == "pipeline-issue-386"
+        assert lc.stage == "pr_review"
+        assert lc.issue_number == 386
+        assert lc.outcome == "DONE"
+        assert lc.duration_s > 0
+
+    def test_outcome_fail_when_ok_false(self):
+        prov = _build_provider()
+        text = "\n".join([
+            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"channel=pipeline-issue-1 issue=1",
+            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=False",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.last_completed is not None
+        assert state.last_completed.outcome == "FAIL"
+
+    def test_outcome_from_explicit_outcome_field(self):
+        """When dispatch_completed carries ``outcome=APPROVE``, that wins
+        over the ok= field normalization."""
+        prov = _build_provider()
+        text = "\n".join([
+            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"channel=pipeline-pr-291 issue=291",
+            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True outcome=APPROVE",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.last_completed is not None
+        assert state.last_completed.outcome == "APPROVE"
+
+    def test_last_completed_none_when_only_started(self):
+        """In-flight task — no completed line — last_completed stays None."""
+        prov = _build_provider()
+        text = (
+            f"{_ts(5)} dispatch_started task=aabbccdd1122 "
+            f"channel=pipeline-issue-396 issue=396"
+        )
+        state = prov._parse("w-1", text)
+        assert state.current_task is not None
+        assert state.last_completed is None
+
+    def test_last_completed_is_most_recent(self):
+        """With two completed tasks, last_completed reflects the later one."""
+        prov = _build_provider()
+        text = "\n".join([
+            f"{_ts(20)} dispatch_started task=aaaa11110000 "
+            f"channel=pipeline-issue-100 issue=100",
+            f"{_ts(15)} dispatch_completed task=aaaa11110000 ok=True",
+            f"{_ts(10)} dispatch_started task=bbbb22220000 "
+            f"channel=pipeline-issue-200 issue=200",
+            f"{_ts(5)} dispatch_completed task=bbbb22220000 ok=False",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.last_completed is not None
+        assert state.last_completed.task_id == "bbbb22220000"
+        assert state.last_completed.outcome == "FAIL"
+
+    def test_duration_calculated_correctly(self):
+        prov = _build_provider()
+        text = "\n".join([
+            f"{_ts(60)} dispatch_started task=aabbccdd1122 "
+            f"channel=pipeline-issue-1 issue=1",
+            f"{_ts(13)} dispatch_completed task=aabbccdd1122 ok=True",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.last_completed is not None
+        # Duration should be approximately 47s (60 - 13), allow some drift
+        assert 44 <= state.last_completed.duration_s <= 50
+
+    def test_completed_without_matching_started_does_not_crash(self):
+        """A dangling dispatch_completed (no matching started) is silently
+        ignored — no exception, no last_completed."""
+        prov = _build_provider()
+        text = f"{_ts(3)} dispatch_completed task=orphan12345 ok=True"
+        state = prov._parse("w-1", text)
+        assert state.last_completed is None
+
+
+# ---------------------------------------------------------------------------
+# WorkerProvider._parse — cost_usd resolution
+# ---------------------------------------------------------------------------
+
+class TestWorkerProviderCostResolution:
+    def _make_db(self, tmp_path: Path, task_id: str, cost: float) -> Path:
+        db = tmp_path / "usage.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "CREATE TABLE usage_records "
+            "(session_id TEXT, provider_id TEXT, cost_usd REAL, timestamp REAL)"
+        )
+        conn.execute(
+            "INSERT INTO usage_records VALUES (?, ?, ?, ?)",
+            (f"worker_{task_id}", "anthropic", cost, 1000.0),
+        )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_cost_resolved_from_db(self, tmp_path):
+        tid = "aabbccdd1122"
+        db = self._make_db(tmp_path, tid, 0.32)
+        costs = pd.CostsProvider(db_path=db)
+        prov = _build_provider(costs=costs)
+        text = "\n".join([
+            f"{_ts(10)} dispatch_started task={tid} channel=pipeline-issue-386 issue=386",
+            f"{_ts(3)} dispatch_completed task={tid} ok=True",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.last_completed is not None
+        assert state.last_completed.cost_usd == pytest.approx(0.32, rel=1e-4)
+
+    def test_cost_none_when_db_missing(self):
+        costs = pd.CostsProvider(db_path=Path("/nonexistent/usage.db"))
+        prov = _build_provider(costs=costs)
+        text = "\n".join([
+            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"channel=pipeline-issue-1 issue=1",
+            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.last_completed is not None
+        assert state.last_completed.cost_usd is None
+
+    def test_cost_none_when_no_provider(self):
+        prov = _build_provider(costs=None)
+        text = "\n".join([
+            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"channel=pipeline-issue-1 issue=1",
+            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True",
+        ])
+        state = prov._parse("w-1", text)
+        assert state.last_completed is not None
+        assert state.last_completed.cost_usd is None
+
+
+# ---------------------------------------------------------------------------
+# PodWatchView._header_body — WORK line rendering
+# ---------------------------------------------------------------------------
+
+class TestPodWatchViewWorkLine:
+    def test_work_line_shows_target_label_and_model(self):
+        ct = pd.CurrentTask(
+            task_id="abc", channel_id="pipeline-issue-396",
+            started_ts=datetime.now(timezone.utc),
+            stage="implement", issue_number=396,
+            branch="auto/issue-396",
+            model="anthropic:claude-sonnet-4-6",
+        )
+        view = _worker_view(current_task=ct, busy=True)
+        out = _render(view)
+        assert "WORK:" in out
+        assert "#396" in out
+        assert "anthropic:claude-sonnet-4-6" in out
+        assert "auto/issue-396" in out
+        # Old "current task:" line should be gone
+        assert "current task:" not in out
+
+    def test_work_line_idle_when_no_current_task(self):
+        view = _worker_view(current_task=None, busy=False)
+        out = _render(view)
+        assert "WORK:" in out
+        assert "idle" in out.lower()
+
+    def test_work_line_without_model_omits_model_segment(self):
+        ct = pd.CurrentTask(
+            task_id="abc", channel_id="pipeline-issue-1",
+            started_ts=datetime.now(timezone.utc),
+            issue_number=1, model=None,
+        )
+        view = _worker_view(current_task=ct, busy=True)
+        out = _render(view)
+        assert "WORK:" in out
+        assert "model" not in out
+
+    def test_no_error_when_both_current_and_last_completed_none(self):
+        view = _worker_view(current_task=None, last_completed=None)
+        out = _render(view)  # must not raise
+        assert "WORK:" in out
+        assert "LAST_COMPLETED" not in out
+
+
+# ---------------------------------------------------------------------------
+# PodWatchView._header_body — LAST_COMPLETED line rendering
+# ---------------------------------------------------------------------------
+
+class TestPodWatchViewLastCompletedLine:
+    def _make_lc(self, outcome: str, cost_usd=None, issue_number=386) -> pd.LastCompletedTask:
+        return pd.LastCompletedTask(
+            task_id="deadbeef1234",
+            channel_id=f"pipeline-issue-{issue_number}",
+            finished_ts=datetime(2026, 5, 29, 5, 23, 59, tzinfo=timezone.utc),
+            outcome=outcome,
+            duration_s=47.0,
+            cost_usd=cost_usd,
+            stage="pr_review",
+            issue_number=issue_number,
+        )
+
+    def test_last_completed_shows_approve_green(self):
+        lc = self._make_lc("APPROVE", cost_usd=0.32)
+        view = _worker_view(last_completed=lc)
+        out = _render(view)
+        assert "LAST_COMPLETED:" in out
+        assert "APPROVE" in out
+        assert "$0.32" in out
+        # Timestamp with Z suffix
+        assert "2026-05-29T05:23:59Z" in out
+
+    def test_last_completed_shows_done_green(self):
+        lc = self._make_lc("DONE", cost_usd=0.10)
+        view = _worker_view(last_completed=lc)
+        out = _render(view)
+        assert "DONE" in out
+        assert "$0.10" in out
+
+    def test_last_completed_shows_fail_red(self):
+        lc = self._make_lc("FAIL", cost_usd=0.05)
+        view = _worker_view(last_completed=lc)
+        out = _render(view)
+        assert "LAST_COMPLETED:" in out
+        assert "FAIL" in out
+
+    def test_last_completed_shows_reject(self):
+        lc = self._make_lc("REJECT", cost_usd=None)
+        view = _worker_view(last_completed=lc)
+        out = _render(view)
+        assert "REJECT" in out
+
+    def test_last_completed_cost_unavailable_shows_placeholder(self):
+        lc = self._make_lc("DONE", cost_usd=None)
+        view = _worker_view(last_completed=lc)
+        out = _render(view)
+        assert "ledger unavailable" in out or "$?" in out
+
+    def test_last_completed_omitted_when_none(self):
+        view = _worker_view(current_task=None, last_completed=None)
+        out = _render(view)
+        assert "LAST_COMPLETED" not in out
+
+    def test_timestamp_uses_z_suffix(self):
+        lc = self._make_lc("DONE", cost_usd=0.01)
+        view = _worker_view(last_completed=lc)
+        out = _render(view)
+        # Must end in Z, not +00:00
+        assert "2026-05-29T05:23:59Z" in out
+        assert "+00:00" not in out
+
+    def test_last_completed_issue_label_uses_target_label(self):
+        lc = self._make_lc("APPROVE", cost_usd=0.20, issue_number=386)
+        view = _worker_view(last_completed=lc)
+        out = _render(view)
+        assert "#386" in out
+
+    def test_non_worker_pod_no_last_completed(self):
+        """Pods that are not worker/claude-worker never show LAST_COMPLETED."""
+        view = panel.PodWatchView(data=MagicMock())
+        view.pod_role = "pipeline"
+        view.pod_name = "deile-pipeline-xyz"
+        pod = MagicMock()
+        pod.name = view.pod_name
+        pod.role = "pipeline"
+        pod.status = "Running"
+        pod.age_s = 60.0
+        pod.restarts = 0
+        pod.ready = True
+        pod.node = "n1"
+        view.data.pods.get.return_value = [pod]
+        view.data.workers.get.return_value = {}
+        view.data.claude_workers = None
+        out = _render(view)
+        assert "LAST_COMPLETED" not in out
+        assert "WORK:" not in out

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -1639,8 +1639,13 @@ class PodWatchView(View):
         pod = next((p for p in self.data.pods.get() if p.name == self.pod_name), None)
         if pod is None:
             return Text(f"pod `{self.pod_name}` não encontrado.", style="red")
-        wstate = self.data.workers.get().get(self.pod_name) \
-            if self.pod_role == "worker" else None
+        if self.pod_role == "worker":
+            wstate = self.data.workers.get().get(self.pod_name)
+        elif self.pod_role == "claude-worker":
+            wstate = (self.data.claude_workers.get().get(self.pod_name)
+                      if self.data.claude_workers is not None else None)
+        else:
+            wstate = None
         lines = [
             Text.assemble(
                 ("name: ", "dim"), (pod.name, "bold"),
@@ -1668,41 +1673,74 @@ class PodWatchView(View):
                 (_fmt_age(wstate.last_activity_s) + " ago"
                  if wstate.last_activity_s is not None else "—", "bold"),
             ))
-            # "Current task" — issue/PR/MR/workflow que o worker está
-            # atendendo no momento (issue #309 fase 2 follow-up). Fonte
-            # de verdade: linha estruturada ``dispatch_started`` emitida
-            # pelo :func:`infra.k8s.worker_server.dispatch_handler` e
-            # parseada pelo :class:`WorkerProvider`. Forge-agnóstico: o
-            # ``target_label`` do CurrentTask devolve ``#N``/``PR#N``/
-            # ``mention …`` independentemente de GitHub ou GitLab — o
-            # vocabulário PR↔MR é abstraído upstream (ver Decisão #42).
-            # Quando idle ou worker antigo sem logs estruturados, mostra
-            # ``—`` (mesmo padrão das outras células do header).
+            # WORK line — replaces the old "current task:" block (issue #396).
+            # Shows what the worker is doing right now, enriched with LLM model
+            # and start time.  Forge-agnostic: target_label returns #N/PR#N/
+            # mention … regardless of GitHub or GitLab (Decisão #42).
             ct = wstate.current_task
             if ct is not None:
-                task_parts: List[Any] = [
-                    ("current task: ", "dim"),
+                work_parts: List[Any] = [
+                    ("WORK: ", "bold"),
                     (ct.target_label, "bold magenta"),
                 ]
-                if ct.stage:
-                    task_parts.extend([
-                        ("   stage: ", "dim"),
-                        (ct.stage, "bold"),
-                    ])
                 if ct.branch:
-                    task_parts.extend([
-                        ("   branch: ", "dim"),
+                    work_parts.extend([
+                        (" (", "dim"),
                         (ct.branch, "dim italic"),
+                        (")", "dim"),
                     ])
-                task_parts.extend([
-                    ("   running: ", "dim"),
-                    (_fmt_age(ct.elapsed_s), "bold"),
+                work_parts.extend([
+                    (" | started ", "dim"),
+                    (_fmt_age(ct.elapsed_s) + " ago", "bold"),
                 ])
-                lines.append(Text.assemble(*task_parts))
+                if ct.model:
+                    work_parts.extend([
+                        (" | model ", "dim"),
+                        (ct.model, "bold cyan"),
+                    ])
+                lines.append(Text.assemble(*work_parts))
             else:
                 lines.append(Text.assemble(
-                    ("current task: ", "dim"),
+                    ("WORK: ", "bold"),
                     ("— (idle)", "dim"),
+                ))
+            # LAST_COMPLETED line — omitted when no completed task in log buffer.
+            lc = wstate.last_completed
+            if lc is not None:
+                outcome = lc.outcome.upper()
+                if outcome in {"APPROVE", "OK", "DONE"}:
+                    outcome_style = "bold green"
+                elif outcome in {"REJECT", "FAIL", "ERROR"}:
+                    outcome_style = "bold red"
+                else:
+                    outcome_style = "dim"
+                # Build target label for the completed task via a temporary
+                # CurrentTask (reuses the existing target_label logic).
+                from _panel_data import CurrentTask as _CT  # noqa: PLC0415
+                _ct_tmp = _CT(
+                    task_id=lc.task_id, channel_id=lc.channel_id,
+                    started_ts=lc.finished_ts,
+                    stage=lc.stage, action_kind=lc.action_kind,
+                    issue_number=lc.issue_number,
+                )
+                if lc.cost_usd is not None:
+                    cost_str = f"${lc.cost_usd:.2f}"
+                    cost_style = "bold"
+                else:
+                    cost_str = "$? (ledger unavailable)"
+                    cost_style = "dim"
+                finished_z = lc.finished_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+                lines.append(Text.assemble(
+                    ("LAST_COMPLETED: ", "bold"),
+                    (_ct_tmp.target_label, "magenta"),
+                    (" → ", "dim"),
+                    (outcome, outcome_style),
+                    (" | ", "dim"),
+                    (_fmt_age(lc.duration_s), "bold"),
+                    (" | ", "dim"),
+                    (cost_str, cost_style),
+                    (" | ", "dim"),
+                    (finished_z, "dim"),
                 ))
         return Group(*lines)
 

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -611,6 +611,8 @@ _ROLE_BY_APP = {
     "deile-worker":   "worker",
     "deilebot":       "bot",
     "deile-shell":    "shell",
+    # issue #396: claude-worker pods are now observable in PodWatchView
+    "claude-worker":  "claude-worker",
 }
 
 
@@ -914,6 +916,7 @@ class CurrentTask:
     action_kind: Optional[str] = None
     issue_number: Optional[int] = None
     branch: Optional[str] = None
+    model: Optional[str] = None
 
     @property
     def target_label(self) -> str:
@@ -958,6 +961,31 @@ class CurrentTask:
 
 
 @dataclass
+class LastCompletedTask:
+    """Snapshot da última task finalizada num pod worker (issue #396).
+
+    Populada pelo :class:`WorkerProvider` quando ele vê um
+    ``dispatch_completed`` para o qual existe um ``dispatch_started``
+    pareado em ``live_tasks``. Contém duração (calculada de
+    ``started_ts → finished_ts``), outcome normalizado e custo USD
+    (resolvido contra :class:`CostsProvider` por ``session_id``, ou
+    ``None`` quando o ledger não tem entrada para esta task).
+
+    Forge-agnóstica: reutiliza ``issue_number`` / ``stage`` /
+    ``action_kind`` do :class:`CurrentTask` correspondente.
+    """
+    task_id: str
+    channel_id: str
+    finished_ts: datetime
+    outcome: str            # "DONE" | "FAIL" | "APPROVE" | "REJECT" | etc.
+    duration_s: float
+    cost_usd: Optional[float]   # None = ledger unavailable
+    stage: Optional[str] = None
+    action_kind: Optional[str] = None
+    issue_number: Optional[int] = None
+
+
+@dataclass
 class WorkerState:
     """Estado deduzido do log de um pod worker."""
     pod_name: str
@@ -971,6 +999,9 @@ class WorkerState:
     # ativo (ainda não cobre todos os workers em deploy, então ``None`` é
     # o caminho silencioso de compatibilidade).
     current_task: Optional[CurrentTask] = None
+    # Última task finalizada (issue #396). ``None`` quando o log de até
+    # TAIL_LINES não contém nenhum ``dispatch_completed`` pareado.
+    last_completed: Optional[LastCompletedTask] = None
 
     @property
     def last_activity_s(self) -> Optional[float]:
@@ -995,7 +1026,8 @@ _DISPATCH_STARTED_RE = re.compile(
     r"dispatch_started\s+(?P<kv>.+)$", re.IGNORECASE,
 )
 _DISPATCH_COMPLETED_RE = re.compile(
-    r"dispatch_completed\s+task=(?P<task_id>[a-f0-9]+)\b", re.IGNORECASE,
+    r"dispatch_completed\s+task=(?P<task_id>[a-f0-9]+)(?P<rest>[^\n]*)$",
+    re.IGNORECASE,
 )
 _KV_RE = re.compile(r"(\w+)=(\S+)")
 # Pipeline channel naming convention (see implementer.py:_dispatch /
@@ -1016,12 +1048,15 @@ class WorkerProvider(_KubectlProviderMixin):
 
     def __init__(self, ttl_s: float = 2.0,
                  namespace: str = NS, worker_deploy: str = "deile-worker",
-                 enabled: bool = True):
+                 enabled: bool = True,
+                 costs: Optional["CostsProvider"] = None):
         # 2s: N `kubectl logs` (1 por worker) — só roda em background.
         self._kubectl = kubectl_bin()
         self._namespace = namespace
         self._worker_deploy = worker_deploy
         self._enabled = enabled
+        # Optional: resolve cost_usd for LastCompletedTask (issue #396).
+        self._costs = costs
         self._cache: Cache[Dict[str, WorkerState]] = Cache(
             ttl_s, self._fetch, fallback={},
         )
@@ -1088,7 +1123,38 @@ class WorkerProvider(_KubectlProviderMixin):
             # genérico porque ambos casam com "dispatch" no body.
             m_done = _DISPATCH_COMPLETED_RE.search(ll.body)
             if m_done:
-                live_tasks.pop(m_done.group("task_id"), None)
+                tid = m_done.group("task_id")
+                started_task = live_tasks.pop(tid, None)
+                if started_task is not None:
+                    # Build LastCompletedTask from the paired started entry.
+                    kv_done = dict(_KV_RE.findall(m_done.group("rest")))
+                    ok_raw = kv_done.get("ok", "")
+                    outcome_raw = (kv_done.get("outcome")
+                                   or kv_done.get("status")
+                                   or ("DONE"
+                                       if ok_raw.lower() in {"true", "1"}
+                                       else "FAIL"))
+                    duration_s = max(
+                        0.0,
+                        (ll.ts - started_task.started_ts).total_seconds(),
+                    )
+                    cost_usd: Optional[float] = None
+                    if self._costs is not None:
+                        try:
+                            cost_usd = self._costs.get_task_cost(tid)
+                        except Exception:
+                            pass
+                    state.last_completed = LastCompletedTask(
+                        task_id=tid,
+                        channel_id=started_task.channel_id,
+                        finished_ts=ll.ts,
+                        outcome=outcome_raw,
+                        duration_s=duration_s,
+                        cost_usd=cost_usd,
+                        stage=started_task.stage,
+                        action_kind=started_task.action_kind,
+                        issue_number=started_task.issue_number,
+                    )
                 # Não é uma "atividade nova" — apenas o término de uma
                 # task já contabilizada via ``dispatch_started``; pular o
                 # restante do bookkeeping evita inflar last_substantive_ts
@@ -1099,7 +1165,7 @@ class WorkerProvider(_KubectlProviderMixin):
                 kv = dict(_KV_RE.findall(m_start.group("kv")))
                 tid = kv.get("task", "")
                 ch = kv.get("channel", "")
-                if tid and ch:
+                if tid:
                     issue_num: Optional[int]
                     try:
                         issue_num = int(kv["issue"]) if "issue" in kv else None
@@ -1111,6 +1177,7 @@ class WorkerProvider(_KubectlProviderMixin):
                         action_kind=kv.get("kind"),
                         issue_number=issue_num,
                         branch=kv.get("branch"),
+                        model=kv.get("model"),
                     )
                 # ``dispatch_started`` é atividade substantiva — atualiza
                 # last_substantive_ts/body também, para o cálculo de
@@ -1449,6 +1516,32 @@ class CostsProvider:
         finally:
             conn.close()
         return snap
+
+    def get_task_cost(self, task_id: str) -> Optional[float]:
+        """Total cost in USD for a specific task (session_id = ``worker_<task_id>``).
+
+        Returns ``None`` when the DB is absent, unreadable, or has no matching
+        session — the caller should treat ``None`` as "ledger unavailable".
+        """
+        if not self._db_path.is_file():
+            return None
+        session_id = f"worker_{task_id}"
+        try:
+            conn = sqlite3.connect(
+                f"file:{self._db_path}?mode=ro", uri=True, timeout=1.0,
+            )
+        except sqlite3.OperationalError:
+            return None
+        try:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(cost_usd), 0) FROM usage_records WHERE session_id=?",
+                (session_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        if row and row[0]:
+            return float(row[0])
+        return None
 
 
 # ===== Model providers ======================================================
@@ -4406,6 +4499,9 @@ class PanelData:
     # exibir contagem de DEILE instances no header. Opcional — quando
     # ausente, o painel só mostra a tabela LOCAL PROCESSES.
     local_registry: Optional["LocalRegistryProvider"] = None
+    # WorkerProvider for the ``claude-worker`` deployment (issue #396).
+    # ``None`` when the pod is not deployed (panel still renders without error).
+    claude_workers: Optional[WorkerProvider] = None
 
     @classmethod
     def from_context(cls, context: RuntimeContext) -> "PanelData":
@@ -4442,7 +4538,8 @@ class PanelData:
                                       enabled=k8s_on),
             workers=WorkerProvider(namespace=context.namespace,
                                    worker_deploy=context.worker_deploy,
-                                   enabled=k8s_on),
+                                   enabled=k8s_on,
+                                   costs=CostsProvider(db_path=context.usage_db)),
             # `context.repo` pode vir vazio se o operador construiu o
             # ctx direto (sem `.detect()`) — resolve no fallback global.
             # forge_kind do contexto (lido do deployment do NS) decide se
@@ -4487,6 +4584,12 @@ class PanelData:
             local_audit=local_audit,
             local_instances=local_instances,
             local_registry=local_registry,
+            claude_workers=WorkerProvider(
+                namespace=context.namespace,
+                worker_deploy="claude-worker",
+                enabled=k8s_on,
+                costs=CostsProvider(db_path=context.usage_db),
+            ),
         )
 
     @classmethod
@@ -4500,11 +4603,11 @@ class PanelData:
                 self.costs, self.models, self.current_model,
                 self.stage_models, self.dispatch_mode, self.stage_dispatch,
                 self.notifier)
-        locals_ = tuple(p for p in (self.local_processes, self.local_logs,
-                                    self.local_audit, self.local_instances,
-                                    self.local_registry)
-                        if p is not None)
-        return base + locals_
+        optionals = tuple(p for p in (self.local_processes, self.local_logs,
+                                      self.local_audit, self.local_instances,
+                                      self.local_registry, self.claude_workers)
+                          if p is not None)
+        return base + optionals
 
     def force_refresh_all(self) -> None:
         """Hotkey [r]: marca todos os caches como vencidos sem bloquear.

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -1076,6 +1076,18 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     model_slug = payload.get("preferred_model")
     resume_session_id = payload.get("resume_session_id")
     prev_task_id = payload.get("prev_task_id")
+    # Pipeline-context fields (issue #396) — forwarded by the pipeline so
+    # the PodWatchView panel can surface "what is this claude-worker doing"
+    # in the WORK/LAST_COMPLETED header. Same wire contract as worker_server.
+    _channel_id = str(payload.get("channel_id") or "").strip()
+    _issue_number_raw = payload.get("issue_number")
+    _issue_number: Optional[int]
+    try:
+        _issue_number = int(_issue_number_raw) if _issue_number_raw is not None else None
+        if _issue_number is not None and _issue_number < 1:
+            _issue_number = None
+    except (TypeError, ValueError):
+        _issue_number = None
     # Per-stage timeout override (issue #391). When set, overrides
     # DEILE_CLAUDE_WORKER_TASK_TIMEOUT_S for this dispatch only.
     dispatch_timeout_s: Optional[int] = None
@@ -1250,6 +1262,22 @@ async def dispatch_handler(request: web.Request) -> web.Response:
         preamble = _render_preamble(stage, branch, task_id)
         full_prompt = preamble + "\n\n---\n\n" + brief
 
+    # Structured dispatch marker consumed by WorkerProvider in the panel
+    # (issue #396). Mirrors worker_server.py format so PodWatchView can
+    # show WORK/LAST_COMPLETED for claude-worker pods as well.
+    _dispatch_parts = [f"task={task_id}"]
+    if _channel_id:
+        _dispatch_parts.append(f"channel={_channel_id}")
+    if stage:
+        _dispatch_parts.append(f"stage={stage}")
+    if _issue_number is not None:
+        _dispatch_parts.append(f"issue={_issue_number}")
+    if branch:
+        _dispatch_parts.append(f"branch={branch}")
+    if claude_model:
+        _dispatch_parts.append(f"model={claude_model}")
+    logger.info("dispatch_started %s", " ".join(_dispatch_parts))
+
     # Mecanismo 2 — Lease: garante que NUNCA dois pods trabalhem no mesmo
     # workspace simultaneamente. Adquirido ANTES do spawn; liberado no finally.
     lease = await _acquire_lease(workspace)
@@ -1408,6 +1436,9 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     elif not ok and claude_result["is_error"] and claude_result["result"]:
         # Falha não-auth reportada pelo claude — propaga o erro pra pipeline.
         response["error"] = claude_result["result"][:500]
+
+    # Terminal marker for the panel — pairs with dispatch_started (issue #396).
+    logger.info("dispatch_completed task=%s ok=%s", task_id, ok)
 
     # Libera heartbeat + lease antes de responder (lease liberado apenas aqui
     # no caminho feliz; o caminho de exceção já liberou no handler acima).

--- a/infra/k8s/worker_server.py
+++ b/infra/k8s/worker_server.py
@@ -973,6 +973,8 @@ async def dispatch_handler(request: web.Request) -> web.Response:
         parts.append(f"issue={issue_number}")
     if branch:
         parts.append(f"branch={branch}")
+    if preferred_model:
+        parts.append(f"model={preferred_model}")
     logger.info("dispatch_started %s", " ".join(parts))
 
     wait_for_result = bool(body.get("wait_for_result", True))


### PR DESCRIPTION
## Summary

- Replaces the old `current task:` header block in `PodWatchView._header_body` with two richer lines per worker pod (`deile-worker` and `claude-worker`):
  - **WORK**: current task — `#N (branch) | started Xm ago | model claude-sonnet-4-6`
  - **LAST_COMPLETED**: last finished task — `#N → APPROVE | 47s | $0.32 | 2026-05-29T05:23:59Z`
- Adds `model` field to `CurrentTask` and emits `model=` in `dispatch_started` logs from both `worker_server.py` and `claude_worker_server.py`
- Adds `LastCompletedTask` dataclass and extends `WorkerProvider._parse` to pair start/completion events, look up USD cost from SQLite via `CostsProvider.get_task_cost`, and populate `WorkerState.last_completed`
- Registers `"claude-worker"` in `_ROLE_BY_APP`; adds `claude_workers` provider to `PanelData`
- 26 new tests in `test_panel_work_header.py`; 5 updated assertions in `test_panel_pod_watch.py`

## Test plan

- [x] `python3 -m pytest deile/tests/infra/test_panel_work_header.py -v` — 26 new tests pass
- [x] `python3 -m pytest deile/tests/infra/test_panel_pod_watch.py deile/tests/infra/test_panel_data.py -q` — 220 existing tests pass

Closes #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)