### PR TITLE
fix(k8s): bake pipeline per-stage defaults + scale claude-worker to 3

### DIFF
--- a/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
+++ b/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
@@ -172,6 +172,36 @@ spec:
             # Bearer token montado em /run/secrets/pipeline-status/.
             - { name: DEILE_PIPELINE_STATUS_HOST,    value: "0.0.0.0" }
             - { name: DEILE_PIPELINE_STATUS_PORT,    value: "8768" }
+            # Per-stage dispatcher routing (Decisão #43) — defaults definidos
+            # após validação empírica da sessão 2026-05-29: classify é leve e
+            # roda no deile-worker (deepseek barato); refine/implement/pr_review/
+            # follow_ups precisam de Claude (opus pra refinar requisitos, sonnet
+            # pra código). Sem esses defaults no manifest, `kubectl apply` zerava
+            # configurações in-flight (kubectl set env) e o dispatch caía no
+            # _DEFAULT_DISPATCHER=deile-worker para tudo, deixando os
+            # claude-worker pods ociosos. Operador pode override via painel TUI
+            # `[d]` (DispatchMatrixView) — o `kubectl set env` aplica patch
+            # incremental, mantém estes como base.
+            - { name: DEILE_PIPELINE_DISPATCH_MODE,        value: "deile-worker" }
+            - { name: DEILE_PIPELINE_DISPATCH_CLASSIFY,    value: "deile-worker" }
+            - { name: DEILE_PIPELINE_DISPATCH_REFINE,      value: "claude-worker" }
+            - { name: DEILE_PIPELINE_DISPATCH_IMPLEMENT,   value: "claude-worker" }
+            - { name: DEILE_PIPELINE_DISPATCH_PR_REVIEW,   value: "claude-worker" }
+            - { name: DEILE_PIPELINE_DISPATCH_FOLLOW_UPS,  value: "claude-worker" }
+            # Per-stage model overrides (Decisão #41). Mesma motivação acima:
+            # sem isso no manifest, `kubectl apply` zerava as escolhas do
+            # painel e o dispatch usava o modelo default global do worker
+            # (que pode não ser o ideal para o stage).
+            - { name: DEILE_PREFERRED_MODEL,               value: "deepseek:deepseek-v4-pro" }
+            - { name: DEILE_PIPELINE_MODEL_CLASSIFY,       value: "deepseek:deepseek-v4-pro" }
+            - { name: DEILE_PIPELINE_MODEL_REFINE,         value: "anthropic:claude-opus-4-7" }
+            - { name: DEILE_PIPELINE_MODEL_IMPLEMENT,      value: "anthropic:claude-sonnet-4-6" }
+            - { name: DEILE_PIPELINE_MODEL_PR_REVIEW,      value: "anthropic:claude-sonnet-4-6" }
+            - { name: DEILE_PIPELINE_MODEL_FOLLOW_UPS,     value: "anthropic:claude-sonnet-4-6" }
+            # Paralelismo: até 5 grupos simultâneos. claude-worker tem 3
+            # réplicas, deile-worker 2 réplicas → ~5 dispatches reais
+            # concorrentes antes da fila.
+            - { name: DEILE_PIPELINE_MAX_PARALLEL,         value: "5" }
           ports:
             - { name: status-api, containerPort: 8768, protocol: TCP }
           readinessProbe:

--- a/infra/k8s/manifests/50-claude-worker-deployment.yaml
+++ b/infra/k8s/manifests/50-claude-worker-deployment.yaml
@@ -19,7 +19,11 @@ metadata:
     app: claude-worker
     role: deile
 spec:
-  replicas: 1
+  # Default 3 réplicas para acompanhar o paralelismo do pipeline
+  # (DEILE_PIPELINE_MAX_PARALLEL=5, com deile-worker em 2 = ~5 concorrentes
+  # totais). Operador escala via painel TUI / `deploy.py k8s scale`; este é
+  # o ponto de partida quando o cluster sobe limpo.
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate: { maxSurge: 1, maxUnavailable: 0 }


### PR DESCRIPTION
## Resumo

Grava no manifest os defaults validados de roteamento per-stage do pipeline e sobe `claude-worker` para 3 réplicas, eliminando o ponto cego em que `kubectl apply` (override completo do bloco `env:`) zerava as configurações in-flight e fazia o pipeline cair no fallback `_DEFAULT_DISPATCHER=deile-worker` para todos os stages.

## Por quê

Durante a sessão de 2026-05-29 reapliquei `46-deile-pipeline-deployment.yaml` para reverter um patch ad-hoc do `initContainer` e descobri que `kubectl apply` sobrescreve o bloco `env:` por inteiro — não faz merge incremental. Resultado: TODAS as env vars per-stage que tinham sido configuradas via `kubectl set env` e pelo painel TUI sumiram, e os pods `claude-worker` ficaram ociosos servindo apenas health checks enquanto o `deile-worker` engolia tudo sozinho.

Solução: gravar os defaults validados no próprio manifest (versionado), de modo que qualquer `kubectl apply` parta da configuração correta. O operador continua livre pra ajustar via painel TUI (`[d]` DispatchMatrixView) — `kubectl set env` aplica patch incremental sobre esta base.

## Defaults adicionados em `46-deile-pipeline-deployment.yaml`

| Stage | Worker | Modelo |
|---|---|---|
| classify | deile-worker | deepseek:deepseek-v4-pro |
| refine | claude-worker | anthropic:claude-opus-4-7 |
| implement | claude-worker | anthropic:claude-sonnet-4-6 |
| pr_review | claude-worker | anthropic:claude-sonnet-4-6 |
| follow_ups | claude-worker | anthropic:claude-sonnet-4-6 |

Outros:
- `DEILE_PIPELINE_DISPATCH_MODE=deile-worker` (fallback global)
- `DEILE_PREFERRED_MODEL=deepseek:deepseek-v4-pro`
- `DEILE_PIPELINE_MAX_PARALLEL=5` (sub-agents em feature decomposta)

## `50-claude-worker-deployment.yaml`

`replicas: 1 → 3` para acompanhar o paralelismo do pipeline. Com `deile-worker=2` (já no manifest) e `claude-worker=3`, o cluster suporta os ~5 dispatches concorrentes em features decompostas sem fila no Service ClusterIP.

## Validação empírica (3 rodadas de 3 min após apply)

- 22:21 — primeiro dispatch `POST http://claude-worker:8767/v1/dispatch HTTP 200`
- 22:21:32 → 22:34:58 — pr_review do PR #422 completou em ~13 min (sonnet, `ok=True`) seguido imediatamente por implement do issue #423 no mesmo claude-worker
- 0 AUTH_EXPIRED, 0 RESUME_BUDGET_EXCEEDED, 0 ERROR no período

## Decisões do system design ratificadas

- Decisão #41 — modelo por stage (`DEILE_PIPELINE_MODEL_<STAGE>`)
- Decisão #43 — worker por stage (`DEILE_PIPELINE_DISPATCH_<STAGE>`)

## Test plan

- [ ] Rebase + smoke test no painel: `[d]` DispatchMatrixView deve mostrar a matriz preenchida com os defaults sem precisar tocar
- [ ] Após `kubectl apply -f 46-...` num cluster zerado, `kubectl get pod -l app=deile-pipeline -o yaml | grep DISPATCH` retorna as 6 chaves esperadas
- [ ] Pipeline real dispatcha pr_review para `claude-worker:8767` (não `deile-worker:8766`)