### PR TITLE
fix(claude-worker): harvester nunca poda custo não colhido + empacota jsonl_cost

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -91,3 +91,4 @@ infra/
 !infra/k8s/_worker_resume.py
 !infra/k8s/pipeline_status_server.py
 !infra/k8s/dispatch_logger.py
+!infra/k8s/jsonl_cost.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -234,6 +234,14 @@ RUN chmod 0555 /app/_worker_resume.py
 COPY --chown=deile:deile infra/k8s/dispatch_logger.py /app/dispatch_logger.py
 RUN chmod 0555 /app/dispatch_logger.py
 
+# Lógica de custo compartilhada (issue #445). Importado por
+# claude_worker_server.py (harvester do ledger) via ``from jsonl_cost import
+# aggregate_jsonl`` e pelo session_tokens_audit.py. Deve ficar em /app ao lado
+# deles — sem este arquivo o harvester aborta a poda (fail-safe) e os JSONL
+# órfãos jamais são limpos.
+COPY --chown=deile:deile infra/k8s/jsonl_cost.py /app/jsonl_cost.py
+RUN chmod 0555 /app/jsonl_cost.py
+
 # Pipeline status server — HTTP introspection endpoints (issue #347 fix). Roda
 # in-process no wrapper.py mode pipeline (asyncio task no mesmo event loop do
 # monitor). Sem este arquivo no /app o `from pipeline_status_server import ...`

--- a/deile/tests/infrastructure/test_cost_ledger_harvest.py
+++ b/deile/tests/infrastructure/test_cost_ledger_harvest.py
@@ -166,3 +166,41 @@ def test_cleanup_scan_includes_orphan_jsonl(cws, env, monkeypatch):
     assert str(env["projects"] / f"-home-claude-work-{TASK_A}") in \
         scan["orphan_jsonl_dirs"]
     assert scan["total_candidate_bytes"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# Fail-safe (incidente 01/jun): NUNCA podar dados de custo não colhidos.
+# Regressão para o bug em que `aggregate_jsonl` ausente da imagem (import
+# falho → None) fazia o harvester colher 0 e podar mesmo assim (337 sessões
+# deletadas sem ledger).
+# --------------------------------------------------------------------------- #
+def test_no_prune_when_aggregator_unavailable(cws, env, monkeypatch):
+    """Sem o agregador (jsonl_cost ausente da imagem), poda é ABORTADA."""
+    pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
+    monkeypatch.setattr(cws, "_aggregate_jsonl", None)
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, now=time.time(),
+    )
+    assert result["jsonl_dirs_removed"] == 0
+    assert result["sessions_harvested"] == 0
+    assert pdir.exists()                      # dir órfão PRESERVADO
+    assert not env["ledger"].exists()
+    assert any("fail-safe" in e for e in result["errors"])
+
+
+def test_no_prune_when_aggregation_raises(cws, env, monkeypatch):
+    """Se a agregação de um JSONL falha, o dir inteiro é preservado."""
+    pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
+
+    def _boom(_path):
+        raise ValueError("parse explodiu")
+
+    monkeypatch.setattr(cws, "_aggregate_jsonl", _boom)
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, now=time.time(),
+    )
+    assert result["jsonl_dirs_removed"] == 0
+    assert pdir.exists()                      # preservado: havia custo não colhido
+    assert any("aggregate" in e for e in result["errors"])

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -3137,31 +3137,63 @@ def _harvest_and_prune_orphan_jsonl(
     if dry_run or not orphans:
         return result
 
+    # Fail-safe cardinal: NUNCA podar dados de custo não colhidos. Sem o
+    # agregador (ex.: jsonl_cost ausente da imagem) não há como preservar o
+    # custo antes de deletar — então aborta a poda e preserva tudo.
+    if _aggregate_jsonl is None:
+        result["errors"].append(
+            "aggregate_jsonl indisponível — poda abortada (fail-safe)")
+        logger.error(
+            "cost-ledger harvest ABORTADO: jsonl_cost.aggregate_jsonl "
+            "indisponível; %d dirs órfãos preservados (sem poda) para não "
+            "perder custo", len(orphans),
+        )
+        return result
+
     harvested = _harvested_session_ids(ledger_path)
     for pdir in orphans:
         task_id = pdir.name.split(_PROJECT_MARKER)[-1]
-        if _aggregate_jsonl is not None:
+        # Só podamos um dir DEPOIS que todo o seu conteúdo foi contabilizado
+        # (colhido para o ledger, já presente nele, ou genuinamente sem
+        # tokens). Qualquer falha de agregação/escrita preserva o dir inteiro.
+        dir_fully_accounted = True
+        try:
+            jsonls = sorted(pdir.glob("*.jsonl"))
+        except OSError as exc:
+            result["errors"].append(f"glob {pdir}: {exc}")
+            continue
+        for jsonl in jsonls:
             try:
-                for jsonl in sorted(pdir.glob("*.jsonl")):
-                    data = _aggregate_jsonl(str(jsonl))
-                    sid = data.get("session_id") or jsonl.stem
-                    if sid in harvested or not data.get("models"):
-                        continue
-                    written = _append_ledger(ledger_path, {
-                        "v": 1,
-                        "session_id": sid,
-                        "task_id": task_id,
-                        "models": data["models"],
-                        "first_ts": data.get("first_ts"),
-                        "last_ts": data.get("last_ts"),
-                        "assistant_rounds": data.get("assistant_rounds", 0),
-                        "harvested_at": now,
-                    })
-                    result["ledger_bytes_written"] += written
-                    result["sessions_harvested"] += 1
-                    harvested.add(sid)
+                data = _aggregate_jsonl(str(jsonl))
+            except Exception as exc:  # noqa: BLE001 — agregação falhou: preserva
+                result["errors"].append(f"aggregate {jsonl}: {exc}")
+                dir_fully_accounted = False
+                continue
+            sid = data.get("session_id") or jsonl.stem
+            if sid in harvested:
+                continue  # já no ledger
+            if not data.get("models"):
+                continue  # zero tokens — nada a colher, nada a perder
+            try:
+                written = _append_ledger(ledger_path, {
+                    "v": 1,
+                    "session_id": sid,
+                    "task_id": task_id,
+                    "models": data["models"],
+                    "first_ts": data.get("first_ts"),
+                    "last_ts": data.get("last_ts"),
+                    "assistant_rounds": data.get("assistant_rounds", 0),
+                    "harvested_at": now,
+                })
             except OSError as exc:
-                result["errors"].append(f"harvest {pdir}: {exc}")
+                result["errors"].append(f"ledger write {jsonl}: {exc}")
+                dir_fully_accounted = False
+                continue
+            result["ledger_bytes_written"] += written
+            result["sessions_harvested"] += 1
+            harvested.add(sid)
+        if not dir_fully_accounted:
+            continue  # preserva o dir: havia custo não contabilizado
         size = _dir_size(pdir)
         try:
             shutil.rmtree(pdir, ignore_errors=True)


### PR DESCRIPTION
## Incidente (01/jun)

O harvester do ledger de custo (#445, PR #492) **deletou 337 transcripts colhendo zero** logo no primeiro deploy. Log do pod:

```
cost-ledger harvest: sessions=0 dirs_removed=337 freed=81241618 bytes ledger=+0 bytes errors=0
```

**Causa raiz (dois defeitos combinados):**
1. **Empacotamento:** o `Dockerfile` não copiava `infra/k8s/jsonl_cost.py` para a imagem (e o `.dockerignore` é deny-all + allow-list, faltava a exceção `!`). In-pod o `from jsonl_cost import aggregate_jsonl` falhava → `_aggregate_jsonl = None`.
2. **Fail-safe ausente:** com `_aggregate_jsonl is None`, o harvester pulava a colheita mas **podava o transcript mesmo assim**. Os testes rodavam com o módulo presente → o caminho `None` nunca era exercitado.

## Correções

- **Fail-safe cardinal** em `_harvest_and_prune_orphan_jsonl`: **nunca podar custo não colhido**. Se `_aggregate_jsonl is None` → poda abortada, todos os órfãos preservados. Por dir, só remove depois que TODO o conteúdo foi contabilizado (colhido para o ledger, já presente nele, ou genuinamente zero-token); qualquer falha de agregação/escrita preserva o dir inteiro.
- **Empacotamento:** `Dockerfile` copia `jsonl_cost.py` para `/app` (como `dispatch_logger.py`) + exceção `!infra/k8s/jsonl_cost.py` no `.dockerignore`.

## Testes

2 testes de regressão novos: caminho `aggregate_jsonl is None` (poda abortada, dir preservado) e falha de agregação (dir preservado). 17 testes do ledger verdes.

## Recuperação (executada)

- `audit-out/session_tokens_audit.json` (backup de 15:59, 250 sessões / US$297,69) foi convertido para o ledger e semeado no PVC.
- O `session_tokens_audit.py` agora mostra o histórico de novo: `(removida) $295,29` no ranking de worktrees (sessões podadas com custo preservado), recompute via `cost_of_model` = **US$297,69 idêntico ao backup**.

## Deploy

Imagem reconstruída e validada ao vivo: `/app/jsonl_cost.py` presente, `import OK`, harvest no boot agora colhe antes de podar (dedup contra o ledger recuperado), órfãos dentro do grace preservados. Zero perda nova.