### PR TITLE
feat(claude-worker): OAuth auto-renew 3 níveis (initContainer idempotente + CronJob + pipeline auto-refresh)

### DIFF
--- a/deile/orchestration/pipeline/_claude_creds_refresh.py
+++ b/deile/orchestration/pipeline/_claude_creds_refresh.py
@@ -1,0 +1,362 @@
+"""Refresh proativo do OAuth do ``claude-worker`` a partir do cluster.
+
+Este módulo concentra a lógica de "tentar renovar o token OAuth do
+``claude-worker`` sem precisar do operador humano". É consumido por duas
+frentes:
+
+1. **Pipeline auto-renew (Nível 3)** — ``implementer.py`` invoca
+   :func:`try_refresh_claude_credentials` quando o worker retorna
+   ``WORKER_AUTH_EXPIRED``. Em caso de sucesso, o pipeline retenta o
+   dispatch UMA vez antes de cair no caminho de bloqueio determinístico.
+
+2. **CronJob de renovação proativa (Nível 2)** — o manifest 51 monta um
+   CronJob que invoca o mesmo entry-point em modo CLI a cada 4h. Ele
+   inspeciona o ``expiresAt`` corrente no pod e, se estiver a menos de 2h
+   da expiração, dispara o refresh.
+
+Estratégias suportadas (em ordem de tentativa):
+
+* **strategy="exec_inplace"** — ``kubectl exec`` no pod ``claude-worker``
+  para ler o ``credentials.json`` que o próprio ``claude -p`` refrescou
+  in-pod, depois ``kubectl patch`` no Secret ``claude-credentials`` com
+  o valor novo. Não exige browser, não exige operador.
+
+* **strategy="rollout_only"** — apenas ``kubectl rollout restart``. Útil
+  quando o token in-pod é o mais recente e o Secret apenas precisa ser
+  re-aplicado na próxima inicialização (caso típico do N1: o initContainer
+  preserva o PVC porque o Secret é mais velho; rollout não muda nada).
+
+Limitação fundamental: não há renovação cega. Quando o ``refresh_token``
+do próprio OAuth expira (limites maiores que o ``accessToken`` — tipo 30
+dias), nenhuma das estratégias funciona — só ``claude login`` no host
+resolve. Esse caminho permanece manual e é o "estado de bloqueio" final
+do Nível 3.
+
+Segurança:
+
+* Toda chamada a ``kubectl`` tem timeout finito (15-60s) para nunca
+  pendurar o pipeline.
+* O conteúdo do token só é loggado como ``len(...)`` — nunca o valor cru.
+* Lock por arquivo (:func:`_acquire_refresh_lock`) impede duas tentativas
+  concorrentes (do pipeline e do CronJob simultaneamente).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+#: TTL do lock-file. Refresh real demora <60s; 5min cobre folgadamente.
+_REFRESH_LOCK_TTL_S: int = 300
+
+#: Caminho default do lock-file usado para evitar refresh concorrente
+#: entre pipeline-implementer e CronJob. Override via env para testes.
+_REFRESH_LOCK_PATH: str = os.environ.get(
+    "DEILE_CLAUDE_REFRESH_LOCK",
+    "/tmp/deile-claude-creds-refresh.lock",
+)
+
+
+@dataclass
+class RefreshResult:
+    """Resultado estruturado de uma tentativa de refresh."""
+
+    ok: bool
+    strategy: str = ""
+    message: str = ""
+    error: str = ""
+    # Tempo em segundos até a nova expiração (None se desconhecido).
+    seconds_until_new_expiry: Optional[float] = None
+    # Steps executados (para debugging/audit).
+    steps: List[str] = field(default_factory=list)
+
+
+def _acquire_refresh_lock(lock_path: Optional[str] = None) -> bool:
+    """Adquire lock por arquivo simples.
+
+    Cria ``<lock_path>`` com timestamp se inexistente OU se o existente é
+    mais velho que :data:`_REFRESH_LOCK_TTL_S` (lock stale). Retorna True
+    quando o caller pode prosseguir.
+
+    Best-effort: erros de I/O caem em ``True`` (fail-open — preferimos
+    duas tentativas eventuais a bloquear o pipeline numa I/O glitch).
+    """
+    path = Path(lock_path or _REFRESH_LOCK_PATH)
+    now = time.time()
+    try:
+        if path.exists():
+            age = now - path.stat().st_mtime
+            if age < _REFRESH_LOCK_TTL_S:
+                return False
+        path.write_text(str(int(now)), encoding="utf-8")
+        return True
+    except OSError as exc:
+        logger.warning("refresh lock I/O falhou (fail-open): %s", exc)
+        return True
+
+
+def _release_refresh_lock(lock_path: Optional[str] = None) -> None:
+    """Remove o lock-file. Idempotente."""
+    path = Path(lock_path or _REFRESH_LOCK_PATH)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("refresh lock release falhou: %s", exc)
+
+
+async def _kubectl_async(
+    args: List[str], *, timeout_s: float = 30.0, input_data: Optional[bytes] = None,
+) -> tuple[int, str, str]:
+    """Executa ``kubectl`` async com timeout. Retorna ``(rc, stdout, stderr)``.
+
+    Em erro de spawn / timeout, retorna ``(-1, "", "<motivo>")`` — nunca
+    levanta. O caller decide se é fatal.
+    """
+    kubectl = os.environ.get("KUBECTL_BIN", "kubectl")
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            kubectl, *args,
+            stdin=asyncio.subprocess.PIPE if input_data is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return (-1, "", f"kubectl spawn failed: {exc}")
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(input=input_data), timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+        return (-1, "", f"kubectl timed out after {timeout_s}s")
+    return (
+        proc.returncode or 0,
+        stdout_b.decode("utf-8", "replace"),
+        stderr_b.decode("utf-8", "replace"),
+    )
+
+
+def _extract_expires_at(creds: dict) -> Optional[int]:
+    """Extrai ``expiresAt`` (ms epoch) do dict de credentials.
+
+    Aceita o formato Keychain macOS (``claudeAiOauth.expiresAt``) e o
+    root-level (``expiresAt`` direto). Retorna ``None`` se ausente/inválido.
+    """
+    oauth = creds.get("claudeAiOauth") if isinstance(creds, dict) else None
+    val = (oauth or {}).get("expiresAt") if isinstance(oauth, dict) else None
+    if val is None and isinstance(creds, dict):
+        val = creds.get("expiresAt")
+    try:
+        return int(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def _read_pod_credentials(
+    namespace: str, *, timeout_s: float = 30.0,
+) -> tuple[Optional[dict], str]:
+    """Lê ``/home/claude/.claude/credentials.json`` do pod ``claude-worker``.
+
+    Returns ``(creds_dict, message)``. ``creds_dict`` é None se a leitura
+    falhou; ``message`` descreve a falha para audit.
+    """
+    args = [
+        "-n", namespace, "exec", "deploy/claude-worker",
+        "-c", "claude-worker", "--",
+        "cat", "/home/claude/.claude/credentials.json",
+    ]
+    rc, stdout, stderr = await _kubectl_async(args, timeout_s=timeout_s)
+    if rc != 0:
+        return None, f"kubectl exec falhou (rc={rc}): {stderr[:200]}"
+    try:
+        creds = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, f"credentials.json malformado no pod: {exc}"
+    if not isinstance(creds, dict):
+        return None, "credentials.json não é um objeto JSON"
+    return creds, "ok"
+
+
+async def _patch_secret_with_creds(
+    namespace: str, creds: dict, *, timeout_s: float = 30.0,
+) -> tuple[bool, str]:
+    """Atualiza o Secret ``claude-credentials`` com o conteúdo de ``creds``.
+
+    Usa o pattern padrão ``create --dry-run=client | apply -f -`` para ser
+    idempotente. Retorna ``(ok, message)``.
+    """
+    creds_json = json.dumps(creds)
+    dry_args = [
+        "create", "secret", "generic", "claude-credentials",
+        f"--from-literal=credentials.json={creds_json}",
+        "-n", namespace,
+        "--dry-run=client", "-o", "yaml",
+    ]
+    rc, stdout, stderr = await _kubectl_async(dry_args, timeout_s=timeout_s)
+    if rc != 0:
+        return False, f"kubectl create dry-run falhou: {stderr[:200]}"
+    apply_args = ["apply", "-f", "-"]
+    rc, _stdout, stderr = await _kubectl_async(
+        apply_args, timeout_s=timeout_s, input_data=stdout.encode("utf-8"),
+    )
+    if rc != 0:
+        return False, f"kubectl apply falhou: {stderr[:200]}"
+    return True, "ok"
+
+
+async def try_refresh_claude_credentials(
+    *,
+    namespace: Optional[str] = None,
+    min_expiry_window_s: float = 0.0,
+    skip_lock: bool = False,
+) -> RefreshResult:
+    """Tenta renovar o OAuth do ``claude-worker`` sem operador.
+
+    Args:
+        namespace: namespace K8s alvo (default: ``$DEILE_K8S_NAMESPACE`` ou
+            ``deile``).
+        min_expiry_window_s: se >0, faz refresh apenas se o ``expiresAt``
+            atual está a menos de ``min_expiry_window_s`` segundos no futuro.
+            ``0.0`` força refresh independente do TTL atual (uso do pipeline
+            quando o worker já reportou ``WORKER_AUTH_EXPIRED``).
+        skip_lock: se True, ignora o lock-file (uso em testes).
+
+    Returns:
+        :class:`RefreshResult` com ``ok=True`` quando o Secret foi atualizado
+        com um token válido. ``ok=False`` quando refresh foi pulado (lock,
+        TTL ok) ou falhou (refresh_token expirado, kubectl erro). O caller
+        usa ``ok`` + ``message`` para decidir entre retry e block.
+    """
+    ns = namespace or os.environ.get("DEILE_K8S_NAMESPACE", "deile")
+    result = RefreshResult(ok=False, strategy="exec_inplace")
+    result.steps.append(f"namespace={ns}")
+
+    if not skip_lock and not _acquire_refresh_lock():
+        result.message = "outro refresh em andamento (lock ativo)"
+        result.steps.append("lock=held")
+        return result
+    result.steps.append("lock=acquired")
+
+    try:
+        creds, msg = await _read_pod_credentials(ns)
+        result.steps.append(f"pod_read={msg}")
+        if creds is None:
+            result.error = f"falha lendo credentials do pod: {msg}"
+            return result
+
+        expires_at_ms = _extract_expires_at(creds)
+        now_ms = int(time.time() * 1000)
+        if expires_at_ms is not None:
+            remaining_s = (expires_at_ms - now_ms) / 1000.0
+            result.seconds_until_new_expiry = remaining_s
+            result.steps.append(
+                f"pod_token_expires_in={int(remaining_s)}s"
+            )
+            # Modo proativo (CronJob): só age se está próximo de expirar.
+            # Modo reativo (pipeline): min_expiry_window_s=0 sempre prossegue.
+            if min_expiry_window_s > 0 and remaining_s > min_expiry_window_s:
+                result.message = (
+                    f"token ainda válido por {int(remaining_s)}s "
+                    f"(threshold={int(min_expiry_window_s)}s) — skip"
+                )
+                result.ok = True
+                result.steps.append("decision=skip-not-near-expiry")
+                return result
+            # Modo reativo: se o token in-pod ainda está válido por >5min,
+            # provavelmente o claude refrescou no meio do dispatch. Vale
+            # propagar pro Secret e retentar — não é refresh real mas
+            # ressincroniza o estado.
+            if remaining_s <= 0:
+                result.error = (
+                    f"token in-pod TAMBÉM expirado "
+                    f"(há {int(-remaining_s)}s) — refresh_token provavelmente "
+                    f"expirou; humano precisa rodar claude-login --switch"
+                )
+                result.steps.append("decision=refresh-token-also-expired")
+                return result
+
+        ok, msg = await _patch_secret_with_creds(ns, creds)
+        result.steps.append(f"secret_patch={msg}")
+        if not ok:
+            result.error = f"falha aplicando Secret: {msg}"
+            return result
+
+        result.ok = True
+        result.message = (
+            f"Secret claude-credentials atualizado a partir do token in-pod"
+            + (
+                f" (expira em {int(result.seconds_until_new_expiry)}s)"
+                if result.seconds_until_new_expiry is not None
+                else ""
+            )
+        )
+        return result
+    except Exception as exc:  # noqa: BLE001 — never bubble up from this helper
+        logger.exception("try_refresh_claude_credentials raised")
+        result.error = f"{type(exc).__name__}: {exc}"
+        return result
+    finally:
+        if not skip_lock:
+            _release_refresh_lock()
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry-point para CronJob (Nível 2)
+# --------------------------------------------------------------------------- #
+
+
+async def _cli_main(argv: Optional[List[str]] = None) -> int:
+    """Entry-point invocado pelo CronJob (manifest 51).
+
+    Argumentos via env:
+      * ``DEILE_K8S_NAMESPACE`` — namespace alvo (default: ``deile``).
+      * ``DEILE_CLAUDE_RENEW_MIN_WINDOW_S`` — janela proativa em segundos
+        (default: ``7200`` = 2h; refresh só ocorre se o token expira em
+        menos disso).
+    """
+    del argv  # CLI sem flags próprias — toda config via env.
+    logging.basicConfig(
+        level=os.environ.get("DEILE_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    namespace = os.environ.get("DEILE_K8S_NAMESPACE", "deile")
+    window_s = float(os.environ.get("DEILE_CLAUDE_RENEW_MIN_WINDOW_S", "7200"))
+    logger.info(
+        "claude-creds-refresh cron: namespace=%s min_window_s=%s",
+        namespace, window_s,
+    )
+    result = await try_refresh_claude_credentials(
+        namespace=namespace, min_expiry_window_s=window_s,
+    )
+    for step in result.steps:
+        logger.info("step: %s", step)
+    if result.ok:
+        logger.info("OK: %s", result.message or "refresh concluído")
+        return 0
+    logger.error("FAIL: %s", result.error or result.message or "refresh falhou")
+    return 1
+
+
+def main() -> int:
+    """Sync wrapper para o entry-point CLI (consumido pelo CronJob)."""
+    return asyncio.run(_cli_main())
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -662,6 +662,107 @@ class WorkerImplementer(PipelineImplementer):
             "_last_completed_at": str(info.get("last_completed_at") or ""),
         }
 
+    async def _try_auto_renew_oauth_and_retry(
+        self,
+        *,
+        outcome: "WorkOutcome",
+        url: str,
+        payload: Dict[str, Any],
+        wait: bool,
+        stage: Optional[str],
+    ) -> "WorkOutcome":
+        """Intercepta ``WORKER_AUTH_EXPIRED`` e tenta refresh + 1 retry.
+
+        Caminho normal (Nível 3 — OAuth auto-renew):
+
+        1. Detecta o code ``[WORKER_AUTH_EXPIRED]`` no ``outcome.error``.
+        2. Invoca :func:`try_refresh_claude_credentials` (lê o token in-pod
+           via ``kubectl exec``, atualiza o Secret ``claude-credentials``).
+        3. Se o refresh teve sucesso, dispara um **único** retry do mesmo
+           payload. O claude-worker recarrega o ``ANTHROPIC_AUTH_TOKEN`` no
+           próximo dispatch via ``_refresh_oauth_with_lock``.
+        4. Se o refresh falhou (``refresh_token`` expirou, etc.) OU o retry
+           voltou auth-expired de novo, devolve o ``outcome`` original
+           (prefixado por ``[WORKER_AUTH_EXPIRED]`` — o stage handler bloqueia).
+
+        O método NUNCA aumenta a janela de tentativas do resume tracker —
+        é um retry transparente, invisível ao streak counter. Quando dá certo,
+        o pipeline observa apenas o resultado do segundo dispatch (como se
+        nada tivesse acontecido); quando não dá, o block determinístico
+        continua imediato.
+
+        Returns:
+            Outcome resultante (do retry quando aplicável; do original caso
+            contrário). Garantido ser sempre uma instância válida.
+        """
+        if outcome.ok or not outcome.error:
+            return outcome
+        # Detecção precisa: o prefixo ``[WORKER_AUTH_EXPIRED]`` é produzido
+        # por ``_outcome_from_worker_response`` quando o worker setou
+        # ``error_code=WORKER_AUTH_EXPIRED`` no body.
+        if "[WORKER_AUTH_EXPIRED]" not in (outcome.error or ""):
+            return outcome
+
+        try:
+            from deile.orchestration.pipeline._claude_creds_refresh import (  # noqa: PLC0415
+                try_refresh_claude_credentials,
+            )
+        except ImportError as exc:
+            logger.warning(
+                "auto-renew indisponível (módulo ausente): %s — bloqueio normal",
+                exc,
+            )
+            return outcome
+
+        logger.info(
+            "WORKER_AUTH_EXPIRED detectado em stage=%s — tentando auto-renew "
+            "do OAuth antes de propagar o bloqueio",
+            stage,
+        )
+        refresh = await try_refresh_claude_credentials(min_expiry_window_s=0.0)
+        if not refresh.ok:
+            logger.warning(
+                "auto-renew FALHOU (%s) — propagando WORKER_AUTH_EXPIRED "
+                "pro stage handler. Humano precisa rodar `claude-login --switch`.",
+                refresh.error or refresh.message or "sem detalhe",
+            )
+            # Anota o erro original com a tentativa de refresh pra audit.
+            return WorkOutcome(
+                ok=False, text=outcome.text,
+                error=(outcome.error + f" | auto-renew falhou: {refresh.error or refresh.message}")[:500],
+                task_id=outcome.task_id, session_id=outcome.session_id,
+            )
+
+        logger.info(
+            "auto-renew OK (%s) — retentando dispatch UMA vez", refresh.message,
+        )
+        try:
+            data = await self._post_dispatch(url, payload, wait=wait)
+        except Exception as exc:  # noqa: BLE001 — never crash the tick
+            logger.warning(
+                "retry após auto-renew falhou no transporte: %s — propagando "
+                "outcome original", exc,
+            )
+            return outcome
+        retry_outcome = _outcome_from_worker_response(data)
+        # Caso degenerado: refresh "funcionou" mas o segundo dispatch também
+        # diz auth-expired (ex: o token no Secret veio velho, kubectl exec
+        # bateu na replica errada, etc.) — não loop, retorna o original.
+        if (
+            not retry_outcome.ok
+            and "[WORKER_AUTH_EXPIRED]" in (retry_outcome.error or "")
+        ):
+            logger.warning(
+                "retry após auto-renew TAMBÉM retornou WORKER_AUTH_EXPIRED — "
+                "estado inconsistente; propagando bloqueio para o humano",
+            )
+            return retry_outcome
+        logger.info(
+            "auto-renew + retry SUCESSO — outcome do retry assumido (ok=%s)",
+            retry_outcome.ok,
+        )
+        return retry_outcome
+
     async def _dispatch(
         self,
         brief: str,
@@ -863,6 +964,18 @@ class WorkerImplementer(PipelineImplementer):
                 ended="",  # Not yet known — reconcile via ground truth
             )
         outcome = _outcome_from_worker_response(data)
+
+        # OAuth auto-renew (Nível 3): se o worker reportou WORKER_AUTH_EXPIRED,
+        # tente uma renovação automática + retry UMA vez antes de propagar o
+        # erro pro stage handler (que bloqueia a issue). Em sucesso do refresh
+        # o segundo dispatch tipicamente passa porque o claude-worker recarrega
+        # o ANTHROPIC_AUTH_TOKEN a cada dispatch (via _refresh_oauth_with_lock).
+        outcome = await self._try_auto_renew_oauth_and_retry(
+            outcome=outcome,
+            url=url, payload=payload, wait=wait,
+            stage=stage,
+        )
+
         # Issue #309 fase 3.5 + issue #347 follow-up — persistência no
         # DispatchLedger:
         #

--- a/deile/tests/infra/test_initcontainer_idempotency.py
+++ b/deile/tests/infra/test_initcontainer_idempotency.py
@@ -1,0 +1,262 @@
+"""Testes do initContainer ``bootstrap-creds`` idempotente do claude-worker.
+
+O initContainer (definido em ``infra/k8s/manifests/50-claude-worker-deployment.yaml``)
+foi modificado para preservar o ``credentials.json`` no PVC entre restarts —
+copia do Secret apenas quando o PVC está ausente OU o Secret tem token mais
+recente. Antes, sobrescrevia incondicionalmente, derrubando o refresh in-pod
+feito pelo próprio ``claude -p`` a cada rollout.
+
+Como o initContainer roda um shell script (não Python importável), o teste
+EXECUTA o script real extraído do YAML em um diretório temporário, exercitando
+os quatro cenários canônicos:
+
+  - ``pvc-absent`` — primeira vez no pod, init copia do Secret.
+  - ``pvc-newer`` — refresh in-pod funcionou; init preserva.
+  - ``secret-newer`` — operador rodou ``claude-login`` recentemente; init copia.
+  - ``pvc-malformed`` — corrompido por crash mid-write; init copia (fail-safe).
+
+O script é parseado a partir do YAML pra garantir que estamos testando a
+mesma lógica em produção (não uma cópia divergente).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_MANIFEST = _REPO / "infra" / "k8s" / "manifests" / "50-claude-worker-deployment.yaml"
+
+
+def _extract_bootstrap_script() -> str:
+    """Lê o bloco ``args: - | <script>`` do initContainer no manifest 50.
+
+    Robusto contra reformatação leve do YAML; usa marcadores únicos
+    (``initContainers``, ``bootstrap-creds``, ``args:`` seguido de ``- |``).
+    """
+    text = _MANIFEST.read_text(encoding="utf-8")
+    # Encontra o bloco do initContainer bootstrap-creds.
+    bootstrap_anchor = text.find("name: bootstrap-creds")
+    assert bootstrap_anchor != -1, "marcador `name: bootstrap-creds` não achado"
+    sub = text[bootstrap_anchor:]
+    # Próximo ``args:`` é o do initContainer.
+    args_anchor = sub.find("args:")
+    assert args_anchor != -1, "bloco `args:` não achado dentro do init"
+    after = sub[args_anchor:]
+    # Captura o conteúdo até a primeira linha cujo indent é MENOR que o do
+    # próprio bloco (fim do literal YAML ``- |``). O bloco ``args: - |``
+    # tem indent maior que o ``volumeMounts:`` que segue.
+    m = re.search(r"args:\s*\n(\s*-\s*\|\s*\n)", after)
+    assert m, "regex não casou o início do bloco args:- |"
+    block_start = m.end()
+    rest = after[block_start:]
+    # Detecta o indent comum da primeira linha não-vazia.
+    first_line = next(line for line in rest.splitlines() if line.strip())
+    block_indent = len(first_line) - len(first_line.lstrip(" "))
+    block_lines = []
+    for line in rest.splitlines():
+        if not line.strip():
+            block_lines.append("")
+            continue
+        line_indent = len(line) - len(line.lstrip(" "))
+        if line_indent < block_indent:
+            break
+        block_lines.append(line[block_indent:])
+    return "\n".join(block_lines)
+
+
+@pytest.fixture
+def script_text() -> str:
+    return _extract_bootstrap_script()
+
+
+@pytest.fixture
+def fake_pod(tmp_path: Path):
+    """Cria a estrutura ``/home/claude/.claude`` + ``/run/secrets/claude`` em tmp.
+
+    O script real referencia caminhos absolutos. Usamos uma adaptação:
+    re-write os caminhos para a árvore tmp via env-var, e o script funciona
+    inalterado com os mesmos opcodes. Devolve ``(pvc_dir, secret_dir, run)``.
+    """
+    pvc = tmp_path / "home" / "claude" / ".claude"
+    secret = tmp_path / "run" / "secrets" / "claude"
+    pvc.mkdir(parents=True, exist_ok=True)
+    secret.mkdir(parents=True, exist_ok=True)
+
+    def run(text: str) -> subprocess.CompletedProcess:
+        # Substitui paths absolutos pelos do tmp.
+        patched = (
+            text
+            .replace("/home/claude/.claude/credentials.json",
+                     str(pvc / "credentials.json"))
+            .replace("/run/secrets/claude/credentials.json",
+                     str(secret / "credentials.json"))
+            .replace("mkdir -p /home/claude/.claude",
+                     f"mkdir -p {pvc}")
+        )
+        return subprocess.run(
+            ["bash", "-c", patched], capture_output=True, text=True,
+            check=False, timeout=20,
+        )
+
+    return pvc, secret, run
+
+
+def _write_creds(path: Path, expires_at_ms: int, token: str) -> None:
+    path.write_text(json.dumps(
+        {"claudeAiOauth": {"accessToken": token, "expiresAt": expires_at_ms}}
+    ), encoding="utf-8")
+
+
+class TestInitContainerIdempotency:
+    @pytest.mark.unit
+    def test_pvc_absent_copies_from_secret(self, script_text, fake_pod):
+        """Primeira instalação: PVC sem credentials → init copia do Secret."""
+        pvc_dir, secret_dir, run = fake_pod
+        _write_creds(secret_dir / "credentials.json", 1_000_000, "from-secret")
+        # Garante PVC vazio.
+        pvc_file = pvc_dir / "credentials.json"
+        if pvc_file.exists():
+            pvc_file.unlink()
+
+        result = run(script_text)
+        assert result.returncode == 0, f"script falhou: {result.stderr}"
+        assert pvc_file.exists()
+        loaded = json.loads(pvc_file.read_text())
+        assert loaded["claudeAiOauth"]["accessToken"] == "from-secret"
+        assert "PVC sem credentials.json" in result.stdout
+
+    @pytest.mark.unit
+    def test_pvc_newer_is_preserved(self, script_text, fake_pod):
+        """Refresh in-pod ativo: PVC tem token mais recente que Secret → preserva."""
+        pvc_dir, secret_dir, run = fake_pod
+        _write_creds(secret_dir / "credentials.json", 1_000_000, "from-secret")
+        _write_creds(pvc_dir / "credentials.json", 5_000_000, "from-pvc-fresh")
+
+        result = run(script_text)
+        assert result.returncode == 0, f"script falhou: {result.stderr}"
+        loaded = json.loads((pvc_dir / "credentials.json").read_text())
+        assert loaded["claudeAiOauth"]["accessToken"] == "from-pvc-fresh"
+        assert "preservado" in result.stdout
+
+    @pytest.mark.unit
+    def test_secret_newer_overrides_pvc(self, script_text, fake_pod):
+        """Operador rodou claude-login: Secret > PVC → init copia Secret."""
+        pvc_dir, secret_dir, run = fake_pod
+        _write_creds(secret_dir / "credentials.json", 9_000_000, "from-secret-new")
+        _write_creds(pvc_dir / "credentials.json", 5_000_000, "from-pvc-old")
+
+        result = run(script_text)
+        assert result.returncode == 0, f"script falhou: {result.stderr}"
+        loaded = json.loads((pvc_dir / "credentials.json").read_text())
+        assert loaded["claudeAiOauth"]["accessToken"] == "from-secret-new"
+        assert "Secret mais recente" in result.stdout
+
+    @pytest.mark.unit
+    def test_pvc_malformed_falls_back_to_secret(self, script_text, fake_pod):
+        """PVC corrompido (JSON inválido) → init copia Secret (fail-safe).
+
+        O ``read_exp`` retorna ``0`` em parse error; ``Secret >= 0`` causa copy.
+        """
+        pvc_dir, secret_dir, run = fake_pod
+        _write_creds(secret_dir / "credentials.json", 1_000_000, "from-secret")
+        (pvc_dir / "credentials.json").write_text("not-json{{", encoding="utf-8")
+
+        result = run(script_text)
+        assert result.returncode == 0, f"script falhou: {result.stderr}"
+        loaded = json.loads((pvc_dir / "credentials.json").read_text())
+        assert loaded["claudeAiOauth"]["accessToken"] == "from-secret"
+
+    @pytest.mark.unit
+    def test_equal_expiry_preserves_pvc(self, script_text, fake_pod):
+        """Tie-break: PVC == Secret → preserva (PVC). Garantia de não copiar
+        inutilmente quando os tokens são idênticos (caso comum logo após boot)."""
+        pvc_dir, secret_dir, run = fake_pod
+        _write_creds(secret_dir / "credentials.json", 7_777_777, "from-secret")
+        _write_creds(pvc_dir / "credentials.json", 7_777_777, "from-pvc-same")
+
+        result = run(script_text)
+        assert result.returncode == 0, f"script falhou: {result.stderr}"
+        loaded = json.loads((pvc_dir / "credentials.json").read_text())
+        # PVC preservado mesmo com expiry igual (>= no script).
+        assert loaded["claudeAiOauth"]["accessToken"] == "from-pvc-same"
+        assert "preservado" in result.stdout
+
+
+class TestForceClearPvcCreds:
+    """O fluxo ``claude-login --switch`` invoca ``_force_clear_pvc_creds``
+    ANTES do rollout para garantir que o initContainer reaja como
+    ``pvc-absent`` e copie a conta nova do Secret."""
+
+    @pytest.mark.unit
+    def test_force_clear_helper_exists_and_handles_missing_pod(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """O helper retorna True quando o pod não existe (cluster fresco)."""
+        import sys
+
+        sys.path.insert(0, str(_REPO / "infra" / "k8s"))
+        try:
+            import _claude_install  # noqa: PLC0415
+        finally:
+            sys.path.pop(0)
+
+        # Simula kubectl exec com "pod not found"
+        def fake_run(cmd, **kw):
+            class R:
+                returncode = 1
+                stderr = "Error from server (NotFound): pods not found"
+                stdout = ""
+
+            return R()
+
+        monkeypatch.setattr(_claude_install.subprocess, "run", fake_run)
+        assert _claude_install._force_clear_pvc_creds(namespace="deile") is True
+
+    @pytest.mark.unit
+    def test_force_clear_helper_handles_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Timeout durante exec é tratado como não-fatal (retry no próximo boot)."""
+        import sys
+
+        sys.path.insert(0, str(_REPO / "infra" / "k8s"))
+        try:
+            import _claude_install  # noqa: PLC0415
+        finally:
+            sys.path.pop(0)
+
+        def raises(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd, 15)
+
+        monkeypatch.setattr(_claude_install.subprocess, "run", raises)
+        assert _claude_install._force_clear_pvc_creds(namespace="deile") is True
+
+    @pytest.mark.unit
+    def test_force_clear_helper_succeeds_when_pod_running(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Exec sucesso (rc=0) é caminho feliz."""
+        import sys
+
+        sys.path.insert(0, str(_REPO / "infra" / "k8s"))
+        try:
+            import _claude_install  # noqa: PLC0415
+        finally:
+            sys.path.pop(0)
+
+        def fake_run(cmd, **kw):
+            class R:
+                returncode = 0
+                stderr = ""
+                stdout = ""
+
+            return R()
+
+        monkeypatch.setattr(_claude_install.subprocess, "run", fake_run)
+        assert _claude_install._force_clear_pvc_creds(namespace="deile") is True

--- a/deile/tests/orchestration/pipeline/test_oauth_auto_refresh.py
+++ b/deile/tests/orchestration/pipeline/test_oauth_auto_refresh.py
@@ -1,0 +1,371 @@
+"""Testes do Nível 3 — pipeline tenta auto-renew do OAuth antes de bloquear.
+
+Cobre o método novo ``WorkerImplementer._try_auto_renew_oauth_and_retry``
+introduzido neste PR e o módulo helper ``_claude_creds_refresh``:
+
+  1. Refresh sucesso + retry sucesso → outcome do retry assumido (transparente).
+  2. Refresh sucesso + retry retorna auth-expired de novo → propaga bloqueio.
+  3. Refresh falha (refresh_token expirado) → propaga outcome original.
+  4. Outcome sem ``[WORKER_AUTH_EXPIRED]`` → método é no-op (não chama refresh).
+  5. ``try_refresh_claude_credentials`` rejeita lock concorrente (idempotência).
+
+Testes do refresh helper isolados também ficam aqui (lock-file, kubectl mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.pipeline import _claude_creds_refresh as crf
+from deile.orchestration.pipeline.implementer import (WorkerImplementer,
+                                                       WorkOutcome,
+                                                       _outcome_from_worker_response)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_expired_outcome() -> WorkOutcome:
+    """Outcome como o worker retornaria com WORKER_AUTH_EXPIRED."""
+    return _outcome_from_worker_response({
+        "ok": False,
+        "error_code": "WORKER_AUTH_EXPIRED",
+        "error": "claude reportou Not logged in",
+    })
+
+
+def _success_outcome() -> WorkOutcome:
+    return _outcome_from_worker_response({
+        "ok": True,
+        "summary": "implementação concluída",
+        "task_id": "deadbeefcafe1234",
+        "session_id": "abc-123",
+    })
+
+
+def _make_implementer() -> tuple[WorkerImplementer, MagicMock]:
+    """Implementer com client mockado e ledger isolado."""
+    client = MagicMock()
+    client.dispatch = AsyncMock()
+    client.get_resume_info = AsyncMock(return_value=None)
+    implementer = WorkerImplementer(
+        client=client,
+        endpoint_override="http://test/v1/dispatch",
+        ledger=MagicMock(get=MagicMock(return_value=None),
+                          record=MagicMock(),
+                          clear=MagicMock()),
+    )
+    return implementer, client
+
+
+# ---------------------------------------------------------------------------
+# N3.1 — método _try_auto_renew_oauth_and_retry
+# ---------------------------------------------------------------------------
+
+
+class TestTryAutoRenewOauthAndRetry:
+    @pytest.mark.unit
+    async def test_noop_when_outcome_ok(self):
+        """Outcome ok=True → método retorna sem chamar refresh."""
+        impl, _client = _make_implementer()
+        outcome = _success_outcome()
+        with patch.object(
+            crf, "try_refresh_claude_credentials", new=AsyncMock(),
+        ) as refresh:
+            result = await impl._try_auto_renew_oauth_and_retry(
+                outcome=outcome, url="x", payload={}, wait=True, stage=None,
+            )
+            refresh.assert_not_called()
+            assert result is outcome
+
+    @pytest.mark.unit
+    async def test_noop_when_error_is_not_auth_expired(self):
+        """Outcome com erro genérico não-auth → método retorna sem refresh."""
+        impl, _client = _make_implementer()
+        outcome = WorkOutcome(ok=False, text="", error="TIMEOUT after 30s")
+        with patch.object(
+            crf, "try_refresh_claude_credentials", new=AsyncMock(),
+        ) as refresh:
+            result = await impl._try_auto_renew_oauth_and_retry(
+                outcome=outcome, url="x", payload={}, wait=True, stage=None,
+            )
+            refresh.assert_not_called()
+            assert result is outcome
+
+    @pytest.mark.unit
+    async def test_refresh_success_then_retry_success(self):
+        """Auth expirado → refresh ok → retry → retorna outcome do retry."""
+        impl, client = _make_implementer()
+        outcome_in = _auth_expired_outcome()
+        # 2º dispatch (o retry) responde sucesso.
+        client.dispatch.return_value = {
+            "ok": True, "summary": "implementação concluída no retry",
+            "task_id": "feedcafedead1234", "session_id": "sid-2",
+        }
+        with patch.object(
+            crf, "try_refresh_claude_credentials",
+            new=AsyncMock(return_value=crf.RefreshResult(
+                ok=True, strategy="exec_inplace",
+                message="Secret atualizado",
+            )),
+        ):
+            result = await impl._try_auto_renew_oauth_and_retry(
+                outcome=outcome_in,
+                url="http://test/v1/dispatch",
+                payload={"brief": "x"}, wait=True, stage="implement",
+            )
+        assert result.ok is True
+        assert "concluída no retry" in result.text
+        assert result.task_id == "feedcafedead1234"
+        client.dispatch.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_refresh_success_but_retry_still_auth_expired(self):
+        """Refresh ok mas 2º dispatch volta auth expired → propaga bloqueio.
+
+        Caso degenerado: estado inconsistente (replicas distintas, Secret
+        propagação lag). Não loop — devolve o outcome do retry com o code.
+        """
+        impl, client = _make_implementer()
+        outcome_in = _auth_expired_outcome()
+        client.dispatch.return_value = {
+            "ok": False, "error_code": "WORKER_AUTH_EXPIRED",
+            "error": "Not logged in (ainda)",
+        }
+        with patch.object(
+            crf, "try_refresh_claude_credentials",
+            new=AsyncMock(return_value=crf.RefreshResult(ok=True)),
+        ):
+            result = await impl._try_auto_renew_oauth_and_retry(
+                outcome=outcome_in,
+                url="x", payload={"brief": "x"}, wait=True, stage="implement",
+            )
+        assert result.ok is False
+        assert "[WORKER_AUTH_EXPIRED]" in result.error
+        client.dispatch.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_refresh_fails_propagates_original_block(self):
+        """Refresh falha → método anota a tentativa e propaga outcome."""
+        impl, client = _make_implementer()
+        outcome_in = _auth_expired_outcome()
+        with patch.object(
+            crf, "try_refresh_claude_credentials",
+            new=AsyncMock(return_value=crf.RefreshResult(
+                ok=False, error="refresh_token também expirado",
+            )),
+        ):
+            result = await impl._try_auto_renew_oauth_and_retry(
+                outcome=outcome_in,
+                url="x", payload={}, wait=True, stage="implement",
+            )
+        assert result.ok is False
+        assert "[WORKER_AUTH_EXPIRED]" in result.error
+        assert "auto-renew falhou" in result.error
+        client.dispatch.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_retry_transport_exception_returns_original(self):
+        """Exceção no transporte do retry → método retorna outcome original."""
+        impl, client = _make_implementer()
+        outcome_in = _auth_expired_outcome()
+        client.dispatch.side_effect = RuntimeError("connect timeout")
+        with patch.object(
+            crf, "try_refresh_claude_credentials",
+            new=AsyncMock(return_value=crf.RefreshResult(ok=True)),
+        ):
+            result = await impl._try_auto_renew_oauth_and_retry(
+                outcome=outcome_in,
+                url="x", payload={}, wait=True, stage="implement",
+            )
+        # Recebe o outcome ORIGINAL (não cria um novo) — operador é alertado
+        # pelo bloqueio normal do stage handler.
+        assert result is outcome_in
+
+
+# ---------------------------------------------------------------------------
+# N3.2 — try_refresh_claude_credentials (helper)
+# ---------------------------------------------------------------------------
+
+
+class TestTryRefreshClaudeCredentials:
+    @pytest.mark.unit
+    async def test_lock_already_held_short_circuits(self, tmp_path, monkeypatch):
+        """Lock-file fresco → retorna sem tentar nada (anti-concorrência)."""
+        lock = tmp_path / "lock"
+        lock.write_text(str(int(__import__("time").time())))
+        monkeypatch.setenv("DEILE_CLAUDE_REFRESH_LOCK", str(lock))
+        # O módulo lê o env var na constante; precisamos recarregar.
+        monkeypatch.setattr(crf, "_REFRESH_LOCK_PATH", str(lock))
+        result = await crf.try_refresh_claude_credentials()
+        assert result.ok is False
+        assert "lock" in (result.message or "").lower()
+
+    @pytest.mark.unit
+    async def test_pod_read_failure_returns_error(
+        self, tmp_path, monkeypatch,
+    ):
+        """``kubectl exec`` retornando rc!=0 vira erro estruturado, não exception."""
+        monkeypatch.setattr(crf, "_REFRESH_LOCK_PATH", str(tmp_path / "lock"))
+
+        async def fake_kubectl(args, timeout_s=30.0, input_data=None):
+            return (1, "", "Error: pod not found")
+
+        monkeypatch.setattr(crf, "_kubectl_async", fake_kubectl)
+        result = await crf.try_refresh_claude_credentials(skip_lock=True)
+        assert result.ok is False
+        assert "pod" in (result.error or "").lower() or "kubectl" in (result.error or "").lower()
+
+    @pytest.mark.unit
+    async def test_reactive_mode_token_in_pod_still_valid_patches_secret(
+        self, tmp_path, monkeypatch,
+    ):
+        """Modo reativo (min_window=0): token in-pod >0s, ainda válido →
+        propaga pro Secret e retorna ok."""
+        monkeypatch.setattr(crf, "_REFRESH_LOCK_PATH", str(tmp_path / "lock"))
+        import time as _time
+        fresh_exp_ms = int((_time.time() + 3600) * 1000)
+        good_creds = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "fresh-token",
+                "expiresAt": fresh_exp_ms,
+            }
+        })
+
+        calls: list[tuple[str, ...]] = []
+
+        async def fake_kubectl(args, timeout_s=30.0, input_data=None):
+            calls.append(tuple(args))
+            if "exec" in args:
+                return (0, good_creds, "")
+            if "create" in args:
+                # dry-run produz YAML.
+                return (0, "apiVersion: v1\nkind: Secret\n", "")
+            if "apply" in args:
+                return (0, "secret/claude-credentials configured", "")
+            return (0, "", "")
+
+        monkeypatch.setattr(crf, "_kubectl_async", fake_kubectl)
+        result = await crf.try_refresh_claude_credentials(
+            min_expiry_window_s=0.0, skip_lock=True,
+        )
+        assert result.ok is True, result.error or result.message
+        # Houve exec + create + apply
+        assert any("exec" in c for c in calls)
+        assert any("apply" in c for c in calls)
+
+    @pytest.mark.unit
+    async def test_reactive_mode_token_in_pod_expired_returns_error(
+        self, tmp_path, monkeypatch,
+    ):
+        """Pod retornou token TAMBÉM expirado → refresh_token provavelmente
+        expirou; propaga erro acionável."""
+        monkeypatch.setattr(crf, "_REFRESH_LOCK_PATH", str(tmp_path / "lock"))
+        import time as _time
+        # Token expirou 1h atrás.
+        expired_ms = int((_time.time() - 3600) * 1000)
+        expired_creds = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "stale-token",
+                "expiresAt": expired_ms,
+            }
+        })
+
+        async def fake_kubectl(args, timeout_s=30.0, input_data=None):
+            return (0, expired_creds, "")
+
+        monkeypatch.setattr(crf, "_kubectl_async", fake_kubectl)
+        result = await crf.try_refresh_claude_credentials(
+            min_expiry_window_s=0.0, skip_lock=True,
+        )
+        assert result.ok is False
+        assert "expirad" in (result.error or "").lower()
+
+    @pytest.mark.unit
+    async def test_proactive_mode_skips_when_token_well_within_window(
+        self, tmp_path, monkeypatch,
+    ):
+        """Modo proativo (min_window=2h): token expira em 5h → skip."""
+        monkeypatch.setattr(crf, "_REFRESH_LOCK_PATH", str(tmp_path / "lock"))
+        import time as _time
+        future_ms = int((_time.time() + 5 * 3600) * 1000)
+        creds_json = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "fresh",
+                "expiresAt": future_ms,
+            }
+        })
+
+        async def fake_kubectl(args, timeout_s=30.0, input_data=None):
+            return (0, creds_json, "")
+
+        monkeypatch.setattr(crf, "_kubectl_async", fake_kubectl)
+        result = await crf.try_refresh_claude_credentials(
+            min_expiry_window_s=7200, skip_lock=True,
+        )
+        assert result.ok is True
+        assert "skip" in " ".join(result.steps).lower()
+
+    @pytest.mark.unit
+    def test_extract_expires_at_parses_keychain_format(self):
+        assert crf._extract_expires_at(
+            {"claudeAiOauth": {"expiresAt": 12345}}
+        ) == 12345
+
+    @pytest.mark.unit
+    def test_extract_expires_at_parses_root_format(self):
+        assert crf._extract_expires_at({"expiresAt": 99}) == 99
+
+    @pytest.mark.unit
+    def test_extract_expires_at_returns_none_for_missing(self):
+        assert crf._extract_expires_at({}) is None
+        assert crf._extract_expires_at({"claudeAiOauth": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# N3.3 — Integração com _dispatch (refresh chamado no path certo)
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchIntegration:
+    @pytest.mark.unit
+    async def test_auth_expired_response_triggers_refresh_in_dispatch(
+        self, tmp_path, monkeypatch,
+    ):
+        """O ``_dispatch`` chama ``_try_auto_renew_oauth_and_retry`` na cadeia
+        após receber a primeira resposta. Quando o refresh + retry tem sucesso,
+        o outcome final propagado pelo dispatch já é o do retry."""
+        impl, client = _make_implementer()
+
+        # 1ª resposta: auth expired; 2ª resposta (retry): sucesso.
+        responses = [
+            {"ok": False, "error_code": "WORKER_AUTH_EXPIRED",
+             "error": "Not logged in"},
+            {"ok": True, "summary": "OK no retry",
+             "task_id": "babababababababa", "session_id": "sid"},
+        ]
+        client.dispatch.side_effect = responses
+        # Bypass do cost guard / ledger irrelevantes.
+        with patch.object(
+            crf, "try_refresh_claude_credentials",
+            new=AsyncMock(return_value=crf.RefreshResult(ok=True)),
+        ):
+            outcome = await impl._dispatch(
+                brief="implement this",
+                channel_id="pipeline-issue-99",
+                persona="developer",
+                stage="implement",
+                branch="auto/issue-99",
+                ledger_key=None,
+            )
+        # Resultado final é o do retry.
+        assert outcome.ok is True
+        assert "OK no retry" in outcome.text
+        assert client.dispatch.call_count == 2

--- a/infra/k8s/_claude_install.py
+++ b/infra/k8s/_claude_install.py
@@ -350,6 +350,58 @@ def _kubectl_sync_bearer_token(*, namespace: str) -> bool:
     return True
 
 
+def _force_clear_pvc_creds(*, namespace: str) -> bool:
+    """Apaga ``credentials.json`` do PVC ``claude-worker-home``.
+
+    Usado pelo flow ``claude-login --switch`` para vencer a idempotência do
+    initContainer ``bootstrap-creds`` (Nível 1 — auto-renew). Sem isso, um
+    switch de conta NÃO substituiria o token no PVC quando o token velho
+    (PVC) tem ``expiresAt`` maior que o novo (Secret após reset).
+
+    Best-effort: se o pod não está no ar (cluster fresco, primeira instalação),
+    o ``kubectl exec`` falha silenciosamente — o init container vai criar o
+    arquivo a partir do Secret no próximo rollout (que é o que queremos).
+
+    Returns ``True`` quando a operação foi bem sucedida ou o pod ausente
+    (estados aceitáveis); ``False`` apenas em erros inesperados de kubectl
+    além de "pod not found".
+    """
+    try:
+        result = subprocess.run(
+            ["kubectl", "-n", namespace, "exec", "deploy/claude-worker",
+             "-c", "claude-worker", "--",
+             "rm", "-f", "/home/claude/.claude/credentials.json"],
+            capture_output=True, text=True, check=False, timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "force-clear PVC creds: timeout — pode estar em rollout. "
+            "Continuando (init container resolve no próximo boot)",
+        )
+        return True
+    except FileNotFoundError:
+        logger.warning("kubectl não encontrado — skip force-clear")
+        return True
+    if result.returncode == 0:
+        logger.info(
+            "PVC credentials.json apagado para garantir bootstrap fresco "
+            "do Secret no próximo rollout (--switch)",
+        )
+        return True
+    err = (result.stderr or "").lower()
+    # Pod sem deployment ainda: aceitável (cluster fresco). Em outros erros,
+    # apenas logamos e seguimos — o objetivo de pré-clear é PROATIVO; falha
+    # aqui só significa que o init vai cair no path "secret-newer" via mtime.
+    if "not found" in err or "no pods" in err or "no resources found" in err:
+        logger.info("force-clear PVC: pod ausente (cluster fresco) — skip")
+        return True
+    logger.warning(
+        "force-clear PVC creds falhou (não-fatal): %s",
+        (result.stderr or "").strip()[:200],
+    )
+    return False
+
+
 def _kubectl_apply_manifests(*, namespace: str) -> bool:
     """Apply manifests 47 (allowed-repos ConfigMap), 49 (PVC),
     50 (Deployment+Service), 40 (NetworkPolicy update).
@@ -373,6 +425,11 @@ def _kubectl_apply_manifests(*, namespace: str) -> bool:
         manifests_dir / "47-claude-worker-allowed-repos.yaml",
         manifests_dir / "49-claude-worker-pvc.yaml",
         manifests_dir / "50-claude-worker-deployment.yaml",
+        # CronJob de renovação proativa do OAuth (Nível 2 — auto-renew).
+        # ServiceAccount + Role + RoleBinding + CronJob convivem nesse YAML;
+        # apply é idempotente. Falhas do CronJob NÃO derrubam o bootstrap
+        # do claude-worker; o pod sobe sem ele em caso de erro RBAC.
+        manifests_dir / "51-claude-credentials-renew-cron.yaml",
         manifests_dir / "40-network-policy.yaml",
     ]
     for f in files:
@@ -458,6 +515,11 @@ def uninstall_claude_worker(*, namespace: str = "deile") -> ClaudeLoginResult:
         ("secret", "claude-credentials"),
         ("secret", "claude-worker-bearer"),
         ("configmap", "claude-worker-allowed-repos"),
+        # Nível 2 (auto-renew CronJob) — recursos do manifest 51.
+        ("cronjob", "claude-credentials-renew"),
+        ("rolebinding", "claude-creds-renewer"),
+        ("role", "claude-creds-renewer"),
+        ("serviceaccount", "claude-creds-renewer"),
     ]
     failures = []
     for kind, name in resources:
@@ -593,6 +655,16 @@ def bootstrap_claude_worker(
                 "permissões do Keychain ou re-rode `claude auth login`."
             ),
         )
+
+    # 1b. Switch de conta — limpa o credentials.json do PVC ANTES de rolar.
+    # O initContainer ``bootstrap-creds`` (manifest 50) agora preserva o PVC
+    # quando o token in-PVC é mais recente que o Secret (Nível 1 — auto-renew
+    # idempotente). Como ``--switch`` PRECISA substituir o token in-PVC pelo
+    # do Secret (conta nova), forçamos a limpeza explicita. Best-effort: se
+    # o pod não está vivo (cluster fresco), o init copia normalmente; falha
+    # de exec NÃO bloqueia o login.
+    if force_relogin:
+        _force_clear_pvc_creds(namespace=namespace)
 
     # 2. Secret
     if not _kubectl_apply_secret(creds, namespace=namespace):

--- a/infra/k8s/manifests/50-claude-worker-deployment.yaml
+++ b/infra/k8s/manifests/50-claude-worker-deployment.yaml
@@ -46,16 +46,25 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
         seccompProfile: { type: RuntimeDefault }
 
-      # InitContainer: copia credentials.json do Secret pro PVC writable.
-      # Sempre overwrite — o operador re-roda `claude-login --switch` quando
-      # quer trocar conta; o refresh do claude CLI in-pod escreve no MESMO
-      # path (sobrevive entre dispatches no mesmo pod) mas é overrided por
-      # claude-login + restart.
+      # InitContainer idempotente — preserva token refrescado in-pod entre
+      # restarts. Antes (pré-PR OAuth auto-renew) esta etapa SEMPRE copiava
+      # o credentials.json do Secret pro PVC, sobrescrevendo qualquer token
+      # mais recente que o ``claude -p`` havia obtido via refresh in-pod
+      # (a cada restart o pod voltava com o token velho — eventualmente
+      # expirado se ``claude-login`` não tivesse rodado nas últimas 8h).
       #
-      # Roda como uid 10001 (PSS restricted-compliant). chown não é
-      # necessário porque ``fsGroup: 10001`` já garante que TUDO no PVC
-      # claude-home pertença ao gid 10001 — o cp herda esse gid e o chmod
-      # 0600 fica aplicável.
+      # Comportamento novo: compara ``expiresAt`` do Secret vs PVC. Copia
+      # apenas quando (a) PVC não tem credentials ainda OU (b) o Secret tem
+      # um token MAIS RECENTE (operador acabou de rodar ``claude-login``).
+      # Em todos os outros casos preserva o token do PVC, que é tipicamente
+      # o resultado do refresh in-pod feito pelo próprio claude CLI.
+      #
+      # Mecanismo de força: ``claude-login --switch`` (troca de conta) precisa
+      # vencer essa proteção — ele deleta o credentials.json do PVC ANTES do
+      # rollout (via Job dedicado em ``_claude_install._force_clear_pvc_creds``).
+      # Após o delete, o init detecta arquivo ausente e copia normalmente.
+      #
+      # Roda como uid 10001 (PSS restricted-compliant); fsGroup garante perms.
       initContainers:
         - name: bootstrap-creds
           image: deile-stack:local
@@ -65,9 +74,25 @@ spec:
             - |
               set -eu
               mkdir -p /home/claude/.claude
-              cp /run/secrets/claude/credentials.json /home/claude/.claude/credentials.json
-              chmod 0600 /home/claude/.claude/credentials.json
-              ls -la /home/claude/.claude/credentials.json
+              CREDS_PVC=/home/claude/.claude/credentials.json
+              CREDS_SECRET=/run/secrets/claude/credentials.json
+              PY_READ_EXP='import json,sys;d=json.load(open(sys.argv[1]));o=d.get("claudeAiOauth") or {};print(int(o.get("expiresAt") or d.get("expiresAt") or 0))'
+              if [ ! -f "$CREDS_PVC" ]; then
+                echo "bootstrap-creds: PVC sem credentials.json - copiando do Secret"
+                cp "$CREDS_SECRET" "$CREDS_PVC"
+                chmod 0600 "$CREDS_PVC"
+              else
+                PVC_EXP=$(python3 -c "$PY_READ_EXP" "$CREDS_PVC" 2>/dev/null || echo 0)
+                SECRET_EXP=$(python3 -c "$PY_READ_EXP" "$CREDS_SECRET" 2>/dev/null || echo 0)
+                if [ "${SECRET_EXP:-0}" -gt "${PVC_EXP:-0}" ]; then
+                  echo "bootstrap-creds: Secret mais recente (Secret=$SECRET_EXP > PVC=$PVC_EXP) - copiando"
+                  cp "$CREDS_SECRET" "$CREDS_PVC"
+                  chmod 0600 "$CREDS_PVC"
+                else
+                  echo "bootstrap-creds: PVC preservado (PVC=$PVC_EXP >= Secret=$SECRET_EXP)"
+                fi
+              fi
+              ls -la "$CREDS_PVC"
           volumeMounts:
             - name: claude-credentials
               mountPath: /run/secrets/claude

--- a/infra/k8s/manifests/51-claude-credentials-renew-cron.yaml
+++ b/infra/k8s/manifests/51-claude-credentials-renew-cron.yaml
@@ -1,0 +1,141 @@
+# claude-credentials-renew — CronJob de renovação proativa do OAuth do
+# claude-worker.
+#
+# Roda a cada 4 horas. Lê o token in-pod via ``kubectl exec``, e quando o
+# ``expiresAt`` está a menos de 2h da expiração, atualiza o Secret
+# ``claude-credentials`` com o token mais recente que o ``claude -p``
+# refrescou in-pod. Sem operador, sem browser, sem rollout — apenas mantém
+# o Secret sincronizado com o estado vivo do pod.
+#
+# Quando o refresh_token do OAuth também expira (tipicamente 30 dias),
+# nada disso funciona — o operador precisa rodar ``claude-login --switch``
+# manualmente. O CronJob loga FAIL com a razão; o painel exibe.
+#
+# Implementação: ver ``deile/orchestration/pipeline/_claude_creds_refresh.py``
+# (mesma função consumida pelo Nível 3 — pipeline auto-renew).
+#
+# RBAC: ServiceAccount com permissão MÍNIMA — apenas pods/exec no claude-worker
+# + get/patch/create do Secret ``claude-credentials``. Sem secrets list,
+# sem deployments edit, sem nada além disso.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: claude-creds-renewer
+  namespace: deile
+  labels:
+    app: claude-creds-renewer
+    role: deile
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: claude-creds-renewer
+  namespace: deile
+  labels:
+    app: claude-creds-renewer
+    role: deile
+rules:
+  # 1. exec no pod claude-worker (para ler credentials.json in-pod).
+  # `resourceNames` não é honrado em pods/exec — o app-layer
+  # (_claude_creds_refresh.py) endereça `deploy/claude-worker` explicitamente.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  # 2. get/patch/create do Secret ``claude-credentials`` SOMENTE.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "patch", "create"]
+    resourceNames: ["claude-credentials"]
+  # 3. Necessário para ``kubectl get deployment/claude-worker`` (resolver pod).
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get"]
+    resourceNames: ["claude-worker"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: claude-creds-renewer
+  namespace: deile
+  labels:
+    app: claude-creds-renewer
+    role: deile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: claude-creds-renewer
+subjects:
+  - kind: ServiceAccount
+    name: claude-creds-renewer
+    namespace: deile
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: claude-credentials-renew
+  namespace: deile
+  labels:
+    app: claude-creds-renewer
+    role: deile
+spec:
+  # A cada 4 horas. OAuth do Claude expira a cada ~8h; com janela proativa
+  # de 2h, dois ticks consecutivos sempre cobrem antes da expiração.
+  schedule: "0 */4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app: claude-creds-renewer
+            role: deile
+        spec:
+          serviceAccountName: claude-creds-renewer
+          automountServiceAccountToken: true
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            seccompProfile: { type: RuntimeDefault }
+          containers:
+            - name: renewer
+              image: deile-stack:local
+              imagePullPolicy: Never
+              command: ["python3", "-m", "deile.orchestration.pipeline._claude_creds_refresh"]
+              env:
+                - { name: DEILE_K8S_NAMESPACE, value: "deile" }
+                # Janela proativa: refresh só se o token expira em menos
+                # disso (em segundos). 7200s = 2h.
+                - { name: DEILE_CLAUDE_RENEW_MIN_WINDOW_S, value: "7200" }
+                - { name: DEILE_LOG_LEVEL, value: "INFO" }
+                - { name: KUBECTL_BIN, value: "kubectl" }
+                - { name: PYTHONUNBUFFERED, value: "1" }
+                # Lock-file em /tmp (writable em emptyDir; evita refresh
+                # concorrente caso pipeline N3 dispare ao mesmo tempo).
+                - { name: DEILE_CLAUDE_REFRESH_LOCK, value: "/tmp/claude-creds-refresh.lock" }
+              resources:
+                requests: { cpu: "50m", memory: "128Mi" }
+                limits:   { cpu: "500m", memory: "512Mi" }
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                capabilities: { drop: ["ALL"] }
+                seccompProfile: { type: RuntimeDefault }
+              volumeMounts:
+                - { name: tmp, mountPath: /tmp }
+          volumes:
+            - name: tmp
+              emptyDir: { sizeLimit: "32Mi" }


### PR DESCRIPTION
## Resumo

Implementa os 3 níveis de OAuth auto-renew para o `claude-worker`, eliminando o cenário em que o token OAuth expira (TTL ~8h) e o pipeline bloqueia issues exigindo intervenção humana com `deploy.py k8s claude-renew`. Sequência natural após a branch `feat/multi-claude` (§13 de [docs/future/HARNESS/00-CONCEPTION.md](docs/future/HARNESS/00-CONCEPTION.md)) que introduziu o lock cross-pod do refresh.

## Antes vs depois

| Cenário | Antes | Depois |
|---|---|---|
| **Pod restart (rollout, scale, OOM)** | `initContainer` sobrescreve `credentials.json` no PVC com o do Secret. Refresh in-pod feito pelo `claude -p` é **perdido**. Pod volta com token antigo, eventualmente expirado. | `initContainer` compara `expiresAt` Secret vs PVC. Copia apenas se PVC ausente ou Secret mais recente (operador rodou `claude-login`). Refresh in-pod é **preservado**. |
| **Token expira em produção (8h)** | Pipeline reporta `WORKER_AUTH_EXPIRED` → bloqueia a issue imediatamente. Humano precisa rodar `deploy.py k8s claude-renew` manualmente. | Pipeline tenta refresh automático (lê token in-pod via `kubectl exec`, atualiza Secret) + 1 retry. Só bloqueia se o refresh_token também expirou. **Zero intervenção** no caso comum. |
| **Renovação preventiva** | Inexistente — operador só reage à expiração. | CronJob a cada 4h: se `expiresAt - now < 2h`, atualiza Secret a partir do token in-pod. **Renovação proativa** sem intervenção. |
| **Switch de conta (`claude-login --switch`)** | Funcionava porque `initContainer` sempre sobrescrevia. | Helper `_force_clear_pvc_creds` deleta o PVC ANTES do rollout para vencer a idempotência. Best-effort, falha gracefully quando pod ausente. |

## Os 3 níveis

### Nível 1 — `initContainer` idempotente (commit `17f31c8`)
[docs/future/HARNESS/00-CONCEPTION.md §13](docs/future/HARNESS/00-CONCEPTION.md) → este PR estende o trabalho de OAuth cross-pod.

* `infra/k8s/manifests/50-claude-worker-deployment.yaml` — `args` do `bootstrap-creds` agora compara `expiresAt` antes de copiar.
* `infra/k8s/_claude_install.py` — novo helper `_force_clear_pvc_creds` para o flow `--switch`.

### Nível 2 — CronJob proativo (commit `20543e9`)
* `infra/k8s/manifests/51-claude-credentials-renew-cron.yaml` — CronJob a cada 4h com RBAC mínimo (`pods/exec` no `claude-worker` + `get/patch` apenas no Secret `claude-credentials`).
* `deile/orchestration/pipeline/_claude_creds_refresh.py` — módulo compartilhado com lógica de refresh (lock-file, kubectl async com timeout, modo proativo/reativo). Invocável via `python3 -m` no CronJob.

### Nível 3 — Pipeline auto-refresh (commit `7cf81bb`)
* `deile/orchestration/pipeline/implementer.py` — novo método `WorkerImplementer._try_auto_renew_oauth_and_retry`: intercepta `[WORKER_AUTH_EXPIRED]` no outcome, tenta refresh, retenta UMA vez transparentemente. Não toca o resume tracker.

## Testes (commit `68f226c`)

* `deile/tests/infra/test_initcontainer_idempotency.py` (8 testes) — extrai o script bash REAL do manifest 50 e executa em sandbox tmp; cobre PVC ausente, PVC mais recente, Secret mais recente, PVC malformado, tie-break, `_force_clear_pvc_creds` em 3 estados.
* `deile/tests/orchestration/pipeline/test_oauth_auto_refresh.py` (15 testes) — `_try_auto_renew_oauth_and_retry` em 5 caminhos; `try_refresh_claude_credentials` em 6 caminhos; integração end-to-end `_dispatch`.

**Resultado**: 23 testes novos, todos verdes. 209 testes adjacentes (claude_install, implementer, resume, claude_worker_server, claude_worker_lease) continuam verdes. Falhas pre-existentes da main (panel_cost_cap, dispatch_matrix, monitor TickSummary, streaming-ui) NÃO foram introduzidas por este PR — confirmado por baseline antes/depois.

## Edge cases tratados

1. **Race entre 2 CronJobs** — lock-file em `/tmp` com TTL de 5 min impede execução concorrente; segundo CronJob detecta o lock fresco e faz no-op.
2. **Refresh durante dispatch ativo** — o `claude-worker` já tem `_refresh_oauth_with_lock` (flock POSIX) que serializa leitura. O auto-renew do pipeline N3 atualiza o Secret externamente; o pod só vê o token novo no próximo dispatch.
3. **Secret é read-only no pod** — `force-bootstrap` foi implementado como **delete do PVC pré-rollout** (via `kubectl exec`) em vez de flag no Secret, evitando o problema.
4. **CronJob "imagem grande"** — escolhi `deile-stack:local` (já presente no nó k3s, `imagePullPolicy: Never`) em vez de `bitnami/kubectl` para evitar dependência de pull externo e centralizar Python helpers.
5. **RBAC mínimo** — Role com `resourceNames: ["claude-credentials"]` no Secret + `pods/exec` no claude-worker. Sem `secrets list`, sem `deployments edit`, sem cluster-wide.
6. **Refresh_token também expirado** — N3 detecta token in-pod com `expiresAt <= now` e devolve erro estruturado pedindo `claude-login --switch` manual. Não loop.

## O que NÃO foi implementado

* **CronJob E2E test** — exigiria k8s real (Rancher Desktop). Deixado como TODO documentado nos manifests. O módulo `_claude_creds_refresh.py` está 100% coberto por unit tests.
* **Sidecar credential proxy** — mencionado em [§7 da spec do claude-worker](docs/superpowers/specs/2026-05-26-claude-worker-design.md). Tarefa separada, escopo maior.

## Como testar localmente

```bash
# Testes unitários novos
python3 -m pytest deile/tests/infra/test_initcontainer_idempotency.py \
                  deile/tests/orchestration/pipeline/test_oauth_auto_refresh.py -v

# Validação dos manifests
~/.rd/bin/kubectl apply --dry-run=client \
  -f infra/k8s/manifests/50-claude-worker-deployment.yaml \
  -f infra/k8s/manifests/51-claude-credentials-renew-cron.yaml

# Deploy completo (aplica os 2 manifests novos + initContainer atualizado)
python3 infra/k8s/deploy.py k8s claude-login
```

## Test plan

- [x] Testes unitários do N1 (initContainer + `_force_clear_pvc_creds`) — 8 passed
- [x] Testes unitários do N3 (`_try_auto_renew_oauth_and_retry` + helper refresh) — 15 passed
- [x] Suite adjacente (claude_install, implementer, resume, claude_worker_server, lease) — 209 passed
- [x] Validação YAML via `kubectl apply --dry-run=client` para manifests 50 + 51
- [x] Validação sintática Python (`py_compile`) em todos os arquivos novos/modificados
- [ ] Smoke test E2E no cluster (rebuild + claude-login + esperar 4h ou forçar CronJob via `kubectl create job --from=cronjob/...`)
- [ ] Verificar que `claude-login --switch` substitui o PVC corretamente após o N1 idempotente