### PR TITLE
test: ordering smoke tests via pytester + multi-seed command in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Entry point: `python3 deile.py` (CLI shell in `DeileAgentCLI`; all logic lives i
 | Lint | `ruff check deile/` |
 | Imports | `isort --check-only deile/` |
 | Complexity | `radon cc deile/ -a` |
+| Multi-seed ordering | `python3 -m pytest deile/tests/ -q --timeout=120 --randomly-seed=<seed>` para seeds `0`, `1`, `2`, `42`, `last` — detecta ordering-issues futuros |
 
 ## Kubernetes / cluster operations
 

--- a/deile/tests/test_ordering_smoke.py
+++ b/deile/tests/test_ordering_smoke.py
@@ -1,0 +1,66 @@
+"""
+Smoke tests verifying that the 3 autouse fixtures in deile/tests/conftest.py
+guarantee ordering-determinism for the 9 known ordering-dependent tests
+(issues #432/#471, delivered in PR #434).
+
+Target node IDs (verbatim):
+    deile/tests/orchestration/pipeline/test_runner_token_warning.py::test_warns_when_no_tokens
+    deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_idle_tick_logs_summary_with_zeros
+    deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_classify_delta
+    deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_review_delta
+    deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_implement_delta
+    deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_dispatched_delta
+    deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_backlog_unavailable_on_forge_error
+    deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_includes_backlog_counts
+    deile/tests/orchestration/test_subagent_orchestrator.py::test_renderer_task_awaited_before_stdout_restore
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+_TARGET_TESTS = [
+    "deile/tests/orchestration/pipeline/test_runner_token_warning.py::test_warns_when_no_tokens",
+    "deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_idle_tick_logs_summary_with_zeros",
+    "deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_classify_delta",
+    "deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_review_delta",
+    "deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_implement_delta",
+    "deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_reflects_dispatched_delta",
+    "deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_backlog_unavailable_on_forge_error",
+    "deile/tests/orchestration/pipeline/test_monitor.py::TestTickSummary::test_tick_summary_includes_backlog_counts",
+    "deile/tests/orchestration/test_subagent_orchestrator.py::test_renderer_task_awaited_before_stdout_restore",
+]
+
+
+def test_ordering_smoke_reversed(pytester):
+    """9 ordering-dependent tests run last→first with random ordering disabled."""
+    reversed_tests = [str(_REPO_ROOT / t) for t in reversed(_TARGET_TESTS)]
+    result = pytester.runpytest(
+        *reversed_tests,
+        "-p", "no:randomly",
+        "-p", "no:cov",
+        f"--rootdir={_REPO_ROOT}",
+        "-q",
+        "--timeout=120",
+    )
+    assert result.ret == 0
+
+
+def test_ordering_smoke_random_seed_42(pytester):
+    """9 ordering-dependent tests run with fixed random seed 42."""
+    pytest.importorskip("pytest_randomly")
+    target_tests = [str(_REPO_ROOT / t) for t in _TARGET_TESTS]
+    result = pytester.runpytest(
+        *target_tests,
+        "--randomly-seed=42",
+        "-p", "no:cov",
+        f"--rootdir={_REPO_ROOT}",
+        "-q",
+        "--timeout=120",
+    )
+    assert result.ret == 0


### PR DESCRIPTION
## Resumo

Implementa a issue #472: cria `deile/tests/test_ordering_smoke.py` com dois testes via `pytester` que verificam o determinismo de ordenação para os 9 testes conhecidos como ordering-dependent, e documenta o comando multi-seed no CLAUDE.md.

### Mudanças

**`deile/tests/test_ordering_smoke.py`** (novo):
- `test_ordering_smoke_reversed` — executa os 9 testes alvo em ordem invertida (último→primeiro) com `-p no:randomly`; asserta `result.ret == 0`
- `test_ordering_smoke_random_seed_42` — executa com `--randomly-seed=42`; usa `pytest.importorskip("pytest_randomly")` para skip limpo se o plugin não estiver instalado; asserta `result.ret == 0`
- Declara os 9 node IDs alvo verbatim na docstring do módulo (AC3)
- Usa `pytester` (não `subprocess.run`) em ambos os testes (AC2)

**`CLAUDE.md`**:
- Adiciona linha "Multi-seed ordering" na tabela de comandos com template `--randomly-seed=<seed>` e seeds `0`, `1`, `2`, `42`, `last` (AC4)

### Critérios de aceite verificados

- [x] AC1 — `pytest deile/tests/test_ordering_smoke.py -q` → 1 passed, 1 skipped (0 failures)
- [x] AC2 — ambos os testes usam `pytester` (verificável por leitura do arquivo)
- [x] AC3 — 9 node IDs declarados verbatim na docstring do módulo
- [x] AC4 — linha "Multi-seed ordering" com 5 seeds no CLAUDE.md
- [x] AC5 — não altera código de produção; failures existentes não são afetados

Closes #472.