### PR TITLE
fix(panel): guard zero retries + banner de overrides ativos

### DIFF
--- a/deile/tests/infra/test_dispatch_matrix_overrides_banner.py
+++ b/deile/tests/infra/test_dispatch_matrix_overrides_banner.py
@@ -1,0 +1,158 @@
+"""Tests for the ``OVERRIDES ATIVOS`` banner in DispatchMatrixView.
+
+O banner aparece acima da matriz quando QUALQUER per-stage override está
+ativo (worker per-stage, model, timeout_s, max_retries, cost_cap_usd) e
+destaca ``retries=0`` em vermelho — o caso que historicamente bloqueou o
+pipeline (env ghost ``DEILE_PIPELINE_RETRIES_IMPLEMENT=0``).
+"""
+
+import os
+import sys
+import types
+from dataclasses import dataclass
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+from rich.console import Console
+
+_INFRA_K8S = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "infra", "k8s"
+)
+if _INFRA_K8S not in sys.path:
+    sys.path.insert(0, _INFRA_K8S)
+
+
+@dataclass(frozen=True)
+class _Entry:
+    stage: str
+    worker: str = "deile-worker"
+    model: Optional[str] = None
+    source: str = "default"
+    timeout_s: Optional[int] = None
+    max_retries: Optional[int] = None
+    cost_cap_usd: Optional[str] = None
+
+
+@pytest.fixture(autouse=True)
+def _stub_panel_data(monkeypatch):
+    if "_panel_data" not in sys.modules:
+        stub = types.ModuleType("_panel_data")
+        stub.NS = "deile"
+        stub.kubectl_bin = lambda: None
+        stub.BackgroundRefresher = MagicMock
+        stub.PanelData = MagicMock
+        stub._fmt_age = lambda *a, **kw: ""
+        stub._audit_dispatch_mode_change = MagicMock()
+        stub._audit_security_policy_change = MagicMock()
+        stub.clear_pipeline_dispatch_mode = MagicMock(return_value=(True, "ok"))
+        stub.clear_stage_model = MagicMock(return_value=(True, "ok"))
+        stub.set_pipeline_dispatch_mode = MagicMock(return_value=(True, "ok"))
+        stub.set_pipeline_dispatch_stage = MagicMock(return_value=(True, "ok"))
+        stub.set_preferred_model = MagicMock(return_value=(True, "ok"))
+        stub.set_stage_model = MagicMock(return_value=(True, "ok"))
+        stub.set_stage_timeout = MagicMock(return_value=(True, "ok"))
+        stub.set_stage_retries = MagicMock(return_value=(True, "ok"))
+        stub.StageDispatchEntry = _Entry
+        stub.ClaudeWorkerStatus = MagicMock
+        sys.modules["_panel_data"] = stub
+
+
+def _render(entries):
+    """Render the banner and return text + rendered ANSI for assertions."""
+    import _panel as panel_mod
+    view = panel_mod.DispatchMatrixView(data=None)
+    out = view._render_overrides_banner(entries)
+    if out is None:
+        return None, ""
+    console = Console(width=120, record=True)
+    console.print(out)
+    return out, console.export_text()
+
+
+def test_banner_hidden_when_no_overrides():
+    entries = [
+        _Entry("classify"),
+        _Entry("implement"),
+    ]
+    out, _ = _render(entries)
+    assert out is None
+
+
+def test_banner_visible_when_retries_zero():
+    entries = [
+        _Entry("classify"),
+        _Entry("implement", max_retries=0),
+    ]
+    out, text = _render(entries)
+    assert out is not None
+    assert "implement" in text
+    assert "FAIL-FAST" in text
+
+
+def test_banner_visible_when_model_overridden():
+    entries = [
+        _Entry("classify", model="anthropic:claude-opus-4-7"),
+    ]
+    out, text = _render(entries)
+    assert out is not None
+    assert "classify" in text
+    assert "model=anthropic:claude-opus-4-7" in text
+
+
+def test_banner_visible_when_timeout_overridden():
+    entries = [
+        _Entry("implement", timeout_s=900),
+    ]
+    out, text = _render(entries)
+    assert out is not None
+    assert "timeout=900s" in text
+
+
+def test_banner_visible_when_cost_cap_set():
+    entries = [
+        _Entry("implement", cost_cap_usd="5.00"),
+    ]
+    out, text = _render(entries)
+    assert out is not None
+    assert "cap=$5.00" in text
+
+
+def test_banner_visible_when_worker_overridden_per_stage():
+    """Worker per-stage (source=env) aparece no banner; source=global não."""
+    entries = [
+        _Entry("classify", worker="claude-worker", source="env"),
+        _Entry("implement", worker="claude-worker", source="global"),
+    ]
+    out, text = _render(entries)
+    assert out is not None
+    assert "classify" in text
+    assert "worker=claude-worker" in text
+    # implement não tem outros overrides nem worker per-stage — não aparece
+    assert "implement" not in text
+
+
+def test_banner_lists_multiple_overrides_per_stage():
+    entries = [
+        _Entry("implement",
+               model="openai:gpt-4-turbo",
+               timeout_s=900,
+               max_retries=5,
+               cost_cap_usd="10.00"),
+    ]
+    out, text = _render(entries)
+    assert out is not None
+    assert "model=openai:gpt-4-turbo" in text
+    assert "timeout=900s" in text
+    assert "retries=5" in text
+    assert "cap=$10.00" in text
+
+
+def test_banner_does_not_flag_positive_retries_as_fail_fast():
+    entries = [
+        _Entry("implement", max_retries=3),
+    ]
+    out, text = _render(entries)
+    assert out is not None
+    assert "retries=3" in text
+    assert "FAIL-FAST" not in text

--- a/deile/tests/infra/test_dispatch_matrix_overrides_banner.py
+++ b/deile/tests/infra/test_dispatch_matrix_overrides_banner.py
@@ -43,6 +43,12 @@ def _stub_panel_data(monkeypatch):
         stub.BackgroundRefresher = MagicMock
         stub.PanelData = MagicMock
         stub._fmt_age = lambda *a, **kw: ""
+        stub._fmt_cpu_display = lambda *a, **kw: ""
+        stub._fmt_mem_display = lambda *a, **kw: ""
+        stub._pct = lambda *a, **kw: None
+        stub.EndpointInfo = MagicMock
+        stub.set_stage_cost_cap_usd = MagicMock(return_value=(True, "ok"))
+        stub.reset_stage_cost_cap_usd = MagicMock(return_value=(True, "ok"))
         stub._audit_dispatch_mode_change = MagicMock()
         stub._audit_security_policy_change = MagicMock()
         stub.clear_pipeline_dispatch_mode = MagicMock(return_value=(True, "ok"))

--- a/deile/tests/infra/test_dispatch_matrix_timeout_retries.py
+++ b/deile/tests/infra/test_dispatch_matrix_timeout_retries.py
@@ -117,17 +117,18 @@ def _make_view():
     return DispatchMatrixView(data=None)
 
 
-def test_cursor_col_max_is_3():
+def test_cursor_col_max_is_4():
+    """Após #392 (cost cap col), a coluna máxima virou 4."""
     view = _make_view()
-    # Navigate right 10 times — should clamp at 3
+    # Navigate right 10 times — should clamp at 4
     for _ in range(10):
         view.handle_key("RIGHT", None)
-    assert view.cursor_col == 3
+    assert view.cursor_col == 4
 
 
 def test_cursor_col_min_is_0():
     view = _make_view()
-    view.cursor_col = 3
+    view.cursor_col = 4
     for _ in range(10):
         view.handle_key("LEFT", None)
     assert view.cursor_col == 0
@@ -238,19 +239,67 @@ def test_numeric_prompt_enter_with_value_calls_helper(monkeypatch):
     assert view.mode is None
 
 
-def test_numeric_prompt_retries_zero_is_valid(monkeypatch):
-    """Retries=0 should not raise invalid value error."""
+def test_numeric_prompt_retries_zero_calls_with_allow_zero_false(monkeypatch):
+    """Retries=0 (sem '!') deve chamar set_stage_retries com allow_zero=False
+    — a camada _panel_data rejeita e devolve mensagem clara."""
     view = _make_view()
     view.mode = ("retries", "implement", ["0"])
     view.data = MagicMock()
     view.data.context.namespace = "deile"
-    import _panel_data as _pd
-    orig = _pd.set_stage_retries
-    _pd.set_stage_retries = MagicMock(return_value=(True, "ok"))
-    view._handle_numeric_prompt_key("\r")
-    _pd.set_stage_retries = orig
+    import _panel as panel_mod
+    captured = {}
+    def fake_set(stage, value, *, allow_zero=False, namespace="deile"):
+        captured["allow_zero"] = allow_zero
+        captured["value"] = value
+        return False, "max_retries=0 = fail-fast..."
+    orig = panel_mod.pd_set_stage_retries
+    panel_mod.pd_set_stage_retries = fake_set
+    try:
+        view._handle_numeric_prompt_key("\r")
+    finally:
+        panel_mod.pd_set_stage_retries = orig
     assert view.mode is None
-    assert view.last_ok is not False or view.last_msg != "retries deve ser >= 0"
+    assert captured == {"allow_zero": False, "value": 0}
+    assert view.last_ok is False
+
+
+def test_numeric_prompt_retries_zero_bang_forces(monkeypatch):
+    """Retries=0! (com bang) chama set_stage_retries com allow_zero=True."""
+    view = _make_view()
+    view.mode = ("retries", "implement", ["0!"])
+    view.data = MagicMock()
+    view.data.context.namespace = "deile"
+    import _panel as panel_mod
+    captured = {}
+    def fake_set(stage, value, *, allow_zero=False, namespace="deile"):
+        captured["allow_zero"] = allow_zero
+        captured["value"] = value
+        return True, "DEILE_PIPELINE_RETRIES_IMPLEMENT=0 (...)"
+    orig = panel_mod.pd_set_stage_retries
+    panel_mod.pd_set_stage_retries = fake_set
+    try:
+        view._handle_numeric_prompt_key("\r")
+    finally:
+        panel_mod.pd_set_stage_retries = orig
+    assert view.mode is None
+    assert captured == {"allow_zero": True, "value": 0}
+    assert view.last_ok is True
+
+
+def test_numeric_prompt_bang_key_appends_to_retries_buffer():
+    """A tecla '!' é aceita no buffer de retries (e somente em retries)."""
+    view = _make_view()
+    view.mode = ("retries", "implement", ["0"])
+    view._handle_numeric_prompt_key("!")
+    assert view.mode[2] == ["0!"]
+
+
+def test_numeric_prompt_bang_key_ignored_in_timeout():
+    """A tecla '!' é ignorada no buffer de timeout (não tem semântica force)."""
+    view = _make_view()
+    view.mode = ("timeout", "implement", ["60"])
+    view._handle_numeric_prompt_key("!")
+    assert view.mode[2] == ["60"]
 
 
 def test_numeric_prompt_timeout_zero_is_invalid():

--- a/deile/tests/infra/test_dispatch_matrix_timeout_retries.py
+++ b/deile/tests/infra/test_dispatch_matrix_timeout_retries.py
@@ -302,6 +302,19 @@ def test_numeric_prompt_bang_key_ignored_in_timeout():
     assert view.mode[2] == ["60"]
 
 
+def test_numeric_prompt_bang_key_idempotent():
+    """Pressionar '!' várias vezes não acumula — evita ``"0!!"`` que parsaria
+    como inteiro inválido. Feedback do review na PR #407."""
+    view = _make_view()
+    view.mode = ("retries", "implement", ["0"])
+    view._handle_numeric_prompt_key("!")
+    assert view.mode[2] == ["0!"]
+    view._handle_numeric_prompt_key("!")
+    assert view.mode[2] == ["0!"]  # segundo '!' ignorado
+    view._handle_numeric_prompt_key("!")
+    assert view.mode[2] == ["0!"]  # terceiro '!' ignorado
+
+
 def test_numeric_prompt_timeout_zero_is_invalid():
     """Timeout=0 should show error (not call kubectl)."""
     view = _make_view()

--- a/deile/tests/infra/test_panel_data_retries_zero_guard.py
+++ b/deile/tests/infra/test_panel_data_retries_zero_guard.py
@@ -24,10 +24,15 @@ if _INFRA_K8S not in sys.path:
 
 @pytest.fixture
 def fresh_panel_data(monkeypatch):
-    """Garante carregamento real do módulo `_panel_data`, sem stub mínimo de
-    sibling tests. Remove stubs prévios se sobreviveram do
-    ``test_dispatch_matrix_timeout_retries.py``."""
-    sys.modules.pop("_panel_data", None)
+    """Garante carregamento real do módulo ``_panel_data``, sem stub mínimo de
+    sibling tests. Usa ``monkeypatch.delitem`` para que ``sys.modules`` seja
+    **restaurado automaticamente no teardown** — caso contrário o módulo
+    real ficaria cacheado em ``sys.modules`` e arquivos vizinhos (cujo
+    fixture autouse só injeta o stub quando ``"_panel_data" not in
+    sys.modules``) passariam a ver o módulo real, quebrando 17 testes em
+    batch. Bug identificado por @deile-one no review da PR #407.
+    """
+    monkeypatch.delitem(sys.modules, "_panel_data", raising=False)
     import importlib
     pd = importlib.import_module("_panel_data")
     return pd

--- a/deile/tests/infra/test_panel_data_retries_zero_guard.py
+++ b/deile/tests/infra/test_panel_data_retries_zero_guard.py
@@ -1,0 +1,117 @@
+"""Tests for the zero-retries guard in ``_panel_data.set_stage_retries``.
+
+Guard rationale: historicamente alguém setou
+``DEILE_PIPELINE_RETRIES_IMPLEMENT=0`` no Deployment achando que ``0``
+significava "default" ou "infinito". Na verdade, ``0`` é semanticamente
+"fail-fast — primeira falha bloqueia o stage" — e o pipeline ficou
+travado sem aviso. O guard exige ``allow_zero=True`` para aceitar ``0``;
+o widget repassa esse flag quando o operador digita ``"0!"`` (bang
+explícito) em vez de só ``"0"``.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_INFRA_K8S = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "infra", "k8s"
+)
+if _INFRA_K8S not in sys.path:
+    sys.path.insert(0, _INFRA_K8S)
+
+
+@pytest.fixture
+def fresh_panel_data(monkeypatch):
+    """Garante carregamento real do módulo `_panel_data`, sem stub mínimo de
+    sibling tests. Remove stubs prévios se sobreviveram do
+    ``test_dispatch_matrix_timeout_retries.py``."""
+    sys.modules.pop("_panel_data", None)
+    import importlib
+    pd = importlib.import_module("_panel_data")
+    return pd
+
+
+def _completed_proc(returncode=0, stdout="rollout", stderr=""):
+    p = MagicMock()
+    p.returncode = returncode
+    p.stdout = stdout
+    p.stderr = stderr
+    return p
+
+
+def test_zero_rejected_without_allow_zero(fresh_panel_data):
+    pd = fresh_panel_data
+    monkey = patch.object(pd, "kubectl_bin", return_value="/fake/kubectl")
+    with monkey, patch.object(pd.subprocess, "run") as run:
+        ok, msg = pd.set_stage_retries("implement", 0)
+    assert ok is False
+    assert "fail-fast" in msg
+    assert "0!" in msg
+    run.assert_not_called()
+
+
+def test_zero_accepted_with_allow_zero_true(fresh_panel_data):
+    pd = fresh_panel_data
+    with patch.object(pd, "kubectl_bin", return_value="/fake/kubectl"), \
+         patch.object(pd.subprocess, "run", return_value=_completed_proc()):
+        ok, msg = pd.set_stage_retries("implement", 0, allow_zero=True)
+    assert ok is True
+    assert "DEILE_PIPELINE_RETRIES_IMPLEMENT=0" in msg
+
+
+def test_positive_retries_unaffected_by_guard(fresh_panel_data):
+    """Valor positivo sempre aceito — guard só toca em 0."""
+    pd = fresh_panel_data
+    with patch.object(pd, "kubectl_bin", return_value="/fake/kubectl"), \
+         patch.object(pd.subprocess, "run", return_value=_completed_proc()):
+        ok, msg = pd.set_stage_retries("implement", 3)
+    assert ok is True
+    assert "RETRIES_IMPLEMENT=3" in msg
+
+
+def test_none_unaffected_by_guard(fresh_panel_data):
+    """``None`` (clear) sempre aceito — guard só toca em 0."""
+    pd = fresh_panel_data
+    with patch.object(pd, "kubectl_bin", return_value="/fake/kubectl"), \
+         patch.object(pd.subprocess, "run",
+                      return_value=_completed_proc(stdout="unset ok")):
+        ok, msg = pd.set_stage_retries("implement", None)
+    assert ok is True
+    assert "unset" in msg
+
+
+def test_negative_rejected_before_zero_guard(fresh_panel_data):
+    """Validação ``< 0`` precede o guard de zero — mensagem original mantida."""
+    pd = fresh_panel_data
+    with patch.object(pd, "kubectl_bin", return_value="/fake/kubectl"), \
+         patch.object(pd.subprocess, "run") as run:
+        ok, msg = pd.set_stage_retries("implement", -1)
+    assert ok is False
+    assert ">= 0" in msg
+    run.assert_not_called()
+
+
+def test_invalid_stage_rejected_before_zero_guard(fresh_panel_data):
+    """Validação de stage canônico precede o guard de zero."""
+    pd = fresh_panel_data
+    with patch.object(pd, "kubectl_bin", return_value="/fake/kubectl"), \
+         patch.object(pd.subprocess, "run") as run:
+        ok, msg = pd.set_stage_retries("not_a_stage", 0)
+    assert ok is False
+    assert "invalid stage" in msg
+    run.assert_not_called()
+
+
+def test_audit_emitted_on_zero_denied(fresh_panel_data):
+    """Zero rejeitado emite audit ``denied`` (rastreabilidade do bloqueio)."""
+    pd = fresh_panel_data
+    with patch.object(pd, "kubectl_bin", return_value="/fake/kubectl"), \
+         patch.object(pd.subprocess, "run"), \
+         patch.object(pd, "_audit_timeout_retries_change") as audit:
+        pd.set_stage_retries("implement", 0)
+    audit.assert_called_once()
+    kw = audit.call_args.kwargs
+    assert kw.get("result") == "denied"
+    assert "zero rejeitado" in kw.get("detail", "")

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -5154,8 +5154,13 @@ class DispatchMatrixView(View):
             return ActionResult.refresh()
 
         # '!' = force flag para retries=0 (semantic zero confirmado).
-        # Sem efeito para timeout (timeout=0 sempre inválido).
+        # Sem efeito para timeout (timeout=0 sempre inválido). Idempotente:
+        # repetir '!' não duplica no buffer — evita ``"0!!"`` que parsaria
+        # como inteiro inválido e renderia mensagem confusa. Feedback do
+        # review na PR #407.
         if key == "!" and kind == "retries":
+            if buf.endswith("!"):
+                return ActionResult()
             new_buf = buf + "!"
             self.mode = (kind, stage, [new_buf])
             return ActionResult.refresh()

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -3994,7 +3994,8 @@ class DispatchMatrixView(View):
         "[enter] editar   [r] reset   "
         "[L] switch claude login   [I] install   [U] uninstall   [q] back   "
         "[s]caling row: enter digita réplicas (0-10)   "
-        "colunas: 0=Worker 1=Model 2=Timeout 3=Retries 4=Cost cap (USD/run)"
+        "colunas: 0=Worker 1=Model 2=Timeout 3=Retries 4=Cost cap (USD/run)   "
+        "retries=0 EXIGE confirmação: digite '0!' (fail-fast, sem retry)"
     )
 
     # Índice de row constante para a linha de scaling (após Global default).
@@ -4306,11 +4307,14 @@ class DispatchMatrixView(View):
         tbl.add_row("Worker Scaling", scale_w_txt, scale_m_txt,
                     "", "", "—", "kubectl")
 
-        # --- Compose: header + matrix + (picker?) + (status?) + hotkeys --
+        # --- Compose: header + (banner?) + matrix + (picker?) + (status?) + hotkeys --
         parts: List[RenderableType] = [
             Text(status_text, style=status_style),
-            tbl,
         ]
+        banner = self._render_overrides_banner(entries)
+        if banner is not None:
+            parts.append(banner)
+        parts.append(tbl)
         if self.mode is not None:
             parts.append(self._render_picker())
         if self.last_msg:
@@ -4323,6 +4327,64 @@ class DispatchMatrixView(View):
             ))
         parts.append(Text(self.HOTKEYS, style="dim"))
         return Group(*parts)
+
+    def _render_overrides_banner(self, entries: List) -> Optional[RenderableType]:
+        """Banner C — lista overrides ativos por stage com destaque.
+
+        Lê a mesma snapshot já carregada em ``entries`` (sem novo round-trip
+        kubectl). Mostra um Panel acima da matriz quando existir pelo menos
+        um override per-stage (worker, model, timeout_s, max_retries,
+        cost_cap_usd). ``retries=0`` recebe destaque vermelho — é o caso
+        que historicamente bloqueou o pipeline silenciosamente
+        (issue ghost env ``DEILE_PIPELINE_RETRIES_IMPLEMENT=0``).
+
+        Retorna ``None`` quando não há overrides — mantém UX limpa.
+        """
+        lines: List[Text] = []
+        for entry in entries:
+            stage = getattr(entry, "stage", None)
+            if not stage:
+                continue
+            bits: List[Text] = []
+            # worker override é só relevante quando source == "env"
+            # (per-stage); "global"/"default" não conta como override
+            # do stage.
+            source = getattr(entry, "source", None)
+            worker = getattr(entry, "worker", None)
+            if source == "env" and worker:
+                bits.append(Text(f"worker={worker}", style="yellow"))
+            model = getattr(entry, "model", None)
+            if model:
+                bits.append(Text(f"model={model}", style="cyan"))
+            timeout_s = getattr(entry, "timeout_s", None)
+            if timeout_s is not None:
+                bits.append(Text(f"timeout={timeout_s}s", style="yellow"))
+            max_retries = getattr(entry, "max_retries", None)
+            if max_retries is not None:
+                style = "bold red reverse" if max_retries == 0 else "yellow"
+                label = (f"retries=0 ⚠ FAIL-FAST" if max_retries == 0
+                         else f"retries={max_retries}")
+                bits.append(Text(label, style=style))
+            cap = getattr(entry, "cost_cap_usd", None)
+            if cap:
+                bits.append(Text(f"cap=${cap}", style="yellow"))
+            if not bits:
+                continue
+            line = Text(f"  {stage}: ", style="bold")
+            for i, bit in enumerate(bits):
+                if i:
+                    line.append("  ")
+                line.append_text(bit)
+            lines.append(line)
+        if not lines:
+            return None
+        return Panel(
+            Group(*lines),
+            title="[bold]OVERRIDES ATIVOS (per-stage)[/bold]",
+            title_align="left",
+            border_style="yellow",
+            padding=(0, 1),
+        )
 
     def _render_picker(self) -> RenderableType:
         """Renderiza o Panel do picker corrente (worker / model / global /
@@ -5091,6 +5153,13 @@ class DispatchMatrixView(View):
             self.mode = (kind, stage, [new_buf])
             return ActionResult.refresh()
 
+        # '!' = force flag para retries=0 (semantic zero confirmado).
+        # Sem efeito para timeout (timeout=0 sempre inválido).
+        if key == "!" and kind == "retries":
+            new_buf = buf + "!"
+            self.mode = (kind, stage, [new_buf])
+            return ActionResult.refresh()
+
         if key in ("\r", "\n"):
             ns = (self.data.context.namespace
                   if self.data is not None and getattr(self.data, "context", None)
@@ -5101,11 +5170,17 @@ class DispatchMatrixView(View):
                 self.last_msg = f"[demo] {kind}={buf!r} para '{stage}' (sem cluster, no-op)"
                 self.last_ok = False
                 return ActionResult.refresh()
+            # Force flag para retries=0: buf == "0!" → allow_zero=True.
+            force_zero = False
+            raw_buf = buf.strip()
+            if kind == "retries" and raw_buf.endswith("!"):
+                force_zero = True
+                raw_buf = raw_buf[:-1].strip()
             # Empty input = clear override.
             value: Optional[int] = None
-            if buf.strip():
+            if raw_buf:
                 try:
-                    value = int(buf.strip())
+                    value = int(raw_buf)
                 except ValueError:
                     self.last_msg = f"valor inválido {buf!r} — esperado inteiro"
                     self.last_ok = False
@@ -5121,7 +5196,9 @@ class DispatchMatrixView(View):
                     self.last_msg = "retries deve ser >= 0"
                     self.last_ok = False
                     return ActionResult.refresh()
-                ok, msg = pd_set_stage_retries(stage, value, namespace=ns)
+                ok, msg = pd_set_stage_retries(
+                    stage, value, allow_zero=force_zero, namespace=ns,
+                )
             self.last_ok = ok
             self.last_msg = msg
             # Invalida cache para render mostrar o novo valor.

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -3150,6 +3150,7 @@ def set_stage_timeout(
 
 def set_stage_retries(
     stage: str, max_retries: Optional[int], *,
+    allow_zero: bool = False,
     namespace: str = NS, timeout: float = 15.0,
 ) -> tuple:
     """Pin ``DEILE_PIPELINE_RETRIES_<STAGE>=<max_retries>`` em ``deile-pipeline``.
@@ -3157,6 +3158,13 @@ def set_stage_retries(
     Args:
         stage: canonical stage name (one of PIPELINE_STAGES).
         max_retries: non-negative int or None (clear the override).
+            **Zero requer ``allow_zero=True`` explícito** — historicamente
+            alguém confundiu zero com "default" e bloqueou o pipeline no
+            primeiro fail. Zero é semanticamente "fail-fast, sem retry":
+            pode ser desejável mas exige confirmação.
+        allow_zero: quando ``True``, aceita ``max_retries=0`` como
+            valor legítimo. Default ``False`` (rejeita zero com mensagem
+            clara). Não afeta ``None`` (clear) nem inteiros positivos.
         namespace: K8s namespace.
         timeout: subprocess timeout for kubectl.
 
@@ -3172,6 +3180,18 @@ def set_stage_retries(
 
     if max_retries is not None and max_retries < 0:
         return False, f"max_retries deve ser >= 0, got {max_retries}"
+
+    if max_retries == 0 and not allow_zero:
+        _audit_timeout_retries_change(
+            stage, "max_retries", 0, result="denied",
+            detail="zero rejeitado sem allow_zero — fail-fast precisa de confirmação",
+            namespace=namespace,
+        )
+        return False, (
+            "max_retries=0 = fail-fast (primeira falha bloqueia o stage). "
+            "Para confirmar, digite '0!' no painel (force). "
+            "Para usar o default, deixe vazio."
+        )
 
     env_var = f"DEILE_PIPELINE_RETRIES_{stage.upper()}"
     kubectl = kubectl_bin()


### PR DESCRIPTION
## Resumo

Fecha a **causa raiz** do bug ghost env ``DEILE_PIPELINE_RETRIES_IMPLEMENT=0`` que bloqueou o pipeline ontem por horas (#404 follow-up — bug colateral, sem issue dedicada).

A causa raiz não era o pod nem o restart — o resolver lia ``0`` literalmente como "fail-fast" (1 tentativa, sem retry), o que é semanticamente válido mas perigoso, e ninguém pediu confirmação na hora de salvar. Alguém digitou ``0`` no painel TUI achando que era "default" ou "infinito" e o sistema aceitou silenciosamente. ``kubectl set env -`` em runtime removeu o efeito; este PR remove o vetor para que não volte.

## O que entra

**Camada A — guard semântico em ``set_stage_retries``** (`infra/k8s/_panel_data.py`)
- Novo parâmetro ``allow_zero: bool = False``.
- ``max_retries=0`` sem ``allow_zero=True`` retorna ``(False, mensagem clara)`` + audit ``denied``.
- Mensagem explica: ``"max_retries=0 = fail-fast (primeira falha bloqueia o stage). Para confirmar, digite '0!' no painel (force). Para usar o default, deixe vazio."``
- ``None`` (clear) e positivos continuam intactos.

**Camada A no widget** (`infra/k8s/_panel.py`)
- ``_handle_numeric_prompt_key`` aceita o sufixo ``!`` no buffer de retries.
- ``"0!"`` → chama ``set_stage_retries(..., allow_zero=True)``.
- ``"0"`` → chama com ``allow_zero=False`` → recebe mensagem do guard.
- ``!`` é ignorado em timeout (timeout=0 sempre inválido, sem semântica force).
- HOTKEYS atualizado.

**Camada C — banner ``OVERRIDES ATIVOS``** (`infra/k8s/_panel.py`)
- Novo ``_render_overrides_banner`` que varre ``entries`` (sem novo round-trip kubectl) e lista por stage os campos não-default: worker per-stage, model, timeout_s, max_retries, cost_cap_usd.
- ``retries=0`` recebe destaque ``bold red reverse`` com label ``⚠ FAIL-FAST``.
- Aparece acima da matriz só quando há overrides — pipeline limpo continua com painel limpo.

## Testes

- ``deile/tests/infra/test_panel_data_retries_zero_guard.py`` — **7 casos novos** cobrindo: rejeição default, força via ``allow_zero``, ordem de validação (negative → stage canônico → guard zero), positive/None unaffected, audit ``denied`` emitido.
- ``deile/tests/infra/test_dispatch_matrix_overrides_banner.py`` — **8 casos novos** cobrindo: banner oculto sem overrides, presente para cada tipo de override individual (worker, model, timeout, retries, cost_cap), retries=0 destacado como FAIL-FAST, retries positivo NÃO destacado, múltiplos overrides no mesmo stage.
- ``deile/tests/infra/test_dispatch_matrix_timeout_retries.py`` — substituí o teste que validava ``"0"`` sempre aceito por 4 novos casos do guard. Também ajustei ``test_cursor_col_max`` de 3 → 4 (estava obsoleto pós-#392 cost cap; passava só por skip em CI).

**Resultado**: 37/37 nos arquivos tocados; 88/88 isolados nos vizinhos (pod_actions/pod_watch). As 16 falhas em ``deile/tests/infra/`` quando rodado em batch existiam ANTES desta branch (test-state-leak entre arquivos do panel — ``sys.modules['_panel']`` cacheado por fixtures vizinhas) e não envolvem o código tocado aqui.

## Test plan

- [ ] `pytest deile/tests/infra/test_panel_data_retries_zero_guard.py -v` (7 verde)
- [ ] `pytest deile/tests/infra/test_dispatch_matrix_overrides_banner.py -v` (8 verde)
- [ ] `pytest deile/tests/infra/test_dispatch_matrix_timeout_retries.py -v` (todos verde)
- [ ] Após merge: subir a imagem nova no cluster e abrir o painel TUI; navegar pra ``[d]``, tentar digitar ``0`` em retries de ``implement`` → vê mensagem de bloqueio; tentar ``0!`` → aceita e mostra banner em vermelho.

## Compatibilidade

- API muda só de forma aditiva (kwarg opcional ``allow_zero``). Callers existentes não são afetados.
- O cluster atual já está com ``DEILE_PIPELINE_RETRIES_IMPLEMENT`` desunset em runtime — este PR previne reincidência.