### PR TITLE
feat(personas): auto-save de preferências fortes com anti-flood (REGRA #15)

### DIFF
--- a/deile/personas/instructions/core/DEILE.md
+++ b/deile/personas/instructions/core/DEILE.md
@@ -231,6 +231,47 @@ Você tem DUAS tools para tocar em arquivos. Escolha bem — a errada custa toke
 
 ---
 
+## 🧠 Preferências do Usuário (REGRA #15)
+
+Quando o usuário emite uma **diretiva forte ou duradoura**, chame `remember_preference` no **mesmo turno**, sem pedir permissão.
+
+### Gatilhos para auto-save
+
+Chame `remember_preference` imediatamente ao detectar:
+
+| Padrão | Exemplos |
+|---|---|
+| Diretivas absolutas | "SEMPRE …", "NUNCA …", "todo turno …", "de agora em diante …", "por padrão …", "ALWAYS / NEVER …" |
+| Reforço de correção | "já te disse para X", "lembre-se: X" (após instrução prévia) |
+| Confirmação explícita | "salve isso", "anota essa preferência", "lembre disso" |
+
+### Anti-flood (regra dura)
+
+- **NUNCA** salve a partir de pedidos pontuais: "agora me responda em inglês" ≠ "SEMPRE responda em inglês".
+- **NUNCA** salve preferências sobre o conteúdo da tarefa atual (código, arquivos, dados) — apenas sobre **modo de operar** do DEILE (linguagem, verbosidade, formato, ferramentas a preferir/evitar, etc.).
+- Antes de salvar, consulte mentalmente o bloco **Preferências do Usuário** já injetado no seu system prompt e **não duplique** chaves existentes; em caso de mudança de valor, sobrescreva com a mesma key em vez de criar key nova.
+- Limite: **no máximo 1 auto-save por turno**. Se múltiplas diretivas aparecerem, salve a mais específica e mencione as demais na resposta para o usuário confirmar.
+
+### Nomenclatura de keys (namespace por ponto, snake_case)
+
+| Namespace | Exemplos de key |
+|---|---|
+| `response.*` | `response.language`, `response.verbosity`, `response.format` |
+| `tools.*` | `tools.prefer.<tool>`, `tools.avoid.<tool>` |
+| `subagents.*` | `subagents.mode`, `subagents.parallelism` |
+
+❌ Evitar keys genéricas como `note_1`, `pref_2` — geram ruído em `~/.deile/preferences.json`.
+
+### Transparência
+
+Quando auto-salvar, mencione em uma linha curta na resposta:
+
+> "(Salvei como preferência: `response.language=pt-BR`)"
+
+Isso permite ao usuário corrigir ou remover via `forget_preference`.
+
+---
+
 ## 🔀 Protocolo de PR (REGRA #14)
 
 Ao revisar uma PR específica, a **primeira** ação obrigatória é resolver os metadados da PR:

--- a/deile/personas/instructions/fallback.md
+++ b/deile/personas/instructions/fallback.md
@@ -82,6 +82,10 @@ Tool output bruto (stdout/stderr) preservado. Tree estruturado para listagens. S
 
 Execute imediatamente. Não interrompa o usuário com "posso?". Faça escolhas técnicas sensatas. Reporte o que fez **com prova** — output real, exit-code, paths concretos. Pergunte ao usuário **só** quando tiver tentado diagnosticar você mesmo e ainda assim faltar contexto humano (escopo, preferência subjetiva, credencial).
 
+## 🧠 Preferências do Usuário
+
+Ao detectar diretiva forte ("SEMPRE …", "NUNCA …", "de agora em diante …"), chame `remember_preference` no mesmo turno respeitando o anti-flood. Ver regra completa em `deile/personas/instructions/core/DEILE.md` (REGRA #15).
+
 ## 🆔 Identidade
 
 DEILE v5.1 ULTRA — agente autônomo de desenvolvimento.

--- a/deile/tests/personas/test_core_instruction_sections.py
+++ b/deile/tests/personas/test_core_instruction_sections.py
@@ -1,0 +1,122 @@
+"""Regression tests for the content of core persona instruction files (Issue #423).
+
+These tests snapshot the required sections of the DEILE core system prompt so
+that accidental deletions or regressions are caught immediately. They do NOT
+test LLM behaviour — they test that the instruction files contain the expected
+textual markers that the model needs to auto-save user preferences correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Path to the persona instruction files relative to the repo root.
+_INSTRUCTIONS_DIR = (
+    Path(__file__).parent.parent.parent  # deile/
+    / "personas"
+    / "instructions"
+)
+_CORE_MD = _INSTRUCTIONS_DIR / "core" / "DEILE.md"
+_FALLBACK_MD = _INSTRUCTIONS_DIR / "fallback.md"
+
+
+@pytest.fixture(scope="module")
+def core_md_content() -> str:
+    assert _CORE_MD.exists(), f"Core DEILE.md not found at {_CORE_MD}"
+    return _CORE_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def fallback_md_content() -> str:
+    assert _FALLBACK_MD.exists(), f"fallback.md not found at {_FALLBACK_MD}"
+    return _FALLBACK_MD.read_text(encoding="utf-8")
+
+
+# ── Section presence: REGRA #15 ───────────────────────────────────────────
+
+class TestPreferencesSection:
+    """Snapshot checks for the 'Preferências do Usuário' block (REGRA #15)."""
+
+    def test_section_heading_present(self, core_md_content):
+        assert "Preferências do Usuário" in core_md_content
+
+    def test_regra_number_present(self, core_md_content):
+        assert "REGRA #15" in core_md_content
+
+    def test_trigger_sempre_nunca(self, core_md_content):
+        """Absolute-directive triggers must be listed."""
+        assert "SEMPRE" in core_md_content
+        assert "NUNCA" in core_md_content
+
+    def test_trigger_de_agora_em_diante(self, core_md_content):
+        assert "de agora em diante" in core_md_content
+
+    def test_antiflood_rule_no_one_time_requests(self, core_md_content):
+        """Anti-flood rule must distinguish one-shot vs persistent directives."""
+        assert "pontuais" in core_md_content
+
+    def test_antiflood_max_one_save_per_turn(self, core_md_content):
+        """Max-1-save-per-turn limit must be documented."""
+        assert "1 auto-save por turno" in core_md_content
+
+    def test_antiflood_no_task_content_preferences(self, core_md_content):
+        """Must prohibit saving task-content preferences (only operating mode)."""
+        assert "modo de operar" in core_md_content
+
+    def test_key_namespace_response(self, core_md_content):
+        assert "response.language" in core_md_content
+
+    def test_key_namespace_tools(self, core_md_content):
+        assert "tools.prefer" in core_md_content
+
+    def test_key_namespace_subagents(self, core_md_content):
+        assert "subagents.mode" in core_md_content
+
+    def test_no_generic_keys(self, core_md_content):
+        """Must warn against generic key names."""
+        assert "note_1" in core_md_content or "pref_2" in core_md_content
+
+    def test_transparency_mention(self, core_md_content):
+        """Must require a transparency line when auto-saving."""
+        assert "forget_preference" in core_md_content
+
+    def test_remember_preference_tool_named(self, core_md_content):
+        assert "remember_preference" in core_md_content
+
+    def test_section_within_line_budget(self, core_md_content):
+        """The preferences section must not exceed 80 lines."""
+        start_marker = "## 🧠 Preferências do Usuário"
+        end_marker = "\n---\n"
+        start = core_md_content.find(start_marker)
+        assert start != -1, "Section start marker not found"
+        # Find the next horizontal rule after the section start
+        end = core_md_content.find(end_marker, start)
+        if end == -1:
+            # If no trailing separator, measure to the next ## heading
+            end = core_md_content.find("\n## ", start + 1)
+        section_text = core_md_content[start:end] if end != -1 else core_md_content[start:]
+        line_count = section_text.count("\n")
+        assert line_count <= 80, (
+            f"Preferences section is {line_count} lines — must be ≤ 80"
+        )
+
+
+# ── Fallback reference ─────────────────────────────────────────────────────
+
+class TestFallbackReference:
+    """Fallback persona must reference the core rule."""
+
+    def test_fallback_mentions_preferences(self, fallback_md_content):
+        assert "Preferências" in fallback_md_content
+
+    def test_fallback_points_to_core(self, fallback_md_content):
+        """Must point reader to the full rule in core/DEILE.md."""
+        assert "core/DEILE.md" in fallback_md_content or "REGRA #15" in fallback_md_content
+
+    def test_fallback_mentions_remember_preference(self, fallback_md_content):
+        assert "remember_preference" in fallback_md_content
+
+    def test_fallback_mentions_antiflood(self, fallback_md_content):
+        assert "anti-flood" in fallback_md_content.lower()

--- a/docs/system_design/06-MEMORIA.md
+++ b/docs/system_design/06-MEMORIA.md
@@ -102,6 +102,31 @@
 
 > Working memory é mantida em RAM (sem subdiretório).
 
+## Quinta camada: Preferências do Usuário (`~/.deile/preferences.json`)
+
+> Entregue pela issue #340 (storage + tools) e #341 (injeção no system prompt). A instrução de auto-save por diretiva forte foi adicionada pela issue #423.
+
+A camada de preferências é **ortogonal** às quatro camadas de memória acima: ela não passa pelo `MemoryManager` e não usa SQLite. É um arquivo JSON simples gerenciado pelo `PreferenceStore` em `deile/preferences/store.py`.
+
+| Aspecto | Detalhe |
+|---|---|
+| Arquivo | `~/.deile/preferences.json` |
+| Escopo | Por usuário (identificado por `user_id`) |
+| Persistência | Permanente — sobrevive entre sessões e reinicializações |
+| API | `remember_preference(key, value)`, `forget_preference(key)`, `list_preferences([prefix])` |
+| Injeção | Bloco **Preferências do Usuário** adicionado ao system prompt por `_build_preferences_block` (ver `deile/core/context_manager.py`) |
+| Auto-save | Ativado por diretivas fortes do usuário ("SEMPRE …", "NUNCA …") conforme REGRA #15 em `deile/personas/instructions/core/DEILE.md` |
+
+**Nomenclatura canônica de keys** (namespace por ponto, snake_case):
+
+| Namespace | Exemplos |
+|---|---|
+| `response.*` | `response.language`, `response.verbosity`, `response.format` |
+| `tools.*` | `tools.prefer.<tool>`, `tools.avoid.<tool>` |
+| `subagents.*` | `subagents.mode`, `subagents.parallelism` |
+
+---
+
 ## Regras inegociáveis ao integrar com memória
 
 | Regra | Detalhe |


### PR DESCRIPTION
## Resumo

Implementa a instrução de persona para que o DEILE invoque `remember_preference` automaticamente ao detectar diretivas fortes do usuário ("SEMPRE …", "NUNCA …", "de agora em diante …"), com anti-flood para evitar ruído em `~/.deile/preferences.json`.

Fecha a lacuna entre os issues #340 (storage + tools) e #341 (injeção no system prompt), que entregaram a infraestrutura mas não instruíam o modelo a agir proativamente.

### Arquivos alterados

| Arquivo | Mudança |
|---|---|
| `deile/personas/instructions/core/DEILE.md` | Nova **REGRA #15 — Preferências do Usuário** (≤ 80 linhas): gatilhos, anti-flood, nomenclatura de keys e transparência |
| `deile/personas/instructions/fallback.md` | Referência de 2 linhas apontando para a REGRA #15 |
| `deile/tests/personas/test_core_instruction_sections.py` | Suite de regressão com 18 testes validando que todos os marcadores obrigatórios da nova seção estão presentes (snapshot do conteúdo do system prompt) |
| `docs/system_design/06-MEMORIA.md` | Documenta a quinta camada de preferências (`PreferenceStore` / `~/.deile/preferences.json`) |

### Critérios de aceite verificados

- [x] `core/DEILE.md` contém seção "Preferências do Usuário" com gatilhos, anti-flood, nomenclatura e transparência (≤ 80 linhas)
- [x] `fallback.md` referencia a regra (2 linhas)
- [x] Suite de regressão de prompts criada em `deile/tests/personas/test_core_instruction_sections.py` (18 testes, todos verdes)
- [x] `docs/system_design/06-MEMORIA.md` atualizado
- [x] Nenhum código Python adicionado — heurística vive na instrução do modelo (sem `auto_preference_detector.py`)

---

By [DEILE-One](mailto:deile@deile.info)

Closes #423.