### PR TITLE
fix(collector): gate assignee-in-issue mention triggers by ~workflow:* (#483)

### DIFF
--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -503,10 +503,18 @@ async def _collect_mention_triggers(
     """Poll all four mention sources and return the raw trigger list.
 
     Comment mentions are cursor-bounded (only comments newer than the saved
-    cursor fire). The sticky sources (assignee / reviewer / body) carry the
-    target's labels with no timestamp, so any target already marked
-    ``~mention:processado`` is filtered out here — see :func:`process_mentions`
-    for the cross-tick dedup rationale.
+    cursor fire).
+
+    Sticky trigger behaviour by source:
+
+    * **assignee/reviewer (PR)** — NOT filtered by ``~mention:processado``.
+      Discovery-by-state: the unified PR brief opens the PR and decides whether
+      there is real work to do.  Sticky-success marks the marker to avoid churn.
+    * **assignee (issue)** — NOT filtered by ``~mention:processado``, but IS
+      gated by ``~workflow:*``: issues already owned by the pipeline (gate label
+      present) are skipped to prevent EVENTS panel flooding (issue #483).
+    * **body** — still filtered by ``~mention:processado`` because the body is
+      static: without the marker it would re-fire every tick indefinitely.
     """
     triggers: list[MentionTrigger] = []
 
@@ -553,6 +561,11 @@ async def _collect_mention_triggers(
             return []
 
     for issue in await _poll("assigned issues", monitor.forge.list_issues_assigned_to(gh_login)):
+        # Gate: skip issues already owned by the pipeline (any ~workflow:* label).
+        # Without this, every tick re-arms a MentionTrigger for every in-flight
+        # issue, flooding the EVENTS panel (issue #483 — V1 fix).
+        if any(lb.startswith("~workflow:") for lb in (issue.labels or [])):
+            continue
         triggers.append(
             MentionTrigger(
                 trigger_type="assignee", issue=issue, trigger_author=gh_login,

--- a/deile/tests/orchestration/pipeline/test_collector_assignee_gated_by_workflow.py
+++ b/deile/tests/orchestration/pipeline/test_collector_assignee_gated_by_workflow.py
@@ -1,0 +1,126 @@
+"""Assignee-in-issue loop is gated by ``~workflow:*`` labels (issue #483 V1 fix).
+
+Issues that already carry a pipeline gate label (``~workflow:<anything>``) are
+skipped by the assignee loop to prevent every tick re-arming a MentionTrigger
+and flooding the EVENTS panel.
+
+Issues WITHOUT any ``~workflow:*`` label (including those with only
+``~mention:processado``) MUST still produce a trigger — this preserves the
+Decisão #45 invariant tested in
+``test_collector_assignee_not_gated_by_mention_done.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deile.orchestration.pipeline.github_client import IssueRef
+from deile.orchestration.pipeline.labels import MENTION_DONE
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+from deile.orchestration.pipeline.stages import _collect_mention_triggers
+
+
+def _make_monitor(*, assigned_issues: list | None = None) -> PipelineMonitor:
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+        mention_handle="@deile-one",
+    )
+    github = MagicMock()
+    github.list_issue_comments_since = AsyncMock(return_value=[])
+    github.list_pr_review_comments_since = AsyncMock(return_value=[])
+    github.list_issues_assigned_to = AsyncMock(return_value=list(assigned_issues or []))
+    github.list_prs_assigned_to = AsyncMock(return_value=[])
+    github.list_prs_with_review_requests = AsyncMock(return_value=[])
+    github.search_items_mentioning = AsyncMock(return_value=([], []))
+    notifier = MagicMock()
+    notifier.error = AsyncMock()
+    return PipelineMonitor(
+        cfg, github=github, worktrees=MagicMock(), claude=MagicMock(),
+        notifier=notifier,
+    )
+
+
+def _issue(number: int, labels=()) -> IssueRef:
+    return IssueRef(
+        number=number, title="t", url=f"https://github.com/o/r/issues/{number}",
+        labels=tuple(labels),
+    )
+
+
+class TestAssigneeIssueGatedByWorkflow:
+    """The assignee-in-issue loop skips gate-owned issues (issue #483 V1 fix)."""
+
+    async def test_issue_with_workflow_nova_is_skipped(self):
+        """An issue with ``~workflow:nova`` must NOT produce a trigger."""
+        monitor = _make_monitor(assigned_issues=[_issue(10, labels=("~workflow:nova",))])
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        assert triggers == []
+
+    async def test_issue_with_workflow_em_implementacao_is_skipped(self):
+        """An issue deep in the pipeline must NOT produce a trigger."""
+        monitor = _make_monitor(
+            assigned_issues=[_issue(11, labels=("~workflow:em_implementacao",))]
+        )
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        assert triggers == []
+
+    async def test_issue_with_arbitrary_workflow_label_is_skipped(self):
+        """Any ``~workflow:*`` variant must suppress the trigger."""
+        for label in (
+            "~workflow:em_revisao",
+            "~workflow:revisada",
+            "~workflow:decomposta",
+            "~workflow:em_pr",
+            "~workflow:bloqueada",
+            "~workflow:em_refinamento",
+            "~workflow:em_arquitetura",
+            "~workflow:aguardando_stakeholder",
+        ):
+            monitor = _make_monitor(assigned_issues=[_issue(12, labels=(label,))])
+            triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+            assert triggers == [], f"Expected no trigger for issue with label {label!r}"
+
+    async def test_issue_without_workflow_label_produces_trigger(self):
+        """An issue with no ``~workflow:*`` label MUST produce a trigger."""
+        monitor = _make_monitor(assigned_issues=[_issue(20)])
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        assert len(triggers) == 1
+        assert triggers[0].trigger_type == "assignee"
+        assert triggers[0].issue is not None
+        assert triggers[0].issue.number == 20
+
+    async def test_issue_with_only_mention_done_produces_trigger(self):
+        """``~mention:processado`` alone must NOT suppress the trigger.
+
+        This preserves Decisão #45 / Decisão #32 invariant: the assignee loop
+        is NOT gated by ``~mention:processado``.  The test mirrors
+        ``test_assignee_issue_with_mention_done_still_arms`` in
+        ``test_collector_assignee_not_gated_by_mention_done.py``.
+        """
+        monitor = _make_monitor(assigned_issues=[_issue(42, labels=(MENTION_DONE,))])
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        assert len(triggers) == 1
+        assert triggers[0].issue is not None
+        assert triggers[0].issue.number == 42
+
+    async def test_mixed_batch_only_non_workflow_issues_fire(self):
+        """When multiple issues are returned, only those without ``~workflow:*``
+        produce triggers."""
+        issues = [
+            _issue(1, labels=("~workflow:nova",)),
+            _issue(2),
+            _issue(3, labels=("~workflow:em_implementacao",)),
+            _issue(4, labels=(MENTION_DONE,)),
+        ]
+        monitor = _make_monitor(assigned_issues=issues)
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        trigger_numbers = {t.issue.number for t in triggers if t.issue}
+        assert trigger_numbers == {2, 4}, (
+            "Expected triggers for issues 2 and 4 (no ~workflow:* label); "
+            f"got {trigger_numbers}"
+        )

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -376,15 +376,16 @@ class TestProcessMentionsCrossTickDedup:
         github.add_labels.assert_any_call("issue", 42, [MENTION_DONE])
 
     async def test_assignee_issue_already_in_pipeline_not_reclassified(self):
-        """If the issue already carries a ~workflow:* label, don't re-add nova —
-        just mark processed."""
+        """If the issue already carries a ~workflow:* label it is gated OUT in
+        the collector (issue #483 V1 fix) — no trigger is produced, so no label
+        is ever added (neither WORKFLOW_NEW nor MENTION_DONE)."""
         monitor, github, notifier = _make_monitor()
         github.list_issues_assigned_to = AsyncMock(
             return_value=[_issue_ref(42, labels=("~workflow:em_revisao",))]
         )
         await monitor._process_mentions()
-        # only the MENTION_DONE marker, never WORKFLOW_NEW
-        github.add_labels.assert_called_once_with("issue", 42, [MENTION_DONE])
+        # The collector skips the issue entirely — no label mutations at all.
+        github.add_labels.assert_not_called()
 
     async def test_assignee_pr_dispatch_marks_processed_with_pr_kind(self):
         monitor, github, notifier = _make_monitor()


### PR DESCRIPTION
## Summary

Fix EVENTS panel flooding with spurious `mention` events on gate-owned issues.

**Root cause:** The assignee-in-issue loop in `_collect_mention_triggers` (stages.py:555-560) appended a MentionTrigger every tick for issues with `~workflow:*` labels, even though they were already in pipeline. The downstream `_route_issue_to_pipeline` correctly skipped them (no-op), but the unconditional `logger.info` at line 613 still fired, causing the panel to display a spurious mention event every ~70s.

**Fix (V1):** Added gate in the assignee-in-issue loop: skip issues where any label starts with `~workflow:`. This is orthogonal to the `~mention:processado` gate (Decisão #45 preserved — see test `test_assignee_issue_with_mention_done_still_arms`).

**Also:** Fixed the incorrect docstring in `_collect_mention_triggers` that falsely claimed sticky loops filter by `~mention:processado`.

Closes #483.