### PR TITLE
fix(k8s): NetworkPolicy egress to apiserver matches post-DNAT endpoint

### DIFF
--- a/deile/tests/infrastructure/test_k8s_manifest_consistency.py
+++ b/deile/tests/infrastructure/test_k8s_manifest_consistency.py
@@ -12,9 +12,12 @@ Regras enforced (cada falha bloqueia merge):
 1. Todo ``serviceAccountName: X`` referencia uma SA que existe.
 2. Todo pod que monta um ServiceAccount custom (não-``default``) e cujo
    código invoca ``kubectl exec`` precisa de NetworkPolicy de egress
-   pro Service CIDR do cluster (10.43.0.0/16 em k3s). Heurística:
-   pods com SA ``claude-creds-renewer`` OU labels ``app=deile-pipeline``
-   precisam dessa regra.
+   pro kube-apiserver. NetworkPolicy filtra o IP *pós-DNAT* (endpoint real
+   do apiserver), NÃO o ClusterIP — então o whitelist precisa alcançar o
+   endpoint real (range RFC1918 na porta 443 ou 6443; o ``deploy.py``
+   estreita para o /32 real em runtime). Heurística: pods com SA
+   ``claude-creds-renewer`` OU labels ``app=deile-pipeline`` precisam dessa
+   regra.
 3. Todo manifest YAML carrega sem erro de sintaxe.
 
 Quando este teste falhar, NÃO mude o teste para passar. Mude o manifest.
@@ -22,7 +25,6 @@ Quando este teste falhar, NÃO mude o teste para passar. Mude o manifest.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +32,10 @@ import pytest
 import yaml
 
 MANIFEST_DIR = Path(__file__).resolve().parents[3] / "infra" / "k8s" / "manifests"
-K3S_SERVICE_CIDR = "10.43.0.0/16"
+# Portas válidas para alcançar o kube-apiserver: 6443 (k3s/kubeadm) e 443
+# (EKS/GKE/AKS). NetworkPolicy filtra o IP/porta pós-DNAT (endpoint real), não
+# o ClusterIP — por isso aceitamos qualquer ipBlock RFC1918 nessas portas.
+APISERVER_PORTS = frozenset({443, 6443})
 
 
 def _load_all_docs() -> list[dict[str, Any]]:
@@ -114,13 +119,20 @@ def test_service_account_refs_are_defined(docs: list[dict[str, Any]]) -> None:
 
 
 def test_kubectl_exec_pods_have_apiserver_egress(docs: list[dict[str, Any]]) -> None:
-    """Regra 2 — pods que fazem ``kubectl exec`` precisam de egress pro Service CIDR.
+    """Regra 2 — pods que fazem ``kubectl exec`` precisam de egress pro apiserver.
 
     Heurística: pods que assumem a SA ``claude-creds-renewer`` (definida no
     manifest 51 com permissão ``pods/exec`` no claude-worker) PRECISAM ter
-    NetworkPolicy que permita TCP/443 para ``10.43.0.0/16``. Sem isso, o
-    ``kubectl exec`` invocado falha com ``connection timed out`` — exato bug
-    que ficou em produção por 4 dias após o PR #420.
+    NetworkPolicy de egress que alcance o kube-apiserver — um ``ipBlock`` com
+    CIDR não-vazio na porta 443 ou 6443.
+
+    NOTA pós-mortem (substitui a heurística antiga que fixava o Service CIDR
+    ``10.43.0.0/16``): NetworkPolicy filtra o IP de destino PÓS-DNAT (o endpoint
+    real do apiserver, ex. ``192.168.64.2:6443``), não o ClusterIP. Whitelist do
+    Service CIDR NUNCA casa com o pacote → ``connection refused``. Por isso o
+    manifest carrega um fallback RFC1918 (443+6443) e o ``deploy.py`` estreita
+    para o /32 real em runtime; este teste exige apenas a presença de uma regra
+    de egress que possa alcançar o apiserver, sem pinar CIDR.
     """
     refs = _service_account_refs(docs)
     pods_needing_apiserver = {
@@ -156,26 +168,29 @@ def test_kubectl_exec_pods_have_apiserver_egress(docs: list[dict[str, Any]]) -> 
         for rule in spec.get("egress") or []:
             to_blocks = rule.get("to") or []
             ports = rule.get("ports") or []
-            has_443 = any(p.get("port") == 443 and p.get("protocol", "TCP") == "TCP" for p in ports)
-            if not has_443:
+            reaches_apiserver_port = any(
+                p.get("port") in APISERVER_PORTS and p.get("protocol", "TCP") == "TCP"
+                for p in ports
+            )
+            if not reaches_apiserver_port:
                 continue
-            for to in to_blocks:
-                ip_block = to.get("ipBlock") or {}
-                if ip_block.get("cidr") == K3S_SERVICE_CIDR:
-                    if covers("deile-pipeline"):
-                        apiserver_egress_covered.add("deile-pipeline")
-                    if covers("claude-creds-renewer"):
-                        apiserver_egress_covered.add("claude-creds-renewer")
+            has_ipblock = any((to.get("ipBlock") or {}).get("cidr") for to in to_blocks)
+            if not has_ipblock:
+                continue
+            if covers("deile-pipeline"):
+                apiserver_egress_covered.add("deile-pipeline")
+            if covers("claude-creds-renewer"):
+                apiserver_egress_covered.add("claude-creds-renewer")
 
     required = {"deile-pipeline", "claude-creds-renewer"}
     missing = required - apiserver_egress_covered
     assert not missing, (
-        f"Pods que invocam `kubectl exec` sem NetworkPolicy de egress para o "
-        f"kube-apiserver (Service CIDR {K3S_SERVICE_CIDR}): {sorted(missing)}.\n"
-        "Sem esta regra, `kubectl exec` falha com 'dial tcp 10.43.0.1:443: "
-        "connect: connection timed out' (foi o bug que afetou o PR #420 em "
-        "produção). Adicione/estenda uma NetworkPolicy de egress no manifest "
-        "40-network-policy.yaml cobrindo esses pods. Exemplo de bloco mínimo:\n"
+        "Pods que invocam `kubectl exec` sem NetworkPolicy de egress capaz de "
+        f"alcançar o kube-apiserver (ipBlock + porta 443/6443): {sorted(missing)}.\n"
+        "Lembre: NetworkPolicy filtra o IP PÓS-DNAT (endpoint real do apiserver), "
+        "NÃO o ClusterIP — liberar 10.43.0.0/16 não funciona ('connection "
+        "refused'). Adicione/estenda uma NetworkPolicy de egress no manifest "
+        "40-network-policy.yaml cobrindo esses pods. Exemplo de fallback portátil:\n"
         "  spec:\n"
         "    podSelector:\n"
         "      matchExpressions:\n"
@@ -183,6 +198,9 @@ def test_kubectl_exec_pods_have_apiserver_egress(docs: list[dict[str, Any]]) -> 
         "claude-creds-renewer] }\n"
         "    policyTypes: [\"Egress\"]\n"
         "    egress:\n"
-        "      - to: [{ ipBlock: { cidr: 10.43.0.0/16 } }]\n"
-        "        ports: [{ protocol: TCP, port: 443 }]"
+        "      - to:\n"
+        "          - ipBlock: { cidr: 10.0.0.0/8 }\n"
+        "          - ipBlock: { cidr: 172.16.0.0/12 }\n"
+        "          - ipBlock: { cidr: 192.168.0.0/16 }\n"
+        "        ports: [{ protocol: TCP, port: 443 }, { protocol: TCP, port: 6443 }]"
     )

--- a/deile/tests/infrastructure/test_k8s_manifest_consistency.py
+++ b/deile/tests/infrastructure/test_k8s_manifest_consistency.py
@@ -25,6 +25,8 @@ Quando este teste falhar, NÃO mude o teste para passar. Mude o manifest.
 
 from __future__ import annotations
 
+import ipaddress
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +38,17 @@ MANIFEST_DIR = Path(__file__).resolve().parents[3] / "infra" / "k8s" / "manifest
 # (EKS/GKE/AKS). NetworkPolicy filtra o IP/porta pós-DNAT (endpoint real), não
 # o ClusterIP — por isso aceitamos qualquer ipBlock RFC1918 nessas portas.
 APISERVER_PORTS = frozenset({443, 6443})
+
+# Nome da egress policy do apiserver (fallback estático no manifest 40 +
+# override de runtime no `deploy.py`/`_netpol.py`, mesmo nome de propósito).
+_APISERVER_POLICY_NAME = "creds-renewer-egress-to-kube-api"
+
+# Importa a FONTE ÚNICA do selector de pods do módulo de runtime, para o
+# teste-guarda de paridade manifest↔runtime (sem stub: _netpol só usa stdlib).
+_INFRA_K8S = MANIFEST_DIR.parent
+if str(_INFRA_K8S) not in sys.path:
+    sys.path.insert(0, str(_INFRA_K8S))
+from _netpol import APISERVER_EGRESS_APPS, POLICY_NAME  # noqa: E402
 
 
 def _load_all_docs() -> list[dict[str, Any]]:
@@ -203,4 +216,84 @@ def test_kubectl_exec_pods_have_apiserver_egress(docs: list[dict[str, Any]]) -> 
         "          - ipBlock: { cidr: 172.16.0.0/12 }\n"
         "          - ipBlock: { cidr: 192.168.0.0/16 }\n"
         "        ports: [{ protocol: TCP, port: 443 }, { protocol: TCP, port: 6443 }]"
+    )
+
+
+def _apiserver_policy(docs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for d in docs:
+        if (
+            d.get("kind") == "NetworkPolicy"
+            and (d.get("metadata", {}) or {}).get("name") == _APISERVER_POLICY_NAME
+        ):
+            return d
+    return None
+
+
+def test_apiserver_egress_selector_matches_runtime() -> None:
+    """Regra 4 — selector do fallback (manifest 40) == fonte única do runtime.
+
+    O ``deploy.py``/``_netpol.py`` estreita a egress policy do apiserver
+    SOBRESCREVENDO-A pelo mesmo nome (``creds-renewer-egress-to-kube-api``) —
+    overwrite-by-name é o que de fato estreita, já que NetworkPolicy é aditiva.
+    Logo o ``podSelector`` renderizado em runtime (lista
+    ``_netpol.APISERVER_EGRESS_APPS``) DEVE casar exatamente com o do fallback
+    estático no manifest 40. Se divergirem, um pod ganharia egress no fallback
+    amplo mas o perderia no /32 (ou vice-versa) conforme qual verbo rodou por
+    último — bug silencioso de postura inconsistente. Este teste é a trava.
+    """
+    assert POLICY_NAME == _APISERVER_POLICY_NAME, (
+        f"_netpol.POLICY_NAME ({POLICY_NAME!r}) divergiu do nome esperado "
+        f"({_APISERVER_POLICY_NAME!r}) — overwrite-by-name deixaria de estreitar."
+    )
+    policy = _apiserver_policy(_load_all_docs())
+    assert policy is not None, (
+        f"NetworkPolicy '{_APISERVER_POLICY_NAME}' (fallback) ausente do "
+        "manifest 40 — sem ela `kubectl apply -f` cru perde o egress ao apiserver."
+    )
+    expr = (policy.get("spec", {}).get("podSelector", {}) or {}).get("matchExpressions") or []
+    manifest_apps: set[str] = set()
+    for e in expr:
+        if e.get("key") == "app" and e.get("operator") == "In":
+            manifest_apps.update(e.get("values") or [])
+    assert manifest_apps == set(APISERVER_EGRESS_APPS), (
+        f"Selector do fallback no manifest 40 ({sorted(manifest_apps)}) divergiu "
+        f"de _netpol.APISERVER_EGRESS_APPS ({sorted(APISERVER_EGRESS_APPS)}). "
+        "Mantenha os dois em sincronia: o override de runtime usa a constante "
+        "Python; o fallback estático usa o YAML. Editar um sem o outro deixa "
+        "pods com egress inconsistente entre os dois caminhos."
+    )
+
+
+def test_apiserver_egress_fallback_is_private() -> None:
+    """Regra 5 — todo ipBlock do fallback estático está em range privado.
+
+    O fallback é amplo de propósito (cobre o endpoint real de qualquer cluster),
+    mas NÃO pode ser irrestrito: um ``0.0.0.0/0`` (ou qualquer range público)
+    daria a esses pods egress ao mundo nas portas 443/6443 — o oposto da
+    intenção. Exige que cada CIDR seja sub-rede de um range RFC1918.
+    """
+    private_nets = [
+        ipaddress.ip_network("10.0.0.0/8"),
+        ipaddress.ip_network("172.16.0.0/12"),
+        ipaddress.ip_network("192.168.0.0/16"),
+    ]
+    policy = _apiserver_policy(_load_all_docs())
+    assert policy is not None, "fallback policy ausente do manifest 40"
+    offenders: list[str] = []
+    for rule in policy.get("spec", {}).get("egress") or []:
+        for to in rule.get("to") or []:
+            cidr = (to.get("ipBlock") or {}).get("cidr")
+            if not cidr:
+                continue
+            try:
+                net = ipaddress.ip_network(cidr)
+            except ValueError:
+                offenders.append(f"{cidr} (CIDR inválido)")
+                continue
+            if not any(net.subnet_of(p) for p in private_nets):
+                offenders.append(cidr)
+    assert not offenders, (
+        f"ipBlock(s) não-privado(s) no fallback do apiserver: {offenders}. "
+        "O fallback deve liberar apenas ranges RFC1918 (10/8, 172.16/12, "
+        "192.168/16) — nunca 0.0.0.0/0 nem espaço público."
     )

--- a/infra/k8s/_claude_install.py
+++ b/infra/k8s/_claude_install.py
@@ -453,6 +453,12 @@ def _kubectl_apply_manifests(*, namespace: str) -> bool:
             logger.error("kubectl apply %s failed: %s", f.name, result.stderr)
             return False
         logger.info("applied %s", f.name)
+    # 40-network-policy.yaml acima reaplica o FALLBACK amplo da egress policy do
+    # apiserver, revertendo qualquer /32 que um `k8s up` anterior tenha
+    # estreitado. Re-estreita aqui para a postura /32 não se perder no fluxo
+    # claude-login (best-effort; mantém o fallback se a descoberta falhar).
+    from _netpol import apply_apiserver_egress_netpol  # noqa: PLC0415
+    apply_apiserver_egress_netpol("kubectl", namespace, info=logger.info, warn=logger.warning)
     return True
 
 

--- a/infra/k8s/_netpol.py
+++ b/infra/k8s/_netpol.py
@@ -1,0 +1,142 @@
+"""Estreitamento em runtime da NetworkPolicy de egress ao kube-apiserver.
+
+Módulo COMPARTILHADO por todos os caminhos que aplicam ``40-network-policy.yaml``
+(``deploy.py`` k8s up / create-namespace / restart / start, ``_setup.py`` k8s
+setup, ``_claude_install.py`` k8s claude-login). Centralizar aqui garante que
+nenhum caminho deixe o fallback RFC1918 amplo no lugar — ou reverta um ``/32``
+estreitado por outro caminho.
+
+Por que existe: NetworkPolicy filtra o IP de destino *pós-DNAT* — o endpoint
+REAL do apiserver — e não o ClusterIP do Service ``kubernetes`` (10.43.0.1 em
+k3s). Liberar só o Service CIDR nunca casa com o pacote; o ``kubectl exec`` do
+auto-renew morre em ``connection refused``. O endpoint real varia por cluster
+(k3s: ``node:6443``; EKS/GKE: ``master:443``), então descobrimos em runtime via
+``endpoints/kubernetes`` e estreitamos para o(s) IP(s) host (``/32`` IPv4 ou
+``/128`` IPv6) + a(s) porta(s) real(is).
+
+A policy renderizada usa o MESMO nome do fallback estático no manifest 40
+(``creds-renewer-egress-to-kube-api``) DE PROPÓSITO: NetworkPolicy é aditiva
+(união entre policies que selecionam o mesmo pod), então estreitar exige
+SOBRESCREVER a policy por nome — um nome distinto só somaria à broad, anulando
+o efeito. O selector de pods é fonte única em :data:`APISERVER_EGRESS_APPS`,
+espelhado no manifest 40 e verificado por teste-guarda
+(``test_k8s_manifest_consistency.py``).
+
+Best-effort: se a descoberta falhar (endpoints vazio, IP inválido, kubectl
+indisponível), mantém-se o fallback do manifest 40 — funcional, apenas mais amplo.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+import subprocess
+from typing import Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Pods que invocam ``kubectl exec`` e precisam de egress ao apiserver.
+# FONTE ÚNICA — espelhada no `podSelector` do manifest 40 (fallback) e
+# renderizada aqui (override de runtime). Divergência é pega pelo teste-guarda
+# `test_apiserver_egress_selector_matches_runtime`.
+APISERVER_EGRESS_APPS: List[str] = [
+    "deile-pipeline",
+    "claude-creds-renewer",
+    "deile-monitor",
+]
+
+# Mesmo nome do fallback no manifest 40 — overwrite-by-name é o que estreita
+# (ver docstring do módulo). NÃO renomear sem entender a semântica aditiva.
+POLICY_NAME = "creds-renewer-egress-to-kube-api"
+
+
+def _noop(_msg: str) -> None:
+    pass
+
+
+def _capture(cmd: List[str], timeout: float = 30.0) -> Optional[str]:
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def apply_apiserver_egress_netpol(
+    kubectl: str,
+    ns: str,
+    *,
+    info: Callable[[str], None] = _noop,
+    warn: Callable[[str], None] = _noop,
+) -> None:
+    """Descobre o endpoint real do apiserver e estreita a egress policy do ns.
+
+    Idempotente e best-effort: nunca levanta; em qualquer falha mantém o
+    fallback do manifest 40. ``info``/``warn`` permitem o caller plugar sua UI
+    (``deploy.py`` passa ``ui.info``/``ui.warn``); por padrão só loga.
+    """
+    raw = _capture([kubectl, "get", "endpoints", "kubernetes",
+                    "-n", "default", "-o", "json"])
+    ips: List[str] = []
+    ports: List[int] = []
+    if raw:
+        try:
+            data = json.loads(raw)
+            for subset in data.get("subsets", []) or []:
+                ips.extend(a["ip"] for a in subset.get("addresses", []) or [] if a.get("ip"))
+                ports.extend(p["port"] for p in subset.get("ports", []) or [] if p.get("port"))
+        except (ValueError, KeyError, TypeError):
+            ips, ports = [], []
+    ips = sorted(set(ips))
+    ports = sorted(set(ports))
+
+    # Host prefix correto por família: /32 IPv4, /128 IPv6. Ignora IP inválido.
+    cidrs: List[str] = []
+    for ip in ips:
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            warn(f"endpoint apiserver inválido ignorado: {ip}")
+            continue
+        cidrs.append(f"{ip}/{addr.max_prefixlen}")
+
+    if not cidrs or not ports:
+        warn("endpoints/kubernetes sem IP/porta válidos — mantendo fallback "
+             "RFC1918 do manifest 40")
+        logger.warning("apiserver endpoints discovery vazio para ns=%s", ns)
+        return
+
+    apps = ", ".join(APISERVER_EGRESS_APPS)
+    to_block = "\n".join(f"        - ipBlock: {{ cidr: {c} }}" for c in cidrs)
+    ports_block = "\n".join(f"        - {{ protocol: TCP, port: {p} }}" for p in ports)
+    manifest = (
+        "apiVersion: networking.k8s.io/v1\n"
+        "kind: NetworkPolicy\n"
+        "metadata:\n"
+        f"  name: {POLICY_NAME}\n"
+        f"  namespace: {ns}\n"
+        "spec:\n"
+        "  podSelector:\n"
+        "    matchExpressions:\n"
+        f"      - {{ key: app, operator: In, values: [{apps}] }}\n"
+        "  policyTypes: [\"Egress\"]\n"
+        "  egress:\n"
+        "    - to:\n"
+        f"{to_block}\n"
+        "      ports:\n"
+        f"{ports_block}\n"
+    )
+    try:
+        proc = subprocess.run(
+            [kubectl, "apply", "-n", ns, "-f", "-"],
+            input=manifest, text=True, capture_output=True,
+        )
+    except OSError as exc:
+        warn(f"netpol apiserver-egress não aplicada: {exc}")
+        return
+    if proc.returncode == 0:
+        info("netpol apiserver-egress estreitada para "
+             f"{', '.join(cidrs)} :{','.join(map(str, ports))}")
+    else:
+        warn(f"netpol apiserver-egress não aplicada: {(proc.stderr or '').strip()}")

--- a/infra/k8s/_setup.py
+++ b/infra/k8s/_setup.py
@@ -573,6 +573,11 @@ def _apply_namespace(
     if rc != 0:
         ui.err(f"[{ns}] falha ao aplicar network policies")
         return False
+    # Estreita a egress policy do apiserver para o /32 real (o manifest 40 acima
+    # só carrega o fallback amplo). Best-effort — mantém o fallback se a
+    # descoberta falhar.
+    from _netpol import apply_apiserver_egress_netpol  # noqa: PLC0415
+    apply_apiserver_egress_netpol(kubectl, ns, info=ui.info, warn=ui.warn)
 
     bot_kv, deile_kv, worker_kv = plan.secrets_kv()
     ui.info(f"[{ns}] criando Secrets (nada é impresso)")

--- a/infra/k8s/deploy.py
+++ b/infra/k8s/deploy.py
@@ -208,69 +208,14 @@ def _capture(cmd: List[str], timeout: float = 30.0) -> Optional[str]:
 
 
 def _apply_apiserver_egress_netpol(kubectl: str, ns: str) -> None:
-    """Estreita a NetworkPolicy de egress ao kube-apiserver para o endpoint real.
+    """Wrapper fino sobre :func:`_netpol.apply_apiserver_egress_netpol`.
 
-    NetworkPolicy filtra o IP de destino *pós-DNAT* — o endpoint real do
-    apiserver — e não o ClusterIP do Service ``kubernetes`` (10.43.0.1 em k3s).
-    Por isso liberar só o Service CIDR (10.43.0.0/16) nunca casa com o pacote;
-    o ``kubectl exec`` do auto-renew morre em ``connection refused``. O endpoint
-    real varia por cluster (k3s: ``node:6443``; EKS/GKE: ``master:443``), então
-    descobrimos em runtime via ``endpoints/kubernetes`` e estreitamos o egress
-    para o(s) IP(s) ``/32`` + a(s) porta(s) real(is).
-
-    Best-effort: se a descoberta falhar, o manifest 40 já carrega um fallback
-    RFC1918 (443 + 6443) que cobre qualquer cluster — apenas mais amplo.
+    A lógica é compartilhada (``infra/k8s/_netpol.py``) com os demais caminhos
+    que aplicam o manifest 40 (``_setup.py``, ``_claude_install.py``); aqui só
+    pluga a UI do ``deploy.py``.
     """
-    raw = _capture([kubectl, "get", "endpoints", "kubernetes",
-                    "-n", "default", "-o", "json"])
-    ips: List[str] = []
-    ports: List[int] = []
-    if raw:
-        try:
-            data = json.loads(raw)
-            for subset in data.get("subsets", []) or []:
-                ips.extend(a["ip"] for a in subset.get("addresses", []) or [] if a.get("ip"))
-                ports.extend(p["port"] for p in subset.get("ports", []) or [] if p.get("port"))
-        except (ValueError, KeyError, TypeError):
-            ips, ports = [], []
-    ips = sorted(set(ips))
-    ports = sorted(set(ports))
-    if not ips or not ports:
-        ui.warn("endpoints/kubernetes vazio — mantendo fallback RFC1918 do manifest 40")
-        return
-
-    to_block = "\n".join(f"        - ipBlock: {{ cidr: {ip}/32 }}" for ip in ips)
-    ports_block = "\n".join(f"        - {{ protocol: TCP, port: {p} }}" for p in ports)
-    manifest = (
-        "apiVersion: networking.k8s.io/v1\n"
-        "kind: NetworkPolicy\n"
-        "metadata:\n"
-        "  name: creds-renewer-egress-to-kube-api\n"
-        f"  namespace: {ns}\n"
-        "spec:\n"
-        "  podSelector:\n"
-        "    matchExpressions:\n"
-        "      - { key: app, operator: In, values: [deile-pipeline, claude-creds-renewer, deile-monitor] }\n"
-        "  policyTypes: [\"Egress\"]\n"
-        "  egress:\n"
-        "    - to:\n"
-        f"{to_block}\n"
-        "      ports:\n"
-        f"{ports_block}\n"
-    )
-    try:
-        proc = subprocess.run(
-            [kubectl, "apply", "-n", ns, "-f", "-"],
-            input=manifest, text=True, capture_output=True, cwd=str(ROOT),
-        )
-    except OSError as exc:
-        ui.warn(f"netpol apiserver-egress não aplicada: {exc}")
-        return
-    if proc.returncode == 0:
-        ui.info("netpol apiserver-egress estreitada para "
-                f"{', '.join(ips)} :{','.join(map(str, ports))}")
-    else:
-        ui.warn(f"netpol apiserver-egress não aplicada: {(proc.stderr or '').strip()}")
+    from _netpol import apply_apiserver_egress_netpol  # noqa: PLC0415
+    apply_apiserver_egress_netpol(kubectl, ns, info=ui.info, warn=ui.warn)
 
 
 def read_env() -> Dict[str, str]:
@@ -802,6 +747,10 @@ def k8s_start(args: dict) -> int:
     for dep in K8S_DEPLOYMENTS:
         _run([kubectl, "-n", ns, "scale", f"deployment/{dep}", "--replicas=1"],
              stdout=subprocess.DEVNULL)
+    # Re-estreita a egress policy do apiserver: o IP do node pode ter mudado
+    # enquanto a stack estava parada (ex.: reboot da VM Rancher) — sem isto o
+    # /32 ficaria stale e o auto-renew voltaria a `connection refused`.
+    _apply_apiserver_egress_netpol(kubectl, ns)
     ui.ok("deployments religados (scale → 1).")
     return 0
 
@@ -838,6 +787,9 @@ def k8s_restart(args: dict) -> int:
     for dep in K8S_DEPLOYMENTS:
         _run([kubectl, "-n", ns, "rollout", "restart", f"deployment/{dep}"],
              stdout=subprocess.DEVNULL)
+    # Re-estreita a egress policy do apiserver (endpoint pode ter mudado desde
+    # o último `up`); barato e idempotente, mantém o /32 fresco.
+    _apply_apiserver_egress_netpol(kubectl, ns)
     ui.ok("rollout restart disparado.")
     return 0
 

--- a/infra/k8s/deploy.py
+++ b/infra/k8s/deploy.py
@@ -207,6 +207,72 @@ def _capture(cmd: List[str], timeout: float = 30.0) -> Optional[str]:
     return proc.stdout if proc.returncode == 0 else None
 
 
+def _apply_apiserver_egress_netpol(kubectl: str, ns: str) -> None:
+    """Estreita a NetworkPolicy de egress ao kube-apiserver para o endpoint real.
+
+    NetworkPolicy filtra o IP de destino *pós-DNAT* — o endpoint real do
+    apiserver — e não o ClusterIP do Service ``kubernetes`` (10.43.0.1 em k3s).
+    Por isso liberar só o Service CIDR (10.43.0.0/16) nunca casa com o pacote;
+    o ``kubectl exec`` do auto-renew morre em ``connection refused``. O endpoint
+    real varia por cluster (k3s: ``node:6443``; EKS/GKE: ``master:443``), então
+    descobrimos em runtime via ``endpoints/kubernetes`` e estreitamos o egress
+    para o(s) IP(s) ``/32`` + a(s) porta(s) real(is).
+
+    Best-effort: se a descoberta falhar, o manifest 40 já carrega um fallback
+    RFC1918 (443 + 6443) que cobre qualquer cluster — apenas mais amplo.
+    """
+    raw = _capture([kubectl, "get", "endpoints", "kubernetes",
+                    "-n", "default", "-o", "json"])
+    ips: List[str] = []
+    ports: List[int] = []
+    if raw:
+        try:
+            data = json.loads(raw)
+            for subset in data.get("subsets", []) or []:
+                ips.extend(a["ip"] for a in subset.get("addresses", []) or [] if a.get("ip"))
+                ports.extend(p["port"] for p in subset.get("ports", []) or [] if p.get("port"))
+        except (ValueError, KeyError, TypeError):
+            ips, ports = [], []
+    ips = sorted(set(ips))
+    ports = sorted(set(ports))
+    if not ips or not ports:
+        ui.warn("endpoints/kubernetes vazio — mantendo fallback RFC1918 do manifest 40")
+        return
+
+    to_block = "\n".join(f"        - ipBlock: {{ cidr: {ip}/32 }}" for ip in ips)
+    ports_block = "\n".join(f"        - {{ protocol: TCP, port: {p} }}" for p in ports)
+    manifest = (
+        "apiVersion: networking.k8s.io/v1\n"
+        "kind: NetworkPolicy\n"
+        "metadata:\n"
+        "  name: creds-renewer-egress-to-kube-api\n"
+        f"  namespace: {ns}\n"
+        "spec:\n"
+        "  podSelector:\n"
+        "    matchExpressions:\n"
+        "      - { key: app, operator: In, values: [deile-pipeline, claude-creds-renewer, deile-monitor] }\n"
+        "  policyTypes: [\"Egress\"]\n"
+        "  egress:\n"
+        "    - to:\n"
+        f"{to_block}\n"
+        "      ports:\n"
+        f"{ports_block}\n"
+    )
+    try:
+        proc = subprocess.run(
+            [kubectl, "apply", "-n", ns, "-f", "-"],
+            input=manifest, text=True, capture_output=True, cwd=str(ROOT),
+        )
+    except OSError as exc:
+        ui.warn(f"netpol apiserver-egress não aplicada: {exc}")
+        return
+    if proc.returncode == 0:
+        ui.info("netpol apiserver-egress estreitada para "
+                f"{', '.join(ips)} :{','.join(map(str, ports))}")
+    else:
+        ui.warn(f"netpol apiserver-egress não aplicada: {(proc.stderr or '').strip()}")
+
+
 def read_env() -> Dict[str, str]:
     """Lê o `.env` da raiz como um dicionário simples."""
     data: Dict[str, str] = {}
@@ -597,6 +663,7 @@ def k8s_up(args: dict) -> int:
 
     ui.info("aplicando network policies")
     _run([kubectl, "apply", "-n", ns, "-f", str(MANIFESTS / "40-network-policy.yaml")])
+    _apply_apiserver_egress_netpol(kubectl, ns)
 
     ui.info("criando os Secrets (nada é impresso)")
     deile_secret: Dict[str, str] = {"DEILE_BOT_AUTH_TOKEN": bearer, **llm}
@@ -1806,6 +1873,7 @@ def do_create_namespace(cfg: CreateNamespaceConfig) -> int:
     ui.info("aplicando NetworkPolicies")
     _run([kubectl, "apply", "-n", ns, "-f",
           str(MANIFESTS / "40-network-policy.yaml")])
+    _apply_apiserver_egress_netpol(kubectl, ns)
 
     # ---- 3. Secrets ---------------------------------------------------------
     ui.info("criando Secrets (nada é impresso)")

--- a/infra/k8s/manifests/40-network-policy.yaml
+++ b/infra/k8s/manifests/40-network-policy.yaml
@@ -306,19 +306,25 @@ spec:
         - { protocol: TCP, port: 443 }
 ---
 # ---- pipeline + claude-creds-renewer egress: kube-apiserver --------------------
-# Fix do gap do PR #420 (Decisão #46 auto-renew): o pipeline pod e o CronJob
-# `claude-credentials-renew` invocam `kubectl exec` para ler/escrever credenciais
-# OAuth dentro do claude-worker pod. Esse `kubectl exec` precisa falar TCP/443 com
-# o kube-apiserver (ClusterIP 10.43.0.1 em k3s/Rancher Desktop).
+# O pipeline pod, o deile-monitor e o CronJob `claude-credentials-renew` invocam
+# `kubectl exec` para ler/escrever credenciais OAuth dentro do claude-worker pod.
+# Esse `kubectl exec` precisa falar com o kube-apiserver.
 #
-# A regra `deile-egress-https-llm` (acima) permite egress 443 para o mundo MAS
-# EXCEPT 10.0.0.0/8 — e o Service CIDR do k3s (10.43.0.0/16) cai dentro desse
-# bloco bloqueado. Sem esta NetworkPolicy específica, `kubectl exec` falha com
-# `dial tcp 10.43.0.1:443: connect: connection timed out` e o auto-renew
-# (Decisão #46) degrada para o caminho de bloqueio que exige renew manual.
+# ARMADILHA (causa do bug que ficou em produção): NetworkPolicy filtra o IP de
+# destino *pós-DNAT* — o endpoint REAL do apiserver — e NÃO o ClusterIP do
+# Service `kubernetes` (10.43.0.1). O kube-proxy faz DNAT do ClusterIP para o
+# endpoint real ANTES de a policy ser avaliada. Logo, liberar o Service CIDR
+# (10.43.0.0/16) nunca casa com o pacote: o `kubectl exec` morre em
+# `dial tcp 10.43.0.1:443: connect: connection refused`.
 #
-# Service CIDR em outros clusters: EKS=172.20.0.0/16, GKE/AKS varia. Ajustar
-# o `cidr` abaixo conforme o cluster alvo (k3s/Rancher Desktop usa 10.43/16).
+# O endpoint real varia por cluster e está SEMPRE num range RFC1918:
+#   - k3s/Rancher Desktop : node IP, porta 6443  (ex.: 192.168.64.2:6443)
+#   - EKS/GKE/AKS         : IP do control-plane, porta 443
+# Este bloco é o FALLBACK PORTÁVEL aplicado pelo arquivo cru (`kubectl apply -f`):
+# libera os três ranges privados nas duas portas (443 + 6443), cobrindo qualquer
+# cluster. O `deploy.py` (`_apply_apiserver_egress_netpol`) ESTREITA isto, logo
+# após aplicar este arquivo, para o(s) IP(s) /32 reais + porta real descobertos
+# via `endpoints/kubernetes` — sobrescrevendo esta policy pelo nome.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -331,10 +337,12 @@ spec:
   policyTypes: ["Egress"]
   egress:
     - to:
-        - ipBlock:
-            cidr: 10.43.0.0/16
+        - ipBlock: { cidr: 10.0.0.0/8 }
+        - ipBlock: { cidr: 172.16.0.0/12 }
+        - ipBlock: { cidr: 192.168.0.0/16 }
       ports:
         - { protocol: TCP, port: 443 }
+        - { protocol: TCP, port: 6443 }
 ---
 # ---- deile-monitor ingress: from deilebot only (command proxying) ----------------
 # The bot proxies ad-hoc questions and steer commands to the monitor. No other

--- a/infra/k8s/manifests/40-network-policy.yaml
+++ b/infra/k8s/manifests/40-network-policy.yaml
@@ -322,9 +322,16 @@ spec:
 #   - EKS/GKE/AKS         : IP do control-plane, porta 443
 # Este bloco é o FALLBACK PORTÁVEL aplicado pelo arquivo cru (`kubectl apply -f`):
 # libera os três ranges privados nas duas portas (443 + 6443), cobrindo qualquer
-# cluster. O `deploy.py` (`_apply_apiserver_egress_netpol`) ESTREITA isto, logo
-# após aplicar este arquivo, para o(s) IP(s) /32 reais + porta real descobertos
-# via `endpoints/kubernetes` — sobrescrevendo esta policy pelo nome.
+# cluster. O `infra/k8s/_netpol.py` (chamado por up/create-namespace/restart/
+# start/setup/claude-login) ESTREITA isto, logo após aplicar este arquivo, para
+# o(s) IP(s) host (/32 IPv4, /128 IPv6) + porta real descobertos via
+# `endpoints/kubernetes` — SOBRESCREVENDO esta policy pelo MESMO nome (overwrite-
+# by-name é o que estreita; NetworkPolicy é aditiva, nome distinto só somaria).
+#
+# CUIDADO ao editar este bloco: a regra `egress` (IPs/portas) é REESCRITA em
+# runtime — edições manuais aqui são perdidas no próximo deploy. Só o
+# `podSelector` (lista de apps) é contrato compartilhado: mantenha-o em sincronia
+# com `_netpol.APISERVER_EGRESS_APPS` (trava em test_k8s_manifest_consistency.py).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/infra/k8s/manifests/51-claude-credentials-renew-cron.yaml
+++ b/infra/k8s/manifests/51-claude-credentials-renew-cron.yaml
@@ -86,12 +86,17 @@ spec:
   # de 2h, dois ticks consecutivos sempre cobrem antes da expiração.
   schedule: "0 */4 * * *"
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 5
+  # Só 1 Job vivo por vez basta — renovação é idempotente. history=1 faz o
+  # CronJob controller fazer GC automático dos Jobs antigos (o "mata os outros"
+  # nativo): nunca acumula. backoffLimit=0 → exatamente 1 pod por tick, sem
+  # retry (o próximo tick de 4h cobre qualquer falha transitória; a janela
+  # proativa de 2h sobre TTL de ~8h dá folga de sobra).
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
-      backoffLimit: 1
+      backoffLimit: 0
       ttlSecondsAfterFinished: 86400
       template:
         metadata:


### PR DESCRIPTION
## Problema

O CronJob `claude-credentials-renew` (renovação proativa do OAuth do claude-worker) **falhava em 100% dos Jobs e nunca renovou um único token**. No cluster: 4 Jobs acumulados, 8 pods em `Error`, todos `0/1` desde que o CronJob existe.

Erro real (truncado no log do pod):
```
dial tcp 10.43.0.1:443: connect: connection refused
```

## Causa raiz

A NetworkPolicy `creds-renewer-egress-to-kube-api` liberava egress para o **ClusterIP** do Service `kubernetes` (`10.43.0.0/16:443`). Mas o controlador de NetworkPolicy avalia o IP de destino **pós-DNAT** — o **endpoint real do apiserver** (`192.168.64.2:6443` no k3s/Rancher Desktop; IP do control-plane na porta 443 em EKS/GKE/AKS). O kube-proxy faz DNAT do ClusterIP para esse endpoint **antes** de a policy ser avaliada, então a regra `10.43/16:443` **nunca casa com o pacote** → `connection refused`.

A correção anterior (PR #428) assumiu que liberar o ClusterIP bastava, viu o `connection refused` residual e o atribuiu a um "quirk de routing do Rancher", adiando para uma issue separada que **nunca foi aberta**. O teste de lint daquela PR ainda **cristalizou a suposição errada** (`K3S_SERVICE_CIDR = "10.43.0.0/16"`), ficando verde no config quebrado.

## Solução (portátil: Rancher Desktop + produção)

| Arquivo | Mudança |
|---|---|
| `infra/k8s/manifests/40-network-policy.yaml` | Bloco estático vira **fallback RFC1918** (`10/8`, `172.16/12`, `192.168/16`) nas portas **443 + 6443** — cobre o endpoint real de qualquer cluster (o apiserver está sempre num range privado em uma dessas portas). |
| `infra/k8s/deploy.py` | Novo `_apply_apiserver_egress_netpol`: descobre o endpoint real via `endpoints/kubernetes` e **estreita** a policy para o(s) IP(s) `/32` + porta real, sobrescrevendo o fallback pelo nome. Chamado em `k8s up` e `create-namespace`, logo após aplicar o manifest 40. |
| `deile/tests/infrastructure/test_k8s_manifest_consistency.py` | Deixa de fixar o ClusterIP `10.43.0.0/16`; passa a exigir um `ipBlock` não-vazio na porta 443 **ou** 6443 (aceita fallback e `/32` renderizado). Remove import `os` sem uso. |

**Por que funciona nos dois:** o `/32` + porta saem do cluster vivo, então sempre batem com o apiserver daquele ambiente. Re-renderiza a cada `k8s up`/`restart` — cobre inclusive troca de IP do node do Rancher. O fallback no arquivo garante que `kubectl apply -f 40` cru também funcione em qualquer cluster.

## Bônus — acúmulo de Jobs falhos (manifest 51)

O CronJob criava vários Jobs e não removia os antigos. Ajustado:
- `backoffLimit: 1 → 0` (1 pod por tick, sem retry).
- `successfulJobsHistoryLimit: 2 → 1`, `failedJobsHistoryLimit: 5 → 1` — o CronJob controller passa a fazer **GC automático** dos Jobs antigos (o "mata os outros" nativo do k8s). Sobra sempre 1.

## Validação

- `python3 -m py_compile infra/k8s/deploy.py` ✅
- YAML parse dos manifests 40 + 51 ✅
- YAML renderizado pelo helper (simulado com `192.168.64.2:6443`) parseia e produz a estrutura correta ✅
- `pytest deile/tests/infrastructure/test_k8s_manifest_consistency.py` → 3 passed ✅
- `ruff check` no teste → clean ✅

## Deploy

NetworkPolicy **não exige rebuild de imagem**. Basta `python3 infra/k8s/deploy.py k8s up` (ou `kubectl apply` do manifest 40 + o estreitamento do deploy.py). Limpeza one-time dos Jobs presos: `kubectl -n deile delete jobs -l app.kubernetes.io/name=claude-credentials-renew`.