### PR TITLE
feat(claude-worker): --output-format stream-json + StreamState incremental parser

### DIFF
--- a/deile/tests/infrastructure/test_claude_worker_server.py
+++ b/deile/tests/infrastructure/test_claude_worker_server.py
@@ -267,10 +267,12 @@ async def test_dispatch_response_shape(
     — contrato consumido pelo ``deile-pipeline`` e pelo painel TUI."""
     import json as _json
     async def fake_run(args, *, cwd, task_id, timeout):
-        # Com --output-format json, stdout é UM JSON object (resultado final).
+        # Com --output-format stream-json, stdout é NDJSON; o evento "result"
+        # é o último e é o que _parse_claude_json_output extrai.
         out = _json.dumps({
-            "is_error": False, "result": "ok", "session_id": "abc-123",
-            "total_cost_usd": 0.05, "duration_ms": 42000, "num_turns": 3,
+            "type": "result", "is_error": False, "result": "ok",
+            "session_id": "abc-123", "total_cost_usd": 0.05,
+            "duration_ms": 42000, "num_turns": 3,
         })
         return claude_worker_module.SubprocessResult(
             returncode=0, stdout=out, stderr="", duration_seconds=42.0,
@@ -639,14 +641,16 @@ async def test_dispatch_persists_session_metadata(
 async def test_dispatch_passes_session_id_flag_to_claude(
     claude_worker_module, monkeypatch, tmp_path,
 ):
-    """Fresh dispatch passa ``--session-id <uuid>`` e ``--output-format json``
-    pro claude CLI. Resume dispatch usa ``-r <session_id>`` em vez."""
+    """Fresh dispatch passa ``--session-id <uuid>`` e ``--output-format stream-json``
+    + ``--verbose`` pro claude CLI. Resume dispatch usa ``-r <session_id>`` em vez."""
     import json as _json
     captured = {}
 
     async def fake_run(args, *, cwd, task_id, timeout):
         captured["args"] = list(args)
-        out = _json.dumps({"is_error": False, "result": "ok", "session_id": "x"})
+        out = _json.dumps({"type": "result", "is_error": False, "result": "ok",
+                           "session_id": "x", "total_cost_usd": 0.0,
+                           "duration_ms": 0, "num_turns": 1})
         return claude_worker_module.SubprocessResult(0, out, "", 1.0)
 
     monkeypatch.setattr(claude_worker_module, "run_subprocess_with_progress", fake_run)
@@ -668,7 +672,8 @@ async def test_dispatch_passes_session_id_flag_to_claude(
     assert args[sid_idx + 1] == body["session_id"]
     assert "--output-format" in args
     fmt_idx = args.index("--output-format")
-    assert args[fmt_idx + 1] == "json"
+    assert args[fmt_idx + 1] == "stream-json"
+    assert "--verbose" in args
     # fresh dispatch NÃO usa -r.
     assert "-r" not in args
 
@@ -2115,3 +2120,261 @@ async def test_dispatch_409_lease_conflict_emits_dispatch_failed(
     assert len(failed) == 1, f"expected exactly one dispatch.failed, got {msgs}"
     assert "error_code=TASK_ALREADY_RUNNING" in failed[0]
     assert "reason=lease_conflict" in failed[0]
+
+
+# --------------------------------------------------------------------------- #
+# Issue #442: StreamState — stream-json incremental parser
+# --------------------------------------------------------------------------- #
+
+
+def test_stream_state_ingest_assistant_increments_turn_and_tokens(
+    claude_worker_module,
+):
+    """``assistant`` event increments turn counter and accumulates token usage."""
+    state = claude_worker_module.StreamState()
+    event = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "usage": {"input_tokens": 150, "output_tokens": 80},
+            "content": [],
+        },
+    }
+    state.ingest(event)
+    assert state.turn == 1
+    assert state.tokens_in == 150
+    assert state.tokens_out == 80
+
+
+def test_stream_state_ingest_multiple_turns_accumulates(claude_worker_module):
+    """Multiple ``assistant`` events accumulate turn count and tokens."""
+    state = claude_worker_module.StreamState()
+    for i in range(3):
+        state.ingest({
+            "type": "assistant",
+            "message": {
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+                "content": [],
+            },
+        })
+    assert state.turn == 3
+    assert state.tokens_in == 300
+    assert state.tokens_out == 150
+
+
+def test_stream_state_ingest_tracks_last_tool_use(claude_worker_module):
+    """Tool use blocks inside ``assistant`` content update ``tool_last``."""
+    state = claude_worker_module.StreamState()
+    state.ingest({
+        "type": "assistant",
+        "message": {
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "content": [
+                {"type": "tool_use", "name": "bash", "id": "t1"},
+                {"type": "tool_use", "name": "read_file", "id": "t2"},
+            ],
+        },
+    })
+    # Last tool_use block wins.
+    assert state.tool_last == "read_file"
+
+
+def test_stream_state_ingest_result_event_populates_final_fields(
+    claude_worker_module,
+):
+    """``result`` event populates is_error, result, total_cost_usd, etc."""
+    state = claude_worker_module.StreamState()
+    state.ingest({
+        "type": "result",
+        "is_error": False,
+        "result": "STATUS: SUCCESS",
+        "session_id": "sess-abc",
+        "total_cost_usd": 0.137,
+        "num_turns": 5,
+        "duration_ms": 60000,
+    })
+    assert state.is_error is False
+    assert state.result == "STATUS: SUCCESS"
+    assert state.session_id == "sess-abc"
+    assert state.total_cost_usd == 0.137
+    assert state.num_turns == 5
+    assert state._has_result is True
+
+
+def test_stream_state_default_is_error_true_before_result(claude_worker_module):
+    """Before any ``result`` event, ``is_error`` defaults to True (conservative)."""
+    state = claude_worker_module.StreamState()
+    assert state.is_error is True
+    assert state._has_result is False
+
+
+def test_stream_state_ingest_system_init_captures_session_id(claude_worker_module):
+    """``system/init`` event populates ``session_id`` early (before result event)."""
+    state = claude_worker_module.StreamState()
+    state.ingest({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "early-session-id",
+    })
+    assert state.session_id == "early-session-id"
+
+
+def test_stream_state_non_json_rolling_buffer_caps_at_8kib(claude_worker_module):
+    """Non-JSON buffer evicts oldest lines when cap (8 KiB) is exceeded."""
+    state = claude_worker_module.StreamState()
+    # Add lines totaling > 8 KiB.
+    line = "x" * 1000 + "\n"  # ~1 KiB per line
+    for _ in range(10):
+        state.add_non_json(line)
+    assert state._non_json_bytes <= 8 * 1024
+    # The buffer should still have content.
+    assert len(state.non_json_tail) > 0
+
+
+def test_stream_state_to_final_dict_shape(claude_worker_module):
+    """``to_final_dict`` matches the shape of ``_parse_claude_json_output``."""
+    state = claude_worker_module.StreamState()
+    state.ingest({
+        "type": "result",
+        "is_error": False,
+        "result": "done",
+        "session_id": "sid-xyz",
+        "total_cost_usd": 0.05,
+        "num_turns": 2,
+        "duration_ms": 10000,
+    })
+    d = state.to_final_dict()
+    assert d["is_error"] is False
+    assert d["result"] == "done"
+    assert d["session_id"] == "sid-xyz"
+    assert d["total_cost_usd"] == 0.05
+    assert d["num_turns"] == 2
+    assert "duration_ms" in d
+
+
+# --------------------------------------------------------------------------- #
+# Issue #442: cross-format equivalence fixture
+# Verifies that stream-json NDJSON and legacy json produce the same final
+# fields when processed by _parse_claude_json_output.
+# --------------------------------------------------------------------------- #
+
+
+def test_cross_format_equivalence_stream_json_vs_json(claude_worker_module):
+    """Fields from ``--output-format stream-json`` NDJSON match those from
+    ``--output-format json`` single-object output via ``_parse_claude_json_output``.
+
+    This is the fixture the issue calls for: same is_error, result,
+    session_id, total_cost_usd, num_turns regardless of which format the
+    CLI was invoked with.
+    """
+    parse = claude_worker_module._parse_claude_json_output
+
+    # --- stream-json format (NDJSON: multiple events, result is last) ---
+    stream_json_stdout = "\n".join([
+        '{"type":"system","subtype":"init","session_id":"sess-42","cwd":"/work"}',
+        '{"type":"assistant","message":{"usage":{"input_tokens":200,"output_tokens":100},"content":[]}}',
+        '{"type":"user","message":{"role":"user","content":"ok"}}',
+        '{"type":"result","is_error":false,"result":"Review completed",'
+        '"session_id":"sess-42","total_cost_usd":0.21,"num_turns":3,"duration_ms":30000}',
+    ])
+
+    # --- legacy json format (single JSON object on stdout) ---
+    json_stdout = (
+        '{"is_error":false,"result":"Review completed",'
+        '"session_id":"sess-42","total_cost_usd":0.21,"num_turns":3,"duration_ms":30000}'
+    )
+
+    result_stream = parse(stream_json_stdout)
+    result_json = parse(json_stdout)
+
+    # Core fields must be identical.
+    for field in ("is_error", "result", "session_id", "total_cost_usd", "num_turns"):
+        assert result_stream[field] == result_json[field], (
+            f"Mismatch for field '{field}': "
+            f"stream-json={result_stream[field]!r} vs json={result_json[field]!r}"
+        )
+
+
+def test_cross_format_equivalence_with_is_error_true(claude_worker_module):
+    """Cross-format equivalence for error case (is_error=true)."""
+    parse = claude_worker_module._parse_claude_json_output
+
+    stream_json_stdout = "\n".join([
+        '{"type":"system","subtype":"init","session_id":"err-sess"}',
+        '{"type":"result","is_error":true,"result":"Not logged in",'
+        '"session_id":"err-sess","total_cost_usd":0.0,"num_turns":1,"duration_ms":100}',
+    ])
+    json_stdout = (
+        '{"is_error":true,"result":"Not logged in",'
+        '"session_id":"err-sess","total_cost_usd":0.0,"num_turns":1,"duration_ms":100}'
+    )
+
+    result_stream = parse(stream_json_stdout)
+    result_json = parse(json_stdout)
+
+    for field in ("is_error", "result", "session_id", "total_cost_usd", "num_turns"):
+        assert result_stream[field] == result_json[field]
+
+
+async def test_run_subprocess_with_progress_uses_incremental_reader(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """``run_subprocess_with_progress`` reads stdout line-by-line and parses
+    NDJSON events, returning the concatenated stdout in the result."""
+    import asyncio as _asyncio
+
+    # Simulate a subprocess that emits stream-json NDJSON line-by-line.
+    ndjson_lines = [
+        '{"type":"system","subtype":"init","session_id":"sid-streaming"}\n',
+        '{"type":"assistant","message":{"usage":{"input_tokens":50,"output_tokens":25},"content":[]}}\n',
+        '{"type":"result","is_error":false,"result":"done","session_id":"sid-streaming",'
+        '"total_cost_usd":0.01,"num_turns":1,"duration_ms":5000}\n',
+    ]
+
+    class _FakeProc:
+        returncode = 0
+
+        class _FakeStream:
+            def __init__(self, lines):
+                self._lines = [l.encode() for l in lines] + [b""]
+
+            async def readline(self):
+                return self._lines.pop(0) if self._lines else b""
+
+            async def read(self, n):
+                return b""
+
+        def __init__(self):
+            self.stdout = self._FakeStream(ndjson_lines)
+            self.stderr = self._FakeStream([])
+
+        async def wait(self):
+            pass
+
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        claude_worker_module.asyncio,
+        "create_subprocess_exec",
+        lambda *a, **kw: _make_coro(_FakeProc()),
+    )
+
+    async def _make_coro(v):
+        return v
+
+    monkeypatch.setattr(
+        claude_worker_module.asyncio,
+        "create_subprocess_exec",
+        lambda *a, **kw: _make_coro(_FakeProc()),
+    )
+
+    result = await claude_worker_module.run_subprocess_with_progress(
+        ["claude", "-p"],
+        cwd=tmp_path,
+        task_id="abcdef0123456789",
+        timeout=60,
+    )
+
+    # All NDJSON lines are concatenated in stdout.
+    assert "sid-streaming" in result.stdout
+    assert result.returncode == 0
+    assert result.duration_seconds >= 0

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -707,6 +707,89 @@ class SubprocessResult:
     duration_seconds: float
 
 
+class StreamState:
+    """Accumulates ``claude -p --output-format stream-json`` events.
+
+    Tracks mid-flight progress fields (``turn``, ``tool_last``,
+    ``tokens_in``, ``tokens_out``) and extracts the final result
+    for equivalence with ``--output-format json`` output.
+    """
+
+    _NON_JSON_CAP = 8 * 1024  # 8 KiB rolling cap
+
+    def __init__(self) -> None:
+        # Mid-flight snapshot
+        self.turn: int = 0
+        self.tool_last: str = ""
+        self.tokens_in: int = 0
+        self.tokens_out: int = 0
+        # Final result fields (from "result" event)
+        self.is_error: bool = True
+        self.result: str = ""
+        self.total_cost_usd: float = 0.0
+        self.num_turns: int = 0
+        self.session_id: str = ""
+        self._has_result: bool = False
+        # Rolling non-JSON buffer
+        self._non_json_lines: list = []
+        self._non_json_bytes: int = 0
+
+    def ingest(self, event: dict) -> None:
+        """Process one NDJSON event from stream-json output."""
+        etype = event.get("type", "")
+        if etype == "assistant":
+            msg = event.get("message", {})
+            if isinstance(msg, dict):
+                usage = msg.get("usage", {})
+                if isinstance(usage, dict):
+                    self.tokens_in += int(usage.get("input_tokens", 0) or 0)
+                    self.tokens_out += int(usage.get("output_tokens", 0) or 0)
+                content = msg.get("content", [])
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            name = block.get("name")
+                            if name:
+                                self.tool_last = str(name)
+            self.turn += 1
+        elif etype == "result":
+            self._has_result = True
+            self.is_error = bool(event.get("is_error", False))
+            self.result = str(event.get("result", "") or "")
+            self.total_cost_usd = float(event.get("total_cost_usd", 0) or 0)
+            self.num_turns = int(event.get("num_turns", 0) or 0)
+            self.session_id = str(event.get("session_id", "") or "")
+        elif etype == "system" and event.get("subtype") == "init":
+            sid = event.get("session_id")
+            if sid:
+                self.session_id = str(sid)
+
+    def add_non_json(self, line: str) -> None:
+        """Add a non-JSON line to the rolling buffer (cap 8 KiB)."""
+        encoded = line.encode("utf-8", "replace")
+        while (self._non_json_bytes + len(encoded) > self._NON_JSON_CAP
+               and self._non_json_lines):
+            removed = self._non_json_lines.pop(0)
+            self._non_json_bytes -= len(removed.encode("utf-8", "replace"))
+        self._non_json_lines.append(line)
+        self._non_json_bytes += len(encoded)
+
+    @property
+    def non_json_tail(self) -> str:
+        return "".join(self._non_json_lines)
+
+    def to_final_dict(self) -> dict:
+        """Fields equivalent to ``_parse_claude_json_output`` output."""
+        return {
+            "is_error": self.is_error,
+            "result": self.result,
+            "session_id": self.session_id,
+            "total_cost_usd": self.total_cost_usd,
+            "duration_ms": 0,
+            "num_turns": self.num_turns,
+        }
+
+
 #: Preambles por stage. Cada um descreve identidade + contrato de output, com
 #: placeholders ``$BRANCH``/``$TASK_ID`` substituídos por
 #: :func:`_render_preamble` antes do exec.
@@ -783,13 +866,16 @@ async def run_subprocess_with_progress(
     timeout: int,
     lease_path: Optional[Path] = None,
 ) -> SubprocessResult:
-    """Spawn de ``claude -p`` com persistência de stdout/stderr para o PVC.
+    """Spawn de ``claude -p`` com leitura incremental de NDJSON (stream-json).
 
     Os arquivos ``<task_id>.stdout.log``/``<task_id>.stderr.log`` ficam em
     ``DEILE_CLAUDE_WORKER_ROOT/.progress/`` e serão consumidos pelo
     ``/v1/progress/{task_id}`` (Task 14) para snapshot mid-flight no painel
     TUI. Em timeout, devolvemos ``returncode=124`` (convenção do ``coreutils
     timeout``) com mensagem em ``stderr``.
+
+    Dois readers concorrentes (stdout + stderr) via ``asyncio.gather`` +
+    ``asyncio.wait_for``; cancelamento propaga para ambos em timeout.
 
     Quando ``lease_path`` é informado, gravamos ``claude_pid`` no lease assim
     que o subprocess é spawnado e limpamos ao terminar — isso permite que um
@@ -800,7 +886,6 @@ async def run_subprocess_with_progress(
     """
     start = time.monotonic()
 
-    # Persistir progress files em DEILE_CLAUDE_WORKER_ROOT/.progress/.
     root = Path(os.environ.get("DEILE_CLAUDE_WORKER_ROOT", "/home/claude/work"))
     progress_dir = root / ".progress"
     progress_dir.mkdir(parents=True, exist_ok=True)
@@ -817,28 +902,61 @@ async def run_subprocess_with_progress(
     if lease_path is not None:
         await _update_lease_claude_pid(lease_path, proc.pid)
 
+    stream_state = StreamState()
+    _active_stream_states[task_id] = stream_state
+    stdout_lines: list = []
+    stderr_chunks: list = []
+
+    async def _read_stdout() -> None:
+        assert proc.stdout is not None
+        while True:
+            raw = await proc.stdout.readline()
+            if not raw:
+                break
+            line = raw.decode("utf-8", "replace")
+            stdout_lines.append(line)
+            stripped = line.strip()
+            if stripped:
+                try:
+                    stream_state.ingest(json.loads(stripped))
+                except json.JSONDecodeError:
+                    stream_state.add_non_json(line)
+
+    async def _read_stderr() -> None:
+        assert proc.stderr is not None
+        while True:
+            chunk = await proc.stderr.read(4096)
+            if not chunk:
+                break
+            stderr_chunks.append(chunk.decode("utf-8", "replace"))
+
     try:
-        stdout_b, stderr_b = await asyncio.wait_for(
-            proc.communicate(), timeout=timeout,
+        await asyncio.wait_for(
+            asyncio.gather(_read_stdout(), _read_stderr()),
+            timeout=timeout,
         )
+        await proc.wait()
     except asyncio.TimeoutError:
         proc.kill()
         await proc.wait()
         if lease_path is not None:
             await _update_lease_claude_pid(lease_path, None)
+        _active_stream_states.pop(task_id, None)
         duration = time.monotonic() - start
         return SubprocessResult(
-            returncode=124, stdout="",
+            returncode=124, stdout="".join(stdout_lines),
             stderr=f"claude -p timed out after {timeout}s",
             duration_seconds=duration,
         )
 
     duration = time.monotonic() - start
-    stdout = stdout_b.decode("utf-8", "replace")
-    stderr = stderr_b.decode("utf-8", "replace")
+    stdout = "".join(stdout_lines)
+    stderr = "".join(stderr_chunks)
 
     if lease_path is not None:
         await _update_lease_claude_pid(lease_path, None)
+
+    _active_stream_states.pop(task_id, None)
 
     # Persiste para o ``/v1/progress`` (Task 14) — best-effort; falha em
     # escrita NÃO derruba o dispatch (o cliente já recebeu o resultado).
@@ -2238,7 +2356,8 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     cmd = [
         claude_bin, "-p",
         "--permission-mode", "bypassPermissions",
-        "--output-format", "json",
+        "--output-format", "stream-json",
+        "--verbose",
     ]
     if is_resume:
         cmd.extend(["-r", session_id])

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -778,16 +778,27 @@ class StreamState:
     def non_json_tail(self) -> str:
         return "".join(self._non_json_lines)
 
-    def to_final_dict(self) -> dict:
+    def to_final_dict(self, duration_seconds: float = 0.0) -> dict:
         """Fields equivalent to ``_parse_claude_json_output`` output."""
         return {
             "is_error": self.is_error,
             "result": self.result,
             "session_id": self.session_id,
             "total_cost_usd": self.total_cost_usd,
-            "duration_ms": 0,
+            "duration_ms": int(duration_seconds * 1000),
             "num_turns": self.num_turns,
         }
+
+
+#: Active StreamState objects keyed by task_id. Populated while
+#: run_subprocess_with_progress is running; removed on completion.
+#: Allows /v1/progress and dispatch_logger to read mid-flight data.
+_active_stream_states: dict = {}
+
+
+def get_stream_state(task_id: str) -> "Optional[StreamState]":
+    """Return the active StreamState for task_id, or None if not running."""
+    return _active_stream_states.get(task_id)
 
 
 #: Preambles por stage. Cada um descreve identidade + contrato de output, com
@@ -2580,10 +2591,23 @@ async def progress_handler(request: web.Request) -> web.Response:
         logger.warning("failed to read %s: %s", stderr_path, exc)
         stderr = ""
 
+    ss = get_stream_state(task_id)
+    stream_snapshot = (
+        {
+            "turn": ss.turn,
+            "tool_last": ss.tool_last,
+            "tokens_in": ss.tokens_in,
+            "tokens_out": ss.tokens_out,
+        }
+        if ss is not None
+        else None
+    )
+
     return web.json_response({
         "task_id": task_id,
         "stdout": stdout[-50_000:],
         "stderr": stderr[-10_000:],
+        "stream_state": stream_snapshot,
     })
 
 


### PR DESCRIPTION
## Summary

- Migrates `claude_worker_server.py` from `--output-format json` (single emission on EOF) to `--output-format stream-json` (NDJSON, one event per line)
- Adds `StreamState` class that ingests NDJSON events from `stream-json` output, tracking mid-flight fields (`turn`, `tool_last`, `tokens_in`, `tokens_out`) and final result fields (`is_error`, `result`, `total_cost_usd`, `num_turns`, `session_id`)
- Replaces `proc.communicate()` in `run_subprocess_with_progress` with two concurrent async readers (`_read_stdout`/`_read_stderr`) via `asyncio.gather` + `asyncio.wait_for`, enabling incremental NDJSON parsing mid-flight
- Adds `--verbose` flag alongside `--output-format stream-json` (required by claude CLI to emit all events in `-p` mode)
- Cross-format equivalence of final fields preserved: `_parse_claude_json_output` already handles NDJSON by scanning reversed lines for the `result` event
- Tests: adds `StreamState` unit tests, cross-format fixture, and incremental reader integration test; fixes existing test that was asserting old `"json"` format

## Test plan

- [x] All 94 existing tests in `deile/tests/infrastructure/test_claude_worker_server.py` pass
- [x] New `StreamState` unit tests: turn/token accumulation, tool tracking, non-JSON buffer capping, result event population
- [x] Cross-format equivalence fixture verifies `_parse_claude_json_output` produces identical fields from stream-json NDJSON and legacy json format
- [x] Incremental reader test verifies `run_subprocess_with_progress` reads line-by-line

Closes #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)