### PR TITLE
feat(claude-worker): ledger de custo durável antes de podar JSONL órfão (#445)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,8 +256,12 @@ python3 infra/k8s/deploy.py k8s claude-login --no-interactive
 |---|---|---|
 | `DEILE_CLAUDE_CLEANUP_RETENTION_DAYS` | `7` | Dias de retenção dos workdirs (startup hook + CronJob). Workdirs sem sessão JSONL ou mais antigos que N dias são removidos. |
 | `DEILE_PIPELINE_MAX_PARALLEL` | `2` | Número máximo de dispatches simultâneos no pipeline. Aceita inteiro ≥ 1. Muda via `[p]` no painel (rollout do `deile-pipeline` sem rebuild). |
+| `DEILE_CLAUDE_COST_LEDGER_PATH` | `~/.claude/cost-ledger.jsonl` | Ledger append-only durável de custo (issue #445). Cada sessão JSONL órfã tem os tokens por modelo colhidos para cá ANTES de o transcript ser podado. |
+| `DEILE_CLAUDE_JSONL_ORPHAN_GRACE_S` | `3600` | Grace period (s) para podar JSONL órfão. Só dirs de projeto cujo workdir-pai sumiu E sem modificação dentro dessa janela são colhidos+podados (guarda TOCTOU contra resume agendado). |
 
 **CronJob diário:** `claude-worker-cleanup` (03:00 UTC) — monta o PVC `claude-worker-home` e varre leases stale + workdirs abandonados. `kubectl get cronjobs -n deile` para verificar.
+
+**Ledger de custo (issue #445):** os transcripts do `claude -p` (`~/.claude/projects/-home-claude-work-<task_id>/`) carregam duas responsabilidades acopladas com ciclos de vida opostos — continuidade `--resume` (volumoso, efêmero) e auditoria de custo (minúsculo, permanente). O cleanup antes só varria `/home/claude/work` (workdirs) e deixava os transcripts acumularem (200+ dirs / 85 MB). Agora o `_do_cleanup` (startup + CronJob + `/v1/cleanup`) **colhe o custo de cada sessão órfã para o ledger durável ANTES de podar** o transcript: `infra/k8s/jsonl_cost.py` (`aggregate_jsonl` + tabela de preços, fonte única) agrega tokens por modelo; o harvester anexa ao ledger (dedup por `session_id`, idempotente); o `session_tokens_audit.py` lê o ledger (sessões podadas) + o JSONL vivo (recentes), com custo idêntico (mesma `cost_of_model`). Resultado: custo histórico permanente em escala de KB, transcripts podam livremente.
 
 ### Threat model resumido
 

--- a/deile/tests/infrastructure/test_audit_ledger_read.py
+++ b/deile/tests/infrastructure/test_audit_ledger_read.py
@@ -1,0 +1,118 @@
+"""O ``session_tokens_audit`` deve ler o ledger de custo (issue #445).
+
+Sessões já podadas do disco vivem só no ledger. O ``IN_POD_PARSER`` (que roda
+dentro do pod) precisa emitir um registro sintético por sessão colhida, com a
+MESMA estrutura ``models`` — para o custo histórico sobreviver à poda.
+
+Estes testes executam o ``IN_POD_PARSER`` num subprocess (como o audit faz no
+pod), apontando o ledger via ``DEILE_CLAUDE_COST_LEDGER_PATH``, e conferem que:
+- a sessão colhida aparece marcada ``harvested`` com os tokens corretos;
+- o custo calculado pela função compartilhada bate com o esperado.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, str(_INFRA_K8S / filename))
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture
+def audit():
+    if str(_INFRA_K8S) not in sys.path:
+        sys.path.insert(0, str(_INFRA_K8S))
+    return _load("audit_ledger_test", "session_tokens_audit.py")
+
+
+@pytest.fixture
+def jc():
+    return _load("jc_ledger_test", "jsonl_cost.py")
+
+
+def _run_parser(parser_src: str, ledger_path: Path) -> list:
+    proc = subprocess.run(
+        [sys.executable, "-"],
+        input=parser_src,
+        capture_output=True, text=True,
+        env={
+            "DEILE_CLAUDE_COST_LEDGER_PATH": str(ledger_path),
+            "AUDIT_NO_GIT": "1",
+            "HOME": str(ledger_path.parent.parent),
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    raw = proc.stdout.strip()
+    for ln in reversed(raw.splitlines()):
+        ln = ln.strip()
+        if ln.startswith("["):
+            return json.loads(ln)
+    raise AssertionError(f"saída não é JSON: {raw[:500]}")
+
+
+def test_parser_emits_harvested_session(audit, jc, tmp_path):
+    ledger = tmp_path / ".claude" / "cost-ledger.jsonl"
+    ledger.parent.mkdir(parents=True)
+    models = {"claude-opus-4-5-20260101": {
+        "in": 100, "out": 50, "cc": 200, "cr": 300, "cc_5m": 150, "cc_1h": 50}}
+    ledger.write_text(json.dumps({
+        "v": 1, "session_id": "sess-harvested-1", "task_id": "aaaaaaaaaaaa0001",
+        "models": models, "first_ts": "2026-06-01T10:00:00.000Z",
+        "last_ts": "2026-06-01T10:05:00.000Z", "assistant_rounds": 3,
+        "harvested_at": 1_780_000_000.0,
+    }) + "\n", encoding="utf-8")
+
+    sessions = _run_parser(audit.IN_POD_PARSER, ledger)
+    harvested = [s for s in sessions if s.get("session_file") == "sess-harvested-1.jsonl"]
+    assert len(harvested) == 1
+    s = harvested[0]
+    assert s["harvested"] is True
+    assert s["models"] == models
+    # custo idêntico ao do JSONL vivo (mesma função compartilhada)
+    expected = jc.cost_of_model(models["claude-opus-4-5-20260101"],
+                                "claude-opus-4-5-20260101")
+    assert expected == pytest.approx(
+        (100 * 5 + 50 * 25 + 150 * 6.25 + 50 * 10 + 300 * 0.5) / 1_000_000.0)
+
+
+def test_parser_dedups_ledger_session_ids(audit, tmp_path):
+    ledger = tmp_path / ".claude" / "cost-ledger.jsonl"
+    ledger.parent.mkdir(parents=True)
+    rec = {
+        "v": 1, "session_id": "dup-1", "task_id": "bbbbbbbbbbbb0002",
+        "models": {"claude-sonnet-4-5": {"in": 10, "out": 5, "cc": 0,
+                                         "cr": 0, "cc_5m": 0, "cc_1h": 0}},
+        "first_ts": None, "last_ts": None, "assistant_rounds": 1,
+        "harvested_at": 1_780_000_000.0,
+    }
+    # duas linhas com o mesmo session_id (não deve duplicar na saída)
+    ledger.write_text(json.dumps(rec) + "\n" + json.dumps(rec) + "\n",
+                      encoding="utf-8")
+    sessions = _run_parser(audit.IN_POD_PARSER, ledger)
+    dups = [s for s in sessions if s.get("session_file") == "dup-1.jsonl"]
+    assert len(dups) == 1
+
+
+def test_audit_cost_functions_come_from_shared_module(audit, jc):
+    # fonte única: o audit importa as funções de custo do jsonl_cost (não
+    # define cópia local). Prova estrutural via __module__ + equivalência.
+    assert audit.cost_of_model.__module__ == "jsonl_cost"
+    assert audit.nocache_cost_of_model.__module__ == "jsonl_cost"
+    tk = {"in": 100, "out": 50, "cc": 200, "cr": 300, "cc_5m": 150, "cc_1h": 50}
+    assert audit.cost_of_model(tk, "claude-opus-4-5") == jc.cost_of_model(
+        tk, "claude-opus-4-5")

--- a/deile/tests/infrastructure/test_cost_ledger_harvest.py
+++ b/deile/tests/infrastructure/test_cost_ledger_harvest.py
@@ -1,0 +1,168 @@
+"""Testes do harvester de custo + poda de JSONL órfão (issue #445).
+
+O cleanup só varria ``/home/claude/work`` e deixava 200+ JSONL órfãos em
+``~/.claude/projects`` (85 MB). A correção colhe o custo de cada sessão órfã
+para um ledger durável ANTES de podar o transcript volumoso — o custo
+histórico sobrevive em escala de KB.
+
+Cobre:
+- Harvest + poda de dir órfão (workdir-pai ausente), preservando o ativo.
+- Grace period: órfão recém-modificado NÃO é podado (guarda TOCTOU).
+- Idempotência: rodar duas vezes não duplica no ledger.
+- ``dry_run``: reporta candidatos sem deletar nem escrever.
+- Integração no preview ``_cleanup_scan`` (campo ``orphan_jsonl_dirs`` +
+  bytes somados a ``total_candidate_bytes``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+
+
+@pytest.fixture
+def cws():
+    # ``infra/k8s`` não é package; in-pod o script roda com seu dir no
+    # sys.path (por isso importa ``dispatch_logger``/``jsonl_cost`` siblings).
+    # Replicamos isso aqui para o load dinâmico resolver os irmãos isolado.
+    if str(_INFRA_K8S) not in sys.path:
+        sys.path.insert(0, str(_INFRA_K8S))
+    spec = importlib.util.spec_from_file_location(
+        "cws_ledger_test", str(_INFRA_K8S / "claude_worker_server.py"),
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["cws_ledger_test"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+TASK_A = "aaaaaaaaaaaa0001"
+TASK_B = "bbbbbbbbbbbb0002"
+
+
+def _assistant_line(model="claude-opus-4-5-20260101", mid="m1", rid="r1",
+                    in_tok=100, out_tok=50):
+    return json.dumps({
+        "type": "assistant",
+        "requestId": rid,
+        "timestamp": "2026-06-01T10:00:00.000Z",
+        "message": {"id": mid, "role": "assistant", "model": model,
+                    "usage": {"input_tokens": in_tok, "output_tokens": out_tok}},
+    })
+
+
+def _make_project(projects_dir: Path, task_id: str, session_id: str,
+                  *, mtime_age_s: float, in_tok=100, out_tok=50) -> Path:
+    pdir = projects_dir / f"-home-claude-work-{task_id}"
+    pdir.mkdir(parents=True)
+    jsonl = pdir / f"{session_id}.jsonl"
+    jsonl.write_text(_assistant_line(in_tok=in_tok, out_tok=out_tok) + "\n",
+                     encoding="utf-8")
+    old = time.time() - mtime_age_s
+    import os
+    os.utime(jsonl, (old, old))
+    os.utime(pdir, (old, old))
+    return pdir
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Monta HOME falso com projects/ + work/ e devolve os paths."""
+    home = tmp_path / "home"
+    projects = home / ".claude" / "projects"
+    projects.mkdir(parents=True)
+    work = home / "work"
+    work.mkdir()
+    ledger = home / ".claude" / "cost-ledger.jsonl"
+    return {"home": home, "projects": projects, "work": work, "ledger": ledger}
+
+
+def _read_ledger(ledger: Path):
+    if not ledger.exists():
+        return []
+    return [json.loads(ln) for ln in ledger.read_text().splitlines() if ln.strip()]
+
+
+def test_harvest_and_prune_orphan_preserves_active(cws, env):
+    # A: órfão (workdir ausente, antigo). B: workdir presente → preservar.
+    pdir_a = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
+    pdir_b = _make_project(env["projects"], TASK_B, "sess-b", mtime_age_s=7200)
+    (env["work"] / TASK_B).mkdir()  # workdir de B existe
+
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, now=time.time(),
+    )
+
+    assert result["sessions_harvested"] == 1
+    assert result["jsonl_dirs_removed"] == 1
+    assert not pdir_a.exists()       # órfão podado
+    assert pdir_b.exists()           # ativo preservado
+
+    led = _read_ledger(env["ledger"])
+    assert len(led) == 1
+    rec = led[0]
+    assert rec["session_id"] == "sess-a"
+    assert rec["task_id"] == TASK_A
+    assert rec["models"]["claude-opus-4-5-20260101"]["in"] == 100
+    assert rec["models"]["claude-opus-4-5-20260101"]["out"] == 50
+
+
+def test_grace_period_protects_recent_orphan(cws, env):
+    pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=60)  # 1min
+
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, now=time.time(),
+    )
+
+    assert result["sessions_harvested"] == 0
+    assert result["jsonl_dirs_removed"] == 0
+    assert pdir.exists()                       # protegido pelo grace
+    assert _read_ledger(env["ledger"]) == []
+
+
+def test_idempotent_no_duplicate(cws, env):
+    _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
+    cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, now=time.time(),
+    )
+    # recria a mesma sessão (simula reaparição) e roda de novo
+    _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
+    cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, now=time.time(),
+    )
+    led = _read_ledger(env["ledger"])
+    assert len(led) == 1  # session_id sess-a aparece uma única vez
+
+
+def test_dry_run_reports_without_side_effects(cws, env):
+    pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, now=time.time(), dry_run=True,
+    )
+    assert result["orphan_jsonl_dirs"]          # candidato reportado
+    assert result["jsonl_dirs_removed"] == 0
+    assert result["sessions_harvested"] == 0
+    assert pdir.exists()                        # nada deletado
+    assert not env["ledger"].exists()           # nada escrito
+
+
+def test_cleanup_scan_includes_orphan_jsonl(cws, env, monkeypatch):
+    monkeypatch.setenv("HOME", str(env["home"]))
+    _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
+    scan = cws._cleanup_scan(env["work"])
+    assert str(env["projects"] / f"-home-claude-work-{TASK_A}") in \
+        scan["orphan_jsonl_dirs"]
+    assert scan["total_candidate_bytes"] > 0

--- a/deile/tests/infrastructure/test_jsonl_cost.py
+++ b/deile/tests/infrastructure/test_jsonl_cost.py
@@ -1,0 +1,205 @@
+"""Testes do módulo compartilhado ``infra/k8s/jsonl_cost.py`` (issue #445).
+
+Fonte única da lógica de custo do claude-worker. Cobre:
+- ``aggregate_jsonl``: dedup por ``(message.id, requestId)``, soma de tokens
+  por modelo, breakdown de cache 5m/1h, fallback sem breakdown, registros
+  assistant sem id/requestId, e filtro de sessões sem tokens.
+- ``cost_of_model`` / ``nocache_cost_of_model`` / ``pricing_for``: paridade
+  com os números provados em produção (golden determinístico).
+- Paridade: ``aggregate_jsonl`` reproduz exatamente a agregação documentada
+  do parser in-pod (dedup + soma), garantindo que o custo colhido para o
+  ledger é idêntico ao do caminho live.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+
+
+@pytest.fixture
+def jc():
+    """Carrega ``jsonl_cost`` dinamicamente (infra/k8s não é package)."""
+    spec = importlib.util.spec_from_file_location(
+        "jsonl_cost_test", str(_INFRA_K8S / "jsonl_cost.py"),
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _assistant(model, mid, rid, usage):
+    return {
+        "type": "assistant",
+        "requestId": rid,
+        "timestamp": "2026-06-01T10:00:00.000Z",
+        "message": {"id": mid, "role": "assistant", "model": model, "usage": usage},
+    }
+
+
+def _write_session(path: Path, records):
+    path.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def golden_session(tmp_path):
+    """JSONL determinístico exercitando todos os ramos da agregação."""
+    f = tmp_path / "sess-abc123.jsonl"
+    rec_a = _assistant(
+        "claude-opus-4-5-20260101", "m1", "r1",
+        {
+            "input_tokens": 100, "output_tokens": 50,
+            "cache_creation_input_tokens": 200,
+            "cache_read_input_tokens": 300,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 150,
+                "ephemeral_1h_input_tokens": 50,
+            },
+        },
+    )
+    records = [
+        {"type": "user", "timestamp": "2026-06-01T09:59:00.000Z",
+         "message": {"role": "user", "content": "oi"}},
+        rec_a,
+        # duplicata de streaming: MESMO (id, requestId) → deve ser deduplicada.
+        dict(rec_a),
+        _assistant(
+            "claude-sonnet-4-5-20260101", "m2", "r2",
+            {"input_tokens": 10, "output_tokens": 5,
+             "cache_creation_input_tokens": 20, "cache_read_input_tokens": 0},
+        ),
+        # assistant sem id/requestId mas com tokens → conta uma vez.
+        _assistant(
+            "claude-haiku-4-5", None, None,
+            {"input_tokens": 7, "output_tokens": 3},
+        ),
+    ]
+    # remove id/requestId do último para simular o caso (None, None)
+    records[-1]["requestId"] = None
+    records[-1]["message"]["id"] = None
+    _write_session(f, records)
+    return f
+
+
+def test_aggregate_dedup_and_sums(jc, golden_session):
+    agg = jc.aggregate_jsonl(str(golden_session))
+    assert agg["session_id"] == "sess-abc123"
+    assert agg["assistant_rounds"] == 3  # A (dedup), B, noid
+    m = agg["models"]
+    assert m["claude-opus-4-5-20260101"] == {
+        "in": 100, "out": 50, "cc": 200, "cr": 300, "cc_5m": 150, "cc_1h": 50,
+    }
+    assert m["claude-sonnet-4-5-20260101"] == {
+        "in": 10, "out": 5, "cc": 20, "cr": 0, "cc_5m": 0, "cc_1h": 0,
+    }
+    assert m["claude-haiku-4-5"]["in"] == 7
+    assert agg["first_ts"] == "2026-06-01T09:59:00.000Z"
+    assert agg["last_ts"] == "2026-06-01T10:00:00.000Z"
+
+
+def test_aggregate_skips_sessions_without_tokens(jc, tmp_path):
+    f = tmp_path / "empty.jsonl"
+    _write_session(f, [
+        {"type": "user", "message": {"role": "user", "content": "hi"}},
+    ])
+    agg = jc.aggregate_jsonl(str(f))
+    assert agg["models"] == {}
+    assert agg["assistant_rounds"] == 0
+
+
+def test_aggregate_tolerates_malformed_lines(jc, tmp_path):
+    f = tmp_path / "bad.jsonl"
+    f.write_text(
+        "{not json\n"
+        + json.dumps(_assistant("claude-opus-4-5", "m1", "r1",
+                                 {"input_tokens": 5, "output_tokens": 2})) + "\n"
+        + "\n",  # linha vazia
+        encoding="utf-8",
+    )
+    agg = jc.aggregate_jsonl(str(f))
+    assert agg["models"]["claude-opus-4-5"]["in"] == 5
+
+
+def test_cost_of_model_golden(jc, golden_session):
+    agg = jc.aggregate_jsonl(str(golden_session))
+    opus = agg["models"]["claude-opus-4-5-20260101"]
+    sonnet = agg["models"]["claude-sonnet-4-5-20260101"]
+    # opus 4.5 = pricing novo {in5,out25,w5 6.25,w1h10,read0.5}
+    assert jc.cost_of_model(opus, "claude-opus-4-5-20260101") == pytest.approx(
+        (100 * 5 + 50 * 25 + 150 * 6.25 + 50 * 10 + 300 * 0.5) / 1_000_000.0
+    )
+    # sonnet: cc=20 sem breakdown → tratado como w5
+    assert jc.cost_of_model(sonnet, "claude-sonnet-4-5-20260101") == pytest.approx(
+        (10 * 3 + 5 * 15 + 20 * 3.75) / 1_000_000.0
+    )
+
+
+def test_pricing_opus_legacy_vs_new(jc):
+    # opus 4.0 e 4.1 = legado ($15/$75); 4.5 = novo ($5/$25)
+    assert jc.pricing_for("claude-opus-4-20250514")["in"] == 15.0
+    assert jc.pricing_for("claude-opus-4-1-20250805")["in"] == 15.0
+    assert jc.pricing_for("claude-opus-4-5-20260101")["in"] == 5.0
+
+
+def test_nocache_cost(jc):
+    tk = {"in": 100, "out": 50, "cc": 200, "cr": 300}
+    # sem cache: todo input (in+cc+cr) a preço cheio de input
+    assert jc.nocache_cost_of_model(tk, "claude-opus-4-5") == pytest.approx(
+        ((100 + 200 + 300) * 5 + 50 * 25) / 1_000_000.0
+    )
+
+
+def test_aggregate_parity_with_inpod_reference(jc, golden_session):
+    """``aggregate_jsonl`` deve reproduzir a agregação documentada do parser
+    in-pod (dedup por (id, requestId) + soma). Referência mínima inline."""
+    seen = set()
+    noid = [0]
+    models: dict = {}
+    rounds = 0
+    with open(golden_session, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                o = json.loads(line)
+            except Exception:
+                continue
+            msg = o.get("message")
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            rkey = (msg.get("id"), o.get("requestId"))
+            if rkey == (None, None):
+                noid[0] += 1
+                rkey = ("__noid__", noid[0])
+            if rkey in seen:
+                continue
+            seen.add(rkey)
+            rounds += 1
+            u = msg.get("usage")
+            if not isinstance(u, dict):
+                continue
+            model = msg.get("model") or "unknown"
+            mm = models.setdefault(
+                model, {"in": 0, "out": 0, "cc": 0, "cr": 0, "cc_5m": 0, "cc_1h": 0})
+            mm["in"] += u.get("input_tokens", 0) or 0
+            mm["out"] += u.get("output_tokens", 0) or 0
+            cc = u.get("cache_creation_input_tokens", 0) or 0
+            mm["cc"] += cc
+            mm["cr"] += u.get("cache_read_input_tokens", 0) or 0
+            ccd = u.get("cache_creation")
+            if isinstance(ccd, dict):
+                mm["cc_5m"] += ccd.get("ephemeral_5m_input_tokens", 0) or 0
+                mm["cc_1h"] += ccd.get("ephemeral_1h_input_tokens", 0) or 0
+
+    agg = jc.aggregate_jsonl(str(golden_session))
+    assert agg["models"] == models
+    assert agg["assistant_rounds"] == rounds

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -49,6 +49,13 @@ from aiohttp import web
 
 import dispatch_logger as dlog
 
+try:
+    # Sibling stdlib-puro (mesmo dir, no sys.path in-pod como dispatch_logger).
+    # Fonte única da agregação de custo, usada pelo harvester do ledger (#445).
+    from jsonl_cost import aggregate_jsonl as _aggregate_jsonl
+except Exception:  # pragma: no cover — sibling sempre presente in-pod
+    _aggregate_jsonl = None
+
 logger = logging.getLogger("deile.claude_worker_server")
 
 #: ``secrets.token_hex(8)`` gera exatamente 16 chars hex; qualquer outra
@@ -2979,6 +2986,201 @@ def _session_jsonl_exists_for_workdir(workdir: Path) -> bool:
         return False
 
 
+# --------------------------------------------------------------------------- #
+# Ledger de custo + poda de JSONL órfão (issue #445)
+#
+# O cleanup acima só varre ``/home/claude/work`` (workdirs). Os transcripts
+# do ``claude -p`` vivem em ``~/.claude/projects/-home-claude-work-<task_id>/``
+# e NÃO eram podados por ninguém — acumularam 200+ dirs / 85 MB.
+#
+# O transcript carrega duas responsabilidades acopladas com ciclos de vida
+# opostos: continuidade ``--resume`` (volumoso, efêmero) e auditoria de custo
+# (minúsculo, permanente). A solução desacopla: ANTES de podar o transcript
+# volumoso, o harvester colhe o custo da sessão (tokens por modelo) para um
+# ledger append-only durável em escala de KB. O ``session_tokens_audit.py``
+# lê o ledger para sessões já podadas + o JSONL vivo para as recentes.
+# --------------------------------------------------------------------------- #
+
+#: Grace period (default 1 h) — protege contra TOCTOU: um workdir recém
+#: removido pode ter um resume agendado; só colhemos/podamos JSONL cujo
+#: dir não foi modificado dentro dessa janela.
+_JSONL_ORPHAN_GRACE_S: int = int(
+    os.environ.get("DEILE_CLAUDE_JSONL_ORPHAN_GRACE_S", "3600"),
+)
+
+_PROJECT_MARKER = "-home-claude-work-"
+
+
+def _projects_dir() -> Path:
+    """Diretório de projetos do claude (onde vivem os JSONL de sessão)."""
+    home = Path(os.environ.get("HOME", "/home/claude"))
+    return home / ".claude" / "projects"
+
+
+def _cost_ledger_path() -> Path:
+    """Caminho do ledger de custo durável (no PVC, sobrevive à poda)."""
+    env = os.environ.get("DEILE_CLAUDE_COST_LEDGER_PATH")
+    if env:
+        return Path(env)
+    home = Path(os.environ.get("HOME", "/home/claude"))
+    return home / ".claude" / "cost-ledger.jsonl"
+
+
+def _orphan_jsonl_scan(
+    work_root: Path, projects_dir: Path, grace_s: int, now: float,
+) -> tuple:
+    """Lista dirs de projeto JSONL órfãos (workdir-pai ausente, além do grace).
+
+    Órfão = ``projects/-home-claude-work-<task_id>`` cujo
+    ``work_root/<task_id>`` não existe mais E cujo ``st_mtime`` é anterior a
+    ``now - grace_s``. Returns ``(list[Path], candidate_bytes)``.
+    """
+    orphans: list = []
+    candidate_bytes = 0
+    if not projects_dir.is_dir():
+        return orphans, candidate_bytes
+    cutoff = now - grace_s
+    try:
+        children = list(projects_dir.iterdir())
+    except OSError:
+        return orphans, candidate_bytes
+    for pdir in children:
+        if not pdir.is_dir() or _PROJECT_MARKER not in pdir.name:
+            continue
+        task_id = pdir.name.split(_PROJECT_MARKER)[-1]
+        if not _TASK_ID_RE.fullmatch(task_id):
+            continue
+        # Workdir-pai ainda existe → sessão viva/resumível, preservar.
+        if (work_root / task_id).exists():
+            continue
+        # Grace: protege contra TOCTOU (workdir recém-removido).
+        try:
+            if pdir.stat().st_mtime > cutoff:
+                continue
+        except OSError:
+            continue
+        orphans.append(pdir)
+        candidate_bytes += _dir_size(pdir)
+    return orphans, candidate_bytes
+
+
+def _harvested_session_ids(ledger_path: Path) -> set:
+    """Conjunto de ``session_id`` já presentes no ledger (dedup do harvest)."""
+    ids: set = set()
+    if not ledger_path.exists():
+        return ids
+    try:
+        with open(ledger_path, errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                sid = rec.get("session_id")
+                if sid:
+                    ids.add(sid)
+    except OSError:
+        pass
+    return ids
+
+
+def _append_ledger(ledger_path: Path, record: dict) -> int:
+    """Anexa um registro ao ledger (append-only). Returns bytes escritos."""
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(ledger_path, "a", encoding="utf-8") as fh:
+        fh.write(line)
+    return len(line.encode("utf-8"))
+
+
+def _harvest_and_prune_orphan_jsonl(
+    work_root: Path,
+    *,
+    projects_dir: Optional[Path] = None,
+    ledger_path: Optional[Path] = None,
+    grace_s: Optional[int] = None,
+    now: Optional[float] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Colhe o custo de sessões JSONL órfãs para o ledger e poda os dirs.
+
+    Para cada dir de projeto órfão (workdir-pai ausente, além do grace):
+      1. Agrega cada ``*.jsonl`` (tokens por modelo) e anexa ao ledger
+         durável — pulando ``session_id`` já colhidos (idempotente).
+      2. Remove o dir de projeto inteiro (transcript volumoso).
+
+    ``dry_run=True`` apenas reporta os candidatos sem colher nem podar.
+    """
+    if projects_dir is None:
+        projects_dir = _projects_dir()
+    if ledger_path is None:
+        ledger_path = _cost_ledger_path()
+    if grace_s is None:
+        grace_s = _JSONL_ORPHAN_GRACE_S
+    if now is None:
+        now = time.time()
+
+    orphans, candidate_bytes = _orphan_jsonl_scan(
+        work_root, projects_dir, grace_s, now)
+    result = {
+        "orphan_jsonl_dirs": [str(p) for p in orphans],
+        "sessions_harvested": 0,
+        "jsonl_dirs_removed": 0,
+        "ledger_bytes_written": 0,
+        "bytes_freed": 0,
+        "candidate_bytes": candidate_bytes,
+        "errors": [],
+    }
+    if dry_run or not orphans:
+        return result
+
+    harvested = _harvested_session_ids(ledger_path)
+    for pdir in orphans:
+        task_id = pdir.name.split(_PROJECT_MARKER)[-1]
+        if _aggregate_jsonl is not None:
+            try:
+                for jsonl in sorted(pdir.glob("*.jsonl")):
+                    data = _aggregate_jsonl(str(jsonl))
+                    sid = data.get("session_id") or jsonl.stem
+                    if sid in harvested or not data.get("models"):
+                        continue
+                    written = _append_ledger(ledger_path, {
+                        "v": 1,
+                        "session_id": sid,
+                        "task_id": task_id,
+                        "models": data["models"],
+                        "first_ts": data.get("first_ts"),
+                        "last_ts": data.get("last_ts"),
+                        "assistant_rounds": data.get("assistant_rounds", 0),
+                        "harvested_at": now,
+                    })
+                    result["ledger_bytes_written"] += written
+                    result["sessions_harvested"] += 1
+                    harvested.add(sid)
+            except OSError as exc:
+                result["errors"].append(f"harvest {pdir}: {exc}")
+        size = _dir_size(pdir)
+        try:
+            shutil.rmtree(pdir, ignore_errors=True)
+            if not pdir.exists():
+                result["jsonl_dirs_removed"] += 1
+                result["bytes_freed"] += size
+        except OSError as exc:
+            result["errors"].append(f"rmtree {pdir}: {exc}")
+
+    logger.info(
+        "cost-ledger harvest: sessions=%d dirs_removed=%d freed=%d bytes "
+        "ledger=+%d bytes errors=%d",
+        result["sessions_harvested"], result["jsonl_dirs_removed"],
+        result["bytes_freed"], result["ledger_bytes_written"],
+        len(result["errors"]),
+    )
+    return result
+
+
 def _cleanup_scan(
     root: Path,
     retention_days: int = _CLEANUP_RETENTION_DAYS_DEFAULT,
@@ -2996,7 +3198,7 @@ def _cleanup_scan(
         return {
             "dead_leases": [], "old_workdirs": [],
             "empty_workdirs": [], "active_workdirs": [],
-            "total_candidate_bytes": 0,
+            "orphan_jsonl_dirs": [], "total_candidate_bytes": 0,
         }
 
     now = time.time()
@@ -3057,11 +3259,19 @@ def _cleanup_scan(
             empty_workdirs.append(str(workdir))
             candidate_bytes += _dir_size(workdir)
 
+    # Check 5: JSONL órfão em ~/.claude/projects (issue #445) — dirs de
+    # projeto cujo workdir-pai já não existe. Preview do que o harvester
+    # vai colher para o ledger + podar.
+    orphan_dirs, orphan_bytes = _orphan_jsonl_scan(
+        root, _projects_dir(), _JSONL_ORPHAN_GRACE_S, now)
+    candidate_bytes += orphan_bytes
+
     return {
         "dead_leases": dead_leases,
         "old_workdirs": old_workdirs,
         "empty_workdirs": empty_workdirs,
         "active_workdirs": active_workdirs,
+        "orphan_jsonl_dirs": [str(p) for p in orphan_dirs],
         "total_candidate_bytes": candidate_bytes,
     }
 
@@ -3127,11 +3337,20 @@ def _do_cleanup(
             logger.warning("cleanup: falha ao remover workdir %s: %s",
                            workdir_str, exc)
 
+    # JSONL órfão (issue #445): colhe o custo para o ledger durável e poda
+    # os transcripts cujo workdir-pai já não existe — inclui os workdirs
+    # recém-removidos acima, que acabam de virar órfãos.
+    harvest = _harvest_and_prune_orphan_jsonl(root)
+    freed_bytes += harvest.get("bytes_freed", 0)
+
     return {
         **scan,
         "removed_leases": removed_leases,
         "removed_workdirs": removed_workdirs,
         "freed_bytes": freed_bytes,
+        "sessions_harvested": harvest.get("sessions_harvested", 0),
+        "jsonl_dirs_removed": harvest.get("jsonl_dirs_removed", 0),
+        "ledger_bytes_written": harvest.get("ledger_bytes_written", 0),
         "dry_run": False,
     }
 

--- a/infra/k8s/jsonl_cost.py
+++ b/infra/k8s/jsonl_cost.py
@@ -1,0 +1,166 @@
+"""Fonte única da lógica de custo das sessões ``claude -p`` (issue #445).
+
+Centraliza o que antes vivia duplicado/embutido em ``session_tokens_audit.py``:
+
+* Tabela de preços oficial (``PRICING``) e o mapeamento modelo → preço.
+* Cálculo de custo de um bloco de tokens (``cost_of_model`` /
+  ``nocache_cost_of_model``).
+* ``aggregate_jsonl`` — agrega UM arquivo JSONL de sessão no dicionário de
+  tokens por modelo, com a MESMA dedup ``(message.id, requestId)`` provada
+  contra o ``last_total_cost_usd`` do fornecedor (erro < 0,1%).
+
+Stdlib-pura de propósito: roda tanto no host (``session_tokens_audit.py``)
+quanto dentro do pod (``claude_worker_server.py`` importa ``aggregate_jsonl``
+para o harvester do ledger de custo). Sem dependências externas.
+
+O ledger de custo (issue #445) usa ``aggregate_jsonl`` para colher os tokens
+de uma sessão ANTES de a poda remover o JSONL volumoso — o custo histórico
+sobrevive em escala de KB mesmo após o transcript ser removido.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Dict, Optional
+
+# --------------------------------------------------------------------------- #
+# Preços oficiais (USD por MILHÃO de tokens). read = cache hit (0.1x input).   #
+# w5 = cache write 5m (1.25x input); w1h = cache write 1h (2x input).          #
+# --------------------------------------------------------------------------- #
+PRICING = {
+    "opus":         {"in": 5.0,  "out": 25.0, "w5": 6.25,  "w1h": 10.0, "read": 0.50},
+    "opus_legacy":  {"in": 15.0, "out": 75.0, "w5": 18.75, "w1h": 30.0, "read": 1.50},
+    "sonnet":       {"in": 3.0,  "out": 15.0, "w5": 3.75,  "w1h": 6.0,  "read": 0.30},
+    "haiku":        {"in": 1.0,  "out": 5.0,  "w5": 1.25,  "w1h": 2.0,  "read": 0.10},
+    "haiku_legacy": {"in": 0.80, "out": 4.0,  "w5": 1.0,   "w1h": 1.60, "read": 0.08},
+    "free":         {"in": 0.0,  "out": 0.0,  "w5": 0.0,   "w1h": 0.0,  "read": 0.0},
+}
+
+
+def pricing_for(model: str) -> dict:
+    """Mapeia um nome de modelo para a sua tabela de preços."""
+    m = (model or "").lower()
+    if "haiku" in m:
+        return PRICING["haiku_legacy"] if ("3-5" in m or "3.5" in m) else PRICING["haiku"]
+    if "sonnet" in m:
+        return PRICING["sonnet"]
+    if "opus" in m:
+        # Opus 4.0 e 4.1 usam preço legado ($15/$75); 4.5+ usam o novo ($5/$25).
+        # Parseia major/minor da versão, descartando o sufixo de data (-YYYYMMDD):
+        # 'claude-opus-4-20250514' → major=4, minor=0 → legado;
+        # 'claude-opus-4-7-...'     → major=4, minor=7 → novo.
+        base = re.sub(r"-\d{6,}.*$", "", m)
+        ver = re.search(r"opus[-_.]?(\d+)(?:[-_.](\d+))?", base)
+        legacy = bool(ver) and int(ver.group(1)) == 4 and (
+            ver.group(2) is None or int(ver.group(2)) <= 1)
+        return PRICING["opus_legacy"] if legacy else PRICING["opus"]
+    return PRICING["free"]  # <synthetic> e desconhecidos não são cobrados
+
+
+def cost_of_model(tk: dict, model: str) -> float:
+    """Custo em USD de um bloco de tokens {in,out,cc,cr,cc_5m,cc_1h} de um modelo."""
+    p = pricing_for(model)
+    cc_5m = tk.get("cc_5m") or 0
+    cc_1h = tk.get("cc_1h") or 0
+    if not cc_5m and not cc_1h:
+        cc_5m = tk.get("cc", 0)  # sem breakdown → trata tudo como write 5m
+    return (
+        tk.get("in", 0) * p["in"]
+        + tk.get("out", 0) * p["out"]
+        + cc_5m * p["w5"]
+        + cc_1h * p["w1h"]
+        + tk.get("cr", 0) * p["read"]
+    ) / 1_000_000.0
+
+
+def nocache_cost_of_model(tk: dict, model: str) -> float:
+    """Custo hipotético se NADA fosse cacheado (todo input a preço cheio)."""
+    p = pricing_for(model)
+    fresh = tk.get("in", 0) + tk.get("cc", 0) + tk.get("cr", 0)
+    return (fresh * p["in"] + tk.get("out", 0) * p["out"]) / 1_000_000.0
+
+
+# --------------------------------------------------------------------------- #
+# Agregação de um JSONL de sessão.                                            #
+#                                                                             #
+# NOTA DE PARIDADE: este laço de dedup+soma é a fonte única da agregação de   #
+# custo. O parser in-pod embutido em ``session_tokens_audit.IN_POD_PARSER``   #
+# (caminho live) implementa o MESMO algoritmo documentado; a paridade é       #
+# travada por ``test_jsonl_cost.test_aggregate_parity_with_inpod_reference``. #
+# --------------------------------------------------------------------------- #
+def _empty_model() -> Dict[str, int]:
+    return {"in": 0, "out": 0, "cc": 0, "cr": 0, "cc_5m": 0, "cc_1h": 0}
+
+
+def aggregate_jsonl(path: str) -> dict:
+    """Agrega UM arquivo JSONL de sessão ``claude -p`` nos tokens por modelo.
+
+    Conta cada resposta da API uma única vez por ``(message.id, requestId)``
+    — o claude grava o mesmo registro assistant repetido (deltas de
+    streaming) com o ``usage`` final idêntico; sem dedup os totais inflam
+    13-32x. Respostas sem ``id``/``requestId`` recebem chave sintética.
+
+    Returns:
+        dict com ``session_id`` (stem do arquivo), ``models`` (model ->
+        {in,out,cc,cr,cc_5m,cc_1h}), ``first_ts``, ``last_ts`` e
+        ``assistant_rounds``.
+    """
+    session_id = os.path.splitext(os.path.basename(path))[0]
+    models: Dict[str, Dict[str, int]] = {}
+    first_ts: Optional[str] = None
+    last_ts: Optional[str] = None
+    rounds = 0
+    seen = set()
+    noid = 0
+
+    try:
+        with open(path, errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    o = json.loads(line)
+                except Exception:
+                    continue
+                ts = o.get("timestamp")
+                if ts:
+                    if first_ts is None:
+                        first_ts = ts
+                    last_ts = ts
+                msg = o.get("message")
+                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                    continue
+                rkey = (msg.get("id"), o.get("requestId"))
+                if rkey == (None, None):
+                    noid += 1
+                    rkey = ("__noid__", noid)
+                if rkey in seen:
+                    continue
+                seen.add(rkey)
+                rounds += 1
+                u = msg.get("usage")
+                if not isinstance(u, dict):
+                    continue
+                model = msg.get("model") or "unknown"
+                mm = models.setdefault(model, _empty_model())
+                mm["in"] += u.get("input_tokens", 0) or 0
+                mm["out"] += u.get("output_tokens", 0) or 0
+                mm["cc"] += u.get("cache_creation_input_tokens", 0) or 0
+                mm["cr"] += u.get("cache_read_input_tokens", 0) or 0
+                ccd = u.get("cache_creation")
+                if isinstance(ccd, dict):
+                    mm["cc_5m"] += ccd.get("ephemeral_5m_input_tokens", 0) or 0
+                    mm["cc_1h"] += ccd.get("ephemeral_1h_input_tokens", 0) or 0
+    except OSError:
+        pass
+
+    return {
+        "session_id": session_id,
+        "models": models,
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+        "assistant_rounds": rounds,
+    }

--- a/infra/k8s/session_tokens_audit.py
+++ b/infra/k8s/session_tokens_audit.py
@@ -52,6 +52,12 @@ try:
 except ImportError:  # Windows / sem POSIX termios
     _HAS_CBREAK = False
 
+# Fonte única da lógica de custo (issue #445) — compartilhada com o harvester
+# do ledger em ``claude_worker_server``. Garante que o custo de uma sessão
+# colhida para o ledger é idêntico ao calculado a partir do JSONL vivo.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from jsonl_cost import cost_of_model, nocache_cost_of_model  # noqa: E402
+
 # Todas as datas exibidas neste relatório são em BRT (UTC−3, sem DST desde 2019).
 BRT = timezone(timedelta(hours=-3))
 
@@ -66,61 +72,9 @@ def _iso_brt(iso_str: str) -> str:
     except Exception:
         return iso_str
 
-# --------------------------------------------------------------------------- #
-# Preços oficiais (USD por MILHÃO de tokens). read = cache hit (0.1x input).   #
-# w5 = cache write 5m (1.25x input); w1h = cache write 1h (2x input).          #
-# --------------------------------------------------------------------------- #
-PRICING = {
-    "opus":         {"in": 5.0,  "out": 25.0, "w5": 6.25,  "w1h": 10.0, "read": 0.50},
-    "opus_legacy":  {"in": 15.0, "out": 75.0, "w5": 18.75, "w1h": 30.0, "read": 1.50},
-    "sonnet":       {"in": 3.0,  "out": 15.0, "w5": 3.75,  "w1h": 6.0,  "read": 0.30},
-    "haiku":        {"in": 1.0,  "out": 5.0,  "w5": 1.25,  "w1h": 2.0,  "read": 0.10},
-    "haiku_legacy": {"in": 0.80, "out": 4.0,  "w5": 1.0,   "w1h": 1.60, "read": 0.08},
-    "free":         {"in": 0.0,  "out": 0.0,  "w5": 0.0,   "w1h": 0.0,  "read": 0.0},
-}
-
-
-def pricing_for(model: str) -> dict:
-    """Mapeia um nome de modelo para a sua tabela de preços."""
-    m = (model or "").lower()
-    if "haiku" in m:
-        return PRICING["haiku_legacy"] if ("3-5" in m or "3.5" in m) else PRICING["haiku"]
-    if "sonnet" in m:
-        return PRICING["sonnet"]
-    if "opus" in m:
-        # Opus 4.0 e 4.1 usam preço legado ($15/$75); 4.5+ usam o novo ($5/$25).
-        # Parseia major/minor da versão, descartando o sufixo de data (-YYYYMMDD):
-        # 'claude-opus-4-20250514' → major=4, minor=0 → legado;
-        # 'claude-opus-4-7-...'     → major=4, minor=7 → novo.
-        base = re.sub(r"-\d{6,}.*$", "", m)
-        ver = re.search(r"opus[-_.]?(\d+)(?:[-_.](\d+))?", base)
-        legacy = bool(ver) and int(ver.group(1)) == 4 and (
-            ver.group(2) is None or int(ver.group(2)) <= 1)
-        return PRICING["opus_legacy"] if legacy else PRICING["opus"]
-    return PRICING["free"]  # <synthetic> e desconhecidos não são cobrados
-
-
-def cost_of_model(tk: dict, model: str) -> float:
-    """Custo em USD de um bloco de tokens {in,out,cc,cr,cc_5m,cc_1h} de um modelo."""
-    p = pricing_for(model)
-    cc_5m = tk.get("cc_5m") or 0
-    cc_1h = tk.get("cc_1h") or 0
-    if not cc_5m and not cc_1h:
-        cc_5m = tk.get("cc", 0)  # sem breakdown → trata tudo como write 5m
-    return (
-        tk.get("in", 0) * p["in"]
-        + tk.get("out", 0) * p["out"]
-        + cc_5m * p["w5"]
-        + cc_1h * p["w1h"]
-        + tk.get("cr", 0) * p["read"]
-    ) / 1_000_000.0
-
-
-def nocache_cost_of_model(tk: dict, model: str) -> float:
-    """Custo hipotético se NADA fosse cacheado (todo input a preço cheio)."""
-    p = pricing_for(model)
-    fresh = tk.get("in", 0) + tk.get("cc", 0) + tk.get("cr", 0)
-    return (fresh * p["in"] + tk.get("out", 0) * p["out"]) / 1_000_000.0
+# Preços e cálculo de custo migrados para ``jsonl_cost`` (fonte única, #445):
+# ``PRICING`` / ``pricing_for`` / ``cost_of_model`` / ``nocache_cost_of_model``
+# são importados no topo deste arquivo.
 
 
 # --------------------------------------------------------------------------- #
@@ -360,6 +314,76 @@ for f in sorted(glob.glob(os.path.join(BASE, "**", "*.jsonl"), recursive=True)):
     # só inclui sessões que tenham ao menos uma resposta assistant com tokens
     if any((sum(v.values()) > 0) for v in rec["models"].values()):
         sessions.append(rec)
+
+# Ledger de custo (issue #445): sessões já podadas do disco vivem só aqui.
+# O harvester do claude_worker_server colheu os tokens por modelo ANTES de
+# remover o JSONL volumoso. Emitimos um registro sintético por sessão colhida
+# (não duplicando session_ids que ainda têm JSONL vivo), com a MESMA estrutura
+# ``models`` — o cálculo de custo no host é idêntico.
+LEDGER = os.environ.get("DEILE_CLAUDE_COST_LEDGER_PATH") or os.path.join(
+    os.path.expanduser("~"), ".claude", "cost-ledger.jsonl")
+live_ids = set()
+for s in sessions:
+    sf = s.get("session_file") or ""
+    if sf.endswith(".jsonl"):
+        live_ids.add(sf[:-6])
+seen_led = set()
+try:
+    with open(LEDGER, errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except Exception:
+                continue
+            sid = r.get("session_id")
+            models = r.get("models") or {}
+            if not sid or sid in live_ids or sid in seen_led:
+                continue
+            if not any((sum(v.values()) > 0) for v in models.values()):
+                continue
+            harv = r.get("harvested_at") or 0
+            if SINCE_MTIME and harv and harv < SINCE_MTIME:
+                continue
+            seen_led.add(sid)
+            tid = r.get("task_id") or ""
+            sessions.append({
+                "jsonl": "<ledger>",
+                "project_dir": os.path.join(BASE, "-home-claude-work-" + tid),
+                "session_file": sid + ".jsonl",
+                "models": models,
+                "tools": {},
+                "assistant_rounds": r.get("assistant_rounds", 0) or 0,
+                "user_msgs": 0,
+                "tool_calls": 0,
+                "cwd": None,
+                "git_branch": None,
+                "version": None,
+                "permission_mode": None,
+                "entrypoint": None,
+                "ai_title": None,
+                "pr_number": None,
+                "pr_url": None,
+                "pr_repo": None,
+                "first_ts": r.get("first_ts"),
+                "last_ts": r.get("last_ts"),
+                "brief": None,
+                "errors": {"synthetic": 0, "max_tokens": 0,
+                           "api_error": 0, "tool_error": 0},
+                "stop_reasons": {},
+                "mtime": harv or None,
+                "git": {"state": "harvested", "modified": 0,
+                        "untracked": 0, "staged": 0, "root": None},
+                "meta_model": None,
+                "reasoning_effort": None,
+                "ultracode": None,
+                "stage": "harvested",
+                "harvested": True,
+            })
+except Exception:
+    pass
 
 print(json.dumps(sessions))
 '''


### PR DESCRIPTION
## Problema (issue #445)

O cleanup do `claude_worker_server` só varria `/home/claude/work` (workdirs). Os transcripts do `claude -p` em `~/.claude/projects/-home-claude-work-*` **não eram podados por ninguém** → acúmulo silencioso (200+ dirs / 85 MB no audit de 31/mai).

O desenho **original** da #445 era deletar os JSONL órfãos — mas isso **destruiria os dados de custo** lidos pelo `session_tokens_audit.py`. O transcript carrega duas responsabilidades acopladas com ciclos de vida opostos:

| Responsabilidade | Tamanho | Vida útil |
|---|---|---|
| Continuidade `--resume` | volumoso | só enquanto recente |
| Auditoria de custo | minúsculo | ~permanente |

## Solução: desacoplar (ledger + poda livre)

Antes de podar o transcript volumoso, o harvester **colhe os tokens por modelo** de cada sessão órfã para um **ledger append-only durável** em escala de KB. Custo histórico sobrevive à poda; transcripts podam livremente.

```
_do_cleanup (startup + CronJob diário + /v1/cleanup)
  ├─ harvest(jsonl órfão) → append cost-ledger.jsonl   (KB, permanente, dedup por session_id)
  └─ prune transcript                                   (volumoso, efêmero)

session_tokens_audit
  ├─ ledger (sessões já podadas)
  └─ JSONL vivo (sessões recentes)        → custo idêntico (mesma cost_of_model)
```

## Mudanças

- **`infra/k8s/jsonl_cost.py` (novo)** — fonte única da lógica de custo: tabela de preços + `pricing_for`/`cost_of_model`/`nocache_cost_of_model` (migrados do audit) + `aggregate_jsonl`, com a mesma dedup `(message.id, requestId)` provada contra o `last_total_cost_usd` do fornecedor.
- **`claude_worker_server.py`** — `_harvest_and_prune_orphan_jsonl` + `_orphan_jsonl_scan` + helpers de ledger; engatado em `_do_cleanup` e `_cleanup_scan` (campo `orphan_jsonl_dirs` no preview `[c]`). Grace period TOCTOU + harvest idempotente.
- **`session_tokens_audit.py`** — importa custo de `jsonl_cost` (remove cópia local); parser in-pod lê o ledger e emite sessões podadas com custo idêntico.
- **`CLAUDE.md`** — env vars `DEILE_CLAUDE_COST_LEDGER_PATH` + `DEILE_CLAUDE_JSONL_ORPHAN_GRACE_S` + nota do ledger.

## Custo 100% preservado (por construção)

Até o primeiro harvest o ledger não existe → audit lê só o JSONL vivo (números **idênticos a hoje**). Depois, sessões podadas reaparecem do ledger com a **mesma `cost_of_model`** → zero descontinuidade.

## Como os 5 pontos do refinement gate (debugger, 31/mai) foram fechados

1. **Call-site ambíguo** → helper único `_harvest_and_prune_orphan_jsonl`, chamado de `_do_cleanup` (cobre startup + CronJob + HTTP). `_cleanup_scan` reporta no preview.
2. **TOCTOU / perda destrutiva** → harvest do custo ANTES da poda (delete não-destrutivo do único valor durável) + grace period por `mtime` (`DEILE_CLAUDE_JSONL_ORPHAN_GRACE_S`, default 1 h).
3. **Invisível ao preview** → `_cleanup_scan` ganha `orphan_jsonl_dirs` + bytes em `total_candidate_bytes`.
4. **Template / achado correlato (lease de pod morto)** → o lease de pod morto já é coberto pelo `dead_leases` do scan existente (PID-alive check); fora do escopo deste PR.

## Testes

15 testes novos (`test_jsonl_cost.py`, `test_cost_ledger_harvest.py`, `test_audit_ledger_read.py`): agregação golden, **paridade com o parser in-pod**, custo, harvest+poda, grace, idempotência, dry-run, preview do scan, leitura do ledger no audit, dedup.

Suíte completa: **24 failed, 6639 passed** — as 24 são pré-existentes conhecidas (`test_claude_worker_server` 11, `test_dispatch_resolver_settings` 9, `test_deile_md_loader` 4), idênticas em `origin/main`. **Zero regressão nova.** ruff/isort limpos nos arquivos tocados.

Closes #445