### PR TITLE
test: failing-restore, leaker table, and meta tests for fixture isolation (#471)

### DIFF
--- a/deile/tests/conftest.py
+++ b/deile/tests/conftest.py
@@ -12,6 +12,18 @@ on the developer's HOME (issue #125 reviewer finding).
 Issue #432: three additional autouse fixtures prevent ordering-dependent
 failures caused by leaked global state (os.environ, logging handlers,
 sys.stdio) across tests that do not use monkeypatch for cleanup.
+
+Issue #471 — Leaker table (bisected during PR #434):
+=======================================================
+Ordering-dependent test         | Leaker source                              | Mechanism
+--------------------------------|--------------------------------------------|------------------------------------------
+test_warns_when_no_tokens       | tests that set GITHUB_TOKEN/GITLAB_TOKEN/  | os.environ mutated via direct assignment,
+                                | GL_TOKEN via direct assignment             | no restore → token present in next test
+TestTickSummary (×7 failures)   | TestFlagSmoke._run_cli() → cli_main()     | logging.disable(CRITICAL) in
+                                | in test_cli_flags.py                       | deile/cli.py:121 leaks
+                                |                                            | logging.root.manager.disable = 50
+test_renderer_task_awaited_     | test that swaps sys.stdout without         | sys.stdout replaced without restore;
+before_stdout_restore           | monkeypatch.setattr                        | next test captures wrong reference
 """
 from __future__ import annotations
 
@@ -104,8 +116,17 @@ def _guard_sys_stdio():
     saved_stderr = sys.stderr
     saved_stdin = sys.stdin
     yield
+    assert sys.stdout is saved_stdout, (
+        f"test mutated sys.stdout without monkeypatch: {sys.stdout!r}"
+    )
     sys.stdout = saved_stdout
+    assert sys.stderr is saved_stderr, (
+        f"test mutated sys.stderr without monkeypatch: {sys.stderr!r}"
+    )
     sys.stderr = saved_stderr
+    assert sys.stdin is saved_stdin, (
+        f"test mutated sys.stdin without monkeypatch: {sys.stdin!r}"
+    )
     sys.stdin = saved_stdin
 
 

--- a/deile/tests/orchestration/pipeline/test_monitor.py
+++ b/deile/tests/orchestration/pipeline/test_monitor.py
@@ -1077,3 +1077,30 @@ class TestTickSummary:
         assert "backlog={issues:3 prs:1}" in msg, (
             f"expected backlog={{issues:3 prs:1}}, got: {msg}"
         )
+
+    async def test_tick_summary_records_count_isolated_from_external_handlers(
+        self, caplog
+    ):
+        """Tick-summary INFO records are captured regardless of prior logging.disable.
+
+        Issue #432: deile/cli.py calls logging.disable(CRITICAL) during CLI runs
+        (TestFlagSmoke → cli_main). Without _clean_logging_handlers restoring
+        logging.root.manager.disable to 0 between tests, all 7 TestTickSummary
+        tests fail when run after TestFlagSmoke because INFO-level records are
+        silently dropped.
+        """
+        assert logging.root.manager.disable == 0, (
+            f"logging.root.manager.disable should be 0 at test start; "
+            f"got {logging.root.manager.disable}. "
+            "_clean_logging_handlers may have failed to restore it."
+        )
+        monitor, _ = _make_monitor()
+        with caplog.at_level(
+            logging.INFO, logger="deile.orchestration.pipeline.monitor"
+        ):
+            await monitor.tick()
+        records = [r for r in caplog.records if "tick #" in r.message]
+        assert len(records) == 1, (
+            f"expected exactly 1 tick-summary record; got {len(records)}. "
+            "Logging isolation may be broken (manager.disable not restored)."
+        )

--- a/deile/tests/orchestration/pipeline/test_runner_token_warning.py
+++ b/deile/tests/orchestration/pipeline/test_runner_token_warning.py
@@ -6,6 +6,7 @@ GITLAB_TOKEN is present, without interrupting execution.
 from __future__ import annotations
 
 import logging
+import os
 
 import pytest
 
@@ -76,3 +77,22 @@ def test_warning_does_not_raise(monkeypatch):
     for key in ("GITHUB_TOKEN", "GITLAB_TOKEN", "GL_TOKEN"):
         monkeypatch.delenv(key, raising=False)
     _warn_if_no_forge_token()  # must not raise
+
+
+def test_warns_even_after_environ_leak(caplog, monkeypatch):
+    """WARNING fires even when os.environ was mutated via direct assignment.
+
+    Issue #432: a prior test could set GITHUB_TOKEN via direct assignment (not
+    monkeypatch), leaving the key in os.environ for subsequent tests. Without
+    _snapshot_os_environ the next call to _warn_if_no_forge_token would find the
+    token and suppress the warning.  This test simulates that leak inline: it
+    sets the key via direct assignment, then verifies the WARNING still fires
+    once the token is removed through normal monkeypatch cleanup.
+    _snapshot_os_environ will restore the original environ after this test ends.
+    """
+    os.environ["GITHUB_TOKEN"] = "leaked-token-direct-assignment"
+    records = _capture_warnings(caplog, {}, monkeypatch)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.levelno == logging.WARNING
+    assert "GITHUB_TOKEN" in rec.message

--- a/deile/tests/test_conftest_isolation.py
+++ b/deile/tests/test_conftest_isolation.py
@@ -1,0 +1,118 @@
+"""Meta-tests that verify the three autouse isolation fixtures in conftest.py.
+
+Issue #471: AC4 — these tests prove that _snapshot_os_environ,
+_clean_logging_handlers, and _guard_sys_stdio (with failing-restore) each
+do their job.  A passing run means the fixtures are functioning; a failure
+means the fixture itself is broken.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import os
+import sys
+
+
+class TestEnvRestore:
+    """_snapshot_os_environ must clean up direct os.environ mutations between tests.
+
+    Two tests run in alphabetical order (a → b). test_a leaks a key via direct
+    assignment; test_b asserts the key is gone.  Pass = fixture worked.
+    """
+
+    def test_a_leaks_env_var(self):
+        """Simulate a leaky test: set env var via direct assignment without monkeypatch."""
+        os.environ["_DEILE_LEAK_KEY"] = "x"
+        assert os.environ["_DEILE_LEAK_KEY"] == "x"
+
+    def test_b_env_is_clean(self):
+        """_snapshot_os_environ must have restored os.environ after test_a."""
+        assert "_DEILE_LEAK_KEY" not in os.environ, (
+            "_DEILE_LEAK_KEY is still in os.environ — "
+            "_snapshot_os_environ did not restore the environment after the previous test."
+        )
+
+
+class TestHandlerRestore:
+    """_clean_logging_handlers must remove handlers added without monkeypatch.
+
+    Two tests run in alphabetical order (a → b). test_a attaches a handler to
+    a named logger; test_b asserts the handler is gone.  Pass = fixture worked.
+    """
+
+    _LOGGER_NAME = "deile._test_handler_restore"
+
+    def test_a_adds_handler(self):
+        """Simulate a leaky test: add a logging handler without cleanup."""
+        logger = logging.getLogger(self._LOGGER_NAME)
+        handler = logging.StreamHandler(io.StringIO())
+        handler.name = "_deile_test_leak_handler"
+        logger.addHandler(handler)
+        assert any(
+            getattr(h, "name", None) == "_deile_test_leak_handler"
+            for h in logger.handlers
+        )
+
+    def test_b_handler_is_gone(self):
+        """_clean_logging_handlers must have removed the handler added in test_a."""
+        logger = logging.getLogger(self._LOGGER_NAME)
+        leaked = [
+            h for h in logger.handlers
+            if getattr(h, "name", None) == "_deile_test_leak_handler"
+        ]
+        assert not leaked, (
+            f"Handler '_deile_test_leak_handler' is still attached to "
+            f"logger '{self._LOGGER_NAME}' — "
+            "_clean_logging_handlers did not restore handlers after the previous test."
+        )
+
+
+def test_stdio_swap_fails_test(pytester):
+    """_guard_sys_stdio's failing-restore marks a test as ERROR if sys.stdout is swapped.
+
+    Uses pytester to spin up an isolated pytest run that contains a conftest
+    with a minimal copy of _guard_sys_stdio (failing-restore variant) and a
+    test that replaces sys.stdout without restoring it.  The run must produce
+    exactly 1 error (teardown assertion failure) and 0 passed/failed tests.
+    Pass = the assert in _guard_sys_stdio fires and exposes the leaker.
+    Fail = silent-restore was used or the fixture is missing.
+    """
+    pytester.makeconftest("""
+import sys
+import pytest
+
+@pytest.fixture(autouse=True)
+def _guard_sys_stdio():
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    saved_stdin = sys.stdin
+    yield
+    assert sys.stdout is saved_stdout, (
+        f"test mutated sys.stdout without monkeypatch: {sys.stdout!r}"
+    )
+    sys.stdout = saved_stdout
+    assert sys.stderr is saved_stderr, (
+        f"test mutated sys.stderr without monkeypatch: {sys.stderr!r}"
+    )
+    sys.stderr = saved_stderr
+    assert sys.stdin is saved_stdin, (
+        f"test mutated sys.stdin without monkeypatch: {sys.stdin!r}"
+    )
+    sys.stdin = saved_stdin
+""")
+    pytester.makepyfile("""
+import sys
+import io
+
+def test_swaps_stdout_without_restore():
+    # Simulate a leaky test: replace sys.stdout without any restore.
+    sys.stdout = io.StringIO()
+""")
+    # -p no:capture: disable pytest's own stdout replacement so the fixture's
+    # failing-restore can observe sys.stdout after the test swapped it.
+    # (With capture enabled, pytest restores sys.stdout before teardown, masking the leak.)
+    result = pytester.runpytest("-p", "no:capture", "-v")
+    # The test body returns normally (passed=1), but the teardown raises
+    # AssertionError (errors=1). Both are expected: the test PASSES, but its
+    # teardown catches the stdout leak and marks it ERROR.
+    result.assert_outcomes(passed=1, errors=1)

--- a/deile/tests/test_conftest_isolation.py
+++ b/deile/tests/test_conftest_isolation.py
@@ -12,6 +12,11 @@ import logging
 import os
 import sys
 
+# Enable the pytester plugin (not loaded by default) so test_stdio_swap_fails_test
+# can spin up an isolated in-process pytest run to verify _guard_sys_stdio's
+# failing-restore assertion.
+pytest_plugins = ["pytester"]
+
 
 class TestEnvRestore:
     """_snapshot_os_environ must clean up direct os.environ mutations between tests.


### PR DESCRIPTION
## Summary

- `_guard_sys_stdio` in `deile/tests/conftest.py`: replaced silent-restore with **failing-restore** — each `assert sys.X is saved_X` before the assignment so teardown exposes leakers as `ERROR` instead of masking them.
- **Leaker table** added to the module docstring of `conftest.py` (3 rows: ordering-dependent test, leaker source, mechanism — derived from bisection during PR #434).
- New `deile/tests/test_conftest_isolation.py` (5 tests / 3 groups): `TestEnvRestore`, `TestHandlerRestore`, and `test_stdio_swap_fails_test` (pytester-based) — meta-tests proving each autouse fixture works.
- `test_warns_even_after_environ_leak` added to `test_runner_token_warning.py`: simulates `GITHUB_TOKEN` leak via direct assignment, asserts warning still fires.
- `test_tick_summary_records_count_isolated_from_external_handlers` added to `TestTickSummary` in `test_monitor.py`: asserts `logging.root.manager.disable == 0` at test start and that the tick-summary record is captured correctly.

All 94 impacted tests pass; `test_subagent_orchestrator.py` (25 tests, AC2) green with no teardown errors.

Closes #471.