### PR TITLE
feat(pipeline/runner): warn at startup when no forge token is set

### DIFF
--- a/deile/orchestration/pipeline/runner.py
+++ b/deile/orchestration/pipeline/runner.py
@@ -155,11 +155,23 @@ async def _start_status_server(monitor) -> "tuple|None":
     return (runner, site)
 
 
+def _warn_if_no_forge_token() -> None:
+    """Emit a WARNING if neither GITHUB_TOKEN nor GITLAB_TOKEN is present."""
+    has_github = bool(os.environ.get("GITHUB_TOKEN"))
+    has_gitlab = bool(os.environ.get("GITLAB_TOKEN") or os.environ.get("GL_TOKEN"))
+    if not has_github and not has_gitlab:
+        logger.warning(
+            "no forge token found — set GITHUB_TOKEN or GITLAB_TOKEN "
+            "before starting the pipeline, otherwise forge API calls will fail"
+        )
+
+
 async def run_pipeline_forever() -> int:
     """Build the monitor from settings, start it, and block until SIGTERM/SIGINT."""
     from deile.orchestration.pipeline.monitor import (
         PipelineMonitor, build_default_pipeline_config)
 
+    _warn_if_no_forge_token()
     cfg = build_default_pipeline_config()
     # review_callback stays None on purpose: the optional issue-body summary
     # would require a local LLM agent. The pipeline still flows

--- a/deile/tests/orchestration/pipeline/test_runner_token_warning.py
+++ b/deile/tests/orchestration/pipeline/test_runner_token_warning.py
@@ -1,0 +1,78 @@
+"""Tests for the forge-token warning emitted by deile.pipeline.runner at startup.
+
+Issue #415: pipeline should emit a WARNING when neither GITHUB_TOKEN nor
+GITLAB_TOKEN is present, without interrupting execution.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from deile.orchestration.pipeline.runner import _warn_if_no_forge_token
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _capture_warnings(caplog, env, monkeypatch):
+    """Run _warn_if_no_forge_token with the given env overrides."""
+    for key in ("GITHUB_TOKEN", "GITLAB_TOKEN", "GL_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    for key, val in env.items():
+        monkeypatch.setenv(key, val)
+
+    with caplog.at_level(logging.WARNING, logger="deile.pipeline.runner"):
+        _warn_if_no_forge_token()
+
+    return [r for r in caplog.records if r.name == "deile.pipeline.runner"]
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+def test_warns_when_no_tokens(caplog, monkeypatch):
+    """WARNING is emitted if neither GITHUB_TOKEN nor GITLAB_TOKEN is set."""
+    records = _capture_warnings(caplog, {}, monkeypatch)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.levelno == logging.WARNING
+    assert "GITHUB_TOKEN" in rec.message
+    assert "GITLAB_TOKEN" in rec.message
+
+
+def test_no_warning_with_github_token(caplog, monkeypatch):
+    """No WARNING when GITHUB_TOKEN is present."""
+    records = _capture_warnings(caplog, {"GITHUB_TOKEN": "ghp_fake"}, monkeypatch)
+    assert records == []
+
+
+def test_no_warning_with_gitlab_token(caplog, monkeypatch):
+    """No WARNING when GITLAB_TOKEN is present."""
+    records = _capture_warnings(caplog, {"GITLAB_TOKEN": "glpat-fake"}, monkeypatch)
+    assert records == []
+
+
+def test_no_warning_with_gl_token_alias(caplog, monkeypatch):
+    """No WARNING when GL_TOKEN alias is present."""
+    records = _capture_warnings(caplog, {"GL_TOKEN": "glpat-alias"}, monkeypatch)
+    assert records == []
+
+
+def test_no_warning_with_both_tokens(caplog, monkeypatch):
+    """No WARNING when both tokens are set."""
+    records = _capture_warnings(
+        caplog,
+        {"GITHUB_TOKEN": "ghp_fake", "GITLAB_TOKEN": "glpat-fake"},
+        monkeypatch,
+    )
+    assert records == []
+
+
+def test_warning_does_not_raise(monkeypatch):
+    """_warn_if_no_forge_token must never raise — warning only, not fatal."""
+    for key in ("GITHUB_TOKEN", "GITLAB_TOKEN", "GL_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    _warn_if_no_forge_token()  # must not raise


### PR DESCRIPTION
## Summary

- Adds `_warn_if_no_forge_token()` helper in `deile/orchestration/pipeline/runner.py` that checks for `GITHUB_TOKEN`, `GITLAB_TOKEN`, and `GL_TOKEN` env vars.
- Called inside `run_pipeline_forever()` before `build_default_pipeline_config()`, so the warning fires before the first tick.
- Emits a `WARNING` with a prescriptive message ("set GITHUB_TOKEN or GITLAB_TOKEN") and does **not** interrupt execution.
- 6 new unit tests in `deile/tests/orchestration/pipeline/test_runner_token_warning.py` covering: no tokens, each token individually, both tokens, and the GL_TOKEN alias.

Closes #415.