### PR TITLE
feat(panel): MultiSourceActivityProvider — ACTIVITY widget multi-source (issue #436)

### DIFF
--- a/deile/tests/infra/test_activity_perf.py
+++ b/deile/tests/infra/test_activity_perf.py
@@ -1,0 +1,60 @@
+"""AC9: MultiSourceActivityProvider._fetch() completes in <500ms.
+
+Skipped unless DEILE_PERF_TEST=1 (or unset — skip is opt-out via =0).
+Five sources each return 80 synthetic lines via a mocked subprocess.run;
+total wall-clock time must be under 500ms.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel_data as pd  # noqa: E402
+
+_SKIP = os.environ.get("DEILE_PERF_TEST", "1") == "0"
+
+
+def _make_80_lines() -> str:
+    # Unique task IDs per line to avoid triggering burst aggregation.
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+    return "".join(
+        f"{ts} dispatch.started task=t{i} channel=pipeline-issue-{i}\n"
+        for i in range(80)
+    )
+
+
+@pytest.mark.skipif(_SKIP, reason="DEILE_PERF_TEST=0")
+def test_fetch_completes_under_500ms():
+    """Five mocked sources each returning 80 lines; _fetch must finish <500ms."""
+    p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
+                                       enabled=True)
+    p._kubectl = "/usr/bin/kubectl"
+
+    def _fast_run(cmd, **kw):
+        # Each mock subprocess returns quickly with 80 lines.
+        return CompletedProcess(cmd, 0, _make_80_lines(), "")
+
+    # Disable burst aggregation to test raw throughput / cap behavior.
+    start = time.perf_counter()
+    with patch.object(pd, "_BURST_THRESHOLD", 10_000):
+        with patch("subprocess.run", side_effect=_fast_run):
+            state = p._fetch()
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.5, (
+        f"_fetch() took {elapsed:.3f}s — expected <0.5s (ThreadPoolExecutor)"
+    )
+    assert len(state.events) == pd._MULTI_BUFFER_CAP

--- a/deile/tests/infra/test_panel_multi_source_activity.py
+++ b/deile/tests/infra/test_panel_multi_source_activity.py
@@ -26,9 +26,11 @@ Coverage:
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from subprocess import CompletedProcess
 from typing import List
 from unittest.mock import MagicMock, patch
 
@@ -214,17 +216,23 @@ class TestMultiSourceActivityProvider:
                                            enabled=False)
         return p
 
+    def _ok(self, stdout: str = "") -> CompletedProcess:
+        return CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    def _fail(self) -> CompletedProcess:
+        return CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
+
     def test_fetch_source_returns_empty_on_none_text(self):
         p = self._make_provider()
         p._kubectl = "/usr/bin/kubectl"
-        with patch("_panel_data._capture_text", return_value=None):
+        with patch("subprocess.run", return_value=self._fail()):
             result = p._fetch_source("deile-pipeline", "pipeline")
         assert result == []
 
     def test_fetch_source_returns_empty_on_empty_string(self):
         p = self._make_provider()
         p._kubectl = "/usr/bin/kubectl"
-        with patch("_panel_data._capture_text", return_value=""):
+        with patch("subprocess.run", return_value=self._ok("")):
             result = p._fetch_source("deile-pipeline", "pipeline")
         assert result == []
 
@@ -233,7 +241,7 @@ class TestMultiSourceActivityProvider:
         p._kubectl = "/usr/bin/kubectl"
         ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
         log_text = f"{ts} dispatch.started task=x channel=pipeline-issue-10\n"
-        with patch("_panel_data._capture_text", return_value=log_text):
+        with patch("subprocess.run", return_value=self._ok(log_text)):
             result = p._fetch_source("deile-worker", "deile-worker")
         assert len(result) == 1
         assert result[0].actor == "deile-worker"
@@ -244,7 +252,7 @@ class TestMultiSourceActivityProvider:
         p._kubectl = "/usr/bin/kubectl"
         ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
         log_text = f"{ts} worker dispatch starting\n"
-        with patch("_panel_data._capture_text", return_value=log_text):
+        with patch("subprocess.run", return_value=self._ok(log_text)):
             result = p._fetch_source("deile-pipeline", "pipeline")
         assert len(result) == 1
         assert result[0].actor == "pipeline"
@@ -254,7 +262,7 @@ class TestMultiSourceActivityProvider:
         p._kubectl = "/usr/bin/kubectl"
         ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
         log_text = f"{ts} GET /v1/health 200\n"
-        with patch("_panel_data._capture_text", return_value=log_text):
+        with patch("subprocess.run", return_value=self._ok(log_text)):
             result = p._fetch_source("deile-pipeline", "pipeline")
         assert result == []
 
@@ -262,19 +270,25 @@ class TestMultiSourceActivityProvider:
         p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
                                            enabled=True)
         p._kubectl = "/usr/bin/kubectl"
-        # Each source returns 60 events; 5 sources × 60 = 300 → capped at 200.
+        # 60 events per source; 5 sources × 60 = 300 → capped at 200.
+        # Patch _BURST_THRESHOLD high so rolling-window cap is tested in isolation.
         ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
-        single_line = (f"{ts} dispatch.started task=x "
-                       f"channel=pipeline-issue-1\n") * 60
-        with patch("_panel_data._capture_text", return_value=single_line):
-            state = p._fetch()
+        lines = "".join(
+            f"{ts} dispatch.started task=t{i} channel=pipeline-issue-{i}\n"
+            for i in range(60)
+        )
+        with patch.object(pd, "_BURST_THRESHOLD", 10_000):
+            with patch("subprocess.run",
+                       return_value=CompletedProcess([], 0, lines, "")):
+                state = p._fetch()
         assert len(state.events) == pd._MULTI_BUFFER_CAP
 
     def test_get_returns_multi_source_state(self):
         p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
                                            enabled=True)
         p._kubectl = "/usr/bin/kubectl"
-        with patch("_panel_data._capture_text", return_value=None):
+        with patch("subprocess.run",
+                   return_value=CompletedProcess([], 1, "", "err")):
             state = p.get(force=True)
         assert isinstance(state, pd.MultiSourceActivityState)
         assert state.events == []
@@ -429,23 +443,25 @@ class TestAC18IntermediateState:
                                            enabled=True)
         p._kubectl = "/usr/bin/kubectl"
         ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
-        # Only deile-pipeline returns events; other sources return None.
-        def _fake_capture(cmd, timeout=5.0):
+        # Only deile-pipeline returns events; other sources fail.
+        def _fake_run(cmd, **kw):
             if "deploy/deile-pipeline" in cmd:
-                return f"{ts} worker dispatch starting\n"
-            return None
-        with patch("_panel_data._capture_text", side_effect=_fake_capture):
+                return CompletedProcess(cmd, 0,
+                                        f"{ts} worker dispatch starting\n", "")
+            return CompletedProcess(cmd, 1, "", "err")
+        with patch("subprocess.run", side_effect=_fake_run):
             state = p._fetch()
         assert isinstance(state, pd.MultiSourceActivityState)
         # At least the pipeline source contributed one event.
         assert len(state.events) >= 1
-        # No crash even though 4 other sources returned None.
+        # No crash even though 4 other sources failed.
 
     def test_provider_functional_when_all_sources_fail(self):
         p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
                                            enabled=True)
         p._kubectl = "/usr/bin/kubectl"
-        with patch("_panel_data._capture_text", return_value=None):
+        with patch("subprocess.run",
+                   return_value=CompletedProcess([], 1, "", "err")):
             state = p._fetch()
         assert isinstance(state, pd.MultiSourceActivityState)
         assert state.events == []
@@ -455,19 +471,21 @@ class TestAC18IntermediateState:
                                            enabled=True)
         p._kubectl = "/usr/bin/kubectl"
         ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
-        def _fake_capture(cmd, timeout=5.0):
+        def _fake_run(cmd, **kw):
             if "deploy/deile-pipeline" in cmd:
-                # Legacy line only
-                return f"{ts} worker dispatch starting\n"
+                return CompletedProcess(cmd, 0,
+                                        f"{ts} worker dispatch starting\n", "")
             if "deploy/deile-worker" in cmd:
-                # Canonical line
-                return (f"{ts} dispatch.started task=x "
-                        f"channel=pipeline-issue-5\n")
+                return CompletedProcess(
+                    cmd, 0,
+                    f"{ts} dispatch.started task=x channel=pipeline-issue-5\n",
+                    "")
             if "deploy/deilebot" in cmd:
-                # Canonical inbound
-                return f"{ts} inbound.mention target=issue:99\n"
-            return None
-        with patch("_panel_data._capture_text", side_effect=_fake_capture):
+                return CompletedProcess(cmd, 0,
+                                        f"{ts} inbound.mention target=issue:99\n",
+                                        "")
+            return CompletedProcess(cmd, 1, "", "err")
+        with patch("subprocess.run", side_effect=_fake_run):
             state = p._fetch()
         actors = {ev.actor for ev in state.events}
         assert "pipeline" in actors      # legacy

--- a/deile/tests/infra/test_panel_multi_source_activity.py
+++ b/deile/tests/infra/test_panel_multi_source_activity.py
@@ -1,0 +1,482 @@
+"""Tests for issue #436: MultiSourceActivityProvider.
+
+Coverage:
+  1.  _classify_canonical returns None for non-canonical lines.
+  2.  _classify_canonical parses dispatch.started correctly.
+  3.  _classify_canonical parses dispatch.completed with outcome.
+  4.  _classify_canonical parses inbound.mention with target extraction.
+  5.  _classify_canonical parses monitor.tick/action.
+  6.  _classify_canonical parses git.commit with branch target.
+  7.  _classify_source_line: canonical path is taken when canonical matches.
+  8.  _classify_source_line: falls back to legacy _classify_pipeline_line.
+  9.  _classify_source_line: overrides actor from legacy with supplied role.
+  10. _classify_source_line: returns None when neither parser matches.
+  11. MultiSourceActivityState.top() returns events sorted desc, capped at N.
+  12. MultiSourceActivityState.top() with empty events returns [].
+  13. MultiSourceActivityProvider._fetch_source: returns [] on empty text.
+  14. MultiSourceActivityProvider._fetch builds rolling buffer capped at 200.
+  15. MultiSourceActivityProvider.get() returns MultiSourceActivityState.
+  16. _activity_from_data uses activity provider when present.
+  17. _activity_from_data falls back to pipeline+local when activity is None.
+  18. _activity_panel renders table without literal width columns.
+  19. _last_activity_caption uses activity provider when present.
+  20. _last_activity_caption falls back to pipeline+local when activity is None.
+  AC18. Each source can be in intermediate state — provider stays functional.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel  # noqa: E402
+import _panel_data as pd  # noqa: E402
+
+_UTC = timezone.utc
+
+
+def _utc_now() -> datetime:
+    return datetime.now(_UTC)
+
+
+def _make_logline(body: str, age_s: float = 0.0) -> pd.LogLine:
+    ts = _utc_now() - timedelta(seconds=age_s)
+    return pd.LogLine(ts=ts, body=body)
+
+
+def _make_event(age_s: float = 0.0, actor: str = "pipeline",
+                action: str = "dispatch", target: str = "#1",
+                detail: str = "") -> pd.ActivityEvent:
+    ts = _utc_now() - timedelta(seconds=age_s)
+    return pd.ActivityEvent(ts=ts, actor=actor, action=action,
+                            target=target, detail=detail)
+
+
+# ---------------------------------------------------------------------------
+# 1–6: _classify_canonical
+# ---------------------------------------------------------------------------
+
+class TestClassifyCanonical:
+    def test_returns_none_for_non_canonical(self):
+        ll = _make_logline("worker dispatch starting some task")
+        assert pd._classify_canonical(ll, "pipeline") is None
+
+    def test_parses_dispatch_started(self):
+        ll = _make_logline(
+            "dispatch.started task=abc123 channel=pipeline-issue-360 stage=implement"
+        )
+        ev = pd._classify_canonical(ll, "deile-worker")
+        assert ev is not None
+        assert ev.actor == "deile-worker"
+        assert ev.action == "dispatch.started"
+        assert ev.target == "#360"
+
+    def test_parses_dispatch_completed_with_outcome(self):
+        ll = _make_logline("dispatch.completed task=abc outcome=DONE duration=45s")
+        ev = pd._classify_canonical(ll, "deile-worker")
+        assert ev is not None
+        assert ev.action == "dispatch.completed"
+        assert "DONE" in ev.detail
+
+    def test_parses_inbound_mention_issue(self):
+        ll = _make_logline("inbound.mention target=issue:420 triggers=[implement]")
+        ev = pd._classify_canonical(ll, "bot")
+        assert ev is not None
+        assert ev.action == "inbound.mention"
+        assert ev.target == "#420"
+
+    def test_parses_inbound_mention_pr(self):
+        ll = _make_logline("inbound.mention target=pr:99")
+        ev = pd._classify_canonical(ll, "bot")
+        assert ev is not None
+        assert ev.target == "PR#99"
+
+    def test_parses_monitor_tick(self):
+        ll = _make_logline("monitor.tick queue=3 pending=1")
+        ev = pd._classify_canonical(ll, "monitor")
+        assert ev is not None
+        assert ev.action == "monitor.tick"
+        assert "queue=3" in ev.detail
+
+    def test_parses_monitor_action(self):
+        ll = _make_logline("monitor.action kind=restart target=deile-worker")
+        ev = pd._classify_canonical(ll, "monitor")
+        assert ev is not None
+        assert ev.action == "monitor.action"
+
+    def test_parses_git_commit_with_branch(self):
+        ll = _make_logline("git.commit sha=abcdef12 branch=auto/issue-360 msg=fix")
+        ev = pd._classify_canonical(ll, "claude-worker")
+        assert ev is not None
+        assert ev.action == "git.commit"
+        assert ev.target == "auto/issue-360"
+
+    def test_parses_forge_verb(self):
+        ll = _make_logline("forge.pr_created number=361")
+        ev = pd._classify_canonical(ll, "pipeline")
+        assert ev is not None
+        assert ev.action == "forge.pr_created"
+
+    def test_parses_refinement_verb(self):
+        ll = _make_logline("refinement.started issue=437")
+        ev = pd._classify_canonical(ll, "pipeline")
+        assert ev is not None
+        assert ev.action == "refinement.started"
+        assert ev.target == "#437"
+
+    def test_parses_cron_verb(self):
+        ll = _make_logline("cron.triggered job=daily-cleanup")
+        ev = pd._classify_canonical(ll, "bot")
+        assert ev is not None
+        assert ev.action == "cron.triggered"
+        assert "daily-cleanup" in ev.detail
+
+
+# ---------------------------------------------------------------------------
+# 7–10: _classify_source_line dual-mode
+# ---------------------------------------------------------------------------
+
+class TestClassifySourceLine:
+    def test_canonical_path_taken_when_matches(self):
+        ll = _make_logline("dispatch.started task=x channel=pipeline-issue-1")
+        ev = pd._classify_source_line(ll, "deile-worker")
+        assert ev is not None
+        assert ev.actor == "deile-worker"
+        assert "dispatch" in ev.action
+
+    def test_falls_back_to_legacy(self):
+        ll = _make_logline("worker dispatch starting legacy line")
+        ev = pd._classify_source_line(ll, "deile-worker")
+        assert ev is not None
+        # The legacy parser sets actor="pipeline"; we override to role.
+        assert ev.actor == "deile-worker"
+        assert ev.action == "dispatch"
+
+    def test_legacy_actor_overridden_with_role(self):
+        ll = _make_logline(
+            "mention group issue:360: triggers=[implement,review]"
+        )
+        ev = pd._classify_source_line(ll, "bot")
+        assert ev is not None
+        assert ev.actor == "bot"
+
+    def test_returns_none_when_no_parser_matches(self):
+        ll = _make_logline("INFO arbitrary unstructured line with no pattern")
+        ev = pd._classify_source_line(ll, "monitor")
+        assert ev is None
+
+
+# ---------------------------------------------------------------------------
+# 11–12: MultiSourceActivityState.top()
+# ---------------------------------------------------------------------------
+
+class TestMultiSourceActivityState:
+    def test_top_returns_sorted_desc_and_capped(self):
+        state = pd.MultiSourceActivityState()
+        state.events = [
+            _make_event(age_s=10, actor="pipeline"),
+            _make_event(age_s=5,  actor="bot"),
+            _make_event(age_s=20, actor="monitor"),
+        ]
+        top = state.top(2)
+        assert len(top) == 2
+        # Most recent first: age_s=5 is newest
+        assert top[0].actor == "bot"
+        assert top[1].actor == "pipeline"
+
+    def test_top_empty_returns_empty(self):
+        state = pd.MultiSourceActivityState()
+        assert state.top(10) == []
+
+    def test_top_respects_n_cap(self):
+        state = pd.MultiSourceActivityState()
+        state.events = [_make_event(age_s=float(i)) for i in range(20)]
+        assert len(state.top(5)) == 5
+
+
+# ---------------------------------------------------------------------------
+# 13–15: MultiSourceActivityProvider
+# ---------------------------------------------------------------------------
+
+class TestMultiSourceActivityProvider:
+    def _make_provider(self) -> pd.MultiSourceActivityProvider:
+        p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
+                                           enabled=False)
+        return p
+
+    def test_fetch_source_returns_empty_on_none_text(self):
+        p = self._make_provider()
+        p._kubectl = "/usr/bin/kubectl"
+        with patch("_panel_data._capture_text", return_value=None):
+            result = p._fetch_source("deile-pipeline", "pipeline")
+        assert result == []
+
+    def test_fetch_source_returns_empty_on_empty_string(self):
+        p = self._make_provider()
+        p._kubectl = "/usr/bin/kubectl"
+        with patch("_panel_data._capture_text", return_value=""):
+            result = p._fetch_source("deile-pipeline", "pipeline")
+        assert result == []
+
+    def test_fetch_source_parses_canonical_line(self):
+        p = self._make_provider()
+        p._kubectl = "/usr/bin/kubectl"
+        ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+        log_text = f"{ts} dispatch.started task=x channel=pipeline-issue-10\n"
+        with patch("_panel_data._capture_text", return_value=log_text):
+            result = p._fetch_source("deile-worker", "deile-worker")
+        assert len(result) == 1
+        assert result[0].actor == "deile-worker"
+        assert result[0].target == "#10"
+
+    def test_fetch_source_parses_legacy_line(self):
+        p = self._make_provider()
+        p._kubectl = "/usr/bin/kubectl"
+        ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+        log_text = f"{ts} worker dispatch starting\n"
+        with patch("_panel_data._capture_text", return_value=log_text):
+            result = p._fetch_source("deile-pipeline", "pipeline")
+        assert len(result) == 1
+        assert result[0].actor == "pipeline"
+
+    def test_fetch_source_skips_noise_lines(self):
+        p = self._make_provider()
+        p._kubectl = "/usr/bin/kubectl"
+        ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+        log_text = f"{ts} GET /v1/health 200\n"
+        with patch("_panel_data._capture_text", return_value=log_text):
+            result = p._fetch_source("deile-pipeline", "pipeline")
+        assert result == []
+
+    def test_fetch_builds_rolling_buffer_capped_at_200(self):
+        p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
+                                           enabled=True)
+        p._kubectl = "/usr/bin/kubectl"
+        # Each source returns 60 events; 5 sources × 60 = 300 → capped at 200.
+        ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+        single_line = (f"{ts} dispatch.started task=x "
+                       f"channel=pipeline-issue-1\n") * 60
+        with patch("_panel_data._capture_text", return_value=single_line):
+            state = p._fetch()
+        assert len(state.events) == pd._MULTI_BUFFER_CAP
+
+    def test_get_returns_multi_source_state(self):
+        p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
+                                           enabled=True)
+        p._kubectl = "/usr/bin/kubectl"
+        with patch("_panel_data._capture_text", return_value=None):
+            state = p.get(force=True)
+        assert isinstance(state, pd.MultiSourceActivityState)
+        assert state.events == []
+
+
+# ---------------------------------------------------------------------------
+# 16–17: _activity_from_data
+# ---------------------------------------------------------------------------
+
+class TestActivityFromData:
+    def _make_data_with_activity(self, events: List[pd.ActivityEvent]):
+        data = MagicMock()
+        state = pd.MultiSourceActivityState()
+        state.events = events
+        data.activity = MagicMock()
+        data.activity.get.return_value = state
+        return data
+
+    def _make_data_without_activity(self, pipeline_events=None,
+                                    local_events=None):
+        data = MagicMock()
+        data.activity = None
+        ps = pd.PipelineState()
+        ps.events = pipeline_events or []
+        data.pipeline.get.return_value = ps
+        if local_events is not None:
+            ls = pd.LocalLogsState()
+            ls.events = local_events
+            data.local_logs = MagicMock()
+            data.local_logs.get.return_value = ls
+        else:
+            data.local_logs = None
+        return data
+
+    def test_uses_activity_provider_when_present(self):
+        ev1 = _make_event(age_s=1, actor="bot")
+        ev2 = _make_event(age_s=2, actor="monitor")
+        data = self._make_data_with_activity([ev1, ev2])
+        rows = panel._activity_from_data(data, limit=10)
+        actors = [r.actor for r in rows]
+        assert "bot" in actors
+        assert "monitor" in actors
+
+    def test_uses_activity_provider_respects_limit(self):
+        events = [_make_event(age_s=float(i)) for i in range(20)]
+        data = self._make_data_with_activity(events)
+        rows = panel._activity_from_data(data, limit=5)
+        assert len(rows) == 5
+
+    def test_fallback_to_pipeline_when_activity_none(self):
+        ev = _make_event(age_s=5, actor="pipeline")
+        data = self._make_data_without_activity(pipeline_events=[ev])
+        rows = panel._activity_from_data(data, limit=10)
+        assert len(rows) == 1
+        assert rows[0].actor == "pipeline"
+
+    def test_fallback_includes_local_events(self):
+        ev_p = _make_event(age_s=10, actor="pipeline")
+        ev_l = _make_event(age_s=3, actor="local")
+        data = self._make_data_without_activity(
+            pipeline_events=[ev_p], local_events=[ev_l]
+        )
+        rows = panel._activity_from_data(data, limit=10)
+        actors = [r.actor for r in rows]
+        assert "pipeline" in actors
+        assert "local" in actors
+
+    def test_returns_demo_rows_when_data_is_none(self):
+        rows = panel._activity_from_data(None, limit=3)
+        assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# 18: _activity_panel adaptive widths
+# ---------------------------------------------------------------------------
+
+class TestActivityPanelAdaptiveWidths:
+    def test_no_literal_width_in_activity_panel(self):
+        """All columns in the activity table must NOT use literal width=<int>."""
+        import inspect
+        src = inspect.getsource(panel.DashboardView._activity_panel)
+        # The pattern `width=<integer>` is forbidden per principle 15.
+        import re
+        matches = re.findall(r"\bwidth\s*=\s*\d+\b", src)
+        assert matches == [], (
+            f"Literal width=N found in _activity_panel: {matches}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 19–20: _last_activity_caption
+# ---------------------------------------------------------------------------
+
+class TestLastActivityCaptionMultiSource:
+    def _make_data_with_activity(self, events):
+        data = MagicMock()
+        state = pd.MultiSourceActivityState()
+        state.events = events
+        data.activity = MagicMock()
+        data.activity.get.return_value = state
+        return data
+
+    def _make_data_without_activity(self, pipeline_events=None):
+        data = MagicMock()
+        data.activity = None
+        ps = pd.PipelineState()
+        ps.events = pipeline_events or []
+        data.pipeline.get.return_value = ps
+        data.local_logs = None
+        return data
+
+    def test_uses_activity_provider_for_caption(self):
+        ev = _make_event(age_s=10, actor="bot", target="#420",
+                         detail="inbound.mention")
+        data = self._make_data_with_activity([ev])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "#420" in caption
+
+    def test_returns_none_when_activity_empty(self):
+        data = self._make_data_with_activity([])
+        assert panel._last_activity_caption(data) is None
+
+    def test_fallback_to_pipeline(self):
+        ev = _make_event(age_s=5, actor="pipeline", target="#99",
+                         detail="dispatch done")
+        data = self._make_data_without_activity(pipeline_events=[ev])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "#99" in caption
+
+    def test_most_recent_event_used(self):
+        ev_old = _make_event(age_s=100, target="#1")
+        ev_new = _make_event(age_s=3, target="#999", detail="recent")
+        data = self._make_data_with_activity([ev_old, ev_new])
+        caption = panel._last_activity_caption(data)
+        assert caption is not None
+        assert "#999" in caption
+
+
+# ---------------------------------------------------------------------------
+# AC18: each source can be in intermediate state — provider stays functional
+# ---------------------------------------------------------------------------
+
+class TestAC18IntermediateState:
+    """Smoke-test: provider survives when individual sources fail or return no
+    events.  The overall MultiSourceActivityState is returned with events from
+    the working sources; no exception is raised."""
+
+    def test_provider_functional_when_some_sources_have_no_events(self):
+        p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
+                                           enabled=True)
+        p._kubectl = "/usr/bin/kubectl"
+        ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+        # Only deile-pipeline returns events; other sources return None.
+        def _fake_capture(cmd, timeout=5.0):
+            if "deploy/deile-pipeline" in cmd:
+                return f"{ts} worker dispatch starting\n"
+            return None
+        with patch("_panel_data._capture_text", side_effect=_fake_capture):
+            state = p._fetch()
+        assert isinstance(state, pd.MultiSourceActivityState)
+        # At least the pipeline source contributed one event.
+        assert len(state.events) >= 1
+        # No crash even though 4 other sources returned None.
+
+    def test_provider_functional_when_all_sources_fail(self):
+        p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
+                                           enabled=True)
+        p._kubectl = "/usr/bin/kubectl"
+        with patch("_panel_data._capture_text", return_value=None):
+            state = p._fetch()
+        assert isinstance(state, pd.MultiSourceActivityState)
+        assert state.events == []
+
+    def test_provider_functional_with_mixed_canonical_and_legacy(self):
+        p = pd.MultiSourceActivityProvider(ttl_s=60.0, namespace="test",
+                                           enabled=True)
+        p._kubectl = "/usr/bin/kubectl"
+        ts = _utc_now().strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+        def _fake_capture(cmd, timeout=5.0):
+            if "deploy/deile-pipeline" in cmd:
+                # Legacy line only
+                return f"{ts} worker dispatch starting\n"
+            if "deploy/deile-worker" in cmd:
+                # Canonical line
+                return (f"{ts} dispatch.started task=x "
+                        f"channel=pipeline-issue-5\n")
+            if "deploy/deilebot" in cmd:
+                # Canonical inbound
+                return f"{ts} inbound.mention target=issue:99\n"
+            return None
+        with patch("_panel_data._capture_text", side_effect=_fake_capture):
+            state = p._fetch()
+        actors = {ev.actor for ev in state.events}
+        assert "pipeline" in actors      # legacy
+        assert "deile-worker" in actors  # canonical
+        assert "bot" in actors           # canonical
+
+    def test_each_source_color_is_defined(self):
+        """All 5 canonical sources have a color in _SOURCE_COLOR_MAP."""
+        for deploy, role, _ in pd._MULTI_SOURCE_DEFS:
+            assert deploy in pd._SOURCE_COLOR_MAP, (
+                f"{deploy} missing from _SOURCE_COLOR_MAP"
+            )

--- a/deile/tests/infra/test_panel_sort_activity.py
+++ b/deile/tests/infra/test_panel_sort_activity.py
@@ -70,6 +70,9 @@ def _fake_data(pipeline_events=None, local_events=None):
         data.local_logs.get.return_value = ls
     else:
         data.local_logs = None
+    # Explicitly None so _activity_from_data / _last_activity_caption
+    # use the legacy pipeline+local fallback path (issue #436).
+    data.activity = None
     return data
 
 

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -63,6 +63,7 @@ from _panel_data import _fmt_cpu_display, _fmt_mem_display, _pct  # noqa: F401
 from _panel_data import EndpointInfo  # noqa: F401
 from _panel_data import kubectl_bin  # noqa: F401
 from _panel_data import BackgroundRefresher, PanelData  # noqa: F401
+from _panel_data import _SOURCE_COLOR_MAP as _ACTIVITY_COLOR_MAP  # noqa: F401
 from _panel_data import \
     _audit_dispatch_mode_change as pd_audit_dispatch_mode_change
 from _panel_data import \
@@ -426,15 +427,19 @@ class ActivityRow:
 def _activity_from_data(data: Optional[PanelData], limit: int = 8) -> List[ActivityRow]:
     if data is None:
         return [ActivityRow(*row) for row in demo.ACTIVITY[:limit]]
-    # Combina eventos k8s + locais ordenando por timestamp desc — assim a
-    # UI mostra atividade real seja qual for a fonte. Locais ganham
-    # actor='local' (setado em LocalLogsState para diferenciar de pipeline).
-    pool = list(data.pipeline.get().events)
-    if data.local_logs is not None:
-        pool.extend(data.local_logs.get().events)
-    pool.sort(key=lambda ev: ev.ts, reverse=True)
+    # Multi-source feed (issue #436): use MultiSourceActivityProvider when
+    # k8s is available; it merges all 5 sources with a 200-event buffer.
+    if getattr(data, "activity", None) is not None:
+        events = data.activity.get().top(limit)
+    else:
+        # Fallback: single-source (pipeline + local) for local-only mode.
+        pool = list(data.pipeline.get().events)
+        if data.local_logs is not None:
+            pool.extend(data.local_logs.get().events)
+        pool.sort(key=lambda ev: ev.ts, reverse=True)
+        events = pool[:limit]
     rows: List[ActivityRow] = []
-    for ev in pool[:limit]:
+    for ev in events:
         rows.append(ActivityRow(
             hhmmss=ev.hhmmss,
             actor=ev.actor,
@@ -448,14 +453,17 @@ def _activity_from_data(data: Optional[PanelData], limit: int = 8) -> List[Activ
 def _last_activity_caption(data: Optional[PanelData]) -> Optional[str]:
     """Retorna string legível do evento mais recente, ex: '23s ago — #360 → em_pr'.
 
-    Combina eventos do pipeline e locais (mesma fonte de `_activity_from_data`).
+    Usa o multi-source buffer quando disponível; fallback pipeline+local.
     Retorna None quando não há eventos para não poluir o rodapé.
     """
     if data is None:
         return None
-    pool: List[Any] = list(data.pipeline.get().events)
-    if data.local_logs is not None:
-        pool.extend(data.local_logs.get().events)
+    if getattr(data, "activity", None) is not None:
+        pool: List[Any] = list(data.activity.get().events)
+    else:
+        pool = list(data.pipeline.get().events)
+        if data.local_logs is not None:
+            pool.extend(data.local_logs.get().events)
     if not pool:
         return None
     ev = max(pool, key=lambda e: e.ts)
@@ -866,14 +874,22 @@ class DashboardView(View):
         else:
             tbl = Table(box=box.SIMPLE, expand=True, show_header=False,
                         pad_edge=False)
-            tbl.add_column(width=8, style="dim")
-            tbl.add_column(width=10, style="bold cyan")
-            tbl.add_column(width=12)
-            tbl.add_column(width=8, style="yellow")
-            tbl.add_column()
+            # Adaptive widths per principle 15 — no literal width=<int>.
+            tbl.add_column(max_width=9, style="dim")        # timestamp
+            tbl.add_column(max_width=14, min_width=6)       # actor/role
+            tbl.add_column(max_width=20, min_width=8)       # action
+            tbl.add_column(max_width=10, style="yellow")    # target
+            tbl.add_column()                                 # detail
             for r in rows:
-                tbl.add_row(r.hhmmss, r.actor, r.action, r.target,
-                            Text(r.detail, style="dim"))
+                # Color by role: look up deploy→color, fall back to dim italic.
+                actor_color = _ACTIVITY_COLOR_MAP.get(r.actor, "dim italic")
+                tbl.add_row(
+                    r.hhmmss,
+                    Text(r.actor, style=f"bold {actor_color}"),
+                    r.action,
+                    r.target,
+                    Text(r.detail, style="dim"),
+                )
             body = tbl
         return Panel(body, title="[bold]ACTIVITY[/bold] (últimos 10)",
                      title_align="left", border_style="green")

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -63,7 +63,8 @@ from _panel_data import _fmt_cpu_display, _fmt_mem_display, _pct  # noqa: F401
 from _panel_data import EndpointInfo  # noqa: F401
 from _panel_data import kubectl_bin  # noqa: F401
 from _panel_data import BackgroundRefresher, PanelData  # noqa: F401
-from _panel_data import _SOURCE_COLOR_MAP as _ACTIVITY_COLOR_MAP  # noqa: F401
+from _panel_data import _ROLE_COLOR_MAP as _ACTIVITY_COLOR_MAP  # noqa: F401
+from _panel_data import _ERROR_DETAIL_RE as _ACTIVITY_ERROR_RE  # noqa: F401
 from _panel_data import \
     _audit_dispatch_mode_change as pd_audit_dispatch_mode_change
 from _panel_data import \
@@ -883,12 +884,17 @@ class DashboardView(View):
             for r in rows:
                 # Color by role: look up deploy→color, fall back to dim italic.
                 actor_color = _ACTIVITY_COLOR_MAP.get(r.actor, "dim italic")
+                # AC7: highlight error details in bold red.
+                detail_style = (
+                    "bold red" if _ACTIVITY_ERROR_RE.search(r.detail)
+                    else "dim"
+                )
                 tbl.add_row(
                     r.hhmmss,
                     Text(r.actor, style=f"bold {actor_color}"),
                     r.action,
                     r.target,
-                    Text(r.detail, style="dim"),
+                    Text(r.detail, style=detail_style),
                 )
             body = tbl
         return Panel(body, title="[bold]ACTIVITY[/bold] (últimos 10)",

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -43,12 +43,13 @@ import sqlite3
 import subprocess
 import threading
 import time
+from collections import deque
 from concurrent import futures
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Callable, Dict, Generic, List, Optional, Set, Tuple, TypeVar
+from typing import Any, Callable, Deque, Dict, Generic, List, Optional, Set, Tuple, TypeVar
 
 T = TypeVar("T")
 
@@ -1386,10 +1387,27 @@ _MULTI_SOURCE_DEFS: Tuple[Tuple[str, str, str], ...] = (
 
 _SOURCE_ROLE_MAP: Dict[str, str] = {d: r for d, r, _ in _MULTI_SOURCE_DEFS}
 _SOURCE_COLOR_MAP: Dict[str, str] = {d: c for d, _, c in _MULTI_SOURCE_DEFS}
+# Maps role_label → color; used by _activity_panel for correct color lookup.
+_ROLE_COLOR_MAP: Dict[str, str] = {r: c for _, r, c in _MULTI_SOURCE_DEFS}
 
 _MULTI_BUFFER_CAP = 200
 _MULTI_TAIL_LINES = 80
 _MULTI_SINCE = "10s"
+
+# AC11 — secret redaction applied before inserting events into the buffer.
+_SECRET_RE = re.compile(
+    r"(?i)(token|bearer|api[-_]?key|secret|password)\s*[=:]\s*\S+",
+)
+# AC8 — extracts task_id from dispatch.progress detail.
+_PROGRESS_TASK_RE = re.compile(r"task=(\S+)")
+# AC10 — burst aggregation thresholds.
+_BURST_THRESHOLD = 20
+_BURST_WINDOW_S = 60.0
+# AC7 — error detail highlight (evaluated in _panel.py _activity_panel).
+_ERROR_DETAIL_RE = re.compile(
+    r"\b(error|failed|traceback|exception)\b|reason=['\"]?\S+['\"]?",
+    re.IGNORECASE,
+)
 
 # Canonical structured-log prefix emitted by issues #435/#437/#438/#439.
 # Format: ``verb.sub [key=val ...]`` at start of log body.
@@ -1419,14 +1437,24 @@ def _classify_canonical(ll: LogLine, role: str) -> Optional[ActivityEvent]:
     detail = action
 
     if verb == "dispatch":
-        channel = kv.get("channel", "")
-        m2 = _PIPELINE_CHANNEL_RE.match(channel)
-        if m2:
-            kind_hint = m2.group(1)
-            num = m2.group(2)
-            target = ("PR#" if kind_hint.endswith("pr") else "#") + num
-        outcome = kv.get("outcome", kv.get("status", ""))
-        detail = f"{action} → {outcome}" if outcome else action
+        if subaction == "progress":
+            # AC8: include task_id and elapsed in detail for dedup by task.
+            task_id = kv.get("task", kv.get("id", ""))
+            elapsed = kv.get("elapsed_s", kv.get("elapsed", ""))
+            detail = "dispatch.progress"
+            if task_id:
+                detail += f" task={task_id}"
+            if elapsed:
+                detail += f" elapsed_s={elapsed}"
+        else:
+            channel = kv.get("channel", "")
+            m2 = _PIPELINE_CHANNEL_RE.match(channel)
+            if m2:
+                kind_hint = m2.group(1)
+                num = m2.group(2)
+                target = ("PR#" if kind_hint.endswith("pr") else "#") + num
+            outcome = kv.get("outcome", kv.get("status", ""))
+            detail = f"{action} → {outcome}" if outcome else action
     elif verb == "inbound" and subaction == "mention":
         raw_t = kv.get("target", kv.get("issue", ""))
         m3 = re.match(r"(issue|pr):(\d+)", raw_t)
@@ -1506,6 +1534,11 @@ class MultiSourceActivityProvider(_KubectlProviderMixin):
         self._cache: Cache[MultiSourceActivityState] = Cache(
             ttl_s, self._fetch, fallback=MultiSourceActivityState(),
         )
+        # AC1 / AC3: per-source error tracking + thread safety.
+        self._last_errors: Dict[str, str] = {}
+        self._lock = threading.Lock()
+        # AC10: burst aggregation counters — (actor, action) → deque[ts_float].
+        self._burst_counters: Dict[Tuple[str, str], Deque[float]] = {}
 
     @property
     def last_error(self) -> Optional[str]:
@@ -1515,17 +1548,32 @@ class MultiSourceActivityProvider(_KubectlProviderMixin):
         return self._cache.get(force)
 
     def _fetch_source(self, deploy: str, role: str) -> List[ActivityEvent]:
-        """Fetch + parse de um único deployment. Retorna [] em caso de erro."""
+        """Fetch + parse de um único deployment. Retorna [] em caso de erro.
+
+        AC3: timeout 3.0s; TimeoutExpired registrado em _last_errors[deploy].
+        AC11: secrets redacted from ev.detail before appending.
+        """
         if self._kubectl is None:
             return []
-        text = _capture_text(
-            [self._kubectl, "-n", self._namespace, "logs",
-             f"deploy/{deploy}",
-             f"--tail={_MULTI_TAIL_LINES}",
-             f"--since={_MULTI_SINCE}",
-             "--timestamps"],
-            timeout=5.0,
-        )
+        cmd = [self._kubectl, "-n", self._namespace, "logs",
+               f"deploy/{deploy}",
+               f"--tail={_MULTI_TAIL_LINES}",
+               f"--since={_MULTI_SINCE}",
+               "--timestamps"]
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True,
+                                 timeout=3.0)
+        except subprocess.TimeoutExpired:
+            with self._lock:
+                self._last_errors[deploy] = "timeout"
+            return []
+        except OSError:
+            return []
+        if out.returncode != 0:
+            with self._lock:
+                self._last_errors[deploy] = f"exit {out.returncode}"
+            return []
+        text = out.stdout
         if not text:
             return []
         if len(text) > MAX_LOG_BYTES:
@@ -1537,6 +1585,12 @@ class MultiSourceActivityProvider(_KubectlProviderMixin):
                 continue
             ev = _classify_source_line(ll, role)
             if ev is not None:
+                # AC11: redact secrets before inserting into buffer.
+                safe_detail = _SECRET_RE.sub(r"\1=<redacted>", ev.detail)
+                if safe_detail != ev.detail:
+                    ev = ActivityEvent(ts=ev.ts, actor=ev.actor,
+                                       action=ev.action, target=ev.target,
+                                       detail=safe_detail)
                 events.append(ev)
         return events
 
@@ -1545,9 +1599,83 @@ class MultiSourceActivityProvider(_KubectlProviderMixin):
         self._resolve_kubectl()
         if self._kubectl is None:
             raise RuntimeError("kubectl não encontrado")
+
+        # AC3: parallel fetch via ThreadPoolExecutor.
         pool: List[ActivityEvent] = []
-        for deploy, role, _ in _MULTI_SOURCE_DEFS:
-            pool.extend(self._fetch_source(deploy, role))
+        with futures.ThreadPoolExecutor(max_workers=5) as executor:
+            future_map = {
+                executor.submit(self._fetch_source, deploy, role): deploy
+                for deploy, role, _ in _MULTI_SOURCE_DEFS
+            }
+            for fut in futures.as_completed(future_map):
+                deploy = future_map[fut]
+                try:
+                    pool.extend(fut.result())
+                except Exception as exc:
+                    with self._lock:
+                        self._last_errors[deploy] = str(exc)
+
+        pool.sort(key=lambda e: e.ts)
+
+        # AC8: dedup dispatch.progress — keep only latest per task_id.
+        progress_latest: Dict[str, int] = {}
+        deduped: List[ActivityEvent] = []
+        for ev in pool:
+            if ev.action == "dispatch.progress":
+                m = _PROGRESS_TASK_RE.search(ev.detail)
+                if m:
+                    task_id = m.group(1)
+                    if task_id in progress_latest:
+                        deduped[progress_latest[task_id]] = ev
+                        continue
+                    progress_latest[task_id] = len(deduped)
+            deduped.append(ev)
+        pool = deduped
+
+        # AC10: burst aggregation — suppress floods of same (actor, action).
+        now_ts = datetime.now(timezone.utc).timestamp()
+        cutoff = now_ts - _BURST_WINDOW_S
+        with self._lock:
+            # Purge timestamps outside the window.
+            for key in list(self._burst_counters):
+                dq = self._burst_counters[key]
+                while dq and dq[0] < cutoff:
+                    dq.popleft()
+            # Register new events.
+            for ev in pool:
+                key = (ev.actor, ev.action)
+                if key not in self._burst_counters:
+                    self._burst_counters[key] = deque()
+                self._burst_counters[key].append(ev.ts.timestamp())
+            # Identify burst keys.
+            burst_keys: Set[Tuple[str, str]] = {
+                k for k, dq in self._burst_counters.items()
+                if len(dq) > _BURST_THRESHOLD
+            }
+            # Build burst summary events and suppress individuals.
+            if burst_keys:
+                burst_events: List[ActivityEvent] = []
+                filtered: List[ActivityEvent] = []
+                seen_burst: Set[Tuple[str, str]] = set()
+                for ev in pool:
+                    key = (ev.actor, ev.action)
+                    if key in burst_keys:
+                        if key not in seen_burst:
+                            seen_burst.add(key)
+                            count = len(self._burst_counters[key])
+                            burst_events.append(ActivityEvent(
+                                ts=ev.ts,
+                                actor=ev.actor,
+                                action=f"{ev.action}.burst",
+                                target=ev.target,
+                                detail=(f"{ev.action}.burst "
+                                        f"{count} em {int(_BURST_WINDOW_S)}s"),
+                            ))
+                            self._burst_counters[key].clear()
+                    else:
+                        filtered.append(ev)
+                pool = filtered + burst_events
+
         # Rolling window: keep newest _MULTI_BUFFER_CAP events.
         pool.sort(key=lambda e: e.ts)
         state = MultiSourceActivityState()

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -1364,6 +1364,197 @@ class WorkerProvider(_KubectlProviderMixin):
         return state
 
 
+# ===== MultiSourceActivityProvider (issue #436) =============================
+#
+# Tail em paralelo de 5 deployments fixos. Eventos mergeados num buffer
+# rolling-window (cap 200), top-10 renderizados em ordem cronológica
+# decrescente com cores por role.
+#
+# Parser dual-mode: tenta parser canônico primeiro (vocabulário das issues
+# pré-req #435/#437/#438/#439); se não casa, cai no legacy
+# _classify_pipeline_line (degradação suave). Source sem nenhum parser que
+# case → silêncio (não erro).
+
+# (deploy, role_label, rich_color)
+_MULTI_SOURCE_DEFS: Tuple[Tuple[str, str, str], ...] = (
+    ("deile-pipeline", "pipeline",     "bright_black"),
+    ("deile-worker",   "deile-worker", "cyan"),
+    ("claude-worker",  "claude-worker","orange1"),
+    ("deilebot",       "bot",          "magenta"),
+    ("deile-monitor",  "monitor",      "blue"),
+)
+
+_SOURCE_ROLE_MAP: Dict[str, str] = {d: r for d, r, _ in _MULTI_SOURCE_DEFS}
+_SOURCE_COLOR_MAP: Dict[str, str] = {d: c for d, _, c in _MULTI_SOURCE_DEFS}
+
+_MULTI_BUFFER_CAP = 200
+_MULTI_TAIL_LINES = 80
+_MULTI_SINCE = "10s"
+
+# Canonical structured-log prefix emitted by issues #435/#437/#438/#439.
+# Format: ``verb.sub [key=val ...]`` at start of log body.
+# Example: ``dispatch.started task=abc123 channel=pipeline-issue-360 stage=implement``
+_CANONICAL_VERB_RE = re.compile(
+    r"^(dispatch|git|forge|inbound|agent|cron"
+    r"|refinement|routing|auth|monitor)\.(\S+)\s*(.*?)$",
+    re.IGNORECASE,
+)
+_KV_PAIR_RE = re.compile(r"(\w+)=(\S+)")
+
+
+def _classify_canonical(ll: LogLine, role: str) -> Optional[ActivityEvent]:
+    """Parser canônico para vocabulário emitido pelas issues #435-#439.
+
+    Retorna None se o padrão não casa — o caller cai no parser legacy.
+    """
+    m = _CANONICAL_VERB_RE.match(ll.body)
+    if not m:
+        return None
+    verb = m.group(1).lower()
+    subaction = m.group(2).lower()
+    rest = m.group(3)
+    kv = dict(_KV_PAIR_RE.findall(rest))
+    action = f"{verb}.{subaction}"
+    target = ""
+    detail = action
+
+    if verb == "dispatch":
+        channel = kv.get("channel", "")
+        m2 = _PIPELINE_CHANNEL_RE.match(channel)
+        if m2:
+            kind_hint = m2.group(1)
+            num = m2.group(2)
+            target = ("PR#" if kind_hint.endswith("pr") else "#") + num
+        outcome = kv.get("outcome", kv.get("status", ""))
+        detail = f"{action} → {outcome}" if outcome else action
+    elif verb == "inbound" and subaction == "mention":
+        raw_t = kv.get("target", kv.get("issue", ""))
+        m3 = re.match(r"(issue|pr):(\d+)", raw_t)
+        if m3:
+            target = ("PR#" if m3.group(1) == "pr" else "#") + m3.group(2)
+    elif verb == "monitor":
+        queue = kv.get("queue", "")
+        detail = (f"monitor.{subaction} queue={queue}"
+                  if queue else f"monitor.{subaction}")
+    elif verb == "git":
+        ref = kv.get("branch", kv.get("ref", kv.get("sha", "")))
+        if ref:
+            target = ref[:20]
+        detail = f"git.{subaction}"
+    elif verb in ("forge", "auth"):
+        detail = f"{verb}.{subaction}"
+    elif verb in ("refinement", "routing"):
+        issue_ref = kv.get("issue", kv.get("number", ""))
+        if issue_ref:
+            target = f"#{issue_ref}"
+        detail = f"{verb}.{subaction}"
+    elif verb == "agent":
+        task = kv.get("task", kv.get("id", ""))
+        detail = f"agent.{subaction}" + (f" task={task}" if task else "")
+    elif verb == "cron":
+        job = kv.get("job", kv.get("name", ""))
+        detail = f"cron.{subaction}" + (f" {job}" if job else "")
+
+    return ActivityEvent(ts=ll.ts, actor=role, action=action,
+                         target=target, detail=detail)
+
+
+def _classify_source_line(ll: LogLine, role: str) -> Optional[ActivityEvent]:
+    """Dual-mode classifier: canônico primeiro, legacy como fallback.
+
+    Legacy sempre sobrescreve ``actor`` com ``role`` para que o widget
+    mostre a origem correta mesmo para fontes ainda sem vocabulário canônico.
+    """
+    ev = _classify_canonical(ll, role)
+    if ev is not None:
+        return ev
+    ev_legacy = _classify_pipeline_line(ll)
+    if ev_legacy is None:
+        return None
+    return ActivityEvent(
+        ts=ev_legacy.ts,
+        actor=role,
+        action=ev_legacy.action,
+        target=ev_legacy.target,
+        detail=ev_legacy.detail,
+    )
+
+
+@dataclass
+class MultiSourceActivityState:
+    """Buffer rolling-window com eventos de todas as fontes."""
+    events: List[ActivityEvent] = field(default_factory=list)
+
+    def top(self, n: int = 10) -> List[ActivityEvent]:
+        return sorted(self.events, key=lambda e: e.ts, reverse=True)[:n]
+
+
+class MultiSourceActivityProvider(_KubectlProviderMixin):
+    """Tail em paralelo de 5 deployments → buffer rolling-window de eventos.
+
+    Usa ``--since=10s --tail=80 --timestamps`` por source. Cada refresh
+    mescla todas as linhas num buffer capped em 200, ordenado por timestamp.
+    Fontes indisponíveis são silenciosamente ignoradas (provider permanece
+    funcional com eventos das demais fontes).
+    """
+
+    def __init__(self, ttl_s: float = 3.0, namespace: str = NS,
+                 enabled: bool = True):
+        self._kubectl = kubectl_bin()
+        self._namespace = namespace
+        self._enabled = enabled
+        self._cache: Cache[MultiSourceActivityState] = Cache(
+            ttl_s, self._fetch, fallback=MultiSourceActivityState(),
+        )
+
+    @property
+    def last_error(self) -> Optional[str]:
+        return self._cache.last_error
+
+    def get(self, force: bool = False) -> MultiSourceActivityState:
+        return self._cache.get(force)
+
+    def _fetch_source(self, deploy: str, role: str) -> List[ActivityEvent]:
+        """Fetch + parse de um único deployment. Retorna [] em caso de erro."""
+        if self._kubectl is None:
+            return []
+        text = _capture_text(
+            [self._kubectl, "-n", self._namespace, "logs",
+             f"deploy/{deploy}",
+             f"--tail={_MULTI_TAIL_LINES}",
+             f"--since={_MULTI_SINCE}",
+             "--timestamps"],
+            timeout=5.0,
+        )
+        if not text:
+            return []
+        if len(text) > MAX_LOG_BYTES:
+            text = text[-MAX_LOG_BYTES:]
+        events: List[ActivityEvent] = []
+        for raw in text.splitlines():
+            ll = _parse_log_line(raw)
+            if ll is None:
+                continue
+            ev = _classify_source_line(ll, role)
+            if ev is not None:
+                events.append(ev)
+        return events
+
+    def _fetch(self) -> MultiSourceActivityState:
+        self._check_enabled()
+        self._resolve_kubectl()
+        if self._kubectl is None:
+            raise RuntimeError("kubectl não encontrado")
+        pool: List[ActivityEvent] = []
+        for deploy, role, _ in _MULTI_SOURCE_DEFS:
+            pool.extend(self._fetch_source(deploy, role))
+        # Rolling window: keep newest _MULTI_BUFFER_CAP events.
+        pool.sort(key=lambda e: e.ts)
+        state = MultiSourceActivityState()
+        state.events = pool[-_MULTI_BUFFER_CAP:]
+        return state
+
+
 # ===== GitHub provider ======================================================
 
 @dataclass
@@ -5179,6 +5370,10 @@ class PanelData:
     # Pod-status provider for claude-worker (issue #395). Instanciado
     # apenas quando k8s está disponível — accessa /v1/pod-status via HTTP.
     claude_worker_info: Optional["ClaudeWorkerInfoProvider"] = None
+    # Multi-source activity feed (issue #436). Tail paralelo dos 5 deploys
+    # fixos V1; buffer rolling-window 200 eventos; parser dual-mode.
+    # ``None`` quando k8s não está disponível (modo local-only ou demo).
+    activity: Optional[MultiSourceActivityProvider] = None
 
     @classmethod
     def from_context(cls, context: RuntimeContext) -> "PanelData":
@@ -5276,6 +5471,12 @@ class PanelData:
             claude_worker_info=(
                 ClaudeWorkerInfoProvider(enabled=True) if k8s_on else None
             ),
+            # MultiSourceActivityProvider (issue #436): only when k8s is on.
+            activity=(
+                MultiSourceActivityProvider(namespace=context.namespace,
+                                            enabled=k8s_on)
+                if k8s_on else None
+            ),
         )
 
     @classmethod
@@ -5292,7 +5493,7 @@ class PanelData:
         optionals = tuple(p for p in (self.local_processes, self.local_logs,
                                       self.local_audit, self.local_instances,
                                       self.local_registry, self.claude_workers,
-                                      self.claude_worker_info)
+                                      self.claude_worker_info, self.activity)
                           if p is not None)
         return base + optionals
 
@@ -5329,6 +5530,8 @@ class PanelData:
             names.append("local_registry")
         if self.claude_worker_info is not None:
             names.append("claude_worker_info")
+        if self.activity is not None:
+            names.append("activity")
         out: List[tuple] = []
         for name, p in zip(names, self._all_providers()):
             err = p.last_error


### PR DESCRIPTION
## Summary

- Adds `MultiSourceActivityProvider` in `infra/k8s/_panel_data.py` that tails 5 fixed V1 deployments in parallel (`deile-pipeline`, `deile-worker`, `claude-worker`, `deilebot`, `deile-monitor`) using `--since=10s --tail=80 --timestamps`, merges events into a rolling-window buffer (cap 200), and surfaces top-10 in the ACTIVITY widget in decreasing chronological order with colors per role.
- **Dual-mode parser**: tries canonical structured-log vocabulary (issues #435/#437/#438/#439 prefixes: `dispatch.*`, `inbound.*`, `monitor.*`, `git.*`, etc.) first; falls back to legacy `_classify_pipeline_line` for sources not yet emitting canonical format. Source with no match → silence (no crash).
- **Adaptive rendering** (principle 15): `_activity_panel` replaces `width=<int>` columns with `max_width`/`min_width`, with actor colored per role (`bright_black` pipeline, `cyan` deile-worker, `orange1` claude-worker, `magenta` bot, `blue` monitor, `dim italic` fallback).
- 39 new tests covering canonical parser, dual-mode fallback, rolling buffer, provider lifecycle, adaptive widths, and AC18 (provider stays functional with partial/intermediate sources).

## Test plan

- [x] `python3 -m pytest deile/tests/infra/test_panel_multi_source_activity.py -p no:cov -q` → 39 passed
- [x] `python3 -m pytest deile/tests/infra/test_panel_sort_activity.py deile/tests/infra/test_panel_data.py -p no:cov -q` → all pass (no regressions)
- [x] Pre-existing failures in `test_panel_cost_cap.py` (4 tests) confirmed to predate this PR

Closes #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)