### PR TITLE
chore(observability): fix 4 mistérios — ps vazio, pipeline silent, lease vs proc, PR órfã

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,16 @@ $K -n deile rollout status deployment/deile-pipeline --timeout=180s
 $K -n deile exec -it deploy/deile-shell -- python3 /app/wrapper.py deile   # interactive REPL in-cluster
 ```
 
+### Observability gotchas — what you see is NOT always reality
+
+The cluster has three traps that make a remote operator misread state:
+
+1. **`ps` was missing — fixed by installing `procps` in the image.** Earlier images shipped without `procps`, so `kubectl exec ... -- ps -ef` returned empty even with healthy processes. After rebuild, `ps`/`pgrep` work normally. If you hit an older image (pre-rebuild), use `cat /proc/*/cmdline | tr '\0' ' '; echo` directly — `/proc` is always mounted with the host PIDNS visible inside the container.
+
+2. **Pipeline logs are quiet when idle.** `kubectl logs deploy/deile-pipeline --tail=60` may look empty, but it is **not** silent in absolute terms — the monitor only emits per-poll-tick output and the rest is health probes that get evicted from short tails. Use `--tail=500` (or `--since=10m`) when investigating; the actual line you want is usually older than `--tail=60`. Pipeline buffering is unbuffered (`PYTHONUNBUFFERED=1` + tini reaps zombies properly), so a true silence-with-RUNNING state would mean either the process is deadlocked (rare) or you cut your tail too aggressively.
+
+3. **`.lease.json` mtime is NOT a liveness signal for `claude -p`.** The wrapper server runs a heartbeat task that re-writes `heartbeat_at` every 5 s while the pod is alive — independent of whether any `claude -p` subprocess is actually running. The lease's `pid` field is the **wrapper** PID (usually 1 or 7), not the claude subprocess. As of this PR, every active dispatch also writes a separate `claude_pid` field plus the `_find_active_lease` payload reports `claude_running` (`True` iff that `claude_pid` is currently alive). Always trust `claude_running` (or `pgrep -a claude`) — never the lease mtime.
+
 ### Roles & ports
 
 | Pod | Port | Role |

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # GitHub's own apt repo, added here with a signed keyring.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        tini git iputils-ping curl ca-certificates gnupg jq \
+        tini git iputils-ping curl ca-certificates gnupg jq procps \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/deile/orchestration/forge/base.py
+++ b/deile/orchestration/forge/base.py
@@ -681,6 +681,19 @@ class ForgeClient(ABC):
         Cached in ``self._config.default_branch`` after the first call.
         """
 
+    async def branch_exists(self, name: str) -> bool:
+        """Return True if ``name`` is a live ref on the remote, False otherwise.
+
+        Defensive default: returns ``True`` so that subclasses which do not
+        implement this never mark a PR as orphan-by-deleted-branch. Concrete
+        forges override with an authoritative API call.
+
+        Used by the pipeline to detect PRs whose head branch was force-deleted
+        on the remote — those PRs cannot be reviewed/merged and should be
+        flagged ``~workflow:bloqueada`` (Mistério #4 defensive guard).
+        """
+        return True
+
     # ------------------------------------------------------------------
     # Internal — subclasses implement label creation per forge
     # ------------------------------------------------------------------

--- a/deile/orchestration/forge/github_forge.py
+++ b/deile/orchestration/forge/github_forge.py
@@ -1172,5 +1172,31 @@ class GitHubForge(ForgeClient):
         self._config.default_branch = name
         return name
 
+    async def branch_exists(self, name: str) -> bool:
+        """Return True iff the branch ref exists on the remote.
+
+        Uses ``gh api repos/<repo>/git/refs/heads/<name>`` — 200 means the
+        ref is live; 404 means deleted; any other error is treated as
+        ``True`` (fail-open) so we never mark a healthy PR as orphan on a
+        transient API hiccup.
+        """
+        if not name:
+            return False
+        # URL-encode '/' in branch names like 'auto/issue-448' (gh api needs
+        # literal slashes in the path, but the rest of the segment is opaque).
+        rc, _, _ = await self._run(
+            "api", f"repos/{self.repo}/git/refs/heads/{name}",
+            "--silent",
+        )
+        if rc == 0:
+            return True
+        # gh exits non-zero on 4xx; 404 is the only response that authoritatively
+        # means "branch deleted". Any other rc (network, auth) is fail-open.
+        rc2, body, _ = await self._run(
+            "api", f"repos/{self.repo}/git/refs/heads/{name}",
+            "-i",
+        )
+        return "HTTP/2 404" not in body and "HTTP/1.1 404" not in body
+
 
 __all__ = ["GitHubForge", "GhCommandError"]

--- a/deile/orchestration/forge/gitlab_forge.py
+++ b/deile/orchestration/forge/gitlab_forge.py
@@ -31,6 +31,7 @@ import asyncio
 import json
 import logging
 import re
+import urllib.parse
 from datetime import datetime, timezone
 from typing import Iterable, List, Literal, Optional, Tuple
 
@@ -1326,6 +1327,32 @@ class GitLabForge(ForgeClient):
         # The project lookup also caches the default branch as a side effect.
         await self._resolve_project_id()
         return self._config.default_branch or "main"
+
+    async def branch_exists(self, name: str) -> bool:
+        """Return True iff the branch ref exists on the GitLab project.
+
+        Uses ``glab api projects/<id>/repository/branches/<name>`` — non-zero
+        return code (404 or other) means "absent or unreachable", which we
+        treat as authoritatively absent only when the response is empty
+        (fail-open on other errors so a transient API hiccup never flags a
+        healthy MR as orphan).
+        """
+        if not name:
+            return False
+        encoded_name = urllib.parse.quote(name, safe="")
+        rc, _, _ = await self._run(
+            "api",
+            f"projects/{self._config.encoded_project_path}/repository/branches/{encoded_name}",
+            "--silent",
+        )
+        if rc == 0:
+            return True
+        # Distinguish 404 (definitive absence) from other failures.
+        rc2, body, _ = await self._run(
+            "api",
+            f"projects/{self._config.encoded_project_path}/repository/branches/{encoded_name}",
+        )
+        return "404" not in (body or "")[:200].lower().split("\n", 1)[0]
 
 
 def _is_before(iso_str: str, cursor: datetime) -> bool:

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -2070,6 +2070,33 @@ async def review_one_open_pr(monitor: "PipelineMonitor") -> None:
     )
     if target is None:
         return
+    # Defensive guard (Mistério #4): if the head branch no longer exists on
+    # the remote (force-deleted, squash-merged with branch removal, etc.),
+    # there is nothing to review/merge — block the PR so it does not churn
+    # the pipeline forever. The human removes ``~workflow:bloqueada`` after
+    # restoring the branch (or closes the PR by hand).
+    if target.head_ref:
+        try:
+            branch_alive = await monitor.forge.branch_exists(target.head_ref)
+        except Exception as exc:  # noqa: BLE001 — fail-open on API hiccup
+            logger.debug(
+                "branch_exists check failed for PR #%d (%s); proceeding",
+                target.number, exc,
+            )
+            branch_alive = True
+        if not branch_alive:
+            logger.warning(
+                "PR #%d has orphan head_ref=%r (branch deleted on remote); "
+                "marking %s",
+                target.number, target.head_ref, WORKFLOW_BLOCKED,
+            )
+            await _block_pr(
+                monitor, target.number, target.title, target.url,
+                f"branch `{target.head_ref}` foi removida do remote — "
+                "restaure a branch ou feche a PR manualmente",
+            )
+            monitor._stats.errors += 1
+            return
     is_resume = REVIEW_IN_PROGRESS in target.labels
     batch = await monitor.forge.claim_with_batch("pr", target.number)
     if batch is None:

--- a/deile/tests/infra/test_claude_worker_lease.py
+++ b/deile/tests/infra/test_claude_worker_lease.py
@@ -220,6 +220,99 @@ class TestHeartbeatLoop:
 
 
 # ---------------------------------------------------------------------------
+# Mistério #3 — claude_pid no lease: distingue "lease vivo por heartbeat" de
+# "subprocess claude rodando agora".
+# ---------------------------------------------------------------------------
+
+
+class TestClaudePidInLease:
+    @pytest.mark.unit
+    async def test_update_lease_claude_pid_sets_field(self, tmp_path: Path):
+        """``_update_lease_claude_pid(pid)`` grava ``claude_pid`` no lease."""
+        workspace = tmp_path / "ws-pid"
+        workspace.mkdir()
+        _make_lease(workspace)
+        lease_path = workspace / ".lease.json"
+
+        await cws._update_lease_claude_pid(lease_path, 12345)
+        data = json.loads(lease_path.read_text())
+        assert data["claude_pid"] == 12345
+        # Wrapper ``pid`` é preservado (não some no merge).
+        assert "pid" in data
+
+    @pytest.mark.unit
+    async def test_update_lease_claude_pid_none_removes_field(self, tmp_path: Path):
+        """``_update_lease_claude_pid(None)`` remove ``claude_pid`` do lease."""
+        workspace = tmp_path / "ws-pid-clear"
+        workspace.mkdir()
+        _make_lease(workspace)
+        lease_path = workspace / ".lease.json"
+
+        await cws._update_lease_claude_pid(lease_path, 12345)
+        await cws._update_lease_claude_pid(lease_path, None)
+        data = json.loads(lease_path.read_text())
+        assert "claude_pid" not in data
+
+    @pytest.mark.unit
+    async def test_update_lease_missing_file_does_not_raise(self, tmp_path: Path):
+        """Se o lease desapareceu, atualizar é best-effort e não levanta."""
+        await cws._update_lease_claude_pid(tmp_path / "missing.json", 99)
+
+    @pytest.mark.unit
+    async def test_find_active_lease_exposes_claude_running_true(
+        self, tmp_path: Path,
+    ):
+        """``_find_active_lease`` reporta ``claude_running=True`` para PID vivo."""
+        root = tmp_path / "root"
+        root.mkdir()
+        workspace = root / ("a" * 16)
+        workspace.mkdir()
+        _make_lease(workspace)
+        await cws._update_lease_claude_pid(workspace / ".lease.json", os.getpid())
+
+        lease = await asyncio.to_thread(cws._find_active_lease, root)
+        assert lease is not None
+        assert lease["task_id"] == "a" * 16
+        assert lease["claude_pid"] == os.getpid()
+        assert lease["claude_running"] is True
+
+    @pytest.mark.unit
+    async def test_find_active_lease_exposes_claude_running_false(
+        self, tmp_path: Path,
+    ):
+        """PID de um processo morto → ``claude_running=False`` (mistério #3)."""
+        root = tmp_path / "root"
+        root.mkdir()
+        workspace = root / ("b" * 16)
+        workspace.mkdir()
+        _make_lease(workspace)
+        # PID muito alto que (com altíssima probabilidade) NÃO existe.
+        await cws._update_lease_claude_pid(workspace / ".lease.json", 2_000_001)
+
+        lease = await asyncio.to_thread(cws._find_active_lease, root)
+        assert lease is not None
+        assert lease["claude_pid"] == 2_000_001
+        assert lease["claude_running"] is False
+
+    @pytest.mark.unit
+    async def test_find_active_lease_claude_running_false_when_field_missing(
+        self, tmp_path: Path,
+    ):
+        """Lease antigo sem ``claude_pid`` → ``claude_running=False``."""
+        root = tmp_path / "root"
+        root.mkdir()
+        workspace = root / ("c" * 16)
+        workspace.mkdir()
+        _make_lease(workspace)
+        # NÃO chama _update_lease_claude_pid — simula lease legacy.
+
+        lease = await asyncio.to_thread(cws._find_active_lease, root)
+        assert lease is not None
+        assert lease.get("claude_pid") is None
+        assert lease["claude_running"] is False
+
+
+# ---------------------------------------------------------------------------
 # Mecanismo 1 — OAuth: _refresh_oauth_with_lock
 # ---------------------------------------------------------------------------
 

--- a/deile/tests/orchestration/forge/test_branch_exists.py
+++ b/deile/tests/orchestration/forge/test_branch_exists.py
@@ -1,0 +1,129 @@
+"""Branch-existence probe — covers Mistério #4 defensive guard.
+
+The pipeline marks a PR ``~workflow:bloqueada`` when its head branch was
+removed from the remote (force-deleted, squash-merge auto-delete, etc.).
+This module verifies that :meth:`ForgeClient.branch_exists` returns the
+right answer per forge against a scripted CLI:
+
+* ``rc=0`` and no error → branch alive.
+* ``rc!=0`` with explicit 404 body → branch absent.
+* ``rc!=0`` with any other body → fail-open (returns True so a transient
+  API hiccup never flags a healthy PR as orphan).
+
+No real ``gh``/``glab`` binary is invoked; every ``_run`` call is
+monkey-patched.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Tuple
+
+import pytest
+
+from deile.orchestration.forge import GitHubForge, GitLabForge
+from deile.orchestration.forge.base import ForgeConfig, ForgeKind
+
+
+@pytest.fixture
+def fake_gh(monkeypatch):
+    responses: "deque[Tuple[int, str, str]]" = deque()
+    calls: list[tuple] = []
+    cfg = ForgeConfig(
+        kind=ForgeKind.GITHUB,
+        host="github.com",
+        project_path="owner/repo",
+        cli_path="/usr/bin/gh",
+    )
+    forge = GitHubForge(cfg)
+
+    async def fake_run(self, *args):
+        calls.append(args)
+        if not responses:
+            return (0, "", "")
+        return responses.popleft()
+
+    monkeypatch.setattr(GitHubForge, "_run", fake_run)
+    return forge, responses, calls
+
+
+@pytest.fixture
+def fake_glab(monkeypatch):
+    responses: "deque[Tuple[int, str, str]]" = deque()
+    calls: list[tuple] = []
+    cfg = ForgeConfig(
+        kind=ForgeKind.GITLAB,
+        host="gitlab.com",
+        project_path="group/project",
+        cli_path="/usr/bin/glab",
+    )
+    forge = GitLabForge(cfg)
+
+    async def fake_run(self, *args):
+        calls.append(args)
+        if not responses:
+            return (0, "", "")
+        return responses.popleft()
+
+    monkeypatch.setattr(GitLabForge, "_run", fake_run)
+    return forge, responses, calls
+
+
+async def test_github_branch_exists_returns_true_on_rc0(fake_gh):
+    forge, responses, _ = fake_gh
+    responses.append((0, "", ""))
+    assert await forge.branch_exists("auto/issue-1") is True
+
+
+async def test_github_branch_exists_returns_false_on_404(fake_gh):
+    forge, responses, _ = fake_gh
+    responses.append((1, "", ""))  # first call (--silent)
+    responses.append((1, "HTTP/2 404\n{\"message\":\"Not Found\"}", ""))  # -i
+    assert await forge.branch_exists("auto/issue-vanished") is False
+
+
+async def test_github_branch_exists_fail_open_on_unknown_error(fake_gh):
+    forge, responses, _ = fake_gh
+    responses.append((1, "", "network: timeout"))  # --silent
+    responses.append((1, "HTTP/2 500\n{\"message\":\"oops\"}", ""))  # -i
+    # Not 404 → fail-open (True) so transient errors never orphan a PR.
+    assert await forge.branch_exists("auto/issue-1") is True
+
+
+async def test_github_branch_exists_returns_false_on_empty_name(fake_gh):
+    forge, _, _ = fake_gh
+    assert await forge.branch_exists("") is False
+
+
+async def test_gitlab_branch_exists_returns_true_on_rc0(fake_glab):
+    forge, responses, _ = fake_glab
+    responses.append((0, "", ""))
+    assert await forge.branch_exists("feature/x") is True
+
+
+async def test_gitlab_branch_exists_returns_false_on_404(fake_glab):
+    forge, responses, _ = fake_glab
+    responses.append((1, "", ""))
+    responses.append((1, "404 Not Found", ""))
+    assert await forge.branch_exists("feature/vanished") is False
+
+
+async def test_abc_branch_exists_default_is_true_fail_safe():
+    """ABC default returns True so forges without an override never flag
+    a PR as orphan-by-deleted-branch on a transient API condition.
+    """
+    from deile.orchestration.forge.base import ForgeClient
+
+    # Inspect the ABC method directly via the GitHubForge MRO ancestor —
+    # GitHubForge overrides it, but we want to assert the *base* behavior.
+    base_method = ForgeClient.branch_exists
+    # The method is async; call it through GitHubForge instance pointing at
+    # the unbound base.
+    cfg = ForgeConfig(
+        kind=ForgeKind.GITHUB, host="github.com", project_path="o/r",
+        cli_path="/usr/bin/gh",
+    )
+    forge = GitHubForge(cfg)
+    # Call the ABC default directly with the instance as self.
+    assert await base_method(forge, "anything") is True
+    assert await base_method(forge, "") is True  # default does not gate on empty

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -327,6 +327,38 @@ async def _acquire_lease(workspace: Path) -> Optional[dict]:
     return await asyncio.to_thread(_write_and_confirm)
 
 
+async def _update_lease_claude_pid(lease_path: Path, claude_pid: Optional[int]) -> None:
+    """Set/clear ``claude_pid`` on the lease — the PID of the spawned ``claude -p``
+    subprocess (NOT the wrapper server process, which lives in ``pid``).
+
+    Without this field, ``mtime`` of ``.lease.json`` is whatever the heartbeat
+    task last wrote (always recent while the server is up) and the ``pid`` is
+    just the wrapper — an observer cannot tell whether a real ``claude``
+    workload is still running. With it, ``claude_pid is not None and pid_alive
+    (claude_pid)`` is the ground truth for "claude is actively working on this
+    workdir". Best-effort: a missing/unwritable lease is logged and ignored —
+    the dispatch is the source of truth, the lease is just an observability
+    aid.
+    """
+    def _update() -> None:
+        try:
+            content = json.loads(lease_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if claude_pid is None:
+            content.pop("claude_pid", None)
+        else:
+            content["claude_pid"] = int(claude_pid)
+        try:
+            tmp = lease_path.with_suffix(".json.pid_tmp")
+            tmp.write_text(json.dumps(content), encoding="utf-8")
+            tmp.rename(lease_path)
+        except OSError as exc:
+            logger.warning("lease claude_pid update failed for %s: %s", lease_path, exc)
+
+    await asyncio.to_thread(_update)
+
+
 async def _release_lease(lease_path: Path) -> None:
     """Remove o arquivo de lease. Idempotente: FileNotFoundError é ignorado."""
     def _unlink() -> None:
@@ -747,6 +779,7 @@ async def run_subprocess_with_progress(
     cwd: Path,
     task_id: str,
     timeout: int,
+    lease_path: Optional[Path] = None,
 ) -> SubprocessResult:
     """Spawn de ``claude -p`` com persistência de stdout/stderr para o PVC.
 
@@ -755,6 +788,13 @@ async def run_subprocess_with_progress(
     ``/v1/progress/{task_id}`` (Task 14) para snapshot mid-flight no painel
     TUI. Em timeout, devolvemos ``returncode=124`` (convenção do ``coreutils
     timeout``) com mensagem em ``stderr``.
+
+    Quando ``lease_path`` é informado, gravamos ``claude_pid`` no lease assim
+    que o subprocess é spawnado e limpamos ao terminar — isso permite que um
+    observador (painel, ``kubectl exec``) distinga "lease vivo por heartbeat"
+    de "claude rodando agora" sem ter que varrer ``/proc`` (gotcha do
+    Mistério #3 — o lease é mantido vivo pela heartbeat task do servidor
+    mesmo quando o subprocess do claude já terminou).
     """
     start = time.monotonic()
 
@@ -772,6 +812,9 @@ async def run_subprocess_with_progress(
         stderr=asyncio.subprocess.PIPE,
     )
 
+    if lease_path is not None:
+        await _update_lease_claude_pid(lease_path, proc.pid)
+
     try:
         stdout_b, stderr_b = await asyncio.wait_for(
             proc.communicate(), timeout=timeout,
@@ -779,6 +822,8 @@ async def run_subprocess_with_progress(
     except asyncio.TimeoutError:
         proc.kill()
         await proc.wait()
+        if lease_path is not None:
+            await _update_lease_claude_pid(lease_path, None)
         duration = time.monotonic() - start
         return SubprocessResult(
             returncode=124, stdout="",
@@ -789,6 +834,9 @@ async def run_subprocess_with_progress(
     duration = time.monotonic() - start
     stdout = stdout_b.decode("utf-8", "replace")
     stderr = stderr_b.decode("utf-8", "replace")
+
+    if lease_path is not None:
+        await _update_lease_claude_pid(lease_path, None)
 
     # Persiste para o ``/v1/progress`` (Task 14) — best-effort; falha em
     # escrita NÃO derruba o dispatch (o cliente já recebeu o resultado).
@@ -1248,8 +1296,17 @@ def _parse_claude_json_output(stdout: str) -> dict:
 def _find_active_lease(root: Path) -> Optional[dict]:
     """Return the most recent alive lease found under *root*/<task_id>/.lease.json.
 
-    Security: exposes only task_id, heartbeat_at, pid — never the full
-    lease payload (no pod name, no prompts, nothing injectable).
+    Security: exposes only task_id, heartbeat_at, pid, claude_pid e
+    claude_running — never the full lease payload (no pod name, no prompts,
+    nothing injectable).
+
+    ``claude_pid``/``claude_running`` distinguish "lease alive (heartbeat
+    fresh)" from "claude subprocess actually running":
+    - ``claude_pid`` is the PID of the spawned ``claude -p`` (None when no
+      subprocess is in flight).
+    - ``claude_running`` is True iff that PID is currently alive.
+    Without these the observer cannot tell — the heartbeat task keeps the
+    lease's mtime fresh long after the subprocess exits.
     """
     now = time.time()
     best: Optional[dict] = None
@@ -1271,10 +1328,16 @@ def _find_active_lease(root: Path) -> Optional[dict]:
             hb = float(data.get("heartbeat_at", 0))
             if (now - hb) < _LEASE_TTL_S and hb > best_hb:
                 best_hb = hb
+                claude_pid = data.get("claude_pid")
+                claude_running = bool(
+                    claude_pid and _pid_alive(int(claude_pid))
+                )
                 best = {
                     "task_id": child.name,
                     "heartbeat_at": hb,
                     "pid": data.get("pid"),
+                    "claude_pid": claude_pid,
+                    "claude_running": claude_running,
                 }
         except (OSError, json.JSONDecodeError, ValueError):
             continue
@@ -1725,16 +1788,22 @@ async def pod_status_handler(request: web.Request) -> web.Response:
     """``GET /v1/pod-status`` — introspection of this pod's own runtime state.
 
     Returns a snapshot of:
-    - ``lease``:           active lease (task_id, heartbeat_at, pid) or null when idle.
+    - ``lease``:           active lease (task_id, heartbeat_at, pid,
+                           ``claude_pid``, ``claude_running``) or null when idle.
+                           ``pid`` is the wrapper server (always alive while
+                           the pod is up); ``claude_pid``/``claude_running``
+                           are the ground truth for a live ``claude -p``
+                           subprocess.
     - ``disk``:            PVC usage via shutil.disk_usage (no subprocess).
     - ``claude_processes``: count of running claude processes.
     - ``anthropic_quota``: last captured rate-limit tokens-remaining + timestamp,
                            or null if never observed.
     - ``ts``:              unix timestamp of this response.
 
-    Security: ``lease`` exposes ONLY task_id, heartbeat_at, and pid — no
-    prompt content, no credentials, nothing that could serve as an injection
-    vector.  Bearer auth required (same middleware as all other endpoints).
+    Security: ``lease`` exposes ONLY task_id, heartbeat_at, pid, claude_pid
+    and claude_running — no prompt content, no credentials, nothing that
+    could serve as an injection vector.  Bearer auth required (same
+    middleware as all other endpoints).
     """
     root = Path(os.environ.get("DEILE_CLAUDE_WORKER_ROOT", "/home/claude/work"))
     disk_mount = os.environ.get("DEILE_CLAUDE_HOME", "/home/claude")
@@ -2108,6 +2177,7 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     try:
         result = await run_subprocess_with_progress(
             cmd, cwd=workspace, task_id=task_id, timeout=timeout,
+            lease_path=workspace / ".lease.json",
         )
     except Exception as exc:
         logger.exception("dispatch failed task_id=%s", task_id)


### PR DESCRIPTION
## Contexto

Investigação remota do pipeline em produção (k3s/Rancher Desktop, ns `deile`) detectou 4 sinais conflitantes que cegavam o operador. Esta PR endereça os 3 reais (1 era percepção do tail curto demais) e adiciona defesa em profundidade para o 4º.

## Os 4 mistérios

### M1 — `ps -ef` retornava vazio no claude-worker

**Evidência:**

```text
$ kubectl -n deile exec claude-worker-... -- which ps
(empty)
$ kubectl -n deile exec claude-worker-... -- pgrep -a claude
(empty)
$ kubectl -n deile exec claude-worker-... -- cat /proc/1/cmdline | tr '\0' ' '
/usr/bin/tini -- python3 /app/wrapper.py claude-worker
```

`/proc` está montado normalmente — só faltava o binário. **Fix:** `procps` adicionado ao `apt-get install` no Dockerfile (linha 113), junto com `tini git iputils-ping curl gnupg jq`. Em imagens pré-rebuild, `cat /proc/*/cmdline | tr '\0' ' '` segue como fallback (documentado no CLAUDE.md).

### M2 — Logs do pipeline pareciam vazios

**Resolvido por investigação, NÃO requer mudança de código:**

```text
$ kubectl logs deploy/deile-pipeline --tail=60   # parecia vazio
$ kubectl logs deploy/deile-pipeline --tail=200  # 200+ linhas reais!
```

Os health probes (a cada 30s) afogavam `--tail=60`. Logs do monitor + dispatches aparecem perfeitamente com tail maior ou `--since=10m`. `PYTHONUNBUFFERED=1` está ativo, tini reapeia zombies corretamente — não há buffering escondido. Documentado no CLAUDE.md (seção nova "Observability gotchas") pra evitar a mesma confusão na próxima investigação.

### M3 — `.lease.json` mostrava heartbeat fresco mesmo sem claude rodando

**Evidência:**

```text
$ kubectl exec claude-worker-... -- cat /home/claude/work/.../.lease.json
{"pod":"claude-worker-...", "pid":7, "started_at":..., "heartbeat_at": NOW}
```

O `pid:7` é o servidor wrapper, NÃO o subprocess do claude. A task `_heartbeat_loop` reescreve `heartbeat_at` a cada 5s independente do estado do dispatch. Resultado: observador vê "lease vivo" e conclui "claude rodando" — sempre.

**Fix:** novo campo `claude_pid` no lease + flag `claude_running` no payload do `/v1/pod-status`.

- `_update_lease_claude_pid(lease_path, pid)` — grava o PID do subprocess `claude -p` recém-spawnado; chamada do dispatch handler com `lease_path=workspace/.lease.json` ao chamar `run_subprocess_with_progress`.
- Mesma função é chamada com `None` ao terminar/timeout (limpa o campo).
- `_find_active_lease` lê `claude_pid`, faz `_pid_alive`, expõe `claude_running` (bool).
- Heartbeat task preserva `claude_pid` automaticamente (já fazia read-merge-write).

Agora o painel/`kubectl exec ... /v1/pod-status` distingue "lease vivo" de "claude rodando" sem `pgrep`/`ps`.

### M4 — PR #465 sumiu na branch local

**Investigação:**

```text
$ git fetch origin auto/issue-448   # vazio
$ gh api repos/elimarcavalli/deile/git/refs/heads/auto/issue-448
{"ref":"refs/heads/auto/issue-448","object":{"sha":"a3a77087...","type":"commit",...}}
```

A branch **existe** no GitHub — foi cache local do `git fetch`. **Não reproduzido como bug real**.

**Mesmo assim, defesa adicionada** (o cenário "force-delete da branch + PR open" é plausível em squash-merge + auto-delete):

- Novo método `ForgeClient.branch_exists(name) -> bool` no ABC (default `True` — fail-safe).
- Implementação em `GitHubForge` (via `gh api repos/<repo>/git/refs/heads/<name>` — distingue 404 explícito de outros erros) e `GitLabForge` (via `glab api projects/<id>/repository/branches/<name>`).
- Guarda em `stage_pr_review` (logo antes do `claim_with_batch`): se `head_ref` não existe no remote, marca `~workflow:bloqueada` em vez de dispatch infinito. Humano restaura branch ou fecha PR à mão; pipeline sai do loop.
- **Fail-open** em todas as falhas que não sejam 404 — transiente API jamais flagga PR saudável.

## Cobertura

- 6 testes novos em `test_claude_worker_lease.py::TestClaudePidInLease` cobrindo set/clear/missing-file/find_active_lease+claude_running True/False/missing-field.
- 7 testes novos em `test_branch_exists.py` cobrindo GitHub (rc=0/404/fail-open/empty) + GitLab (rc=0/404) + ABC default fail-safe.

```text
$ pytest deile/tests/orchestration/forge/ deile/tests/infra/test_claude_worker_lease.py deile/tests/orchestration/pipeline/ -q -p no:cov
1272 passed, 2 skipped in 41.09s
```

Run completo: 36 falhas pré-existentes (pollution de ordenação documentada em memória do projeto — confirmado isolando os arquivos, todos passam).

## Risco

- **M1 Dockerfile:** layer cache pode demorar a invalidar; `--no-cache` ou bump explícito do `RUN apt-get` se rebuild não pegar.
- **M3 lease:** lease legacy sem `claude_pid` → `claude_running=False` (correto — não há subprocess registrado). Heartbeat task preserva campos extras (já testado).
- **M4 branch_exists:** fail-open em qualquer 5xx/timeout — cenário pior é "PR órfã não detectada", nunca "PR saudável flaggada". 

## Test plan

- [x] Suíte completa contra áreas tocadas verde (1272/0).
- [x] Lint nos arquivos novos (ruff/isort).
- [ ] Rebuild + restart claude-worker → `kubectl exec ... -- ps -ef` deve listar processos; `pgrep -a claude` deve achar subprocess durante dispatch ativo.
- [ ] Validar `claude_pid` no lease em produção: durante dispatch, ler `.lease.json` e ver campo populado; após término, ver campo ausente.
- [ ] Forçar deleção de branch de uma PR de teste e observar pipeline marcar `~workflow:bloqueada`.