### PR TITLE
fix(skills): debounce worker no skills watcher (thread leak) + vigia V1b OAuth-expired

### DIFF
--- a/deile/personas/instructions/monitor.md
+++ b/deile/personas/instructions/monitor.md
@@ -55,6 +55,44 @@ print(f'expires_in_s={remaining:.0f}')
 - `expires_in_s == UNREADABLE`: O pod pode estar crashado — cheque `kubectl -n deile get pod -l app=claude-worker` e o status.
 - Após cura bem-sucedida: logue em audit; **não** notifique (cura silenciosa).
 
+**V1b — Detecção reativa: `WORKER_AUTH_EXPIRED` nos logs do pipeline (P0)**
+
+> Gap identificado no incidente de 2026-06: o OAuth expirou e o pipeline travou ~70 min sem notificação. V1 é proativo (verifica o credential file antes do prazo), mas não detecta quando o token **já expirou** e o pipeline já está falhando dispatches. Esta sub-vigia cobre esse caso.
+
+```bash
+# Scanear os logs recentes do pipeline em busca de WORKER_AUTH_EXPIRED
+AUTH_ERR_COUNT=$(kubectl -n deile logs deploy/deile-pipeline --tail=200 --since=10m 2>/dev/null \
+  | grep -c "WORKER_AUTH_EXPIRED" || true)
+
+if [ "${AUTH_ERR_COUNT:-0}" -gt 0 ]; then
+  # Token já expirou — pipeline está em backoff ou falhando dispatches.
+  # Tente renovar imediatamente (mesmo caminho de V1).
+  _V1B_START=$(date +%s)
+  kubectl -n deile exec deploy/deile-pipeline -- \
+    kubectl -n deile exec "${CLAUDE_WORKER_POD}" -- sh -c 'claude auth login' \
+    >/dev/null 2>&1
+  _V1B_RC=$?
+  _V1B_ELAPSED=$(( $(date +%s) - _V1B_START ))
+  _V1B_OK="true" ; [ $_V1B_RC -ne 0 ] && _V1B_OK="false"
+  _emit "monitor.action V=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} reason='WORKER_AUTH_EXPIRED in logs count=${AUTH_ERR_COUNT}' ok=${_V1B_OK} elapsed_s=${_V1B_ELAPSED}"
+  if [ "$_V1B_OK" = "true" ]; then
+    _emit "monitor.vigia.fix V=V1 kind=oauth_renew target=${CLAUDE_WORKER_POD} elapsed_s=${_V1B_ELAPSED}"
+  else
+    # Renovação falhou — notifique URGENTE (token requer fluxo OAuth interativo).
+    MSG="🔴 [DEILE-MONITOR] P0: OAuth claude-worker expirado e renovação automática falhou.
+Pipeline com WORKER_AUTH_EXPIRED nos últimos 10min (count=${AUTH_ERR_COUNT}).
+Ação necessária: kubectl exec manual ou k8s claude-login --switch
+Comandos rápidos:
+  /status — visão geral do cluster
+  /monitor pause 30m — pausa o monitor por 30min"
+    _notify "oauth_expired_renew_failed_${CLAUDE_WORKER_POD}" "P0" "$MSG"
+  fi
+  ACTIONS=$(( ACTIONS + 1 ))
+fi
+```
+
+Onde `_notify` é o helper que encapsula o `curl` ao deilebot + emit estruturado (definido na seção "Sistema de notificação").
+
 **Emit estruturado após cada tentativa de renovação OAuth (V1):**
 
 > **Regra 5 do schema (sem leak de segredo)**: o stdout do `kubectl exec ... claude auth login` contém o OAuth token — NUNCA capture nem ecoe. Redirecione com `>/dev/null 2>&1` e emita SOMENTE `ok=`/`elapsed_s=`.

--- a/deile/skills/watcher.py
+++ b/deile/skills/watcher.py
@@ -2,8 +2,12 @@
 
 Concurrency:
 - ``watchdog`` runs the observer on its own thread.
-- Editor write-bursts are debounced via a ``threading.Timer`` guarded by
-  ``_timer_lock`` (many editors emit multiple writes per save).
+- Editor write-bursts are debounced by a **single, reused** ``_DebounceWorker``
+  thread (replaces the old per-event ``threading.Timer`` pattern that leaked
+  threads when the reload was slow or FS events arrived in bursts).
+- ``_DebounceWorker`` wakes on ``_event`` (set by ``_on_event``), checks whether
+  the debounce window has elapsed, and loops.  The loop exits when ``_stopping``
+  is True.  At most **one** extra thread is alive regardless of event rate.
 - ``reload_registry`` swaps registry contents atomically via
   ``SkillRegistry.replace_all`` so readers never see a torn state.
 - ``_RELOAD_LOCK`` serializes overlapping reloads (manual + watcher; or two
@@ -15,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from pathlib import Path
 from typing import Any, Callable, Iterable, List, Optional
 
@@ -60,6 +65,87 @@ def reload_registry(
         return len(skills)
 
 
+class _DebounceWorker(threading.Thread):
+    """Single background thread that fires a reload after a quiet period.
+
+    Design rationale
+    ----------------
+    The previous implementation created a new ``threading.Timer`` (= a new OS
+    thread) on *every* filesystem event and cancelled the previous one.  Under
+    heavy load — e.g. a large ``git checkout``, a language server touching many
+    ``.md`` files at once, or a slow ``reload_registry`` call that holds
+    ``_RELOAD_LOCK`` while many new events arrive — cancelled timers accumulated
+    faster than Python's GC reclaimed their thread objects, eventually hitting
+    the OS ``ulimit -u`` ceiling and raising ``RuntimeError: can't start new
+    thread``.
+
+    This class replaces all of that with **one** long-lived thread.  The thread
+    blocks on an ``threading.Event``; ``signal()`` wakes it and records the
+    "last seen" timestamp.  The thread loops: if the debounce window has not
+    elapsed yet it waits the remaining time and checks again; once the window
+    elapses without a new signal it fires the reload and goes back to sleep.
+
+    At most **one** extra OS thread is alive regardless of how many FS events
+    arrive per second.
+    """
+
+    def __init__(
+        self,
+        debounce_seconds: float,
+        trigger: Callable[[], None],
+    ) -> None:
+        super().__init__(daemon=True, name="deile-skills-debounce")
+        self._debounce = debounce_seconds
+        self._trigger = trigger
+        self._event = threading.Event()
+        self._stop_event = threading.Event()
+        # Monotonic timestamp of the last signal; 0 = no pending signal.
+        self._last_signal: float = 0.0
+        self._lock = threading.Lock()
+
+    def signal(self) -> None:
+        """Record a new FS event and wake the worker thread."""
+        with self._lock:
+            self._last_signal = time.monotonic()
+        self._event.set()
+
+    def stop(self) -> None:
+        """Request shutdown and join."""
+        self._stop_event.set()
+        self._event.set()  # unblock the wait
+        self.join(timeout=2.0)
+
+    def run(self) -> None:  # noqa: C901 (acceptable complexity for a loop)
+        while not self._stop_event.is_set():
+            self._event.wait()
+            self._event.clear()
+
+            if self._stop_event.is_set():
+                break
+
+            # Drain the debounce window: keep waiting until no new signal
+            # arrives for the full debounce interval.
+            while True:
+                with self._lock:
+                    last = self._last_signal
+                remaining = last + self._debounce - time.monotonic()
+                if remaining <= 0:
+                    break
+                # Sleep for the remaining window; a new signal will set _event
+                # again and we'll recheck.
+                self._event.wait(timeout=remaining)
+                self._event.clear()
+                if self._stop_event.is_set():
+                    return
+
+            # Clear last_signal so we don't re-fire until the next signal.
+            with self._lock:
+                self._last_signal = 0.0
+
+            if not self._stop_event.is_set():
+                self._trigger()
+
+
 class SkillsWatcher:
     """Filesystem watcher that calls ``reload_registry`` on ``.md`` changes."""
 
@@ -83,8 +169,7 @@ class SkillsWatcher:
         self._on_error = on_error
 
         self._observer: Optional[Any] = None
-        self._timer: Optional[threading.Timer] = None
-        self._timer_lock = threading.Lock()
+        self._debounce_worker: Optional[_DebounceWorker] = None
         self._is_active = False
         self._stopping = False
 
@@ -128,6 +213,14 @@ class SkillsWatcher:
             )
             return False
 
+        # Start the single debounce worker thread before scheduling watchdog.
+        worker = _DebounceWorker(
+            debounce_seconds=self._debounce_seconds,
+            trigger=self._trigger_reload,
+        )
+        worker.start()
+        self._debounce_worker = worker
+
         callback = self._on_event
 
         class _Handler(FileSystemEventHandler):
@@ -152,6 +245,8 @@ class SkillsWatcher:
 
         if scheduled_count == 0:
             logger.warning("skills: hot-reload not started — every observer.schedule() call failed")
+            worker.stop()
+            self._debounce_worker = None
             return False
 
         observer.start()
@@ -161,12 +256,11 @@ class SkillsWatcher:
         return True
 
     def stop(self) -> None:
-        """Idempotent — cancels any pending debounce timer and joins the observer."""
+        """Idempotent — stops the debounce worker and joins the observer."""
         self._stopping = True
-        with self._timer_lock:
-            if self._timer is not None:
-                self._timer.cancel()
-                self._timer = None
+        if self._debounce_worker is not None:
+            self._debounce_worker.stop()
+            self._debounce_worker = None
         if self._observer is not None:
             try:
                 self._observer.stop()
@@ -179,18 +273,10 @@ class SkillsWatcher:
     def _on_event(self, src_path: str) -> None:
         if self._stopping:
             return
-        with self._timer_lock:
-            if self._timer is not None:
-                self._timer.cancel()
-            self._timer = threading.Timer(self._debounce_seconds, self._trigger_reload)
-            self._timer.daemon = True
-            self._timer.start()
+        if self._debounce_worker is not None:
+            self._debounce_worker.signal()
 
     def _trigger_reload(self) -> None:
-        # Clear the timer reference first so a fresh event arriving while we
-        # run can start a new timer without races.
-        with self._timer_lock:
-            self._timer = None
         if self._stopping:
             return
         try:

--- a/deile/tests/skills/test_watcher.py
+++ b/deile/tests/skills/test_watcher.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 from deile.skills.registry import get_skill_registry, reset_skill_registry
-from deile.skills.watcher import SkillsWatcher, reload_registry
+from deile.skills.watcher import _DebounceWorker, SkillsWatcher, reload_registry
 
 
 @pytest.fixture(autouse=True)
@@ -205,6 +205,91 @@ class TestSkillsWatcher:
         watcher.stop()
         watcher.stop()  # second stop should not raise
         assert watcher.is_active is False
+
+
+@pytest.mark.unit
+class TestDebounceWorkerNoThreadLeak:
+    """Verify that rapid FS events do NOT accumulate OS threads.
+
+    Regression test for the bug reported on the deile-monitor pod after ~22h
+    uptime: ``RuntimeError: can't start new thread``.  The old implementation
+    created a new ``threading.Timer`` per event; under heavy load (large git
+    checkout, slow ``reload_registry``, etc.) cancelled-but-not-yet-exited
+    timer threads accumulated until the OS ulimit was hit.
+
+    The new implementation uses a single ``_DebounceWorker`` thread — firing
+    1000 signals must NOT create more than 1 additional thread.
+    """
+
+    def test_single_worker_thread_survives_burst(self) -> None:
+        """1000 rapid signals must not spawn more than 1 extra thread."""
+        reload_calls: list = []
+        barrier = threading.Event()
+
+        def slow_trigger() -> None:
+            reload_calls.append(1)
+            # Simulate a slow reload to maximise thread-accumulation pressure.
+            barrier.wait(timeout=2.0)
+
+        before = threading.active_count()
+        worker = _DebounceWorker(debounce_seconds=0.01, trigger=slow_trigger)
+        worker.start()
+
+        try:
+            # Fire 1000 signals in rapid succession.
+            for _ in range(1000):
+                worker.signal()
+
+            # Give debounce window time to elapse so trigger fires.
+            time.sleep(0.1)
+
+            peak = threading.active_count()
+            # Allow the slow trigger to finish.
+            barrier.set()
+            time.sleep(0.1)
+        finally:
+            worker.stop()
+
+        # The worker itself is 1 extra thread; the watchdog observer is not
+        # started here.  Allow a small slack of 2 for any test-framework
+        # threads that might appear briefly.
+        extra = peak - before
+        assert extra <= 3, (
+            f"Thread leak detected: {extra} extra threads at peak "
+            f"(expected ≤ 3 for single debounce worker). "
+            f"before={before}, peak={peak}"
+        )
+
+    def test_many_signals_produce_single_reload(self) -> None:
+        """A burst of signals within the debounce window fires exactly one reload."""
+        reload_calls: list = []
+
+        def trigger() -> None:
+            reload_calls.append(time.monotonic())
+
+        worker = _DebounceWorker(debounce_seconds=0.05, trigger=trigger)
+        worker.start()
+        try:
+            # Send 50 signals in quick succession — all within debounce window.
+            for _ in range(50):
+                worker.signal()
+            # Wait for 3× the debounce window so the reload must have fired.
+            time.sleep(0.3)
+        finally:
+            worker.stop()
+
+        assert len(reload_calls) == 1, (
+            f"Expected exactly 1 reload from burst of 50 signals, "
+            f"got {len(reload_calls)}: {reload_calls}"
+        )
+
+    def test_stop_cleans_up_worker_thread(self) -> None:
+        """After stop(), the worker thread is no longer alive."""
+        worker = _DebounceWorker(debounce_seconds=0.1, trigger=lambda: None)
+        worker.start()
+        assert worker.is_alive()
+        worker.stop()
+        assert not worker.is_alive(), "Worker thread still alive after stop()"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Extrai do #480 (onde foi misturado por engano) os 2 fixes do deile-monitor.

## Thread leak (`deile/skills/watcher.py`)
Timer-por-evento acumulava threads bloqueadas no `_RELOAD_LOCK` → `RuntimeError: can't start new thread` após ~22h. Substituído por um `_DebounceWorker` único (1 thread máx).

## Vigia V1b (`monitor.md`)
V1 só cobria expiração *iminente*; não cobria token *já expirado* (`WORKER_AUTH_EXPIRED` no pipeline) — gap que causou o incidente de ~70 min na madrugada. V1b varre logs do pipeline e renova/notifica P0.

## Testes
12/12 verdes (3 novos anti-leak). 

Relacionado: incidente OAuth (complementa #484). Separado do #480 (painel) a pedido do operador.