### PR TITLE
fix: persist pod logs across restarts — apply PVCs from 42b and fix RWX→RWO

### DIFF
--- a/deile/tests/infra/test_logs_pvc_wiring_404.py
+++ b/deile/tests/infra/test_logs_pvc_wiring_404.py
@@ -1,0 +1,149 @@
+"""Tests for log PVC wiring fix (issue #404).
+
+Covers:
+  - 42b-deile-logs-pvc.yaml uses ReadWriteOnce (compatible with k3s local-path)
+  - Both deile-logs and deile-logs-pipeline PVCs are declared in 42b
+  - 42b-deile-logs-pvc.yaml is in the manifests list of every DeploymentProfile
+  - 42b is applied before Deployments in every profile's manifests tuple
+  - 46-deile-pipeline-deployment.yaml mounts deile-logs-pipeline at /home/deile/logs
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO = Path(__file__).resolve().parents[3]
+_MANIFESTS = _REPO / "infra" / "k8s" / "manifests"
+
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import deploy  # noqa: E402
+
+
+def _load_all(filename: str) -> list[dict]:
+    return list(yaml.safe_load_all((_MANIFESTS / filename).read_text()))
+
+
+class TestLogsPvcYaml:
+    """42b-deile-logs-pvc.yaml structure."""
+
+    def test_deile_logs_pvc_uses_rwo(self):
+        docs = _load_all("42b-deile-logs-pvc.yaml")
+        worker_pvc = next(d for d in docs if d["metadata"]["name"] == "deile-logs")
+        modes = worker_pvc["spec"]["accessModes"]
+        assert modes == ["ReadWriteOnce"], (
+            "deile-logs must use ReadWriteOnce — local-path (k3s default) "
+            "does not support ReadWriteMany"
+        )
+
+    def test_deile_logs_pipeline_pvc_exists(self):
+        docs = _load_all("42b-deile-logs-pvc.yaml")
+        names = [d["metadata"]["name"] for d in docs]
+        assert "deile-logs-pipeline" in names, (
+            "deile-logs-pipeline PVC must be declared in 42b for pipeline "
+            "log persistence (issue #404)"
+        )
+
+    def test_deile_logs_pipeline_pvc_uses_rwo(self):
+        docs = _load_all("42b-deile-logs-pvc.yaml")
+        pipeline_pvc = next(d for d in docs if d["metadata"]["name"] == "deile-logs-pipeline")
+        modes = pipeline_pvc["spec"]["accessModes"]
+        assert modes == ["ReadWriteOnce"], (
+            "deile-logs-pipeline must use ReadWriteOnce for k3s local-path compatibility"
+        )
+
+    def test_both_pvcs_have_256mi_storage(self):
+        docs = _load_all("42b-deile-logs-pvc.yaml")
+        for doc in docs:
+            storage = doc["spec"]["resources"]["requests"]["storage"]
+            assert storage == "256Mi", (
+                f"PVC {doc['metadata']['name']} must request 256Mi storage"
+            )
+
+
+class TestDeploymentProfileManifests:
+    """42b must appear before the deployments that mount its PVCs."""
+
+    @pytest.mark.parametrize("profile_name", ["pipeline-only", "full", "claude-only"])
+    def test_logs_pvc_in_manifests(self, profile_name):
+        m = deploy.DeploymentProfile(profile_name).manifests
+        assert "42b-deile-logs-pvc.yaml" in m, (
+            f"Profile '{profile_name}' manifests must include 42b-deile-logs-pvc.yaml "
+            f"so the PVC exists before the Deployments start"
+        )
+
+    @pytest.mark.parametrize("profile_name", ["pipeline-only", "full", "claude-only"])
+    def test_logs_pvc_before_worker_deployment(self, profile_name):
+        m = list(deploy.DeploymentProfile(profile_name).manifests)
+        assert "42b-deile-logs-pvc.yaml" in m, f"42b missing from {profile_name}"
+        assert "45-deile-worker-deployment.yaml" in m, f"45 missing from {profile_name}"
+        idx_pvc = m.index("42b-deile-logs-pvc.yaml")
+        idx_dep = m.index("45-deile-worker-deployment.yaml")
+        assert idx_pvc < idx_dep, (
+            f"Profile '{profile_name}': 42b-deile-logs-pvc.yaml (idx {idx_pvc}) must "
+            f"come before 45-deile-worker-deployment.yaml (idx {idx_dep})"
+        )
+
+    @pytest.mark.parametrize("profile_name", ["pipeline-only", "full", "claude-only"])
+    def test_logs_pvc_before_pipeline_deployment(self, profile_name):
+        m = list(deploy.DeploymentProfile(profile_name).manifests)
+        assert "42b-deile-logs-pvc.yaml" in m
+        assert "46-deile-pipeline-deployment.yaml" in m
+        idx_pvc = m.index("42b-deile-logs-pvc.yaml")
+        idx_dep = m.index("46-deile-pipeline-deployment.yaml")
+        assert idx_pvc < idx_dep, (
+            f"Profile '{profile_name}': 42b must come before 46 — pipeline "
+            f"deployment now mounts deile-logs-pipeline PVC"
+        )
+
+
+class TestPipelineDeploymentLogsMount:
+    """46-deile-pipeline-deployment.yaml must mount deile-logs-pipeline."""
+
+    def _spec(self) -> dict:
+        docs = _load_all("46-deile-pipeline-deployment.yaml")
+        return docs[0]["spec"]["template"]["spec"]
+
+    def test_logs_volume_declared(self):
+        volumes = self._spec().get("volumes", [])
+        names = [v["name"] for v in volumes]
+        assert "logs" in names, (
+            "Volume 'logs' must be declared in deile-pipeline so logs survive rollout"
+        )
+
+    def test_logs_volume_uses_deile_logs_pipeline_pvc(self):
+        volumes = self._spec().get("volumes", [])
+        logs_vol = next((v for v in volumes if v["name"] == "logs"), None)
+        assert logs_vol is not None
+        claim = logs_vol.get("persistentVolumeClaim", {}).get("claimName")
+        assert claim == "deile-logs-pipeline", (
+            f"Pipeline logs volume must use deile-logs-pipeline PVC, got: {claim!r}"
+        )
+
+    def test_logs_volumemount_at_home_deile_logs(self):
+        containers = self._spec().get("containers", [])
+        assert containers
+        mounts = containers[0].get("volumeMounts", [])
+        logs_mounts = [m for m in mounts if m["name"] == "logs"]
+        assert logs_mounts, "volumeMount 'logs' not found in pipeline container"
+        assert logs_mounts[0]["mountPath"] == "/home/deile/logs", (
+            "logs must be mounted at /home/deile/logs — CappedRotatingFileHandler "
+            "writes to /home/deile/logs/<pod-name>/ (log_mgmt/log_rotator.py)"
+        )
+
+
+class TestDoCreateNamespaceManifestsOrder:
+    """do_create_namespace must apply 42b before deployments."""
+
+    def test_logs_pvc_in_create_namespace_order(self):
+        import inspect
+        src = inspect.getsource(deploy.do_create_namespace)
+        assert "42b-deile-logs-pvc.yaml" in src, (
+            "do_create_namespace must include 42b-deile-logs-pvc.yaml in manifests_order"
+        )

--- a/infra/k8s/deploy.py
+++ b/infra/k8s/deploy.py
@@ -126,6 +126,8 @@ class DeploymentProfile:
             "15-bot-config.yaml",
             "47-deile-runtime-config.yaml",
             "41-worker-pvc.yaml",
+            # issue #404 — logs PVCs must precede the Deployments that mount them.
+            "42b-deile-logs-pvc.yaml",
             "45-deile-worker-deployment.yaml",
             "46b-deile-pipeline-pvc.yaml",
             "46-deile-pipeline-deployment.yaml",
@@ -146,6 +148,8 @@ class DeploymentProfile:
             "20-bot-deployment.yaml",
             "35-deile-interactive.yaml",
             "41-worker-pvc.yaml",
+            # issue #404 — logs PVCs must precede the Deployments that mount them.
+            "42b-deile-logs-pvc.yaml",
             "45-deile-worker-deployment.yaml",
             "46b-deile-pipeline-pvc.yaml",
             "46-deile-pipeline-deployment.yaml",
@@ -1607,7 +1611,10 @@ def do_create_namespace(cfg: CreateNamespaceConfig) -> int:
         "15-bot-config.yaml", "47-deile-runtime-config.yaml",
         "19-bot-data-pvc.yaml",
         "20-bot-deployment.yaml", "35-deile-interactive.yaml",
-        "41-worker-pvc.yaml", "45-deile-worker-deployment.yaml",
+        "41-worker-pvc.yaml",
+        # issue #404 — logs PVCs must precede the Deployments that mount them.
+        "42b-deile-logs-pvc.yaml",
+        "45-deile-worker-deployment.yaml",
         "46b-deile-pipeline-pvc.yaml",
         "46-deile-pipeline-deployment.yaml",
     )

--- a/infra/k8s/manifests/42b-deile-logs-pvc.yaml
+++ b/infra/k8s/manifests/42b-deile-logs-pvc.yaml
@@ -1,10 +1,14 @@
-# PVC isolado para logs rotacionados dos pods DEILE.
+# PVCs de logs rotacionados para os pods DEILE (issue #404).
 #
-# Montado em /home/deile/logs/<pod-name>/ em cada pod. RWX para que o
-# DaemonSet log-analyzer possa ler os logs de todos os pods no nó.
+# Dois PVCs separados — um por deployment — porque local-path (k3s default)
+# só suporta ReadWriteOnce. Cada pod grava em /home/deile/logs/<pod-name>/
+# via CappedRotatingFileHandler (issue #371, deile/log_mgmt/log_rotator.py).
 #
-# 256Mi cobre ~30 dias de logs (5 MB por pod × 4 pods × 3 backups ≈ 60 MB
-# peak; folga de 4× para picos e logs de debug).
+# 256Mi cobre ~30 dias de logs por pod (5 MB × 3 backups ≈ 15 MB peak;
+# folga de 16× para picos e logs de debug).
+#
+# deile-worker tem 2 réplicas; no k3s single-node ambas ficam no mesmo nó
+# e podem montar o mesmo PVC ReadWriteOnce (RWO é restrição de nó, não de pod).
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,12 +17,25 @@ metadata:
   labels:
     app: deile
     component: logs
+    workload: deile-worker
 spec:
-  accessModes: ["ReadWriteMany"]
+  accessModes: ["ReadWriteOnce"]
   resources:
     requests:
       storage: 256Mi
-  # storageClassName left unset → cluster default.
-  # RWX requires a provisioner that supports it (Longhorn, NFS, EFS).
-  # If unavailable, operator can deploy this PVC with a different
-  # storageClass or fallback to emptyDir without persistence.
+  # storageClassName: default (local-path no k3s) — suporta RWO.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deile-logs-pipeline
+  namespace: deile
+  labels:
+    app: deile
+    component: logs
+    workload: deile-pipeline
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 256Mi

--- a/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
+++ b/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
@@ -188,6 +188,8 @@ spec:
             # Montado em subpath de /home/deile: o emptyDir "home" cobre a
             # raiz (repo clone) e o PVC overlay cobre .deile/pipeline/ (ledger).
             - { name: pipeline-ledger, mountPath: /home/deile/.deile/pipeline }
+            # PVC de logs rotacionados (issue #404 / log_mgmt/log_rotator.py).
+            - { name: logs,           mountPath: /home/deile/logs }
             # settings.json layered (issue #111). Apontado pelo env var
             # DEILE_SETTINGS_FILE para evitar collision com ~/.deile/ writable.
             - name: runtime-config
@@ -220,6 +222,8 @@ spec:
         # restarts/rollouts. O path ~/.deile/pipeline/dispatches.json
         # resolve naturalmente pra este mount sem alterar dispatch_ledger.py.
         - { name: pipeline-ledger, persistentVolumeClaim: { claimName: deile-pipeline-ledger } }
+        # PVC de logs rotacionados (issue #404).
+        - { name: logs,            persistentVolumeClaim: { claimName: deile-logs-pipeline } }
         - name: runtime-config
           configMap:
             name: deile-runtime-config


### PR DESCRIPTION
## Summary

- **Root cause 1:** `42b-deile-logs-pvc.yaml` declared `accessModes: ReadWriteMany`, which k3s `local-path` StorageClass (RWO-only) cannot provision — the PVC would fail to be created.
- **Root cause 2:** `deploy.py k8s_up` (and `do_create_namespace`) never included `42b` in the manifests list, so `deile-logs` PVC was never applied. The worker Deployment referenced it anyway; K8s silently fell back to the parent emptyDir — all logs evaporated on every restart.
- **Root cause 3:** `deile-pipeline` writes to `/home/deile/logs/` (via `CappedRotatingFileHandler`, issue #371) but had no PVC backing that path, so pipeline logs were equally volatile.

**Changes:**
- `42b-deile-logs-pvc.yaml`: split into two `ReadWriteOnce` PVCs — `deile-logs` (worker) and `deile-logs-pipeline` — compatible with `local-path`.
- `46-deile-pipeline-deployment.yaml`: add `logs` volumeMount at `/home/deile/logs` + matching volume using `deile-logs-pipeline`.
- `deploy.py` — `DeploymentProfile.manifests` (all 3 profiles) and `do_create_namespace`: add `42b-deile-logs-pvc.yaml` before the Deployments that mount it.
- New test `deile/tests/infra/test_logs_pvc_wiring_404.py`: 17 tests verifying PVC access modes, ordering in every profile, and pipeline volumeMount wiring.

## Test plan

- [ ] `python3 -m pytest deile/tests/infra/test_logs_pvc_wiring_404.py -v` — all 17 pass
- [ ] `python3 -m pytest deile/tests/infra/test_k8s_up_refactor.py deile/tests/infra/test_manifest_wiring_355.py -q` — no regressions
- [ ] To confirm persistence manually:
  ```bash
  K=~/.rd/bin/kubectl
  # 1. After k8s up, PVC must exist:
  $K -n deile get pvc deile-logs deile-logs-pipeline
  # 2. Trigger a rollout:
  $K -n deile rollout restart deploy/deile-pipeline deploy/deile-worker
  # 3. After rollout completes, log file still present:
  $K -n deile exec deploy/deile-worker -- ls /home/deile/logs/
  $K -n deile exec deploy/deile-pipeline -- ls /home/deile/logs/
  ```

Closes #404.