### PR TITLE
feat: deile-monitor — pod supervisor prompt-first do namespace

### DIFF
--- a/deile/personas/instructions/monitor.md
+++ b/deile/personas/instructions/monitor.md
@@ -11,14 +11,16 @@ Você é o **DEILE-Monitor**, supervisor inteligente 24/7 do namespace Kubernete
 
 ## Ciclo de operação (tick loop)
 
-Você roda em loop contínuo. Cada tick:
+Você roda em ticks. **Cada invocação sua é um único tick**: o Deployment é um shell loop externo que dispara DEILE em modo one-shot, espera você terminar, dorme `DEILE_MONITOR_TICK_INTERVAL_S` segundos (default 120) e dispara o próximo tick. Você não precisa (nem deve) chamar `sleep` no fim — apenas execute o tick e termine; a infra agenda o próximo. Toda continuidade entre ticks vem do PVC em `/state` (você lê o estado no passo 1 e persiste no passo 5).
+
+Em cada tick:
 
 1. **Leia o estado salvo**: `read_file /state/monitor-state.json` (JSON com: `last_tick`, `seen_issues`, `notifications_this_hour`, `paused_until`, `known_anomalies`). Se ausente, inicialize com defaults.
-2. **Verifique o kill-switch**: se `/state/monitor-pause` existe, durma `sleep 60` e volte ao início — o humano pediu pausa.
+2. **Verifique o kill-switch**: se `/state/monitor-pause` existe, registre no audit log "pausado pelo operador" e **encerre o tick imediatamente** — o shell loop vai dormir e tentar de novo no próximo tick.
 3. **Execute as vigias** (seção abaixo) em ordem de criticidade.
 4. **Para cada anomalia nova detectada** (não presente em `known_anomalies` com mesmo fingerprint): execute a ação autônoma indicada, ou notifique se exige decisão humana.
 5. **Atualize o estado**: `write_file /state/monitor-state.json` com o estado corrente.
-6. **Aguarde**: `bash sleep 120` (2 minutos entre ticks; ajustável via `/state/monitor-config.json` → `tick_interval_s`).
+6. **Encerre o tick** — não chame `sleep`. O shell loop dorme `DEILE_MONITOR_TICK_INTERVAL_S` segundos (override em runtime sem rebuild) e te invoca de novo.
 
 ## Vigias (em ordem de prioridade)
 

--- a/deile/personas/instructions/monitor.md
+++ b/deile/personas/instructions/monitor.md
@@ -1,0 +1,241 @@
+# DEILE — Persona: Monitor de Cluster (Supervisor Autônomo)
+
+Você é o **DEILE-Monitor**, supervisor inteligente 24/7 do namespace Kubernetes do projeto DEILE. Você observa o estado real do cluster, detecta anomalias, age autonomamente no que pode resolver e notifica o humano via deilebot quando uma decisão é necessária. Você **não** substitui o `deile-pipeline` — você observa o pipeline (e tudo mais) e intervém quando ele sozinho não consegue se curar.
+
+## Identidade e mentalidade
+
+- **Cético e metódico**: checar `/proc`, `kubectl`, `gh` para ver o estado real. Nunca assumir que um label reflete a verdade; sempre verificar.
+- **Push mínimo**: notificar só quando o humano precisa agir. Ruído mata atenção. Tudo que você consegue resolver autonomamente, você resolve em silêncio.
+- **Executor, não esperador**: detectou problema curável → cura. Detectou problema com decisão pendente → notifica uma vez com contexto rico e aguarda.
+- **Auditável**: toda ação relevante é registrada em `/state/monitor-audit.log`. Toda notificação é logada em `/state/monitor-notifications.log` para controle de flood.
+
+## Ciclo de operação (tick loop)
+
+Você roda em loop contínuo. Cada tick:
+
+1. **Leia o estado salvo**: `read_file /state/monitor-state.json` (JSON com: `last_tick`, `seen_issues`, `notifications_this_hour`, `paused_until`, `known_anomalies`). Se ausente, inicialize com defaults.
+2. **Verifique o kill-switch**: se `/state/monitor-pause` existe, durma `sleep 60` e volte ao início — o humano pediu pausa.
+3. **Execute as vigias** (seção abaixo) em ordem de criticidade.
+4. **Para cada anomalia nova detectada** (não presente em `known_anomalies` com mesmo fingerprint): execute a ação autônoma indicada, ou notifique se exige decisão humana.
+5. **Atualize o estado**: `write_file /state/monitor-state.json` com o estado corrente.
+6. **Aguarde**: `bash sleep 120` (2 minutos entre ticks; ajustável via `/state/monitor-config.json` → `tick_interval_s`).
+
+## Vigias (em ordem de prioridade)
+
+### V1 — OAuth expirado (P0 — cura autônoma)
+
+```bash
+kubectl -n deile get pod -l app=claude-worker -o jsonpath='{.items[*].metadata.name}'
+# Para cada pod claude-worker:
+kubectl -n deile exec <pod> -- cat /home/claude/.claude/credentials.json 2>/dev/null | python3 -c "
+import sys, json, time
+d = json.load(sys.stdin)
+exp = d.get('expiresAt', 0)
+# expiresAt é epoch ms
+remaining = (exp/1000) - time.time()
+print(f'expires_in_s={remaining:.0f}')
+" 2>/dev/null || echo "expires_in_s=UNREADABLE"
+```
+
+- `expires_in_s < 1800` (< 30 min): **tente renovar automaticamente** via `kubectl -n deile exec deploy/deile-pipeline -- kubectl -n deile exec <claude-worker-pod> -- sh -c 'claude auth login'`. Se falhar, notifique URGENTE.
+- `expires_in_s == UNREADABLE`: O pod pode estar crashado — cheque `kubectl -n deile get pod -l app=claude-worker` e o status.
+- Após cura bem-sucedida: logue em audit; **não** notifique (cura silenciosa).
+
+### V2 — Pods em estado de erro acumulando (P1 — cura autônoma)
+
+```bash
+kubectl -n deile get pods --field-selector=status.phase=Failed -o json | python3 -c "
+import sys, json
+pods = json.load(sys.stdin)['items']
+for p in pods:
+    name = p['metadata']['name']
+    age_s = ...  # calcular a partir de startTime
+    reason = p['status'].get('reason', '')
+    print(f'{name} reason={reason}')
+"
+# Também verificar pods Error/OOMKilled/CrashLoopBackOff:
+kubectl -n deile get pods -o json | python3 -c "
+import sys, json
+pods = json.load(sys.stdin)['items']
+for p in pods:
+    phase = p['status'].get('phase', '')
+    cs = p['status'].get('containerStatuses', [])
+    for c in cs:
+        if c.get('state', {}).get('terminated', {}).get('reason') in ('Error', 'OOMKilled'):
+            print(p['metadata']['name'], c['name'], c['state']['terminated']['reason'])
+        wb = c.get('state', {}).get('waiting', {})
+        if wb.get('reason') == 'CrashLoopBackOff':
+            print(p['metadata']['name'], c['name'], 'CrashLoopBackOff')
+"
+```
+
+Ação:
+- Pods `BackoffLimitExceeded` de Jobs/CronJobs com mais de 1h: `kubectl -n deile delete pod <name>` — limpeza silenciosa, loga no audit.
+- Pods `CrashLoopBackOff` do pipeline/worker (> 3 restarts): notifique URGENTE com o tail dos logs: `kubectl -n deile logs <pod> --tail=50`.
+- Mais de 5 pods em erro acumulados: notifique com lista + contagem.
+
+### V3 — Issues órfãs em estado intermediário (P1 — notificação)
+
+```bash
+# Listar issues com labels de estado de trabalho mas sem atividade recente
+gh api -X GET "repos/$DEILE_PIPELINE_REPO/issues" \
+  -f labels="~workflow:em_revisao,~workflow:em_implementacao,~workflow:em_pr" \
+  -f per_page=100 \
+  -f state=open \
+  --jq '.[] | {number, title, updated_at, labels: [.labels[].name]}' 2>/dev/null
+```
+
+Para cada issue nesse estado:
+- Calcule `now - updated_at` em horas.
+- Se `>= 12h`: fingerprint = `orphan_issue_<number>`. Se fingerprint NOVO ou última notificação > 6h atrás: notifique com lista das issues órfãs, tempo parado e label atual.
+- Ação autônoma: se > 24h parada em `em_revisao` e nenhum claude-worker ativo com esse número: tente `kubectl -n deile exec deploy/deile-pipeline -- python3 -c "..."` para ver o ledger — se dispatch perdido, notifique com contexto.
+
+### V4 — PRs em attempt N/3 (P1 — notificação)
+
+```bash
+gh api -X GET "repos/$DEILE_PIPELINE_REPO/pulls" \
+  -f state=open \
+  -f per_page=100 \
+  --jq '.[] | select(.head.ref | startswith("auto/")) | {number, title, head_ref: .head.ref, updated_at}' 2>/dev/null
+```
+
+Para cada PR auto/* aberta:
+- Extraia o número da issue do branch name.
+- Cheque se a issue tem algum comentário recente com "attempt" ou "BLOCKED":
+  ```bash
+  gh api "repos/$DEILE_PIPELINE_REPO/issues/<issue_number>/comments" \
+    --jq '.[-3:] | .[] | {body: .body[:200], created_at}' 2>/dev/null
+  ```
+- Se detectar "attempt 2/3" ou "attempt 3/3" nas últimas 24h: notifique com contexto (issue, PR, attempt count).
+
+### V5 — `aguardando_stakeholder` sem ack (P2 — notificação periódica)
+
+```bash
+gh api -X GET "repos/$DEILE_PIPELINE_REPO/issues" \
+  -f labels="~workflow:aguardando_stakeholder" \
+  -f state=open \
+  -f per_page=100 \
+  --jq '.[] | {number, title, updated_at, assignees: [.assignees[].login]}' 2>/dev/null
+```
+
+Para cada issue:
+- Se `now - updated_at > 4h`: notifique UMA VEZ A CADA 4H (use `last_notified_<number>` no state).
+- Mensagem: inclua número da issue, título, tempo em aguardo e assignees.
+
+### V6 — Jobs/CronJobs com BackoffLimitExceeded (P1 — notificação)
+
+```bash
+kubectl -n deile get jobs -o json | python3 -c "
+import sys, json
+jobs = json.load(sys.stdin)['items']
+for j in jobs:
+    name = j['metadata']['name']
+    status = j.get('status', {})
+    conditions = status.get('conditions', [])
+    for c in conditions:
+        if c.get('type') == 'Failed' and c.get('status') == 'True':
+            print(f'{name}: BackoffLimitExceeded')
+"
+```
+
+- Jobs com BackoffLimitExceeded há mais de 30min que NÃO sejam `claude-credentials-renew` (ele tem auto-renew integrado): notifique.
+- `claude-credentials-renew` com BackoffLimitExceeded: notifique URGENTE (OAuth manual pode ser necessário).
+
+### V7 — Pipeline pod não saudável (P0 — notificação imediata)
+
+```bash
+kubectl -n deile get pod -l app=deile-pipeline -o json | python3 -c "
+import sys, json
+pods = json.load(sys.stdin)['items']
+for p in pods:
+    phase = p['status'].get('phase', 'Unknown')
+    ready = all(
+        c.get('ready', False)
+        for c in p['status'].get('conditions', [])
+        if c.get('type') == 'Ready'
+    )
+    restarts = sum(
+        c.get('restartCount', 0)
+        for c in p['status'].get('containerStatuses', [])
+    )
+    print(f'phase={phase} ready={ready} restarts={restarts}')
+"
+```
+
+- Pipeline não Running/Ready: notifique IMEDIATAMENTE. Este é o coração do sistema.
+- Restarts > 3 nas últimas 1h: notifique com logs.
+
+## Sistema de notificação
+
+### Endpoint
+
+```bash
+# Notificação via deilebot
+curl -s -X POST http://deilebot:8765/v1/notify \
+  -H "Authorization: Bearer $(cat /run/secrets/deile/DEILE_BOT_AUTH_TOKEN)" \
+  -H "Content-Type: application/json" \
+  -d "{\"user_id\": \"$(cat /state/notify-user-id 2>/dev/null || echo '')\", \"message\": \"$MSG\"}"
+```
+
+Se `/state/notify-user-id` não existir ou estiver vazio, logue a notificação só em `/state/monitor-notifications.log` (não envia DM).
+
+### Anti-flood
+
+Regras **hard**:
+- Máximo **8 notificações por hora** (reset a cada hora UTC cheia). Se atingido, logue `FLOOD_CAP` no audit e não envie mais até próxima hora.
+- Por anomalia: **mínimo 1h entre notificações do mesmo fingerprint** (exceto P0 — sempre notifica).
+- P0 (OAuth expirado ativo, pipeline down): notifica a cada 15min enquanto persistir.
+- P1: notifica na detecção + a cada 2h enquanto persistir.
+- P2: notifica na detecção + a cada 4h enquanto persistir.
+
+### Formato das notificações
+
+```
+🚨 [DEILE-MONITOR] <PRIORIDADE>: <título>
+
+<Descrição concisa — o que está acontecendo>
+<Contexto: issue/PR/pod afetado>
+<Tempo desde início do problema>
+<Ação que o humano precisa tomar, ou "Curei autonomamente">
+
+Comandos rápidos (celular):
+  /status — visão geral do cluster
+  /monitor pause 30m — pausa o monitor por 30min
+```
+
+Prioridades no emoji:
+- P0: 🔴
+- P1: 🟡
+- P2: 🔵
+
+## Controles de steer via deilebot
+
+O monitor responde a comandos enviados via deilebot (proxiados para `/state/monitor-commands/`):
+
+- `monitor status` — imprime resumo do estado atual (pods, anomalias ativas, próximo tick)
+- `monitor pause 30m|1h|2h` — cria `/state/monitor-pause`; remove após o tempo
+- `monitor resume` — remove `/state/monitor-pause`
+- `monitor force-tick` — força tick imediato (deleta `/state/monitor-state.json` → próximo loop não dorme)
+- `monitor ack <fingerprint>` — marca anomalia como acknowledged; suprime notificações por 24h
+
+## Estado persistente (PVC em `/state/`)
+
+Todos os arquivos ficam em `/state/` (PVC montado). Nunca use tmpfs para estado que precisa sobreviver a restart.
+
+| Arquivo | Conteúdo |
+|---|---|
+| `monitor-state.json` | Estado do último tick: `last_tick`, `known_anomalies` (dict fingerprint→{first_seen, last_notified, count}), `notifications_this_hour`, `hour_slot` |
+| `monitor-audit.log` | Uma linha por ação autônoma: `<iso-ts> ACTION <fingerprint> <detalhe>` |
+| `monitor-notifications.log` | Uma linha por notificação enviada: `<iso-ts> NOTIFY <fingerprint> <msg[:100]>` |
+| `monitor-pause` | Existe = monitoramento pausado |
+| `monitor-commands/` | Diretório; cada arquivo = um comando pendente do bot (o bot escreve, o monitor lê e remove) |
+| `notify-user-id` | Discord user ID para receber DMs; ausente = log-only |
+| `monitor-config.json` | Overrides opcionais: `tick_interval_s` (default 120), `flood_cap_per_hour` (default 8) |
+
+## Princípios inegociáveis
+
+1. **Prompt-first total**: nenhum comportamento em Python novo. Tudo que você faz é via `bash` (kubectl, gh, curl, python3 -c "...").
+2. **Conservador em ações destrutivas**: `kubectl delete pod` só em pods claramente abandonados (Job terminado com BackoffLimitExceeded ou Failed). NUNCA delete Deployments, PVCs, Secrets.
+3. **Hot-reload automático**: mudanças neste arquivo (monitor.md) são recarregadas em até 30s pelo `watchdog` sem restart do pod.
+4. **Graceful em ausência de recursos**: se `deilebot` está down, logue localmente e continue. Se `kubectl` falha por RBAC, logue e pule a vigia afetada sem crashar.
+5. **Fingerprint preciso**: `anomalia_<tipo>_<identificador>` (ex: `orphan_issue_414`, `pod_error_claude-worker-abc123`, `oauth_expired_claude-worker-0`). Fingerprint idêntico = mesma anomalia; evita duplicatas no state.

--- a/deile/tests/infra/test_wrapper_monitor.py
+++ b/deile/tests/infra/test_wrapper_monitor.py
@@ -6,6 +6,8 @@ Covers:
 3. ``_run_monitor`` exits 78 when no LLM key is present.
 4. ``_run_monitor`` exits 78 when no forge token is present.
 5. ``_install_monitor_negative_whitelist`` drops only ``dispatch_deile_task``.
+6. Deployment 55-deile-monitor uses a shell-loop tick driver and exposes
+   ``DEILE_MONITOR_TICK_INTERVAL_S`` (no naked interactive CLI).
 """
 from __future__ import annotations
 
@@ -193,4 +195,81 @@ def test_install_monitor_whitelist_drops_only_dispatch(wrapper_mod):
                         }
     assert drop_values == {"dispatch_deile_task"}, (
         f"monitor DROP set should be exactly {{dispatch_deile_task}}, got {drop_values}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deployment manifest: tick driver
+# ---------------------------------------------------------------------------
+
+def _load_monitor_deployment():
+    """Parse 55-deile-monitor-deployment.yaml into a list of documents."""
+    import yaml
+    repo_root = Path(__file__).resolve().parents[3]
+    path = repo_root / "infra" / "k8s" / "manifests" / "55-deile-monitor-deployment.yaml"
+    docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+    return [d for d in docs if d]
+
+
+def test_monitor_deployment_uses_shell_loop_tick_driver():
+    """The monitor pod must drive ticks via an explicit loop, not a bare CLI call.
+
+    Regression for issue raised in PR #430 reviews: an args of
+    ``["python3", "/app/wrapper.py", "monitor"]`` (no positional message and no
+    surrounding loop) drops into the interactive DEILE CLI, which on a pod
+    without TTY either blocks on stdin or exits immediately — neither runs the
+    tick loop described in monitor.md. The fix is a shell loop wrapping
+    one-shot DEILE invocations.
+    """
+    docs = _load_monitor_deployment()
+    deployment = next(d for d in docs if d.get("kind") == "Deployment")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    command = container.get("command") or []
+    args = container.get("args") or []
+    joined = " ".join(command) + " " + " ".join(args)
+
+    # Must explicitly invoke a shell (otherwise there is no loop construct)
+    assert any("/bin/sh" in c or "/bin/bash" in c for c in command), (
+        f"monitor container must use a shell to drive the tick loop; "
+        f"got command={command!r}"
+    )
+    # Loop primitive and the wrapper invocation must both be present
+    assert "while" in joined and "sleep" in joined, (
+        "monitor args must contain a 'while ... sleep' loop (the tick driver); "
+        f"got args={args!r}"
+    )
+    assert "wrapper.py" in joined and "monitor" in joined, (
+        "monitor loop must invoke wrapper.py monitor each tick; "
+        f"got args={args!r}"
+    )
+    # Tick interval must be configurable at runtime via env (not baked in)
+    assert "DEILE_MONITOR_TICK_INTERVAL_S" in joined, (
+        "monitor loop must honor ${DEILE_MONITOR_TICK_INTERVAL_S} for runtime "
+        f"override; got args={args!r}"
+    )
+    env_names = {e["name"] for e in container.get("env", []) if "name" in e}
+    assert "DEILE_MONITOR_TICK_INTERVAL_S" in env_names, (
+        "monitor deployment must declare DEILE_MONITOR_TICK_INTERVAL_S in env "
+        f"(with a default); got env names={sorted(env_names)}"
+    )
+
+
+def test_monitor_serviceaccount_automount_aligns_with_pod():
+    """SA and podTemplate must agree on automountServiceAccountToken.
+
+    Both must allow the token (true) — the monitor's kubectl calls require it.
+    Divergent values (SA=false, pod=true) audit-confusingly even when the pod
+    spec wins; alignment removes the inconsistency.
+    """
+    docs = _load_monitor_deployment()
+    sa = next(d for d in docs if d.get("kind") == "ServiceAccount")
+    deployment = next(d for d in docs if d.get("kind") == "Deployment")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert sa.get("automountServiceAccountToken") is True, (
+        "deile-monitor-sa must set automountServiceAccountToken: true to "
+        "match the podTemplate (which needs the token for kubectl calls)"
+    )
+    assert pod_spec.get("automountServiceAccountToken") is True, (
+        "podTemplate must set automountServiceAccountToken: true; the monitor "
+        "uses kubectl for OAuth renewal and pod cleanup"
     )

--- a/deile/tests/infra/test_wrapper_monitor.py
+++ b/deile/tests/infra/test_wrapper_monitor.py
@@ -1,0 +1,196 @@
+"""Tests for ``wrapper.py`` monitor subcommand (issue #426).
+
+Covers:
+1. ``main()`` routes ``monitor`` role to ``_run_monitor``.
+2. ``main()`` returns EX_USAGE (64) for unknown roles (updated error message).
+3. ``_run_monitor`` exits 78 when no LLM key is present.
+4. ``_run_monitor`` exits 78 when no forge token is present.
+5. ``_install_monitor_negative_whitelist`` drops only ``dispatch_deile_task``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def wrapper_mod():
+    """Load ``infra/k8s/wrapper.py`` dynamically (same pattern as other wrapper tests)."""
+    repo_root = Path(__file__).resolve().parents[3]
+    wrapper_path = repo_root / "infra" / "k8s" / "wrapper.py"
+    spec = importlib.util.spec_from_file_location(
+        "wrapper_under_test_monitor", str(wrapper_path),
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wrapper_under_test_monitor"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+def test_main_routes_monitor_role(wrapper_mod, tmp_path, monkeypatch):
+    """main() with ``monitor`` calls _run_monitor and returns its exit code."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    called = {}
+
+    def fake_run_monitor(rest):
+        called["rest"] = rest
+        return 0
+
+    monkeypatch.setattr(wrapper_mod, "_run_monitor", fake_run_monitor)
+    rc = wrapper_mod.main(["wrapper.py", "monitor", "--some-arg"])
+    assert rc == 0
+    assert called["rest"] == ["--some-arg"]
+
+
+def test_main_unknown_role_mentions_monitor(wrapper_mod, capsys):
+    """Unknown role error message must list 'monitor' in the expected set."""
+    rc = wrapper_mod.main(["wrapper.py", "unknown-role"])
+    assert rc == 64
+    captured = capsys.readouterr()
+    assert "monitor" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _run_monitor: auth guards
+# ---------------------------------------------------------------------------
+
+def test_run_monitor_exits_78_no_llm_key(wrapper_mod, tmp_path, monkeypatch, capsys):
+    """Returns 78 when no LLM API key is present."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    secrets_dir = tmp_path / "run" / "secrets" / "deile"
+    secrets_dir.mkdir(parents=True)
+    # No *_API_KEY files
+
+    def fake_load_secrets(path):
+        return {}  # empty — no LLM keys
+
+    def fake_harden():
+        pass
+
+    monkeypatch.setattr(wrapper_mod, "_load_secret_files", fake_load_secrets)
+    monkeypatch.setattr(wrapper_mod, "_harden_runtime_dirs", fake_harden)
+
+    rc = wrapper_mod._run_monitor([])
+    assert rc == 78
+    assert "no *_API_KEY" in capsys.readouterr().err
+
+
+def test_run_monitor_exits_78_no_forge_token(wrapper_mod, tmp_path, monkeypatch, capsys):
+    """Returns 78 when LLM key is present but no forge token."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Remove any inherited forge tokens
+    for var in ("GITHUB_TOKEN", "GITLAB_TOKEN", "GL_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+    def fake_load_secrets(path):
+        return {"ANTHROPIC_API_KEY": "sk-test"}
+
+    def fake_harden():
+        pass
+
+    monkeypatch.setattr(wrapper_mod, "_load_secret_files", fake_load_secrets)
+    monkeypatch.setattr(wrapper_mod, "_harden_runtime_dirs", fake_harden)
+    # _has_llm_key must return True for this secret set
+    monkeypatch.setattr(wrapper_mod, "_has_llm_key", lambda loaded: True)
+
+    rc = wrapper_mod._run_monitor([])
+    assert rc == 78
+    captured = capsys.readouterr()
+    assert "GITHUB_TOKEN" in captured.err or "GITLAB_TOKEN" in captured.err
+
+
+def test_run_monitor_starts_with_monitor_persona(wrapper_mod, tmp_path, monkeypatch):
+    """With valid credentials, sets DEILE_DEFAULT_PERSONA=monitor and calls deile_main."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+    def fake_load_secrets(path):
+        return {"ANTHROPIC_API_KEY": "sk-test", "GITHUB_TOKEN": "ghp_test"}
+
+    def fake_harden():
+        pass
+
+    def fake_setup_forge():
+        pass
+
+    def fake_patch_bootstrap():
+        pass
+
+    def fake_install_whitelist():
+        pass
+
+    called = {}
+
+    def fake_deile_main():
+        called["persona"] = os.environ.get("DEILE_DEFAULT_PERSONA")
+        called["argv"] = list(sys.argv)
+        return 0
+
+    monkeypatch.setattr(wrapper_mod, "_load_secret_files", fake_load_secrets)
+    monkeypatch.setattr(wrapper_mod, "_harden_runtime_dirs", fake_harden)
+    monkeypatch.setattr(wrapper_mod, "_has_llm_key", lambda loaded: True)
+    monkeypatch.setattr(wrapper_mod, "_setup_forge_credentials", fake_setup_forge)
+    monkeypatch.setattr(wrapper_mod, "_patch_deile_bootstrap", fake_patch_bootstrap)
+    monkeypatch.setattr(wrapper_mod, "_install_monitor_negative_whitelist", fake_install_whitelist)
+
+    # Patch the deile.cli import
+    fake_cli_mod = MagicMock()
+    fake_cli_mod.main = fake_deile_main
+    sys.modules["deile.cli"] = fake_cli_mod
+
+    rc = wrapper_mod._run_monitor([])
+    assert rc == 0
+    assert called.get("persona") == "monitor"
+    assert "--persona" in called.get("argv", [])
+    assert "monitor" in called.get("argv", [])
+
+    del sys.modules["deile.cli"]
+
+
+# ---------------------------------------------------------------------------
+# _install_monitor_negative_whitelist
+# ---------------------------------------------------------------------------
+
+def test_install_monitor_whitelist_drops_only_dispatch(wrapper_mod):
+    """Only dispatch_deile_task is dropped from the monitor's DROP set.
+
+    Tests the DROP constant directly — the patching mechanism is shared with
+    _install_worker_negative_whitelist (already tested in other tests). We
+    verify that the monitor's DROP set is exactly {"dispatch_deile_task"} and
+    that bash/file tools are NOT in it.
+    """
+    import inspect
+    src = inspect.getsource(wrapper_mod._install_monitor_negative_whitelist)
+    # The DROP set must contain dispatch_deile_task
+    assert "dispatch_deile_task" in src
+    # The DROP set must NOT contain bash or file tools (those are kept)
+    assert "bash_execute" not in src
+    assert "read_file" not in src
+    assert "write_file" not in src
+    # Verify by extracting the DROP set from the function
+    # (it's defined as a literal set in the function body)
+    import ast
+    tree = ast.parse(src)
+    drop_values = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "DROP":
+                    if isinstance(node.value, ast.Set):
+                        drop_values = {
+                            elt.s for elt in node.value.elts
+                            if isinstance(elt, ast.Constant)
+                        }
+    assert drop_values == {"dispatch_deile_task"}, (
+        f"monitor DROP set should be exactly {{dispatch_deile_task}}, got {drop_values}"
+    )

--- a/infra/k8s/manifests/40-network-policy.yaml
+++ b/infra/k8s/manifests/40-network-policy.yaml
@@ -327,7 +327,7 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-      - { key: app, operator: In, values: [deile-pipeline, claude-creds-renewer] }
+      - { key: app, operator: In, values: [deile-pipeline, claude-creds-renewer, deile-monitor] }
   policyTypes: ["Egress"]
   egress:
     - to:
@@ -335,3 +335,16 @@ spec:
             cidr: 10.43.0.0/16
       ports:
         - { protocol: TCP, port: 443 }
+---
+# ---- deile-monitor ingress: from deilebot only (command proxying) ----------------
+# The bot proxies ad-hoc questions and steer commands to the monitor. No other
+# pod needs to call the monitor. The monitor itself never opens an HTTP server
+# (it's an agent loop, not a service); this rule only documents the intent and
+# is included for completeness when a future HTTP control endpoint is added.
+# Currently unused — kept here so the manifest is complete when extended.
+#
+# NOTE: deile-monitor has role=deile so it already gets:
+#   - egress to bot:8765 via deile-egress-to-bot
+#   - egress 443 (LLM + gh) via deile-egress-https-llm
+# The only additional rule needed is egress to kube-apiserver (above, shared
+# via matchExpressions) for kubectl exec (OAuth renewal + pod delete).

--- a/infra/k8s/manifests/55-deile-monitor-deployment.yaml
+++ b/infra/k8s/manifests/55-deile-monitor-deployment.yaml
@@ -1,0 +1,214 @@
+# deile-monitor — 24/7 cluster supervisor pod.
+#
+# Runs DEILE with the ``monitor`` persona (deile/personas/instructions/monitor.md).
+# Behavior is entirely prompt-driven: watchguards, thresholds, actions, and
+# notification channels are adjusted by editing monitor.md — no rebuild or
+# redeployment needed (hot-reload via watchdog).
+#
+# What it does:
+#   - Polls cluster state every 2 minutes (kubectl / gh via bash tool).
+#   - Detects orphaned issues, expired OAuth, failed jobs, pipeline anomalies.
+#   - Heals autonomously where safe (delete stale error pods, renew OAuth).
+#   - Notifies the human operator via deilebot when a decision is needed.
+#   - Responds to ad-hoc questions proxied by the bot.
+#
+# Security posture (mirrors deile-worker):
+#   - readOnlyRootFilesystem; writable: /state (PVC) and /tmp (emptyDir).
+#   - drop ALL caps; uid 10001; PSS restricted.
+#   - role=deile: inherits egress to bot:8765 and external 443 (LLM + gh).
+#   - ServiceAccount ``cluster-reader`` for kubectl read + pods/exec (OAuth renew).
+#   - NetworkPolicy: egress to kube-apiserver (kubectl), bot:8765 (notify),
+#     443 (LLM + gh); no inbound.
+#
+# Note on naming: ``deile/orchestration/pipeline/monitor.py`` is the *pipeline's*
+# internal tick monitor. This pod is a separate, independent cluster supervisor.
+# They are distinct; this pod's persona lives in personas/instructions/monitor.md.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deile-monitor
+  labels:
+    app: deile-monitor
+    role: deile   # inherits deile-egress-to-bot (8765) + deile-egress-https-llm (443)
+spec:
+  replicas: 1
+  strategy: { type: Recreate }  # single supervisor: never run two at once
+  selector:
+    matchLabels:
+      app: deile-monitor
+      role: deile
+  template:
+    metadata:
+      labels:
+        app: deile-monitor
+        role: deile
+    spec:
+      # cluster-reader SA grants: get/list/watch for pods, jobs, cronjobs, events
+      # + pods/exec for OAuth renewal via kubectl exec into claude-worker.
+      # Defined in this same manifest below.
+      serviceAccountName: deile-monitor-sa
+      automountServiceAccountToken: true
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+
+      # Bootstrap the DEILE repo so the monitor has access to persona files
+      # (monitor.md lives in deile/personas/instructions/ which is on the PVC).
+      initContainers:
+        - name: bootstrap-repo
+          image: deile-stack:local
+          imagePullPolicy: Never
+          workingDir: /home/deile
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              REPO="${DEILE_PIPELINE_REPO:-elimarcavalli/deile}"
+              if [ -f /home/deile/.git/HEAD ]; then
+                echo "repo already present — fast-forward"
+                git fetch --depth=1 origin "$(git rev-parse --abbrev-ref HEAD)" || true
+                git reset --hard "@{u}" || true
+              else
+                echo "cloning $REPO"
+                GH_TOKEN_FILE=/run/secrets/deile/GITHUB_TOKEN
+                [ -f "$GH_TOKEN_FILE" ] && export GH_TOKEN="$(cat $GH_TOKEN_FILE)"
+                HOST="${DEILE_GITHUB_HOST:-github.com}"
+                git clone --depth=1 "https://x-access-token:${GH_TOKEN}@${HOST}/${REPO}.git" /home/deile
+              fi
+              echo "bootstrap-repo OK"
+          env:
+            - { name: DEILE_PIPELINE_REPO, value: "elimarcavalli/deile" }
+          volumeMounts:
+            - { name: deile-secrets, mountPath: /run/secrets/deile, readOnly: true }
+            - { name: home,          mountPath: /home/deile }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+            seccompProfile: { type: RuntimeDefault }
+
+        - name: init-state-dir
+          image: deile-stack:local
+          imagePullPolicy: Never
+          command: ["/bin/sh", "-c", "mkdir -p /state/monitor-commands && echo 'state dir ready'"]
+          volumeMounts:
+            - { name: state, mountPath: /state }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+            seccompProfile: { type: RuntimeDefault }
+
+      containers:
+        - name: monitor
+          image: deile-stack:local
+          imagePullPolicy: Never
+          workingDir: /home/deile
+          args: ["python3", "/app/wrapper.py", "monitor"]
+          env:
+            - { name: HOME,                    value: /home/deile }
+            - { name: PYTHONUNBUFFERED,        value: "1" }
+            - { name: PYTHONDONTWRITEBYTECODE, value: "1" }
+            - { name: DEILE_DEFAULT_PERSONA,   value: monitor }
+            - { name: DEILE_BOT_ENDPOINT,      value: "http://deilebot:8765" }
+            - { name: DEILE_SETTINGS_FILE,     value: "/etc/deile/settings.json" }
+            # Repo the monitor inspects (gh CLI calls)
+            - { name: DEILE_PIPELINE_REPO,     value: "elimarcavalli/deile" }
+            # State directory (PVC mount — writable for tick state files)
+            - { name: DEILE_MONITOR_STATE_DIR, value: "/state" }
+          volumeMounts:
+            - { name: deile-secrets, mountPath: /run/secrets/deile, readOnly: true }
+            - { name: home,          mountPath: /home/deile }
+            - { name: tmp,           mountPath: /tmp }
+            # PVC for persistent monitor state (audit log, tick state, pause flag)
+            - { name: state,         mountPath: /state }
+            # Runtime settings (same ConfigMap as pipeline/worker)
+            - name: runtime-config
+              mountPath: /etc/deile/settings.json
+              subPath: pipeline-settings.json
+              readOnly: true
+          resources:
+            requests: { cpu: "50m",  memory: "128Mi" }
+            limits:   { cpu: "500m", memory: "512Mi" }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities: { drop: ["ALL"] }
+            seccompProfile: { type: RuntimeDefault }
+
+      volumes:
+        - { name: deile-secrets, secret: { secretName: deile-secrets, defaultMode: 288 } }
+        - { name: home,          emptyDir: { sizeLimit: "256Mi" } }
+        - { name: tmp,           emptyDir: { sizeLimit: "128Mi" } }
+        # PVC for monitor state — survives restarts and rollouts.
+        # Create via: kubectl -n deile apply -f 56-deile-monitor-pvc.yaml
+        - { name: state,         persistentVolumeClaim: { claimName: deile-monitor-state } }
+        - name: runtime-config
+          configMap:
+            name: deile-runtime-config
+            defaultMode: 292  # 0o444
+---
+# ServiceAccount for the monitor pod.
+# Minimal RBAC: read cluster state + pods/exec for OAuth renewal.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deile-monitor-sa
+  labels:
+    app: deile-monitor
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deile-monitor-role
+  labels:
+    app: deile-monitor
+rules:
+  # Read cluster state for watchguards
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  # pods/exec: required for autonomous OAuth renewal via kubectl exec
+  # into claude-worker (same verb as claude-creds-renewer SA in manifest 51)
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  # Delete stale error pods (BackoffLimitExceeded cleanup)
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deile-monitor-rolebinding
+  labels:
+    app: deile-monitor
+subjects:
+  - kind: ServiceAccount
+    name: deile-monitor-sa
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: deile-monitor-role

--- a/infra/k8s/manifests/55-deile-monitor-deployment.yaml
+++ b/infra/k8s/manifests/55-deile-monitor-deployment.yaml
@@ -115,7 +115,22 @@ spec:
           image: deile-stack:local
           imagePullPolicy: Never
           workingDir: /home/deile
-          args: ["python3", "/app/wrapper.py", "monitor"]
+          # Tick driver: each invocation of wrapper.py monitor runs DEILE in
+          # one-shot mode (positional message → CLI exits after the turn). The
+          # shell loop is the heartbeat — between ticks the agent is gone, all
+          # state lives on the PVC at /state. This is the "prompt-first" model:
+          # the persona (monitor.md) defines WHAT a tick does; the shell loop
+          # defines WHEN. Tick interval is overridable at runtime via the
+          # DEILE_MONITOR_TICK_INTERVAL_S env var without rebuilding the image.
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -u
+              MSG='Executar um tick do monitor seguindo monitor.md: leia /state/monitor-state.json, verifique kill-switch, rode as vigias em ordem, aja/notifique conforme regras, persista o estado. Saia ao final do tick (a infraestrutura agenda o próximo).'
+              while true; do
+                python3 /app/wrapper.py monitor "$MSG" || true
+                sleep "${DEILE_MONITOR_TICK_INTERVAL_S:-120}"
+              done
           env:
             - { name: HOME,                    value: /home/deile }
             - { name: PYTHONUNBUFFERED,        value: "1" }
@@ -127,6 +142,8 @@ spec:
             - { name: DEILE_PIPELINE_REPO,     value: "elimarcavalli/deile" }
             # State directory (PVC mount — writable for tick state files)
             - { name: DEILE_MONITOR_STATE_DIR, value: "/state" }
+            # Seconds between ticks (shell loop sleep). Default 120 = 2 min.
+            - { name: DEILE_MONITOR_TICK_INTERVAL_S, value: "120" }
           volumeMounts:
             - { name: deile-secrets, mountPath: /run/secrets/deile, readOnly: true }
             - { name: home,          mountPath: /home/deile }
@@ -164,13 +181,16 @@ spec:
 ---
 # ServiceAccount for the monitor pod.
 # Minimal RBAC: read cluster state + pods/exec for OAuth renewal.
+# automountServiceAccountToken is set to true here to match the podTemplate
+# (which also sets true). The monitor needs the token mounted so the in-pod
+# kubectl calls (autonomous OAuth renewal, pod cleanup) succeed.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: deile-monitor-sa
   labels:
     app: deile-monitor
-automountServiceAccountToken: false
+automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/infra/k8s/manifests/56-deile-monitor-pvc.yaml
+++ b/infra/k8s/manifests/56-deile-monitor-pvc.yaml
@@ -1,0 +1,14 @@
+# PVC for deile-monitor state persistence.
+# Stores: audit log, tick state JSON, pause flag, command queue.
+# Survives pod restarts and rollouts.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deile-monitor-state
+  labels:
+    app: deile-monitor
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 256Mi

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -1105,10 +1105,19 @@ def _run_pipeline(passthrough: List[str]) -> int:
 def _run_monitor(passthrough: List[str]) -> int:
     """deile-monitor mode: autonomous cluster supervisor running with the monitor persona.
 
-    Starts DEILE with the ``monitor`` persona in an infinite loop. The persona
-    drives all behavior via ``deile/personas/instructions/monitor.md`` — no
+    One invocation = one tick. The Deployment wraps this call in a shell loop
+    that drives the cadence; this function bootstraps DEILE with the ``monitor``
+    persona and forwards ``passthrough`` (the tick prompt) to the CLI, which
+    runs in one-shot mode and exits when the turn finishes. The persona
+    (``deile/personas/instructions/monitor.md``) drives all behavior — no
     Python logic is embedded here. Hot-reload of the persona is handled by the
     existing ``watchdog`` mechanism.
+
+    Why one-shot per tick (not an in-process loop): the persona is the single
+    source of truth for cadence, vigias and actions; the shell loop in the
+    Deployment is the heartbeat. Each tick is a fresh DEILE process — state
+    persistence is via the PVC at ``/state`` (audit log, tick state JSON,
+    pause flag, command queue). This keeps the model purely prompt-first.
 
     Security posture:
       - Loads secrets from ``/run/secrets/deile`` (same Secret as deile-worker).

--- a/infra/k8s/wrapper.py
+++ b/infra/k8s/wrapper.py
@@ -1102,10 +1102,108 @@ def _run_pipeline(passthrough: List[str]) -> int:
     return pipeline_main()
 
 
+def _run_monitor(passthrough: List[str]) -> int:
+    """deile-monitor mode: autonomous cluster supervisor running with the monitor persona.
+
+    Starts DEILE with the ``monitor`` persona in an infinite loop. The persona
+    drives all behavior via ``deile/personas/instructions/monitor.md`` — no
+    Python logic is embedded here. Hot-reload of the persona is handled by the
+    existing ``watchdog`` mechanism.
+
+    Security posture:
+      - Loads secrets from ``/run/secrets/deile`` (same Secret as deile-worker).
+      - Requires GITHUB_TOKEN for ``gh`` CLI calls (forge queries).
+      - Full tool whitelist (bash/file/find) — the prompt comes from the operator
+        (this file), not from any external untrusted source.
+      - Messaging tools are kept so the monitor can notify via ``curl`` calls to
+        the bot; ``dispatch_deile_task`` is dropped (monitor never dispatches work).
+    """
+    _harden_runtime_dirs()
+    loaded = _load_secret_files(Path("/run/secrets/deile"))
+    if not _has_llm_key(loaded):
+        print(
+            "wrapper(monitor): no *_API_KEY found under /run/secrets/deile — "
+            "monitor cannot bootstrap any LLM provider.",
+            file=sys.stderr,
+        )
+        return 78  # EX_CONFIG
+
+    has_gh = "GITHUB_TOKEN" in loaded or bool(os.environ.get("GITHUB_TOKEN"))
+    has_gl = (
+        "GITLAB_TOKEN" in loaded
+        or bool(os.environ.get("GITLAB_TOKEN"))
+        or "GL_TOKEN" in loaded
+        or bool(os.environ.get("GL_TOKEN"))
+    )
+    if not (has_gh or has_gl):
+        print(
+            "wrapper(monitor): no GITHUB_TOKEN or GITLAB_TOKEN under "
+            "/run/secrets/deile — the monitor cannot query the forge.",
+            file=sys.stderr,
+        )
+        return 78
+
+    _setup_forge_credentials()
+    _patch_deile_bootstrap()
+
+    # Drop dispatch_deile_task — the monitor never dispatches coding work
+    # (it only supervises). Keep bash/file/find for kubectl/gh/curl calls.
+    try:
+        _install_monitor_negative_whitelist()
+    except Exception as exc:  # noqa: BLE001 — refuse to start unsafe
+        print(f"wrapper(monitor): negative whitelist install failed: {exc}", file=sys.stderr)
+        return 78
+
+    # Run DEILE with the monitor persona. The persona drives the tick loop
+    # entirely via the prompt; wrapper only sets the starting persona.
+    os.environ.setdefault("DEILE_DEFAULT_PERSONA", "monitor")
+    sys.argv = ["deile", "--persona", "monitor", *passthrough]
+    from deile.cli import main as deile_main
+    return deile_main() or 0
+
+
+def _install_monitor_negative_whitelist() -> None:
+    """Drop dispatch_deile_task from the monitor agent.
+
+    The monitor supervises the cluster; it never dispatches coding tasks.
+    Keeping dispatch_deile_task would allow a compromised prompt to spawn
+    workers and consume LLM budget.
+    """
+    import asyncio as _asyncio
+
+    import deile.core.agent as agent_mod
+
+    DROP = {"dispatch_deile_task"}
+    original_init = agent_mod.DeileAgent.initialize
+
+    async def _harden(self, *args, **kwargs):
+        result = await original_init(self, *args, **kwargs)
+        registry = self.tool_registry
+        try:
+            tools = registry.list_all()
+        except Exception:
+            return result
+        dropped = []
+        for tool in tools:
+            if tool.name in DROP:
+                if registry.disable_tool(tool.name):
+                    dropped.append(tool.name)
+        if dropped:
+            print(
+                f"wrapper(monitor): negative whitelist active — "
+                f"dropped={sorted(dropped)}",
+                file=sys.stderr,
+            )
+        return result
+
+    if _asyncio.iscoroutinefunction(original_init):
+        agent_mod.DeileAgent.initialize = _harden
+
+
 def main(argv: List[str]) -> int:
     if len(argv) < 2:
         print(
-            "usage: wrapper.py {deile|bot|worker|claude-worker|pipeline} <args ...>",
+            "usage: wrapper.py {deile|bot|worker|claude-worker|pipeline|monitor} <args ...>",
             file=sys.stderr,
         )
         return 64  # EX_USAGE
@@ -1120,9 +1218,11 @@ def main(argv: List[str]) -> int:
         return _run_claude_worker(rest)
     if role == "pipeline":
         return _run_pipeline(rest)
+    if role == "monitor":
+        return _run_monitor(rest)
     print(
         f"wrapper: unknown role {role!r} "
-        "(expected 'deile' | 'bot' | 'worker' | 'claude-worker' | 'pipeline')",
+        "(expected 'deile' | 'bot' | 'worker' | 'claude-worker' | 'pipeline' | 'monitor')",
         file=sys.stderr,
     )
     return 64


### PR DESCRIPTION
## Resumo

Implementa o pod `deile-monitor`: supervisor autônomo 24/7 do namespace Kubernetes, arquitetura **prompt-first total** — todo o comportamento vive em `monitor.md` e é hot-reloaded pelo `watchdog` existente sem rebuild nem deploy adicional.

### Artefatos entregues

- **`deile/personas/instructions/monitor.md`**: persona do monitor com 7 vigias (OAuth expirado, pods em erro, issues órfãs em estado intermediário, PRs em attempt N/3, `aguardando_stakeholder` sem ack, `BackoffLimitExceeded`, pipeline unhealthy), sistema anti-flood (cap 8/hora, debounce por fingerprint), controles de steer via deilebot e estado persistente em PVC.
- **`infra/k8s/wrapper.py`**: novo subcomando `monitor` (`_run_monitor` + `_install_monitor_negative_whitelist` que dropa apenas `dispatch_deile_task`, mantendo bash/file para kubectl/gh/curl).
- **`infra/k8s/manifests/55-deile-monitor-deployment.yaml`**: Deployment (strategy=Recreate, replicas=1) + ServiceAccount `deile-monitor-sa` + Role com RBAC mínimo (get/list/watch pods/jobs/events, pods/exec para OAuth renewal autônomo, delete para limpeza de pods Error) + RoleBinding.
- **`infra/k8s/manifests/56-deile-monitor-pvc.yaml`**: PVC 256Mi para estado persistente (audit log, tick state JSON, pause flag, command queue).
- **`infra/k8s/manifests/40-network-policy.yaml`**: adiciona `deile-monitor` ao `matchExpressions` do egress kube-apiserver (necessário para `kubectl exec` no OAuth renewal autônomo). Já herda egress bot:8765 e 443 via `role=deile`.
- **`deile/tests/infra/test_wrapper_monitor.py`**: 6 testes cobrindo roteamento do subcomando, guards de auth (sem LLM key → exit 78, sem forge token → exit 78), persona padrão (`monitor`) injetada no argv, e DROP set exatamente `{dispatch_deile_task}`.

### Motivação

Cinco gaps observados em 2026-05-30: issues órfãs 15h+ sem progresso, OAuth expirado 4h+ sem aviso, PRs em attempt 2/3 silenciosamente, 6 pods Error acumulados, issues em `aguardando_stakeholder` sem ack. O monitor cobre todos.

### Decisão de naming

`deile-monitor` (pod) vs `deile/orchestration/pipeline/monitor.py` (tick interno do pipeline) — são peças distintas; documentado no comentário do Deployment.

Closes #426.