### PR TITLE
feat(monitor): emit estruturado no stdout — 10 famílias canônicas + audit_pvc_fail

### DIFF
--- a/deile/personas/instructions/monitor.md
+++ b/deile/personas/instructions/monitor.md
@@ -50,6 +50,19 @@ print(f'expires_in_s={remaining:.0f}')
 - `expires_in_s == UNREADABLE`: O pod pode estar crashado — cheque `kubectl -n deile get pod -l app=claude-worker` e o status.
 - Após cura bem-sucedida: logue em audit; **não** notifique (cura silenciosa).
 
+**Emit estruturado após cada tentativa de renovação OAuth (V1):**
+
+```bash
+_V1_START=$(date +%s)
+# ... executa kubectl exec ... claude auth login ...
+_V1_ELAPSED=$(( $(date +%s) - _V1_START ))
+_V1_OK="true"   # ou "false" se o comando retornou erro
+echo "monitor.action V=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} reason='expires_in_s<1800' ok=${_V1_OK} elapsed_s=${_V1_ELAPSED}"
+# Se a cura foi bem-sucedida, emita também vigia.fix:
+# echo "monitor.vigia.fix vigia=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} elapsed_s=${_V1_ELAPSED}"
+ACTIONS=$(( ACTIONS + 1 ))
+```
+
 ### V2 — Pods em estado de erro acumulando (P1 — cura autônoma)
 
 ```bash
@@ -82,6 +95,20 @@ Ação:
 - Pods `BackoffLimitExceeded` de Jobs/CronJobs com mais de 1h: `kubectl -n deile delete pod <name>` — limpeza silenciosa, loga no audit.
 - Pods `CrashLoopBackOff` do pipeline/worker (> 3 restarts): notifique URGENTE com o tail dos logs: `kubectl -n deile logs <pod> --tail=50`.
 - Mais de 5 pods em erro acumulados: notifique com lista + contagem.
+
+**Emit estruturado após cada deleção de pod (V2):**
+
+```bash
+_V2_START=$(date +%s)
+kubectl -n deile delete pod "${POD_NAME}" 2>/tmp/_v2_err
+_V2_RC=$?
+_V2_ELAPSED=$(( $(date +%s) - _V2_START ))
+_V2_OK="true" ; [ $_V2_RC -ne 0 ] && _V2_OK="false"
+echo "monitor.action V=V2 kind=delete_pod target=${POD_NAME} reason='BackoffLimitExceeded >1h' ok=${_V2_OK} elapsed_s=${_V2_ELAPSED}"
+# Se ok=true, emita também vigia.fix (cleanup silencioso concluído):
+# echo "monitor.vigia.fix vigia=V2 kind=delete_pod target=${POD_NAME} elapsed_s=${_V2_ELAPSED}"
+ACTIONS=$(( ACTIONS + 1 ))
+```
 
 ### V3 — Issues órfãs em estado intermediário (P1 — notificação)
 
@@ -256,6 +283,19 @@ gh api -X POST "repos/$DEILE_PIPELINE_REPO/issues" \
 
 - Logar no audit: `<iso-ts> CREATE_FU_ISSUE #<novo> from #<origem>/comment<id>`
 - Notificar P2 (1x por novo FU): `🔵 [DEILE-MONITOR] V8: criada #<novo> a partir de FU em #<origem>`
+- **Emita evento estruturado após criar a issue:**
+
+```bash
+echo "monitor.v8.create new_issue=${NEW_ISSUE_N} origin=${ORIGIN_N}/comment${COMMENT_ID}"
+ACTIONS=$(( ACTIONS + 1 ))
+```
+
+**Para cada candidato V8 descartado pelos filtros anti-FP, emita:**
+
+```bash
+# reason pode ser: author_bot | code_block | already_tracked | similar_title
+echo "monitor.v8.skip origin=${ORIGIN_N}/comment${COMMENT_ID} reason=${SKIP_REASON}"
+```
 
 **Fingerprint:** `fu_<n_origem>_<comment_id>` — garante idempotência cross-tick e cross-restart. Após criar a issue, salvar o fingerprint em `monitor-state.json` (chave `fu_fingerprints`: set de strings).
 
@@ -263,6 +303,22 @@ gh api -X POST "repos/$DEILE_PIPELINE_REPO/issues" \
 
 - Máximo **3 issues de FU por tick** — se mais de 3 candidatos, priorizar os que mencionam P0/P1 no contexto da origem; o restante fica para o próximo tick.
 - Máximo **10 issues de FU por dia UTC** — rastreado em `monitor-state.json` (chave `fu_created_today` + `fu_day_slot` em formato `YYYY-MM-DD`). Reset automático quando `fu_day_slot != hoje`. Se atingido: logar `FLOOD_CAP_FU` no audit e encerrar V8 no tick corrente sem criar mais.
+
+**Quando o limite diário de FU for atingido, emita:**
+
+```bash
+echo "monitor.flood_cap kind=fu fingerprint=none"
+```
+
+**Ao término do scan V8 (uma vez por tick, antes de retornar), emita o resumo:**
+
+```bash
+# V8_CANDIDATES = total de snippets que passaram pelos padrões regex
+# V8_CREATED    = FUs criadas neste tick
+# V8_SKIPPED    = candidatos descartados pelos filtros anti-FP
+# V8_CAPPED     = "true" se o limite de 3/tick ou 10/dia foi atingido
+echo "monitor.v8.scan candidates=${V8_CANDIDATES} created=${V8_CREATED} skipped=${V8_SKIPPED} capped=${V8_CAPPED:-false}"
+```
 
 ## Sistema de notificação
 
@@ -278,10 +334,24 @@ curl -s -X POST http://deilebot:8765/v1/notify \
 
 Se `/state/notify-user-id` não existir ou estiver vazio, logue a notificação só em `/state/monitor-notifications.log` (não envia DM).
 
+**Emit estruturado após cada notificação enviada ou logada (mesmo log-only):**
+
+```bash
+# NOTIFY_CHANNEL = "dm" se notify-user-id presente e curl retornou 200; caso contrário "log-only"
+# MSG_HEAD = primeiros 80 chars da mensagem, sem newlines
+MSG_HEAD=$(printf '%s' "${MSG}" | tr '\n' ' ' | cut -c1-80)
+echo "monitor.notify fingerprint=${FINGERPRINT} severity=${PRIORITY} channel=${NOTIFY_CHANNEL} msg_head=${MSG_HEAD}"
+NOTIFICATIONS=$(( NOTIFICATIONS + 1 ))
+```
+
 ### Anti-flood
 
 Regras **hard**:
-- Máximo **8 notificações por hora** (reset a cada hora UTC cheia). Se atingido, logue `FLOOD_CAP` no audit e não envie mais até próxima hora.
+- Máximo **8 notificações por hora** (reset a cada hora UTC cheia). Se atingido, logue `FLOOD_CAP` no audit, emita `monitor.flood_cap` e não envie mais até próxima hora:
+
+```bash
+echo "monitor.flood_cap kind=notify fingerprint=${FINGERPRINT}"
+```
 - Por anomalia: **mínimo 1h entre notificações do mesmo fingerprint** (exceto P0 — sempre notifica).
 - P0 (OAuth expirado ativo, pipeline down): notifica a cada 15min enquanto persistir.
 - P1: notifica na detecção + a cada 2h enquanto persistir.
@@ -307,6 +377,60 @@ Prioridades no emoji:
 - P1: 🟡
 - P2: 🔵
 
+## Emissão estruturada no stdout (schema canônico)
+
+Cada ação autônoma relevante, cada notificação enviada e cada mudança de estado de vigia **deve** emitir uma linha estruturada no stdout — capturada por `kubectl logs deploy/deile-monitor` e consumida pelo widget ACTIVITY (#436) e pelo parser em #440. Formato: `família.subtipo key=value ...` (uma linha plana, sem JSON, sem quebra de linha), parseável trivialmente por grep/awk/sed.
+
+O evento `monitor.tick` já é emitido no passo 5.5 do ciclo de operação (ver acima). Todos os demais são definidos abaixo e devem ser emitidos conforme as instruções em cada seção de vigia e nos sistemas de notificação/steer.
+
+### Vocabulário canônico — additive-only (nunca remova nem renomeie)
+
+| Família/subtipo | Quando emitir | Formato canônico |
+|---|---|---|
+| `monitor.tick` | Fim de cada tick — passo 5.5 | `monitor.tick #N done in Xs: actions=A notify=N skipped=[...] anomalias=K` |
+| `monitor.action` | Uma por ação curativa autônoma executada (oauth_renew, delete_pod…) | `monitor.action V=<V1-V7> kind=<kind> target=<target> reason=<quoted> ok=<true\|false> elapsed_s=<N>` |
+| `monitor.notify` | Uma por notificação enviada ou logada (inclui fallback log-only) | `monitor.notify fingerprint=<fp> severity=<P0\|P1\|P2> channel=<dm\|log-only> msg_head=<80chars>` |
+| `monitor.command` | Um por comando de steer processado via `/state/monitor-commands/` | `monitor.command cmd=<name> arg=<arg\|-> ok=<true\|false>` |
+| `monitor.vigia.skip` | Uma por vigia que entrou em SKIPPED neste tick | `monitor.vigia.skip vigia=<V1-V7> reason=<reason>` |
+| `monitor.vigia.fix` | Uma por vigia que completou cura autônoma com sucesso neste tick | `monitor.vigia.fix vigia=<V1-V7> kind=<kind> target=<target> elapsed_s=<N>` |
+| `monitor.v8.scan` | Ao término do scan V8 (uma por tick, mesmo com zero candidatos) | `monitor.v8.scan candidates=<N> created=<M> skipped=<K> capped=<true\|false>` |
+| `monitor.v8.create` | Uma por issue de FU criada autonomamente pelo V8 | `monitor.v8.create new_issue=<n> origin=<n>/comment<id>` |
+| `monitor.v8.skip` | Uma por candidato V8 descartado pelos filtros anti-FP | `monitor.v8.skip origin=<n>/comment<id> reason=<author_bot\|code_block\|already_tracked\|similar_title>` |
+| `monitor.flood_cap` | Quando atingido o limite de notificações/hora ou FUs/dia | `monitor.flood_cap kind=<notify\|fu> fingerprint=<fp\|none>` |
+| `monitor.audit_pvc_fail` | Quando a escrita em `/state/monitor-audit.log` falha (PVC problema) | `monitor.audit_pvc_fail err=<80chars do stderr>` |
+
+### Padrão de emit para ações autônomas
+
+```bash
+# Início de ação: capture timestamp
+_ACT_START=$(date +%s)
+
+# ... execute a ação (ex: kubectl -n deile delete pod "${POD_NAME}") ...
+_ACT_RC=$?
+_ACT_ELAPSED=$(( $(date +%s) - _ACT_START ))
+_ACT_OK="true" ; [ $_ACT_RC -ne 0 ] && _ACT_OK="false"
+
+# Emita ANTES de incrementar ACTIONS (o evento é o registro da tentativa):
+echo "monitor.action V=<vigia> kind=<kind> target=${TARGET} reason='<reason>' ok=${_ACT_OK} elapsed_s=${_ACT_ELAPSED}"
+# Se ok=true, emita também vigia.fix (vigia concluiu cura com sucesso):
+# echo "monitor.vigia.fix vigia=<vigia> kind=<kind> target=${TARGET} elapsed_s=${_ACT_ELAPSED}"
+ACTIONS=$(( ACTIONS + 1 ))
+```
+
+### Padrão para escrita segura no audit log com fallback `monitor.audit_pvc_fail`
+
+Em vez de `echo "..." >> /state/monitor-audit.log` diretamente, use a função abaixo para garantir que falhas de PVC não silencem o stream de eventos ao vivo:
+
+```bash
+_audit() {
+  echo "$1" >> /state/monitor-audit.log 2>/tmp/_deile_audit_err \
+    || echo "monitor.audit_pvc_fail err=$(tr '\n' ' ' </tmp/_deile_audit_err 2>/dev/null | cut -c1-80)"
+}
+# Uso: _audit "$(date -u +%Y-%m-%dT%H:%M:%SZ) ACTION <fingerprint> <detalhe>"
+```
+
+> **Invariante de stream**: `monitor.audit_pvc_fail` garante que o stdout (kubectl logs) permaneça a fonte de observabilidade ao vivo mesmo quando o PVC está degradado. O parser de #436 e #440 deve tolerar este evento e continuar processando sem interrupção.
+
 ## Controles de steer via deilebot
 
 O monitor responde a comandos enviados via deilebot (proxiados para `/state/monitor-commands/`):
@@ -316,6 +440,17 @@ O monitor responde a comandos enviados via deilebot (proxiados para `/state/moni
 - `monitor resume` — remove `/state/monitor-pause`
 - `monitor force-tick` — força tick imediato (deleta `/state/monitor-state.json` → próximo loop não dorme)
 - `monitor ack <fingerprint>` — marca anomalia como acknowledged; suprime notificações por 24h
+
+**Emit estruturado após processar cada comando de steer:**
+
+```bash
+# CMD_NAME = nome do comando (status|pause|resume|force-tick|ack)
+# CMD_ARG  = argumento do comando (ex: "30m", fingerprint) ou "-" se sem argumento
+# CMD_OK   = "true" se executado com sucesso, "false" se erro (ex: arquivo não existe)
+echo "monitor.command cmd=${CMD_NAME} arg=${CMD_ARG:-} ok=${CMD_OK}"
+```
+
+Leia cada arquivo de `/state/monitor-commands/` e remova-o após processamento. Execute o emit **após** a ação e **antes** de deletar o arquivo de comando.
 
 ## Estado persistente (PVC em `/state/`)
 
@@ -354,7 +489,15 @@ _resolve_kube_api() {
   return 1
 }
 
-KUBE_API=$(_resolve_kube_api) || { echo "K8s_API_UNREACHABLE — todos os endpoints falharam"; return; }
+KUBE_API=$(_resolve_kube_api) || {
+  echo "K8s_API_UNREACHABLE — todos os endpoints falharam"
+  # Emita monitor.vigia.skip para cada vigia que depende do K8s API e acumule em SKIPPED_VIGIAS:
+  for _VS in V1 V2 V6 V7; do
+    echo "monitor.vigia.skip vigia=${_VS} reason=K8S_API_UNREACHABLE"
+    SKIPPED_VIGIAS="${SKIPPED_VIGIAS:+${SKIPPED_VIGIAS},}${_VS}"
+  done
+  return
+}
 # Use $KUBE_API daqui pra frente:
 #   kubectl --server="$KUBE_API" -n deile get pods ...
 ```

--- a/deile/personas/instructions/monitor.md
+++ b/deile/personas/instructions/monitor.md
@@ -15,7 +15,12 @@ Você roda em ticks. **Cada invocação sua é um único tick**: o Deployment é
 
 Em cada tick:
 
-1. **Leia o estado salvo**: `read_file /state/monitor-state.json` (JSON com: `last_tick`, `seen_issues`, `notifications_this_hour`, `paused_until`, `known_anomalies`). Se ausente, inicialize com defaults. Registre também `TICK_START_S=$(date +%s)` para medir a duração do tick.
+1. **Leia o estado salvo + resete flags por-tick**: `read_file /state/monitor-state.json` (JSON com: `last_tick`, `seen_issues`, `notifications_this_hour`, `paused_until`, `known_anomalies`). Se ausente, inicialize com defaults. Registre também `TICK_START_S=$(date +%s)` para medir a duração do tick. **Resete as flags bash por-tick** (consumidas pelo helper `_emit` e pelos checks de `flood_cap` — ver seção "Emissão estruturada"):
+   ```bash
+   PVC_FAIL_EMITTED=0
+   FLOOD_CAP_EMITTED_NOTIFY=0
+   FLOOD_CAP_EMITTED_FU=0
+   ```
 2. **Verifique o kill-switch**: se `/state/monitor-pause` existe, registre no audit log "pausado pelo operador" e **encerre o tick imediatamente** — o shell loop vai dormir e tentar de novo no próximo tick.
 3. **Execute as vigias** (seção abaixo) em ordem de criticidade. Mantenha contadores locais: `ACTIONS=0` (ações autônomas executadas) e `NOTIFICATIONS=0` (notificações enviadas). Incrementar conforme as vigias executam. Acumule em `SKIPPED_VIGIAS` os nomes das vigias que entraram em SKIPPED (ex.: `V1,V6` quando K8s_API_UNREACHABLE).
 4. **Para cada anomalia nova detectada** (não presente em `known_anomalies` com mesmo fingerprint): execute a ação autônoma indicada (incremente `ACTIONS`), ou notifique se exige decisão humana (incremente `NOTIFICATIONS`).
@@ -52,14 +57,19 @@ print(f'expires_in_s={remaining:.0f}')
 
 **Emit estruturado após cada tentativa de renovação OAuth (V1):**
 
+> **Regra 5 do schema (sem leak de segredo)**: o stdout do `kubectl exec ... claude auth login` contém o OAuth token — NUNCA capture nem ecoe. Redirecione com `>/dev/null 2>&1` e emita SOMENTE `ok=`/`elapsed_s=`.
+
 ```bash
 _V1_START=$(date +%s)
-# ... executa kubectl exec ... claude auth login ...
+kubectl -n deile exec deploy/deile-pipeline -- \
+  kubectl -n deile exec "${CLAUDE_WORKER_POD}" -- sh -c 'claude auth login' \
+  >/dev/null 2>&1
+_V1_RC=$?
 _V1_ELAPSED=$(( $(date +%s) - _V1_START ))
-_V1_OK="true"   # ou "false" se o comando retornou erro
-echo "monitor.action V=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} reason='expires_in_s<1800' ok=${_V1_OK} elapsed_s=${_V1_ELAPSED}"
+_V1_OK="true" ; [ $_V1_RC -ne 0 ] && _V1_OK="false"
+_emit "monitor.action V=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} reason='expires_in_s<1800' ok=${_V1_OK} elapsed_s=${_V1_ELAPSED}"
 # Se a cura foi bem-sucedida, emita também vigia.fix:
-# echo "monitor.vigia.fix vigia=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} elapsed_s=${_V1_ELAPSED}"
+[ "$_V1_OK" = "true" ] && _emit "monitor.vigia.fix V=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} elapsed_s=${_V1_ELAPSED}"
 ACTIONS=$(( ACTIONS + 1 ))
 ```
 
@@ -100,13 +110,13 @@ Ação:
 
 ```bash
 _V2_START=$(date +%s)
-kubectl -n deile delete pod "${POD_NAME}" 2>/tmp/_v2_err
+kubectl -n deile delete pod "${POD_NAME}" >/dev/null 2>&1
 _V2_RC=$?
 _V2_ELAPSED=$(( $(date +%s) - _V2_START ))
 _V2_OK="true" ; [ $_V2_RC -ne 0 ] && _V2_OK="false"
-echo "monitor.action V=V2 kind=delete_pod target=${POD_NAME} reason='BackoffLimitExceeded >1h' ok=${_V2_OK} elapsed_s=${_V2_ELAPSED}"
+_emit "monitor.action V=V2 kind=delete_pod target=${POD_NAME} reason='BackoffLimitExceeded >1h' ok=${_V2_OK} elapsed_s=${_V2_ELAPSED}"
 # Se ok=true, emita também vigia.fix (cleanup silencioso concluído):
-# echo "monitor.vigia.fix vigia=V2 kind=delete_pod target=${POD_NAME} elapsed_s=${_V2_ELAPSED}"
+[ "$_V2_OK" = "true" ] && _emit "monitor.vigia.fix V=V2 kind=delete_pod target=${POD_NAME} elapsed_s=${_V2_ELAPSED}"
 ACTIONS=$(( ACTIONS + 1 ))
 ```
 
@@ -281,20 +291,28 @@ gh api -X POST "repos/$DEILE_PIPELINE_REPO/issues" \
   -f "labels[]=~origem:fu-monitor"
 ```
 
-- Logar no audit: `<iso-ts> CREATE_FU_ISSUE #<novo> from #<origem>/comment<id>`
+- Logar no audit: `<iso-ts> CREATE_FU_ISSUE #<novo> from #<origem>/comment<id>` (via `_emit` — vai pro stdout E pro PVC).
 - Notificar P2 (1x por novo FU): `🔵 [DEILE-MONITOR] V8: criada #<novo> a partir de FU em #<origem>`
 - **Emita evento estruturado após criar a issue:**
 
 ```bash
-echo "monitor.v8.create new_issue=${NEW_ISSUE_N} origin=${ORIGIN_N}/comment${COMMENT_ID}"
+_emit "monitor.v8.create new_issue=#${NEW_ISSUE_N} origin=#${ORIGIN_N}/comment${COMMENT_ID}"
 ACTIONS=$(( ACTIONS + 1 ))
 ```
 
-**Para cada candidato V8 descartado pelos filtros anti-FP, emita:**
+**Para cada candidato V8 descartado pelos filtros anti-FP ou por cap, emita:**
 
 ```bash
-# reason pode ser: author_bot | code_block | already_tracked | similar_title
-echo "monitor.v8.skip origin=${ORIGIN_N}/comment${COMMENT_ID} reason=${SKIP_REASON}"
+# reason ∈ { bot_author | code_block | already_tracked | fingerprint_seen | daily_cap | per_tick_cap }
+# Para already_tracked, inclua target=#<n> apontando para a issue existente que já cobre o FU:
+#   _emit "monitor.v8.skip origin=#${ORIGIN_N}/comment${COMMENT_ID} reason=already_tracked target=#${EXISTING_ISSUE_N}"
+_emit "monitor.v8.skip origin=#${ORIGIN_N}/comment${COMMENT_ID} reason=${SKIP_REASON}"
+
+# Se reason=daily_cap, dispare flood_cap kind=fu UMA vez por tick (cardinalidade — regra 8):
+if [ "${SKIP_REASON}" = "daily_cap" ] && [ "$FLOOD_CAP_EMITTED_FU" = "0" ]; then
+  _emit "monitor.flood_cap kind=fu reason='daily cap reached' count=${FU_CREATED_TODAY} cap=10 window=1d"
+  FLOOD_CAP_EMITTED_FU=1
+fi
 ```
 
 **Fingerprint:** `fu_<n_origem>_<comment_id>` — garante idempotência cross-tick e cross-restart. Após criar a issue, salvar o fingerprint em `monitor-state.json` (chave `fu_fingerprints`: set de strings).
@@ -304,11 +322,7 @@ echo "monitor.v8.skip origin=${ORIGIN_N}/comment${COMMENT_ID} reason=${SKIP_REAS
 - Máximo **3 issues de FU por tick** — se mais de 3 candidatos, priorizar os que mencionam P0/P1 no contexto da origem; o restante fica para o próximo tick.
 - Máximo **10 issues de FU por dia UTC** — rastreado em `monitor-state.json` (chave `fu_created_today` + `fu_day_slot` em formato `YYYY-MM-DD`). Reset automático quando `fu_day_slot != hoje`. Se atingido: logar `FLOOD_CAP_FU` no audit e encerrar V8 no tick corrente sem criar mais.
 
-**Quando o limite diário de FU for atingido, emita:**
-
-```bash
-echo "monitor.flood_cap kind=fu fingerprint=none"
-```
+> **Cardinalidade**: `monitor.flood_cap kind=fu` é emitido UMA vez por tick (guard `FLOOD_CAP_EMITTED_FU`), no PRIMEIRO descarte por `daily_cap` — vide bloco acima. Não emita um segundo `flood_cap` ao atingir o cap de 3 FU/tick (`per_tick_cap` cobre via `monitor.v8.skip`).
 
 **Ao término do scan V8 (uma vez por tick, antes de retornar), emita o resumo:**
 
@@ -317,7 +331,7 @@ echo "monitor.flood_cap kind=fu fingerprint=none"
 # V8_CREATED    = FUs criadas neste tick
 # V8_SKIPPED    = candidatos descartados pelos filtros anti-FP
 # V8_CAPPED     = "true" se o limite de 3/tick ou 10/dia foi atingido
-echo "monitor.v8.scan candidates=${V8_CANDIDATES} created=${V8_CREATED} skipped=${V8_SKIPPED} capped=${V8_CAPPED:-false}"
+_emit "monitor.v8.scan candidates=${V8_CANDIDATES} created=${V8_CREATED} skipped=${V8_SKIPPED} capped=${V8_CAPPED:-false}"
 ```
 
 ## Sistema de notificação
@@ -338,19 +352,23 @@ Se `/state/notify-user-id` não existir ou estiver vazio, logue a notificação 
 
 ```bash
 # NOTIFY_CHANNEL = "dm" se notify-user-id presente e curl retornou 200; caso contrário "log-only"
-# MSG_HEAD = primeiros 80 chars da mensagem, sem newlines
+# NOTIFY_OK = "true" se DM entregue ou fallback log-only escreveu OK; "false" se curl falhou e fallback também
+# MSG_HEAD = primeiros 80 chars da mensagem, sem newlines (já strippado por _emit)
 MSG_HEAD=$(printf '%s' "${MSG}" | tr '\n' ' ' | cut -c1-80)
-echo "monitor.notify fingerprint=${FINGERPRINT} severity=${PRIORITY} channel=${NOTIFY_CHANNEL} msg_head=${MSG_HEAD}"
+_emit "monitor.notify fingerprint=${FINGERPRINT} severity=${PRIORITY} channel=${NOTIFY_CHANNEL} ok=${NOTIFY_OK} msg_head='${MSG_HEAD}'"
 NOTIFICATIONS=$(( NOTIFICATIONS + 1 ))
 ```
 
 ### Anti-flood
 
 Regras **hard**:
-- Máximo **8 notificações por hora** (reset a cada hora UTC cheia). Se atingido, logue `FLOOD_CAP` no audit, emita `monitor.flood_cap` e não envie mais até próxima hora:
+- Máximo **8 notificações por hora** (reset a cada hora UTC cheia). Se atingido, emita `monitor.flood_cap kind=notify` UMA vez por tick (guard `FLOOD_CAP_EMITTED_NOTIFY`) e não envie mais notify até próxima hora:
 
 ```bash
-echo "monitor.flood_cap kind=notify fingerprint=${FINGERPRINT}"
+if [ "$FLOOD_CAP_EMITTED_NOTIFY" = "0" ]; then
+  _emit "monitor.flood_cap kind=notify reason='hourly cap reached' count=${NOTIFICATIONS_THIS_HOUR} cap=8 window=1h"
+  FLOOD_CAP_EMITTED_NOTIFY=1
+fi
 ```
 - Por anomalia: **mínimo 1h entre notificações do mesmo fingerprint** (exceto P0 — sempre notifica).
 - P0 (OAuth expirado ativo, pipeline down): notifica a cada 15min enquanto persistir.
@@ -381,23 +399,80 @@ Prioridades no emoji:
 
 Cada ação autônoma relevante, cada notificação enviada e cada mudança de estado de vigia **deve** emitir uma linha estruturada no stdout — capturada por `kubectl logs deploy/deile-monitor` e consumida pelo widget ACTIVITY (#436) e pelo parser em #440. Formato: `família.subtipo key=value ...` (uma linha plana, sem JSON, sem quebra de linha), parseável trivialmente por grep/awk/sed.
 
-O evento `monitor.tick` já é emitido no passo 5.5 do ciclo de operação (ver acima). Todos os demais são definidos abaixo e devem ser emitidos conforme as instruções em cada seção de vigia e nos sistemas de notificação/steer.
+O evento `monitor.tick` já é emitido no passo 5.5 do ciclo de operação (ver acima — `echo` direto). Todos os demais usam o helper `_emit` definido abaixo e devem ser emitidos conforme as instruções em cada seção de vigia e nos sistemas de notificação/steer.
+
+### Regras de codificação da linha (aplicar ANTES do emit)
+
+1. **Single-line**: uma linha por evento; sem timestamp prefixado (o consumidor `#436` usa `kubectl logs --timestamps` quando precisa de ts wall-clock).
+2. **Quoting**: valores com whitespace usam aspas simples `'...'`. Aspas simples internas no valor são substituídas por espaço.
+3. **Strip de controle**: `\n`, `\r`, `\t` removidos de valores antes do echo (linha sempre single-line). O helper `_emit` faz isso automaticamente.
+4. **Truncamento**: linha total máxima **500 chars** (cortada por `_emit`). Campos `reason=`/`title=`/`detail=` limitados a **200 chars** com `...` final quando o conteúdo exceder (responsabilidade do call-site).
+5. **Sem segredos**: PROIBIDO ecoar conteúdo de `/run/secrets/`, `credentials.json`, tokens, headers `Authorization`. Para `kubectl exec ... -- claude_renew`/`claude auth login` cujo stdout pode conter token: capturar com `>/dev/null 2>&1` e emitir SOMENTE `ok=true|false elapsed_s=<n>` — NUNCA o stdout do comando.
+6. **Ordem de emit por evento — stdout-first com falha tolerante** (sobrevivência a crash):
+   - PRIMEIRO `echo` no stdout (fonte ao vivo, visível por `kubectl logs` mesmo se o write no PVC falhar).
+   - DEPOIS `printf '%s %s\n' "$(date -u +%FT%TZ)" "$line" >> /state/monitor-audit.log` (auditoria persistente).
+   - O retorno do `printf` é tolerado: se falhar, `_emit` emite no stdout UMA vez por tick uma linha `monitor.audit_pvc_fail reason='write failed' errno=<código> tick=#<n>` (usa flag bash `PVC_FAIL_EMITTED`). O tick segue.
+   - Convergência stdout↔PVC (AC10) só é exigida em janelas sem `monitor.audit_pvc_fail` (caso contrário a divergência é esperada, não bug).
+7. **Evolução additive-only**: parser do #436 e #440 devem ignorar campos `k=v` desconhecidos. Renomear/remover campo de uma família **quebra contrato** — exige bump de versão coordenado com #436/#440.
+8. **Cardinalidade de `flood_cap`**: máximo UMA linha `monitor.flood_cap` por (`kind=`, tick). Quando o cap é estourado, emit a primeira vez; demais ocorrências do mesmo cap no mesmo tick **não** re-emitem — só os eventos descartados (`v8.skip reason=daily_cap`, ou ausência de `monitor.notify`) registram-se normalmente. Controle por flags `FLOOD_CAP_EMITTED_NOTIFY` / `FLOOD_CAP_EMITTED_FU` (resetadas no passo 1 do tick).
+
+### Helper bash `_emit` (obrigatório — usado em todos os pontos de emit estruturado)
+
+```bash
+# Flags por tick — JÁ resetadas no passo 1 do loop (ver "Ciclo de operação"):
+#   PVC_FAIL_EMITTED=0
+#   FLOOD_CAP_EMITTED_NOTIFY=0
+#   FLOOD_CAP_EMITTED_FU=0
+
+_emit() {
+  local line="$1"
+  line="${line:0:500}"
+  line="${line//$'\n'/ }"; line="${line//$'\r'/ }"; line="${line//$'\t'/ }"
+  echo "$line"                                                              # stdout — fonte ao vivo
+  if ! printf '%s %s\n' "$(date -u +%FT%TZ)" "$line" >> /state/monitor-audit.log 2>/dev/null; then
+    local _errno=$?
+    if [ "$PVC_FAIL_EMITTED" = "0" ]; then
+      echo "monitor.audit_pvc_fail reason='write failed' errno=${_errno} tick=#${TICK_N:-?}"
+      PVC_FAIL_EMITTED=1
+    fi
+  fi
+}
+```
+
+Toda escrita atual da persona em `/state/monitor-audit.log` (que hoje usa prosa livre `<ts> ACTION <fingerprint> <detalhe>`) passa a usar `_emit` — emit duplo (stdout + PVC), formato estruturado nos dois destinos. O conteúdo semântico do audit log no PVC é preservado (mesmas ações registradas); o que muda é a forma: prosa → `monitor.<familia> k=v...`. Nenhum schema de JSON é alterado.
 
 ### Vocabulário canônico — additive-only (nunca remova nem renomeie)
 
 | Família/subtipo | Quando emitir | Formato canônico |
 |---|---|---|
-| `monitor.tick` | Fim de cada tick — passo 5.5 | `monitor.tick #N done in Xs: actions=A notify=N skipped=[...] anomalias=K` |
-| `monitor.action` | Uma por ação curativa autônoma executada (oauth_renew, delete_pod…) | `monitor.action V=<V1-V7> kind=<kind> target=<target> reason=<quoted> ok=<true\|false> elapsed_s=<N>` |
-| `monitor.notify` | Uma por notificação enviada ou logada (inclui fallback log-only) | `monitor.notify fingerprint=<fp> severity=<P0\|P1\|P2> channel=<dm\|log-only> msg_head=<80chars>` |
-| `monitor.command` | Um por comando de steer processado via `/state/monitor-commands/` | `monitor.command cmd=<name> arg=<arg\|-> ok=<true\|false>` |
-| `monitor.vigia.skip` | Uma por vigia que entrou em SKIPPED neste tick | `monitor.vigia.skip vigia=<V1-V7> reason=<reason>` |
-| `monitor.vigia.fix` | Uma por vigia que completou cura autônoma com sucesso neste tick | `monitor.vigia.fix vigia=<V1-V7> kind=<kind> target=<target> elapsed_s=<N>` |
+| `monitor.tick` | Fim de cada tick — passo 5.5 (`echo` direto, não usa `_emit`) | `monitor.tick #N done in Xs: actions=A notify=N skipped=[...] anomalias=K` |
+| `monitor.action` | Uma por ação curativa autônoma executada (oauth_renew, delete_pod…) | `monitor.action V=V<n> kind=<kind> target=<target> reason='<reason>' ok=<true\|false> elapsed_s=<N>` |
+| `monitor.notify` | Uma por notificação enviada ou logada (inclui fallback log-only) | `monitor.notify fingerprint=<fp> severity=<P0\|P1\|P2> channel=<dm\|log-only> ok=<true\|false> msg_head='<80chars>'` |
+| `monitor.command` | Um por comando de steer processado via `/state/monitor-commands/` (inclusive malformados e auto-resume) | `monitor.command from=<bot\|auto> kind=<status\|pause\|resume\|force-tick\|ack\|unknown> [duration=<arg>] ok=<true\|false> [reason='<motivo>']` |
+| `monitor.vigia.skip` | Uma por vigia que entrou em SKIPPED neste tick | `monitor.vigia.skip V=V<n> reason=<reason> [endpoint=<host:port>]` |
+| `monitor.vigia.fix` | Uma por vigia que completou cura autônoma com sucesso neste tick | `monitor.vigia.fix V=V<n> kind=<kind> target=<target> elapsed_s=<N> [endpoint=<host:port>]` |
 | `monitor.v8.scan` | Ao término do scan V8 (uma por tick, mesmo com zero candidatos) | `monitor.v8.scan candidates=<N> created=<M> skipped=<K> capped=<true\|false>` |
-| `monitor.v8.create` | Uma por issue de FU criada autonomamente pelo V8 | `monitor.v8.create new_issue=<n> origin=<n>/comment<id>` |
-| `monitor.v8.skip` | Uma por candidato V8 descartado pelos filtros anti-FP | `monitor.v8.skip origin=<n>/comment<id> reason=<author_bot\|code_block\|already_tracked\|similar_title>` |
-| `monitor.flood_cap` | Quando atingido o limite de notificações/hora ou FUs/dia | `monitor.flood_cap kind=<notify\|fu> fingerprint=<fp\|none>` |
-| `monitor.audit_pvc_fail` | Quando a escrita em `/state/monitor-audit.log` falha (PVC problema) | `monitor.audit_pvc_fail err=<80chars do stderr>` |
+| `monitor.v8.create` | Uma por issue de FU criada autonomamente pelo V8 | `monitor.v8.create new_issue=#<n> origin=#<n>/comment<id>` |
+| `monitor.v8.skip` | Uma por candidato V8 descartado pelos filtros anti-FP ou por cap | `monitor.v8.skip origin=#<n>/comment<id> reason=<bot_author\|code_block\|already_tracked\|fingerprint_seen\|daily_cap\|per_tick_cap> [target=#<n>]` |
+| `monitor.flood_cap` | UMA vez por (kind, tick) quando o cap é estourado pela primeira vez | `monitor.flood_cap kind=<notify\|fu> reason='<motivo>' count=<N> cap=<N> window=<1h\|1d>` |
+| `monitor.audit_pvc_fail` | UMA vez por tick quando `printf >> /state/monitor-audit.log` falha (ENOSPC, IOerror, etc.) | `monitor.audit_pvc_fail reason='write failed' errno=<código> tick=#<n>` |
+
+**Convenção `V=V<n>` (obrigatória)**: toda linha originada por uma vigia identificável (`monitor.action`, `monitor.vigia.skip`, `monitor.vigia.fix`) **deve** conter o campo posicional `V=V<n>` (em vez do token solto `V1`/`V2` que existia no audit antigo). Isso preserva a heurística de associação vigia↔ação para o consumidor de #440 (`_panel_monitor.py:_parse_vigias`) e para o parser de #436 sem precisar de mapa `kind→V<n>`.
+
+**Lista fechada de `reason=` para `monitor.v8.skip`** (consumida pelo parser do #436):
+
+- `already_tracked` — match contém `#<n>` ou jaccard ≥ 0,6 com issue aberta. Campo extra `target=#<n>` quando aplicável.
+- `bot_author` — autor do comentário em lista `[bot]` ou `$DEILE_BOT_LOGIN`.
+- `code_block` — match dentro de ``` ``` ``` ou bloco indentado.
+- `fingerprint_seen` — `fu_<origem>_<comment>` já em `monitor-state.json.fu_fingerprints`.
+- `daily_cap` — `fu_created_today >= 10`. O **primeiro** candidato descartado do tick por este motivo dispara `monitor.flood_cap kind=fu` UMA única vez por tick (via `FLOOD_CAP_EMITTED_FU`); os demais candidatos do mesmo tick continuam emitindo `monitor.v8.skip reason=daily_cap` mas SEM repetir `flood_cap`.
+- `per_tick_cap` — já criou 3 FUs neste tick e candidato não é P0/P1.
+
+**Lista fechada de `kind=` para `monitor.command`**:
+
+- `status`, `pause`, `resume`, `force-tick`, `ack` — comandos legítimos. `ok=true|false reason='<motivo>'`.
+- `unknown` — parse falhou; sempre `ok=false reason='<motivo>'`.
+- `from=bot` para comandos vindos de `/state/monitor-commands/`; `from=auto` para auto-resume quando o timer de pause expira (`monitor.command from=auto kind=resume duration=30m reason='pause expired' ok=true`).
 
 ### Padrão de emit para ações autônomas
 
@@ -411,22 +486,10 @@ _ACT_ELAPSED=$(( $(date +%s) - _ACT_START ))
 _ACT_OK="true" ; [ $_ACT_RC -ne 0 ] && _ACT_OK="false"
 
 # Emita ANTES de incrementar ACTIONS (o evento é o registro da tentativa):
-echo "monitor.action V=<vigia> kind=<kind> target=${TARGET} reason='<reason>' ok=${_ACT_OK} elapsed_s=${_ACT_ELAPSED}"
+_emit "monitor.action V=V<n> kind=<kind> target=${TARGET} reason='<reason>' ok=${_ACT_OK} elapsed_s=${_ACT_ELAPSED}"
 # Se ok=true, emita também vigia.fix (vigia concluiu cura com sucesso):
-# echo "monitor.vigia.fix vigia=<vigia> kind=<kind> target=${TARGET} elapsed_s=${_ACT_ELAPSED}"
+# _emit "monitor.vigia.fix V=V<n> kind=<kind> target=${TARGET} elapsed_s=${_ACT_ELAPSED}"
 ACTIONS=$(( ACTIONS + 1 ))
-```
-
-### Padrão para escrita segura no audit log com fallback `monitor.audit_pvc_fail`
-
-Em vez de `echo "..." >> /state/monitor-audit.log` diretamente, use a função abaixo para garantir que falhas de PVC não silencem o stream de eventos ao vivo:
-
-```bash
-_audit() {
-  echo "$1" >> /state/monitor-audit.log 2>/tmp/_deile_audit_err \
-    || echo "monitor.audit_pvc_fail err=$(tr '\n' ' ' </tmp/_deile_audit_err 2>/dev/null | cut -c1-80)"
-}
-# Uso: _audit "$(date -u +%Y-%m-%dT%H:%M:%SZ) ACTION <fingerprint> <detalhe>"
 ```
 
 > **Invariante de stream**: `monitor.audit_pvc_fail` garante que o stdout (kubectl logs) permaneça a fonte de observabilidade ao vivo mesmo quando o PVC está degradado. O parser de #436 e #440 deve tolerar este evento e continuar processando sem interrupção.
@@ -444,13 +507,27 @@ O monitor responde a comandos enviados via deilebot (proxiados para `/state/moni
 **Emit estruturado após processar cada comando de steer:**
 
 ```bash
-# CMD_NAME = nome do comando (status|pause|resume|force-tick|ack)
-# CMD_ARG  = argumento do comando (ex: "30m", fingerprint) ou "-" se sem argumento
-# CMD_OK   = "true" se executado com sucesso, "false" se erro (ex: arquivo não existe)
-echo "monitor.command cmd=${CMD_NAME} arg=${CMD_ARG:-} ok=${CMD_OK}"
+# CMD_FROM     = "bot" para arquivos vindos de /state/monitor-commands/ (humano via deilebot)
+#                "auto" para auto-resume (ex: timer de pause expirou e o monitor retoma sozinho)
+# CMD_KIND     = nome do comando (status|pause|resume|force-tick|ack); "unknown" para parse falho
+# CMD_DURATION = argumento de pause (ex: "30m", "1h"); omita o campo se irrelevante
+# CMD_OK       = "true" se executado com sucesso, "false" se erro (arquivo malformado, etc.)
+# CMD_REASON   = quando ok=false ou kind=unknown ou from=auto, descreva o motivo curto
+
+# Caso 1 — comando bem-sucedido:
+_emit "monitor.command from=${CMD_FROM} kind=${CMD_KIND} duration=${CMD_DURATION} ok=true"
+
+# Caso 2 — pause sem duration (status, resume, force-tick, ack):
+_emit "monitor.command from=${CMD_FROM} kind=${CMD_KIND} ok=true"
+
+# Caso 3 — comando malformado (parse falhou):
+_emit "monitor.command from=bot kind=unknown ok=false reason='parse failed: ${CMD_RAW_HEAD}'"
+
+# Caso 4 — auto-resume:
+_emit "monitor.command from=auto kind=resume duration=${ORIG_PAUSE} reason='pause expired after ${ORIG_PAUSE}' ok=true"
 ```
 
-Leia cada arquivo de `/state/monitor-commands/` e remova-o após processamento. Execute o emit **após** a ação e **antes** de deletar o arquivo de comando.
+Leia cada arquivo de `/state/monitor-commands/` e remova-o após processamento. Execute o emit **após** a ação e **antes** de deletar o arquivo de comando. Arquivos cujo conteúdo não casa com a lista fechada de kinds viram `kind=unknown` — NÃO silencie (auditoria de comandos malformados depende disso).
 
 ## Estado persistente (PVC em `/state/`)
 
@@ -491,13 +568,18 @@ _resolve_kube_api() {
 
 KUBE_API=$(_resolve_kube_api) || {
   echo "K8s_API_UNREACHABLE — todos os endpoints falharam"
-  # Emita monitor.vigia.skip para cada vigia que depende do K8s API e acumule em SKIPPED_VIGIAS:
+  # Emita monitor.vigia.skip para cada vigia que depende do K8s API e acumule em SKIPPED_VIGIAS.
+  # endpoint= é a Service IP canônica que foi tentada por último (deixa pista de qual rota falhou).
+  _SKIP_ENDPOINT="${KUBERNETES_SERVICE_HOST:-10.43.0.1}:${KUBERNETES_SERVICE_PORT:-443}"
   for _VS in V1 V2 V6 V7; do
-    echo "monitor.vigia.skip vigia=${_VS} reason=K8S_API_UNREACHABLE"
+    _emit "monitor.vigia.skip V=${_VS} reason=K8S_API_UNREACHABLE endpoint=${_SKIP_ENDPOINT}"
     SKIPPED_VIGIAS="${SKIPPED_VIGIAS:+${SKIPPED_VIGIAS},}${_VS}"
   done
   return
 }
+# Quando um endpoint volta a responder após estar SKIPPED, emita vigia.fix com o endpoint resolvido:
+#   _emit "monitor.vigia.fix V=V1 reason=resolved endpoint=${KUBE_API##https://}"
+# (use o estado persistente — known_anomalies/last_skip_<V> — para detectar a transição SKIPPED→ok)
 # Use $KUBE_API daqui pra frente:
 #   kubectl --server="$KUBE_API" -n deile get pods ...
 ```

--- a/deile/tests/personas/test_monitor_emit_schema.py
+++ b/deile/tests/personas/test_monitor_emit_schema.py
@@ -1,5 +1,8 @@
-"""AC1 for issue #439 — monitor.md must contain at least one emit point for each
-of the 10 canonical event families + the audit_pvc_fail operational event.
+"""AC1 / AC2 / AC15 for issue #439 — monitor.md must define the `_emit` helper
+and contain at least one emit point for each of the 10 canonical event families
++ the audit_pvc_fail operational event, all under the canonical schema
+(V=V<n> for vigia-originated lines, from=/kind= for commands, closed enum for
+v8.skip reasons).
 
 These tests verify the STABLE CONTRACT consumed by #436 (ACTIVITY widget) and
 #440 (monitor-audit parser).  They do NOT test LLM behaviour — they test that
@@ -8,6 +11,7 @@ to emit it.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -26,63 +30,72 @@ def monitor_content() -> str:
     return _MONITOR_MD.read_text(encoding="utf-8")
 
 
-# ── 10 canonical families ──────────────────────────────────────────────────
+# ── 10 canonical families + 1 operational (AC1) ─────────────────────────────
 
 class TestCanonicalEmitFamilies:
-    """Every family must have at least one concrete echo/emit point in monitor.md."""
+    """Every family must have at least one concrete emit point in monitor.md.
+
+    Spec (AC1): `monitor.tick` may use `echo` direct (passo 5.5 unchanged);
+    `monitor.audit_pvc_fail` is the fallback inside `_emit` itself and may be a
+    literal `echo`. Every other family must use the `_emit "monitor.<family>`
+    helper so the call duplicates to stdout + PVC.
+    """
 
     def test_monitor_tick_present(self, monitor_content):
-        """monitor.tick — already existed; must not have been removed."""
+        """monitor.tick — echo direct in passo 5.5 (preserved)."""
         assert 'echo "monitor.tick' in monitor_content
 
     def test_monitor_action_present(self, monitor_content):
-        """monitor.action — one per autonomous corrective action."""
-        assert 'echo "monitor.action' in monitor_content
+        assert '_emit "monitor.action' in monitor_content
 
     def test_monitor_notify_present(self, monitor_content):
-        """monitor.notify — one per notification sent or logged."""
-        assert 'echo "monitor.notify' in monitor_content
+        assert '_emit "monitor.notify' in monitor_content
 
     def test_monitor_command_present(self, monitor_content):
-        """monitor.command — one per steer command processed."""
-        assert 'echo "monitor.command' in monitor_content
+        assert '_emit "monitor.command' in monitor_content
 
     def test_monitor_vigia_skip_present(self, monitor_content):
-        """monitor.vigia.skip — one per vigia entering SKIPPED."""
-        assert 'echo "monitor.vigia.skip' in monitor_content
+        assert '_emit "monitor.vigia.skip' in monitor_content
 
     def test_monitor_vigia_fix_present(self, monitor_content):
-        """monitor.vigia.fix — one per vigia completing autonomous cure."""
-        assert "monitor.vigia.fix" in monitor_content
+        assert '_emit "monitor.vigia.fix' in monitor_content
 
     def test_monitor_v8_scan_present(self, monitor_content):
-        """monitor.v8.scan — emitted at end of V8 scan."""
-        assert 'echo "monitor.v8.scan' in monitor_content
+        assert '_emit "monitor.v8.scan' in monitor_content
 
     def test_monitor_v8_create_present(self, monitor_content):
-        """monitor.v8.create — one per FU issue created by V8."""
-        assert 'echo "monitor.v8.create' in monitor_content
+        assert '_emit "monitor.v8.create' in monitor_content
 
     def test_monitor_v8_skip_present(self, monitor_content):
-        """monitor.v8.skip — one per V8 candidate discarded by anti-FP."""
-        assert 'echo "monitor.v8.skip' in monitor_content
+        assert '_emit "monitor.v8.skip' in monitor_content
 
     def test_monitor_flood_cap_present(self, monitor_content):
-        """monitor.flood_cap — emitted when notify/fu cap is reached."""
-        assert 'echo "monitor.flood_cap' in monitor_content
+        assert '_emit "monitor.flood_cap' in monitor_content
 
 
 # ── Operational event ──────────────────────────────────────────────────────
 
 class TestAuditPvcFail:
-    """monitor.audit_pvc_fail must be documented as the PVC-failure fallback."""
+    """monitor.audit_pvc_fail must be documented as the PVC-failure fallback,
+    living inside the `_emit` helper itself (one literal `echo` is enough)."""
 
     def test_audit_pvc_fail_present(self, monitor_content):
         assert "monitor.audit_pvc_fail" in monitor_content
 
     def test_audit_pvc_fail_has_emit(self, monitor_content):
-        """Must include an actual echo call, not just a mention in prose."""
+        """Must include an actual echo call inside `_emit`, not just a mention in prose."""
         assert 'echo "monitor.audit_pvc_fail' in monitor_content
+
+    def test_audit_pvc_fail_canonical_fields(self, monitor_content):
+        """Spec requires `reason='write failed' errno=<código> tick=#<n>`."""
+        pattern = re.compile(
+            r"echo \"monitor\.audit_pvc_fail reason='write failed' errno=\$\{_?errno\} tick=#\$\{TICK_N",
+            re.IGNORECASE,
+        )
+        assert pattern.search(monitor_content), (
+            "monitor.audit_pvc_fail must follow canonical schema "
+            "`reason='write failed' errno=<código> tick=#<n>`"
+        )
 
 
 # ── Schema section ─────────────────────────────────────────────────────────
@@ -111,11 +124,9 @@ class TestSchemaSection:
             assert family in monitor_content, f"Family '{family}' missing from monitor.md"
 
     def test_additive_only_note_present(self, monitor_content):
-        """The additive-only constraint must be documented."""
         assert "additive-only" in monitor_content
 
     def test_audit_pvc_fail_invariant_documented(self, monitor_content):
-        """The stream-invariant for audit_pvc_fail must be described."""
         assert "Invariante de stream" in monitor_content or "invariant" in monitor_content.lower()
 
 
@@ -137,7 +148,230 @@ class TestFloodCapCoverage:
     """Both notify and fu kinds must have flood_cap emit documented."""
 
     def test_flood_cap_notify_kind(self, monitor_content):
-        assert "kind=notify" in monitor_content or "kind=<notify" in monitor_content
+        assert "kind=notify" in monitor_content
 
     def test_flood_cap_fu_kind(self, monitor_content):
-        assert "kind=fu" in monitor_content or "kind=<notify\\|fu>" in monitor_content
+        assert "kind=fu" in monitor_content
+
+
+# ── AC2 — `_emit` helper defined & widely used ─────────────────────────────
+
+class TestEmitHelper:
+    """AC2: `_emit` must be defined with the spec body AND used in ≥10 places."""
+
+    def test_emit_defined(self, monitor_content):
+        """`_emit() {` definition must appear in the body of monitor.md."""
+        assert "_emit() {" in monitor_content, (
+            "monitor.md must define the `_emit()` bash helper per spec §AC2"
+        )
+
+    def test_emit_truncates_to_500_chars(self, monitor_content):
+        """Spec rule 4: linha total máxima 500 chars (cortada por `_emit`)."""
+        assert '"${line:0:500}"' in monitor_content, (
+            "_emit must truncate the line to 500 chars (rule 4)"
+        )
+
+    def test_emit_strips_control_chars(self, monitor_content):
+        """Spec rule 3: strip de \\n, \\r, \\t (single-line invariant)."""
+        for ctrl in ("$'\\n'", "$'\\r'", "$'\\t'"):
+            assert ctrl in monitor_content, (
+                f"_emit must strip control char {ctrl!r} from values (rule 3)"
+            )
+
+    def test_emit_writes_stdout_first(self, monitor_content):
+        """Spec rule 6: PRIMEIRO echo no stdout, DEPOIS printf no PVC."""
+        # The function body must echo before printf-to-PVC; check structural order
+        emit_body = re.search(
+            r"_emit\(\)\s*\{([\s\S]+?)^\}",
+            monitor_content,
+            re.MULTILINE,
+        )
+        assert emit_body, "could not locate `_emit()` body"
+        body = emit_body.group(1)
+        echo_idx = body.find('echo "$line"')
+        printf_idx = body.find("printf")
+        assert echo_idx != -1 and printf_idx != -1, (
+            "_emit body must contain both `echo \"$line\"` and `printf`"
+        )
+        assert echo_idx < printf_idx, (
+            "stdout-first invariant: `echo` must run before `printf` to PVC (rule 6)"
+        )
+
+    def test_emit_pvc_fallback_emits_audit_pvc_fail(self, monitor_content):
+        """Spec rule 6: on PVC write failure, emit `monitor.audit_pvc_fail` once per tick."""
+        emit_body = re.search(
+            r"_emit\(\)\s*\{([\s\S]+?)^\}",
+            monitor_content,
+            re.MULTILINE,
+        )
+        assert emit_body
+        body = emit_body.group(1)
+        assert "PVC_FAIL_EMITTED" in body, (
+            "_emit must guard the audit_pvc_fail echo with PVC_FAIL_EMITTED flag"
+        )
+        assert "monitor.audit_pvc_fail" in body, (
+            "_emit must emit monitor.audit_pvc_fail on PVC write failure"
+        )
+
+    def test_emit_used_at_least_10_times(self, monitor_content):
+        """AC2: `grep -c '_emit ' monitor.md` ≥ 10."""
+        count = len(re.findall(r"\b_emit ", monitor_content))
+        assert count >= 10, (
+            f"_emit must be invoked at ≥10 emit points (AC2); found {count}"
+        )
+
+    def test_tick_flags_reset_in_step_1(self, monitor_content):
+        """Spec §Helper bash: PVC_FAIL_EMITTED / FLOOD_CAP_EMITTED_* reset at start of tick."""
+        for flag in ("PVC_FAIL_EMITTED=0", "FLOOD_CAP_EMITTED_NOTIFY=0", "FLOOD_CAP_EMITTED_FU=0"):
+            assert flag in monitor_content, (
+                f"per-tick flag reset `{flag}` must appear (step 1 of tick loop)"
+            )
+
+
+# ── AC15 — V=V<n> token enforcement ────────────────────────────────────────
+
+class TestVigiaTokenConvention:
+    """AC15: every `monitor.action` / `monitor.vigia.{skip,fix}` emit must carry V=V<n>."""
+
+    _VIGIA_FAMILY_RE = re.compile(
+        r'^[^#\n]*_emit "(monitor\.(?:action|vigia\.(?:skip|fix))) ([^"]*)"',
+        re.MULTILINE,
+    )
+
+    def test_every_vigia_originated_emit_carries_v_token(self, monitor_content):
+        """Each concrete `_emit "monitor.<vigia-family> ..."` line must include V=V<n>."""
+        offenders: list[str] = []
+        for match in self._VIGIA_FAMILY_RE.finditer(monitor_content):
+            family, payload = match.group(1), match.group(2)
+            # Accept either:
+            #   `V=V<digit>` literal (e.g. V=V1)
+            #   `V=V<n>` placeholder in patterns / examples
+            #   `V=${var}` bash-substituted vigia loop var (resolves to V1/V2/... at runtime)
+            if not re.search(r"V=(V[1-9]|V<n>|V<\$|\$\{)", payload):
+                offenders.append(f"{family}: {payload[:80]}")
+        assert not offenders, (
+            "monitor.action / monitor.vigia.* emit points must include `V=V<n>` (AC15). "
+            "Offenders:\n" + "\n".join(offenders)
+        )
+
+    def test_no_legacy_vigia_eq_token(self, monitor_content):
+        """The legacy `vigia=V<n>` token must be gone in active emit lines (AC15).
+
+        We allow it only inside the canonical-table example column (rendered with
+        the `vigia=` literal as a *forbidden* form) — but no `_emit` call should
+        produce a `vigia=V<n>` field.
+        """
+        offenders = re.findall(r'_emit "[^"]*\bvigia=V[1-9][^"]*"', monitor_content)
+        assert not offenders, (
+            "Legacy `vigia=V<n>` token must not appear in emit lines; use `V=V<n>` "
+            "(AC15). Offenders:\n" + "\n".join(offenders)
+        )
+
+
+# ── AC13 — monitor.command schema ───────────────────────────────────────────
+
+class TestCommandSchema:
+    """AC13 / §Lista fechada de kind=: monitor.command uses `from=`/`kind=` not `cmd=`."""
+
+    def test_command_uses_from_kind_not_cmd(self, monitor_content):
+        """Spec: `monitor.command from=<bot|auto> kind=<...> ok=...` — never `cmd=`."""
+        offenders = re.findall(
+            r'_emit "monitor\.command [^"]*\bcmd=', monitor_content
+        )
+        assert not offenders, (
+            "`monitor.command` must use `from=...` + `kind=...` (spec §Lista fechada de kind=), "
+            "not the legacy `cmd=` field. Offenders:\n" + "\n".join(offenders)
+        )
+
+    def test_command_has_from_field(self, monitor_content):
+        assert re.search(r'_emit "monitor\.command from=', monitor_content), (
+            "monitor.command emit must start with `from=<bot|auto>`"
+        )
+
+    def test_command_unknown_branch_documented(self, monitor_content):
+        """AC13: malformed commands → kind=unknown with ok=false."""
+        assert re.search(
+            r'_emit "monitor\.command [^"]*kind=unknown[^"]*ok=false',
+            monitor_content,
+        ), "Spec §Lista fechada / AC13 requires a `kind=unknown ok=false` emit example"
+
+
+# ── monitor.v8.skip reason enum ─────────────────────────────────────────────
+
+class TestV8SkipReasonEnum:
+    """Spec §Lista fechada de reason= for monitor.v8.skip:
+    bot_author | code_block | already_tracked | fingerprint_seen | daily_cap | per_tick_cap.
+    `similar_title` was removed; `author_bot` was renamed to `bot_author`.
+    """
+
+    def test_canonical_reasons_documented(self, monitor_content):
+        for reason in (
+            "bot_author",
+            "code_block",
+            "already_tracked",
+            "fingerprint_seen",
+            "daily_cap",
+            "per_tick_cap",
+        ):
+            assert reason in monitor_content, (
+                f"v8.skip reason `{reason}` must be documented in monitor.md"
+            )
+
+    def test_legacy_author_bot_removed(self, monitor_content):
+        """`author_bot` (legacy) must not appear as the documented v8.skip reason
+        — the spec renamed it to `bot_author`."""
+        # Allow the substring inside other words (e.g. in prose), but not as
+        # an emit-field value `reason=author_bot`.
+        offenders = re.findall(r"reason=author_bot\b", monitor_content)
+        assert not offenders, (
+            "Legacy `reason=author_bot` must be replaced with `reason=bot_author`"
+        )
+
+    def test_legacy_similar_title_removed(self, monitor_content):
+        offenders = re.findall(r"reason=similar_title\b", monitor_content)
+        assert not offenders, (
+            "Legacy `reason=similar_title` must be removed (not in spec enum)"
+        )
+
+
+# ── monitor.notify ok= field ────────────────────────────────────────────────
+
+class TestNotifyHasOkField:
+    def test_notify_emit_has_ok(self, monitor_content):
+        """Spec table + AC8: monitor.notify emit must include `ok=`."""
+        match = re.search(r'_emit "monitor\.notify [^"]*"', monitor_content)
+        assert match, "monitor.notify _emit line not found"
+        assert "ok=" in match.group(0), (
+            "monitor.notify emit must include `ok=<true|false>` (spec §Vocabulário canônico)"
+        )
+
+
+# ── V1 OAuth — Rule 5 (no secret leak) ──────────────────────────────────────
+
+class TestV1SecretSuppression:
+    """AC4 / spec rule 5: V1 OAuth must redirect stdout/stderr away."""
+
+    def test_v1_oauth_redirects_stdout(self, monitor_content):
+        """The OAuth login command must include `>/dev/null 2>&1` to suppress token leak."""
+        # Locate the V1 section roughly; we look for `claude auth login` and confirm a
+        # redirect is in scope.
+        match = re.search(
+            r"claude auth login[^\n]*>/dev/null 2>&1",
+            monitor_content,
+        )
+        assert match, (
+            "V1 OAuth renew must redirect stdout/stderr with `>/dev/null 2>&1` "
+            "(spec rule 5 / AC4: never echo token)"
+        )
+
+    def test_rule5_documented_in_schema_section(self, monitor_content):
+        """The 8 schema-line rules must be documented (rule 5 = no secret leak)."""
+        assert "Sem segredos" in monitor_content, (
+            "Spec rule 5 (`Sem segredos`) must be written into the schema section"
+        )
+
+    def test_schema_rules_block_present(self, monitor_content):
+        """The block of 8 rules ('Regras de codificação da linha') must be in the persona."""
+        assert "Regras de codificação da linha" in monitor_content, (
+            "The 8 schema-line rules must appear under a `Regras de codificação` heading"
+        )

--- a/deile/tests/personas/test_monitor_emit_schema.py
+++ b/deile/tests/personas/test_monitor_emit_schema.py
@@ -1,0 +1,143 @@
+"""AC1 for issue #439 — monitor.md must contain at least one emit point for each
+of the 10 canonical event families + the audit_pvc_fail operational event.
+
+These tests verify the STABLE CONTRACT consumed by #436 (ACTIVITY widget) and
+#440 (monitor-audit parser).  They do NOT test LLM behaviour — they test that
+the persona instruction file documents every required family so the model knows
+to emit it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_MONITOR_MD = (
+    Path(__file__).parent.parent.parent  # deile/
+    / "personas"
+    / "instructions"
+    / "monitor.md"
+)
+
+
+@pytest.fixture(scope="module")
+def monitor_content() -> str:
+    assert _MONITOR_MD.exists(), f"monitor.md not found at {_MONITOR_MD}"
+    return _MONITOR_MD.read_text(encoding="utf-8")
+
+
+# ── 10 canonical families ──────────────────────────────────────────────────
+
+class TestCanonicalEmitFamilies:
+    """Every family must have at least one concrete echo/emit point in monitor.md."""
+
+    def test_monitor_tick_present(self, monitor_content):
+        """monitor.tick — already existed; must not have been removed."""
+        assert 'echo "monitor.tick' in monitor_content
+
+    def test_monitor_action_present(self, monitor_content):
+        """monitor.action — one per autonomous corrective action."""
+        assert 'echo "monitor.action' in monitor_content
+
+    def test_monitor_notify_present(self, monitor_content):
+        """monitor.notify — one per notification sent or logged."""
+        assert 'echo "monitor.notify' in monitor_content
+
+    def test_monitor_command_present(self, monitor_content):
+        """monitor.command — one per steer command processed."""
+        assert 'echo "monitor.command' in monitor_content
+
+    def test_monitor_vigia_skip_present(self, monitor_content):
+        """monitor.vigia.skip — one per vigia entering SKIPPED."""
+        assert 'echo "monitor.vigia.skip' in monitor_content
+
+    def test_monitor_vigia_fix_present(self, monitor_content):
+        """monitor.vigia.fix — one per vigia completing autonomous cure."""
+        assert "monitor.vigia.fix" in monitor_content
+
+    def test_monitor_v8_scan_present(self, monitor_content):
+        """monitor.v8.scan — emitted at end of V8 scan."""
+        assert 'echo "monitor.v8.scan' in monitor_content
+
+    def test_monitor_v8_create_present(self, monitor_content):
+        """monitor.v8.create — one per FU issue created by V8."""
+        assert 'echo "monitor.v8.create' in monitor_content
+
+    def test_monitor_v8_skip_present(self, monitor_content):
+        """monitor.v8.skip — one per V8 candidate discarded by anti-FP."""
+        assert 'echo "monitor.v8.skip' in monitor_content
+
+    def test_monitor_flood_cap_present(self, monitor_content):
+        """monitor.flood_cap — emitted when notify/fu cap is reached."""
+        assert 'echo "monitor.flood_cap' in monitor_content
+
+
+# ── Operational event ──────────────────────────────────────────────────────
+
+class TestAuditPvcFail:
+    """monitor.audit_pvc_fail must be documented as the PVC-failure fallback."""
+
+    def test_audit_pvc_fail_present(self, monitor_content):
+        assert "monitor.audit_pvc_fail" in monitor_content
+
+    def test_audit_pvc_fail_has_emit(self, monitor_content):
+        """Must include an actual echo call, not just a mention in prose."""
+        assert 'echo "monitor.audit_pvc_fail' in monitor_content
+
+
+# ── Schema section ─────────────────────────────────────────────────────────
+
+class TestSchemaSection:
+    """The canonical vocabulary table must be present."""
+
+    def test_schema_section_heading(self, monitor_content):
+        assert "Emissão estruturada no stdout" in monitor_content
+
+    def test_schema_table_has_all_families(self, monitor_content):
+        """The vocabulary table must list every family."""
+        for family in (
+            "monitor.tick",
+            "monitor.action",
+            "monitor.notify",
+            "monitor.command",
+            "monitor.vigia.skip",
+            "monitor.vigia.fix",
+            "monitor.v8.scan",
+            "monitor.v8.create",
+            "monitor.v8.skip",
+            "monitor.flood_cap",
+            "monitor.audit_pvc_fail",
+        ):
+            assert family in monitor_content, f"Family '{family}' missing from monitor.md"
+
+    def test_additive_only_note_present(self, monitor_content):
+        """The additive-only constraint must be documented."""
+        assert "additive-only" in monitor_content
+
+    def test_audit_pvc_fail_invariant_documented(self, monitor_content):
+        """The stream-invariant for audit_pvc_fail must be described."""
+        assert "Invariante de stream" in monitor_content or "invariant" in monitor_content.lower()
+
+
+# ── K8s API unreachable path ────────────────────────────────────────────────
+
+class TestK8sUnreachableEmit:
+    """When K8s API is unreachable, vigia.skip must fire for all affected vigias."""
+
+    def test_v1_in_unreachable_skip_loop(self, monitor_content):
+        assert "V1" in monitor_content
+
+    def test_vigia_skip_reason_unreachable(self, monitor_content):
+        assert "K8S_API_UNREACHABLE" in monitor_content
+
+
+# ── Flood cap coverage ─────────────────────────────────────────────────────
+
+class TestFloodCapCoverage:
+    """Both notify and fu kinds must have flood_cap emit documented."""
+
+    def test_flood_cap_notify_kind(self, monitor_content):
+        assert "kind=notify" in monitor_content or "kind=<notify" in monitor_content
+
+    def test_flood_cap_fu_kind(self, monitor_content):
+        assert "kind=fu" in monitor_content or "kind=<notify\\|fu>" in monitor_content


### PR DESCRIPTION
## Resumo

Estende `deile/personas/instructions/monitor.md` para emitir **eventos estruturados no stdout** cobrindo todas as ações autônomas, notificações, comandos de steer e mudanças de estado de vigia. Trabalho é edit-only na persona (prompt-first total, princípio 1).

### O que foi adicionado

- **Nova seção `## Emissão estruturada no stdout (schema canônico)`** com tabela de vocabulário estável (additive-only), padrão de emit para ações autônomas, e o wrapper `_audit()` com fallback `monitor.audit_pvc_fail` para falhas de PVC.
- **Pontos de emit inline em cada seção relevante:**
  - V1 (OAuth): `monitor.action V=V1 kind=oauth_renew` + `monitor.vigia.fix vigia=V1`
  - V2 (Pods): `monitor.action V=V2 kind=delete_pod` + `monitor.vigia.fix vigia=V2`
  - V8 (FU tracking): `monitor.v8.scan`, `monitor.v8.create`, `monitor.v8.skip`, `monitor.flood_cap kind=fu`
  - Sistema de notificação: `monitor.notify` (inclui log-only) + `monitor.flood_cap kind=notify`
  - Controles de steer: `monitor.command`
  - Robustez / K8s_API_UNREACHABLE: loop emitindo `monitor.vigia.skip` para V1, V2, V6, V7

### Schema canônico (contrato estável — consumido por #436 e #440)

| Família | Exemplo |
|---|---|
| `monitor.tick` | `monitor.tick #45 done in 4s: actions=1 notify=0 skipped=[V6] anomalias=2` |
| `monitor.action` | `monitor.action V=V2 kind=delete_pod target=pod-xyz reason='BackoffLimitExceeded >1h' ok=true elapsed_s=1` |
| `monitor.notify` | `monitor.notify fingerprint=oauth_expired_pod-0 severity=P0 channel=dm msg_head=🔴 [DEILE-MONITOR]...` |
| `monitor.command` | `monitor.command cmd=pause arg=30m ok=true` |
| `monitor.vigia.skip` | `monitor.vigia.skip vigia=V1 reason=K8S_API_UNREACHABLE` |
| `monitor.vigia.fix` | `monitor.vigia.fix vigia=V1 kind=oauth_renew target=claude-worker-0 elapsed_s=3` |
| `monitor.v8.scan` | `monitor.v8.scan candidates=4 created=1 skipped=2 capped=false` |
| `monitor.v8.create` | `monitor.v8.create new_issue=441 origin=439/comment12345` |
| `monitor.v8.skip` | `monitor.v8.skip origin=438/comment99 reason=already_tracked` |
| `monitor.flood_cap` | `monitor.flood_cap kind=notify fingerprint=orphan_issue_420` |
| `monitor.audit_pvc_fail` | `monitor.audit_pvc_fail err=write /state/monitor-audit.log: no space left` |

### Testes

Adiciona `deile/tests/personas/test_monitor_emit_schema.py` com 20 AC1 checks verificando que todas as famílias têm pontos de emit na persona.

### Consumidores existentes não afetados

`infra/k8s/_panel_monitor.py` usa regex `\bV([1-7])\b` + `"ACTION"` em caixa alta sobre `monitor-audit.log` no PVC. O novo formato (`monitor.action` em minúsculo, com `V=<vigia>` em campo chave) **regride essa heurística** — migração cobre-se em **#440** (lateral, separada para honrar prompt-first total aqui).

Closes #439.