### PR TITLE
fix(briefs): autor=deile-one + meu review CHANGES → próximo tick IMPLEMENTA

### DIFF
--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -195,6 +195,7 @@ PASSO 1 — WORK-LIST (do estado, não do trigger):
 - comment dirigido a mim sem resposta → atender o pedido
 - sou assignee + APPROVED + threads ok + CI verde → MERGEAR
 - reviewer só, HEAD igual → comentar curto "já APPROVED em <sha>, sem novidade"
+- **autor==`{gh_login}` (sou eu) + meu_review_atual.body contém "REQUEST_CHANGES" OU "CHANGES" → IMPLEMENTAR**: tratar este tick como `implement-resume`. Ler o último review meu (`gh api repos/{repo}/pulls/{number}/reviews | last`), extrair os achados, escrever code que atende OU comentar justificando por que cada achado é fora-de-escopo/inválido. NUNCA re-revisar a mesma HEAD pedindo as mesmas mudanças — isso é o loop infinito que bate attempt cap. O ciclo é: review-pede → próximo tick implementa OU justifica → review aprova.
 
 REGRA — execute o pedido SEMPRE (não importa o autor):
 - {pr_noun} está OPEN → push direto na própria branch.


### PR DESCRIPTION
## Anomalia detectada em runtime

PR #459 BLOCKED 4/4 attempts hoje (19:30 BRT) sem code novo. Pipeline V4 ficou em loop:
1. Review postada como comment (GitHub bloqueia REQUEST_CHANGES formal em PR própria)
2. Próximo tick: re-aciona review stage → re-revisa MESMA HEAD → mesmas CHANGES
3. attempt cap → BLOCKED

**Custo desperdiçado em loops (31/mai):**
- #459: $1.63 em 3 reviews repetidas
- #465: $5.43 em 4 reviews repetidas

## Causa

GitHub bloqueia `REQUEST_CHANGES` formal quando autor==reviewer. `deile-one` é assignee de quase todas PRs auto-geradas. Brief V4 não reconhece o padrão "meu review prévio pediu CHANGES via comment" e re-aciona review stage indefinidamente.

## Fix

Bullet adicional em PASSO 1 do `_WORKER_PR_BRIEF`:

> **autor==gh_login + meu_review_atual.body contém "REQUEST_CHANGES" → IMPLEMENTAR**: tratar como implement-resume. Ler review, implementar OU justificar fora-de-escopo. NUNCA re-revisar mesma HEAD com mesmas críticas.

O ciclo correto: review-pede → próximo tick implementa OU justifica → review aprova → merge.

## Quote do stakeholder

> "o comentário não precisa nem incluir que não é possível... se comentou o próximo pega critica e continua... ou altera ou justifica"

## Impacto esperado

- #459 BLOCKED pode ser destravada manualmente → próximo tick implementa
- Sem mais loops infinitos de review-only em PRs próprias
- Próximo round de PRs idem: economiza ~$5-10/PR em ciclos perdidos