### PR TITLE
fix(tests): add autouse fixtures to eliminate 9 ordering-dependent failures

### DIFF
--- a/deile/tests/conftest.py
+++ b/deile/tests/conftest.py
@@ -8,10 +8,96 @@ Also redirects the AuditLogger singleton to a per-session tmp directory so
 tests that exercise audit-emitting code (e.g. ``set_setting``,
 ``add_skills_path``) do not pollute ``~/.deile/logs/security_audit.log``
 on the developer's HOME (issue #125 reviewer finding).
+
+Issue #432: three additional autouse fixtures prevent ordering-dependent
+failures caused by leaked global state (os.environ, logging handlers,
+sys.stdio) across tests that do not use monkeypatch for cleanup.
 """
 from __future__ import annotations
 
+import logging
+import os
+import sys
+
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _snapshot_os_environ():
+    """Restore os.environ to its pre-test state after each test.
+
+    Prevents tests that mutate os.environ via direct assignment (not
+    monkeypatch) from leaking token variables such as GITHUB_TOKEN /
+    GITLAB_TOKEN / GL_TOKEN into subsequent tests, which would suppress the
+    expected WARNING in test_warns_when_no_tokens (issue #432).
+    """
+    saved = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _clean_logging_handlers():
+    """Snapshot and restore logger handler/level/propagate state around each test.
+
+    caplog captures records by attaching a handler to the root logger and
+    relying on propagation. If a test adds handlers to a named logger, sets
+    propagate=False, or changes its effective level without cleanup, subsequent
+    tests using caplog.at_level(..., logger=name) receive 0 records even when
+    the code does emit — this is the root cause of the 7 TestTickSummary and
+    1 test_warns_when_no_tokens ordering failures (issue #432).
+    """
+    root = logging.root
+    root_handlers_before = root.handlers[:]
+    root_level_before = root.level
+
+    mgr = logging.Logger.manager
+    snapshot: dict = {}
+    for name, obj in list(mgr.loggerDict.items()):
+        if isinstance(obj, logging.Logger):
+            snapshot[name] = {
+                "handlers": obj.handlers[:],
+                "level": obj.level,
+                "propagate": obj.propagate,
+            }
+
+    yield
+
+    root.handlers[:] = root_handlers_before
+    root.level = root_level_before
+
+    for name, state in snapshot.items():
+        obj = mgr.loggerDict.get(name)
+        if isinstance(obj, logging.Logger):
+            obj.handlers[:] = state["handlers"]
+            obj.level = state["level"]
+            obj.propagate = state["propagate"]
+
+    for name, obj in list(mgr.loggerDict.items()):
+        if name not in snapshot and isinstance(obj, logging.Logger):
+            obj.handlers.clear()
+            obj.level = logging.NOTSET
+            obj.propagate = True
+
+
+@pytest.fixture(autouse=True)
+def _guard_sys_stdio():
+    """Restore sys.stdout/stderr/stdin to their pre-test values after each test.
+
+    SubAgentOrchestrator(capture_output=True) replaces sys.stdout during its
+    run and restores it in a finally block. If a test (or earlier fixture)
+    replaces sys.stdout without cleanup, test_renderer_task_awaited_before_
+    stdout_restore captures the wrong reference as saved_stdout and the
+    identity assertion fails (issue #432).
+    """
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    saved_stdin = sys.stdin
+    yield
+    sys.stdout = saved_stdout
+    sys.stderr = saved_stderr
+    sys.stdin = saved_stdin
 
 
 @pytest.fixture(autouse=True)

--- a/deile/tests/conftest.py
+++ b/deile/tests/conftest.py
@@ -47,10 +47,16 @@ def _clean_logging_handlers():
     tests using caplog.at_level(..., logger=name) receive 0 records even when
     the code does emit — this is the root cause of the 7 TestTickSummary and
     1 test_warns_when_no_tokens ordering failures (issue #432).
+
+    Also restores logging.Manager.disable: deile/cli.py calls logging.disable()
+    to suppress output during CLI runs; without this restore, all subsequent
+    logging.info() / logging.warning() calls return False from isEnabledFor()
+    and are silently dropped — causing deile/tests/log_mgmt/ failures.
     """
     root = logging.root
     root_handlers_before = root.handlers[:]
     root_level_before = root.level
+    manager_disable_before = root.manager.disable
 
     mgr = logging.Logger.manager
     snapshot: dict = {}
@@ -63,6 +69,9 @@ def _clean_logging_handlers():
             }
 
     yield
+
+    if root.manager.disable != manager_disable_before:
+        logging.disable(manager_disable_before)
 
     root.handlers[:] = root_handlers_before
     root.level = root_level_before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ test = [
     "pytest>=7",
     "pytest-asyncio>=0.23",
     "pytest-cov>=4",
+    "pytest-randomly>=3",
     "pytest-textual-snapshot>=1.0",
     "pytest-timeout>=2.3",
 ]


### PR DESCRIPTION
## Summary

- Adds `_snapshot_os_environ` autouse fixture to `deile/tests/conftest.py`: snapshots and restores `os.environ` around every test, preventing forge-token env vars (`GITHUB_TOKEN`/`GITLAB_TOKEN`/`GL_TOKEN`) set without `monkeypatch` from suppressing the WARNING expected by `test_warns_when_no_tokens`.
- Adds `_clean_logging_handlers` autouse fixture: snapshots and restores every logger's `handlers`/`level`/`propagate` state, so a test that sets `propagate=False` or adds a handler without cleanup cannot prevent `caplog` from capturing records in the 7 `TestTickSummary` tests.
- Adds `_guard_sys_stdio` autouse fixture: restores `sys.stdout`/`sys.stderr`/`sys.stdin` after each test, ensuring `test_renderer_task_awaited_before_stdout_restore` always captures the correct reference as `saved_stdout` regardless of prior test ordering.
- Adds `pytest-randomly>=3` to the `[test]` extra in `pyproject.toml` so ordering-dependent regressions are detected in CI via randomised seeds.

## Test plan

- [x] All 9 ordering-dependent tests pass in isolation (confirmed pre-existing)
- [x] All 14 tests in the three impacted files pass together: `pytest deile/tests/orchestration/pipeline/test_runner_token_warning.py deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary deile/tests/orchestration/test_subagent_orchestrator.py::test_renderer_task_awaited_before_stdout_restore -p no:cov -q` → **14 passed**
- [x] Full orchestration test suite regression check: `pytest deile/tests/orchestration/pipeline/ deile/tests/orchestration/test_subagent_orchestrator.py -p no:cov -q` → **1066 passed, 2 skipped**

Closes #432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)