### PR TITLE
feat(claude-worker): retenção JSONL configurável + harvest rico do ledger (#445)

### DIFF
--- a/deile/tests/infra/test_dispatch_matrix_jsonl_retention.py
+++ b/deile/tests/infra/test_dispatch_matrix_jsonl_retention.py
@@ -1,0 +1,226 @@
+"""Testes da retenção JSONL editável no DispatchMatrixView (issue #445 parte 2).
+
+O Humano controla por quanto tempo os transcripts JSONL órfãos sobrevivem
+antes de serem colhidos para o ledger + podados. Além da env var no manifest,
+a tela [d] do painel expõe o atalho [J] (maiúsculo — 'j' minúsculo é navegação
+DOWN) que abre um prompt numérico e aplica em claude-worker + cron via
+``kubectl set env`` (sem rebuild).
+
+Cobre:
+- [J] abre retention_prompt; 'j' minúsculo continua navegação DOWN.
+- _handle_retention_prompt_key: dígitos, multi-dígito, backspace, enter, esc.
+- _apply_retention: demo (no-op), sem kubectl (erro), inválido (<1), sucesso
+  (seta nos DOIS alvos), value=None (clear → default 30), falha parcial.
+- Render: modal retention_prompt aparece no output.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+if str(_INFRA_K8S) not in sys.path:
+    sys.path.insert(0, str(_INFRA_K8S))
+
+
+@pytest.fixture
+def view_demo():
+    from _panel import DispatchMatrixView
+    return DispatchMatrixView(data=None)
+
+
+@pytest.fixture
+def view_with_data():
+    from _panel import DispatchMatrixView
+    from _panel_data import ClaudeWorkerStatus, StageDispatchEntry
+
+    data = MagicMock()
+    data.stage_dispatch.get_all_stages.return_value = [
+        StageDispatchEntry(s, "deile-worker", None, "default")
+        for s in ("classify", "refine", "implement", "pr_review", "follow_ups")
+    ]
+    data.stage_dispatch.get_claude_worker_status.return_value = ClaudeWorkerStatus(
+        deployment_applied=False, pod_ready=False, logged_in_email=None,
+    )
+    data.context = MagicMock()
+    data.context.namespace = "deile"
+    data.models = MagicMock()
+    data.models.get.return_value = []
+    return DispatchMatrixView(data=data)
+
+
+@pytest.fixture
+def app_stub():
+    return MagicMock()
+
+
+# --------------------------------------------------------------------------- #
+# [J] abre o prompt; 'j' minúsculo NÃO (continua navegação DOWN)
+# --------------------------------------------------------------------------- #
+
+def test_J_uppercase_opens_retention_prompt(view_demo, app_stub):
+    view_demo.cursor_row = 0
+    view_demo.handle_key("J", app_stub)
+    assert view_demo.mode is not None
+    kind, _, _ = view_demo.mode
+    assert kind == "retention_prompt"
+
+
+def test_j_lowercase_is_navigation_not_retention(view_demo, app_stub):
+    """Regressão: 'j' minúsculo é DOWN (vim); só 'J' abre o prompt."""
+    view_demo.cursor_row = 0
+    view_demo.handle_key("j", app_stub)
+    assert view_demo.mode is None          # não abriu modal
+    assert view_demo.cursor_row == 1        # navegou para baixo
+
+
+# --------------------------------------------------------------------------- #
+# _handle_retention_prompt_key
+# --------------------------------------------------------------------------- #
+
+def test_retention_prompt_digit_input(view_demo, app_stub):
+    view_demo._open_retention_prompt()
+    view_demo.handle_key("7", app_stub)
+    _, _, opts = view_demo.mode
+    assert "7" in opts[0]
+
+
+def test_retention_prompt_multi_digit(view_demo, app_stub):
+    view_demo._open_retention_prompt()
+    view_demo.handle_key("6", app_stub)
+    view_demo.handle_key("0", app_stub)
+    _, _, opts = view_demo.mode
+    assert opts[0] == "60"
+
+
+def test_retention_prompt_backspace(view_demo, app_stub):
+    view_demo._open_retention_prompt()
+    view_demo.handle_key("3", app_stub)
+    view_demo.handle_key("0", app_stub)
+    view_demo.handle_key("BACKSPACE", app_stub)
+    _, _, opts = view_demo.mode
+    assert opts[0] == "3"
+
+
+def test_retention_prompt_esc_cancels(view_demo, app_stub):
+    view_demo._open_retention_prompt()
+    view_demo.handle_key("ESC", app_stub)
+    assert view_demo.mode is None
+    assert "cancel" in (view_demo.last_msg or "").lower()
+
+
+def test_retention_prompt_enter_applies_demo(view_demo, app_stub):
+    view_demo._open_retention_prompt()
+    view_demo.handle_key("3", app_stub)
+    view_demo.handle_key("0", app_stub)
+    view_demo.handle_key("\r", app_stub)
+    assert view_demo.mode is None
+    assert view_demo.last_msg is not None
+
+
+def test_retention_prompt_enter_empty_applies_clear(view_demo, app_stub):
+    view_demo._open_retention_prompt()
+    view_demo.handle_key("\r", app_stub)   # buffer vazio → _apply_retention(None)
+    assert view_demo.mode is None
+
+
+# --------------------------------------------------------------------------- #
+# _apply_retention
+# --------------------------------------------------------------------------- #
+
+def test_apply_retention_demo_mode(view_demo):
+    view_demo._apply_retention("30")
+    assert view_demo.last_ok is False
+    assert "demo" in (view_demo.last_msg or "").lower()
+
+
+def test_apply_retention_no_kubectl(view_with_data):
+    with patch("_panel.kubectl_bin", return_value=None):
+        view_with_data._apply_retention("30")
+    assert view_with_data.last_ok is False
+    assert "kubectl" in (view_with_data.last_msg or "").lower()
+
+
+def test_apply_retention_invalid_value(view_with_data):
+    with patch("_panel.kubectl_bin", return_value="/usr/bin/kubectl"):
+        view_with_data._apply_retention("0")   # < 1 → inválido
+    assert view_with_data.last_ok is False
+    assert "inválido" in (view_with_data.last_msg or "").lower()
+
+
+def test_apply_retention_success_sets_both_targets(view_with_data):
+    """Sucesso aplica nos DOIS alvos (deployment + cronjob) e reporta ok."""
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = ""
+        return m
+
+    with patch("_panel.kubectl_bin", return_value="/usr/bin/kubectl"), \
+         patch("subprocess.run", side_effect=fake_run):
+        view_with_data._apply_retention("45")
+
+    assert view_with_data.last_ok is True
+    assert "45" in (view_with_data.last_msg or "")
+    targets = " ".join(" ".join(c) for c in calls)
+    assert "deployment/claude-worker" in targets
+    assert "cronjob/claude-worker-cleanup" in targets
+    assert "DEILE_CLAUDE_JSONL_RETENTION_DAYS=45" in targets
+
+
+def test_apply_retention_clear_removes_override(view_with_data):
+    def fake_run(cmd, **kw):
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = ""
+        return m
+
+    with patch("_panel.kubectl_bin", return_value="/usr/bin/kubectl"), \
+         patch("subprocess.run", side_effect=fake_run):
+        view_with_data._apply_retention(None)
+
+    assert view_with_data.last_ok is True
+    assert "default" in (view_with_data.last_msg or "").lower()
+
+
+def test_apply_retention_partial_failure(view_with_data):
+    """Um alvo ok + um falho → last_ok False e mensagem de parcial."""
+    def fake_run(cmd, **kw):
+        m = MagicMock()
+        flat = " ".join(cmd)
+        if "cronjob" in flat:
+            m.returncode = 1
+            m.stderr = "cronjob not found"
+        else:
+            m.returncode = 0
+            m.stderr = ""
+        return m
+
+    with patch("_panel.kubectl_bin", return_value="/usr/bin/kubectl"), \
+         patch("subprocess.run", side_effect=fake_run):
+        view_with_data._apply_retention("30")
+
+    assert view_with_data.last_ok is False
+    assert "parcial" in (view_with_data.last_msg or "").lower()
+
+
+# --------------------------------------------------------------------------- #
+# Render: modal retention_prompt aparece
+# --------------------------------------------------------------------------- #
+
+def test_render_retention_prompt_modal_visible(view_demo, app_stub):
+    from rich.console import Console
+    view_demo.handle_key("J", app_stub)
+    console = Console(width=120)
+    renderable = view_demo.render(app_stub)
+    with console.capture() as cap:
+        console.print(renderable)
+    out = cap.get()
+    assert "RETENÇÃO" in out.upper() or "RETENTION_DAYS" in out.upper()

--- a/deile/tests/infra/test_dispatch_matrix_jsonl_retention.py
+++ b/deile/tests/infra/test_dispatch_matrix_jsonl_retention.py
@@ -190,14 +190,37 @@ def test_apply_retention_clear_removes_override(view_with_data):
     assert "default" in (view_with_data.last_msg or "").lower()
 
 
-def test_apply_retention_partial_failure(view_with_data):
-    """Um alvo ok + um falho → last_ok False e mensagem de parcial."""
+def test_apply_retention_cron_notfound_is_skipped_not_failed(view_with_data):
+    """CronJob ausente (NotFound) é PULADO — deployment ok → sucesso geral.
+    O cron de cleanup nem sempre está aplicado; só o deployment é obrigatório."""
     def fake_run(cmd, **kw):
         m = MagicMock()
         flat = " ".join(cmd)
         if "cronjob" in flat:
             m.returncode = 1
-            m.stderr = "cronjob not found"
+            m.stderr = 'Error from server (NotFound): cronjobs.batch "x" not found'
+        else:
+            m.returncode = 0
+            m.stderr = ""
+        return m
+
+    with patch("_panel.kubectl_bin", return_value="/usr/bin/kubectl"), \
+         patch("subprocess.run", side_effect=fake_run):
+        view_with_data._apply_retention("30")
+
+    assert view_with_data.last_ok is True
+    assert "claude-worker" in (view_with_data.last_msg or "")
+    assert "pulado" in (view_with_data.last_msg or "").lower()
+
+
+def test_apply_retention_hard_failure_on_deployment(view_with_data):
+    """Falha REAL no deployment (não-NotFound) → last_ok False."""
+    def fake_run(cmd, **kw):
+        m = MagicMock()
+        flat = " ".join(cmd)
+        if "deployment" in flat:
+            m.returncode = 1
+            m.stderr = "Error from server (Forbidden): deployments forbidden"
         else:
             m.returncode = 0
             m.stderr = ""

--- a/deile/tests/infrastructure/test_audit_ledger_read.py
+++ b/deile/tests/infrastructure/test_audit_ledger_read.py
@@ -90,6 +90,71 @@ def test_parser_emits_harvested_session(audit, jc, tmp_path):
         (100 * 5 + 50 * 25 + 150 * 6.25 + 50 * 10 + 300 * 0.5) / 1_000_000.0)
 
 
+def test_parser_reads_rich_v2_detail(audit, tmp_path):
+    """Registro v:2 → o registro sintético carrega o DETALHE completo
+    (título/brief/tools/PR/meta), não só tokens. Detalhe da sessão colhida
+    fica idêntico ao da viva na tela de tokens (issue #445 parte 2)."""
+    ledger = tmp_path / ".claude" / "cost-ledger.jsonl"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text(json.dumps({
+        "v": 2, "session_id": "sess-rich-1", "task_id": "cccccccccccc0003",
+        "models": {"claude-opus-4-5-20260101": {
+            "in": 100, "out": 50, "cc": 0, "cr": 0, "cc_5m": 0, "cc_1h": 0}},
+        "first_ts": "2026-04-01T09:00:00.000Z",
+        "last_ts": "2026-04-01T09:05:00.000Z", "assistant_rounds": 2,
+        "harvested_at": 1_790_000_000.0, "source_mtime": 1_780_500_000.0,
+        "tools": {"Read": 3, "Edit": 1}, "user_msgs": 4, "tool_calls": 4,
+        "cwd": "/home/claude/work/x/repo", "git_branch": "auto/issue-9",
+        "version": "2.1.158", "permission_mode": "bypassPermissions",
+        "entrypoint": "cli", "ai_title": "Corrige X", "pr_number": 42,
+        "pr_url": "https://github.com/o/r/pull/42", "pr_repo": "o/r",
+        "brief": "implementa a issue 9", "stop_reasons": {"end_turn": 2},
+        "errors": {"synthetic": 0, "max_tokens": 1, "api_error": 0, "tool_error": 0},
+        "meta_model": "anthropic:claude-opus-4-5", "reasoning_effort": "xhigh",
+        "ultracode": True, "stage": "implement",
+    }) + "\n", encoding="utf-8")
+
+    sessions = _run_parser(audit.IN_POD_PARSER, ledger)
+    s = next(x for x in sessions if x["session_file"] == "sess-rich-1.jsonl")
+    assert s["harvested"] is True
+    assert s["ai_title"] == "Corrige X"
+    assert s["brief"] == "implementa a issue 9"
+    assert s["tools"] == {"Read": 3, "Edit": 1}
+    assert s["tool_calls"] == 4
+    assert s["user_msgs"] == 4
+    assert s["pr_number"] == 42
+    assert s["pr_repo"] == "o/r"
+    assert s["git_branch"] == "auto/issue-9"
+    assert s["version"] == "2.1.158"
+    assert s["stage"] == "implement"
+    assert s["meta_model"] == "anthropic:claude-opus-4-5"
+    assert s["reasoning_effort"] == "xhigh"
+    assert s["ultracode"] is True
+    assert s["stop_reasons"] == {"end_turn": 2}
+    assert s["errors"]["max_tokens"] == 1
+    assert s["mtime"] == 1_780_500_000.0   # source_mtime, não harvested_at
+
+
+def test_parser_v1_backcompat_empty_detail(audit, tmp_path):
+    """Registro v:1 (legado, só tokens) → detalhe vazio sem quebrar."""
+    ledger = tmp_path / ".claude" / "cost-ledger.jsonl"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text(json.dumps({
+        "v": 1, "session_id": "old-1", "task_id": "dddddddddddd0004",
+        "models": {"claude-sonnet-4-5": {"in": 10, "out": 5, "cc": 0,
+                                         "cr": 0, "cc_5m": 0, "cc_1h": 0}},
+        "first_ts": None, "last_ts": None, "assistant_rounds": 1,
+        "harvested_at": 1_780_000_000.0,
+    }) + "\n", encoding="utf-8")
+    sessions = _run_parser(audit.IN_POD_PARSER, ledger)
+    s = next(x for x in sessions if x["session_file"] == "old-1.jsonl")
+    assert s["ai_title"] is None
+    assert s["brief"] is None
+    assert s["tools"] == {}
+    assert s["stage"] == "harvested"          # sem meta → fallback
+    assert s["mtime"] == 1_780_000_000.0      # sem source_mtime → harvested_at
+
+
 def test_parser_dedups_ledger_session_ids(audit, tmp_path):
     ledger = tmp_path / ".claude" / "cost-ledger.jsonl"
     ledger.parent.mkdir(parents=True)

--- a/deile/tests/infrastructure/test_cost_ledger_harvest.py
+++ b/deile/tests/infrastructure/test_cost_ledger_harvest.py
@@ -8,10 +8,18 @@ histórico sobrevive em escala de KB.
 Cobre:
 - Harvest + poda de dir órfão (workdir-pai ausente), preservando o ativo.
 - Grace period: órfão recém-modificado NÃO é podado (guarda TOCTOU).
+- Retenção em dias (default 30d): órfão dentro da janela NÃO é podado, mesmo
+  com workdir-pai ausente — o Humano controla o período (issue #445 parte 2).
+- Registro RICO (v:2): preserva título/brief/tools/PR/erros/meta, não só
+  tokens — a sessão colhida fica idêntica à viva na tela de tokens.
 - Idempotência: rodar duas vezes não duplica no ledger.
 - ``dry_run``: reporta candidatos sem deletar nem escrever.
 - Integração no preview ``_cleanup_scan`` (campo ``orphan_jsonl_dirs`` +
   bytes somados a ``total_candidate_bytes``).
+- Fail-safe: sem o extrator (jsonl_cost ausente) a poda é abortada.
+
+Nota: os testes de MECÂNICA passam ``retention_days=0`` para isolar o piso
+grace (TOCTOU) do gatilho de retenção — a retenção em si tem testes próprios.
 """
 
 from __future__ import annotations
@@ -99,7 +107,7 @@ def test_harvest_and_prune_orphan_preserves_active(cws, env):
 
     result = cws._harvest_and_prune_orphan_jsonl(
         env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
-        grace_s=3600, now=time.time(),
+        grace_s=3600, retention_days=0, now=time.time(),
     )
 
     assert result["sessions_harvested"] == 1
@@ -121,7 +129,7 @@ def test_grace_period_protects_recent_orphan(cws, env):
 
     result = cws._harvest_and_prune_orphan_jsonl(
         env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
-        grace_s=3600, now=time.time(),
+        grace_s=3600, retention_days=0, now=time.time(),
     )
 
     assert result["sessions_harvested"] == 0
@@ -130,17 +138,51 @@ def test_grace_period_protects_recent_orphan(cws, env):
     assert _read_ledger(env["ledger"]) == []
 
 
+def test_retention_days_protects_orphan_within_window(cws, env):
+    """O gatilho PRINCIPAL: um órfão (workdir-pai ausente) com 5 dias NÃO é
+    podado sob retenção de 30d — mesmo muito além do grace de 1h. É o pedido
+    do Humano: nunca ceifar sessões com menos de N dias (issue #445)."""
+    five_days = 5 * 86400
+    pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=five_days)
+
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, retention_days=30, now=time.time(),
+    )
+
+    assert result["sessions_harvested"] == 0
+    assert result["jsonl_dirs_removed"] == 0
+    assert pdir.exists()                       # protegido pela retenção 30d
+    assert _read_ledger(env["ledger"]) == []
+
+
+def test_retention_days_prunes_orphan_past_window(cws, env):
+    """Além da retenção (40 dias > 30d), o órfão é colhido + podado."""
+    forty_days = 40 * 86400
+    pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=forty_days)
+
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, retention_days=30, now=time.time(),
+    )
+
+    assert result["sessions_harvested"] == 1
+    assert result["jsonl_dirs_removed"] == 1
+    assert not pdir.exists()
+    assert len(_read_ledger(env["ledger"])) == 1
+
+
 def test_idempotent_no_duplicate(cws, env):
     _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
     cws._harvest_and_prune_orphan_jsonl(
         env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
-        grace_s=3600, now=time.time(),
+        grace_s=3600, retention_days=0, now=time.time(),
     )
     # recria a mesma sessão (simula reaparição) e roda de novo
     _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
     cws._harvest_and_prune_orphan_jsonl(
         env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
-        grace_s=3600, now=time.time(),
+        grace_s=3600, retention_days=0, now=time.time(),
     )
     led = _read_ledger(env["ledger"])
     assert len(led) == 1  # session_id sess-a aparece uma única vez
@@ -150,7 +192,7 @@ def test_dry_run_reports_without_side_effects(cws, env):
     pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
     result = cws._harvest_and_prune_orphan_jsonl(
         env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
-        grace_s=3600, now=time.time(), dry_run=True,
+        grace_s=3600, retention_days=0, now=time.time(), dry_run=True,
     )
     assert result["orphan_jsonl_dirs"]          # candidato reportado
     assert result["jsonl_dirs_removed"] == 0
@@ -161,6 +203,8 @@ def test_dry_run_reports_without_side_effects(cws, env):
 
 def test_cleanup_scan_includes_orphan_jsonl(cws, env, monkeypatch):
     monkeypatch.setenv("HOME", str(env["home"]))
+    # retenção 0 → o piso grace (1h) governa; órfão de 2h aparece no preview.
+    monkeypatch.setattr(cws, "_JSONL_RETENTION_DAYS", 0)
     _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
     scan = cws._cleanup_scan(env["work"])
     assert str(env["projects"] / f"-home-claude-work-{TASK_A}") in \
@@ -175,12 +219,12 @@ def test_cleanup_scan_includes_orphan_jsonl(cws, env, monkeypatch):
 # deletadas sem ledger).
 # --------------------------------------------------------------------------- #
 def test_no_prune_when_aggregator_unavailable(cws, env, monkeypatch):
-    """Sem o agregador (jsonl_cost ausente da imagem), poda é ABORTADA."""
+    """Sem o extrator (jsonl_cost ausente da imagem), poda é ABORTADA."""
     pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
-    monkeypatch.setattr(cws, "_aggregate_jsonl", None)
+    monkeypatch.setattr(cws, "_summarize_jsonl", None)
     result = cws._harvest_and_prune_orphan_jsonl(
         env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
-        grace_s=3600, now=time.time(),
+        grace_s=3600, retention_days=0, now=time.time(),
     )
     assert result["jsonl_dirs_removed"] == 0
     assert result["sessions_harvested"] == 0
@@ -190,17 +234,75 @@ def test_no_prune_when_aggregator_unavailable(cws, env, monkeypatch):
 
 
 def test_no_prune_when_aggregation_raises(cws, env, monkeypatch):
-    """Se a agregação de um JSONL falha, o dir inteiro é preservado."""
+    """Se o resumo de um JSONL falha, o dir inteiro é preservado."""
     pdir = _make_project(env["projects"], TASK_A, "sess-a", mtime_age_s=7200)
 
     def _boom(_path):
         raise ValueError("parse explodiu")
 
-    monkeypatch.setattr(cws, "_aggregate_jsonl", _boom)
+    monkeypatch.setattr(cws, "_summarize_jsonl", _boom)
     result = cws._harvest_and_prune_orphan_jsonl(
         env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
-        grace_s=3600, now=time.time(),
+        grace_s=3600, retention_days=0, now=time.time(),
     )
     assert result["jsonl_dirs_removed"] == 0
     assert pdir.exists()                      # preservado: havia custo não colhido
-    assert any("aggregate" in e for e in result["errors"])
+    assert any("summarize" in e for e in result["errors"])
+
+
+def test_harvested_record_preserves_full_detail(cws, env, monkeypatch):
+    """O registro do ledger (v:2) carrega o DETALHE que a tela de tokens
+    mostra — título/brief/tools/PR/erros + meta (model/stage) — não só tokens.
+    É o pedido do Humano: 'se tem coisa que mostra na tabela, tem que manter'."""
+    pdir = env["projects"] / f"-home-claude-work-{TASK_A}"
+    pdir.mkdir(parents=True)
+    jsonl = pdir / "sess-rich.jsonl"
+    jsonl.write_text("\n".join(json.dumps(r) for r in [
+        {"type": "user", "timestamp": "2026-04-01T09:00:00.000Z",
+         "cwd": "/home/claude/work/x/repo", "gitBranch": "auto/issue-9",
+         "version": "2.1.158", "permissionMode": "bypassPermissions",
+         "entrypoint": "cli", "aiTitle": "Corrige X", "prNumber": 42,
+         "prUrl": "https://github.com/o/r/pull/42", "prRepository": "o/r",
+         "message": {"role": "user", "content": "implementa a issue 9"}},
+        {"type": "assistant", "requestId": "r1",
+         "timestamp": "2026-04-01T09:01:00.000Z",
+         "message": {"id": "m1", "role": "assistant",
+                     "model": "claude-opus-4-5-20260101", "stop_reason": "tool_use",
+                     "content": [{"type": "tool_use", "name": "Read"}],
+                     "usage": {"input_tokens": 100, "output_tokens": 50}}},
+    ]) + "\n", encoding="utf-8")
+    import os
+    old = time.time() - 40 * 86400
+    os.utime(jsonl, (old, old))
+    os.utime(pdir, (old, old))
+    # session.json (ground truth do pipeline) — meta lida pelo harvester.
+    meta_dir = env["home"] / ".claude" / "tasks" / TASK_A
+    meta_dir.mkdir(parents=True)
+    (meta_dir / "session.json").write_text(json.dumps({
+        "model": "anthropic:claude-opus-4-5", "reasoning_effort": "xhigh",
+        "ultracode": True, "stage": "implement",
+    }), encoding="utf-8")
+    monkeypatch.setenv("HOME", str(env["home"]))
+
+    result = cws._harvest_and_prune_orphan_jsonl(
+        env["work"], projects_dir=env["projects"], ledger_path=env["ledger"],
+        grace_s=3600, retention_days=30, now=time.time(),
+    )
+    assert result["sessions_harvested"] == 1
+    rec = _read_ledger(env["ledger"])[0]
+    assert rec["v"] == 2
+    assert rec["ai_title"] == "Corrige X"
+    assert rec["brief"] == "implementa a issue 9"
+    assert rec["tools"] == {"Read": 1}
+    assert rec["tool_calls"] == 1
+    assert rec["user_msgs"] == 1
+    assert rec["pr_number"] == 42
+    assert rec["pr_repo"] == "o/r"
+    assert rec["git_branch"] == "auto/issue-9"
+    assert rec["version"] == "2.1.158"
+    assert rec["stop_reasons"] == {"tool_use": 1}
+    assert rec["meta_model"] == "anthropic:claude-opus-4-5"
+    assert rec["reasoning_effort"] == "xhigh"
+    assert rec["ultracode"] is True
+    assert rec["stage"] == "implement"
+    assert rec["source_mtime"] == pytest.approx(old, abs=2)

--- a/deile/tests/infrastructure/test_jsonl_cost.py
+++ b/deile/tests/infrastructure/test_jsonl_cost.py
@@ -203,3 +203,104 @@ def test_aggregate_parity_with_inpod_reference(jc, golden_session):
     agg = jc.aggregate_jsonl(str(golden_session))
     assert agg["models"] == models
     assert agg["assistant_rounds"] == rounds
+
+
+# --------------------------------------------------------------------------- #
+# summarize_jsonl — extrator rico do harvest do ledger (issue #445 parte 2)    #
+# --------------------------------------------------------------------------- #
+def test_aggregate_is_subset_of_summarize(jc, golden_session):
+    """``aggregate_jsonl`` é exatamente o subset de custo de ``summarize_jsonl``
+    — mesmos models/rounds/timestamps (paridade preservada no refactor)."""
+    agg = jc.aggregate_jsonl(str(golden_session))
+    summ = jc.summarize_jsonl(str(golden_session))
+    assert agg["session_id"] == summ["session_id"]
+    assert agg["models"] == summ["models"]
+    assert agg["assistant_rounds"] == summ["assistant_rounds"]
+    assert agg["first_ts"] == summ["first_ts"]
+    assert agg["last_ts"] == summ["last_ts"]
+
+
+def test_summarize_extracts_full_detail(jc, tmp_path):
+    """``summarize_jsonl`` colhe TUDO que a tela de tokens mostra no detalhe."""
+    f = tmp_path / "sess-detail.jsonl"
+    records = [
+        {"type": "user", "timestamp": "2026-06-01T09:00:00.000Z",
+         "cwd": "/home/claude/work/abc/repo", "gitBranch": "auto/issue-9",
+         "version": "2.1.158", "permissionMode": "bypassPermissions",
+         "entrypoint": "cli", "aiTitle": "Corrige bug X",
+         "prNumber": 42, "prUrl": "https://github.com/o/r/pull/42",
+         "prRepository": "o/r",
+         "message": {"role": "user", "content": "implementa a issue 9 por favor"}},
+        {"type": "assistant", "requestId": "r1",
+         "timestamp": "2026-06-01T09:01:00.000Z",
+         "message": {"id": "m1", "role": "assistant",
+                     "model": "claude-opus-4-5-20260101", "stop_reason": "tool_use",
+                     "content": [
+                         {"type": "text", "text": "vou ler o arquivo"},
+                         {"type": "tool_use", "name": "Read"},
+                         {"type": "tool_use", "name": "Edit"},
+                     ],
+                     "usage": {"input_tokens": 100, "output_tokens": 50}}},
+        # tool result com erro → conta tool_error
+        {"type": "user", "timestamp": "2026-06-01T09:02:00.000Z",
+         "toolUseResult": {"is_error": True},
+         "message": {"role": "user", "content": "erro!"}},
+        {"type": "assistant", "requestId": "r2",
+         "timestamp": "2026-06-01T09:03:00.000Z",
+         "message": {"id": "m2", "role": "assistant",
+                     "model": "claude-opus-4-5-20260101", "stop_reason": "end_turn",
+                     "content": [{"type": "tool_use", "name": "Read"}],
+                     "usage": {"input_tokens": 10, "output_tokens": 5}}},
+    ]
+    _write_session(f, records)
+    s = jc.summarize_jsonl(str(f))
+
+    assert s["session_id"] == "sess-detail"
+    assert s["cwd"] == "/home/claude/work/abc/repo"
+    assert s["git_branch"] == "auto/issue-9"
+    assert s["version"] == "2.1.158"
+    assert s["permission_mode"] == "bypassPermissions"
+    assert s["entrypoint"] == "cli"
+    assert s["ai_title"] == "Corrige bug X"
+    assert s["pr_number"] == 42
+    assert s["pr_url"] == "https://github.com/o/r/pull/42"
+    assert s["pr_repo"] == "o/r"
+    assert s["brief"] == "implementa a issue 9 por favor"  # 1ª msg user
+    assert s["user_msgs"] == 2
+    assert s["assistant_rounds"] == 2
+    assert s["tool_calls"] == 3
+    assert s["tools"] == {"Read": 2, "Edit": 1}
+    assert s["stop_reasons"] == {"tool_use": 1, "end_turn": 1}
+    assert s["errors"]["tool_error"] == 1
+    assert s["models"]["claude-opus-4-5-20260101"]["in"] == 110
+
+
+def test_summarize_counts_synthetic_and_max_tokens(jc, tmp_path):
+    f = tmp_path / "sess-err.jsonl"
+    records = [
+        {"type": "assistant", "requestId": "r1",
+         "message": {"id": "m1", "role": "assistant", "model": "<synthetic>",
+                     "stop_reason": "max_tokens",
+                     "content": "prompt is too long: blah",
+                     "usage": {"input_tokens": 1, "output_tokens": 1}}},
+    ]
+    _write_session(f, records)
+    s = jc.summarize_jsonl(str(f))
+    assert s["errors"]["synthetic"] == 1
+    assert s["errors"]["max_tokens"] == 1
+    assert s["errors"]["api_error"] == 1  # "prompt is too long"
+    assert s["stop_reasons"] == {"max_tokens": 1}
+
+
+def test_summarize_brief_capped(jc, tmp_path):
+    f = tmp_path / "sess-big.jsonl"
+    big = "x" * 9000
+    _write_session(f, [
+        {"type": "user", "message": {"role": "user", "content": big}},
+        {"type": "assistant", "requestId": "r1",
+         "message": {"id": "m1", "role": "assistant", "model": "claude-opus-4-5",
+                     "usage": {"input_tokens": 1, "output_tokens": 1}}},
+    ])
+    s = jc.summarize_jsonl(str(f))
+    assert s["brief"] is not None
+    assert len(s["brief"]) == jc._BRIEF_CAP  # capado em 4000

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -4490,6 +4490,7 @@ class DispatchMatrixView(View):
         "[s]caling row: enter digita réplicas (0-10)   "
         "[c] cleanup on-demand (preview + confirm)   "
         "[p] editar max_parallel (parallelism do pipeline)   "
+        "[J] editar retenção JSONL em dias (claude-worker + cron, default 30d)   "
         "colunas: 0=Worker 1=Model 2=Timeout 3=Retries 4=Cost cap (USD/run) 5=Reasoning   "
         "retries=0 EXIGE confirmação: digite '0!' (fail-fast, sem retry)   "
         "linha monitor: Worker=in-pod (não editável)  Model=DEILE_PREFERRED_MODEL do deile-monitor"
@@ -4990,6 +4991,9 @@ class DispatchMatrixView(View):
             title = "CLEANUP ON-DEMAND — CONFIRMAR?"
         elif kind == "max_parallel_prompt":
             title = "MAX_PARALLEL DO PIPELINE (DEILE_PIPELINE_MAX_PARALLEL)"
+        elif kind == "retention_prompt":
+            title = ("RETENÇÃO JSONL EM DIAS (DEILE_CLAUDE_JSONL_RETENTION_DAYS"
+                     " — enter vazio = default 30d)")
         else:  # defensivo
             title = "AÇÃO"
 
@@ -5047,6 +5051,16 @@ class DispatchMatrixView(View):
             hint_line = Text(
                 "[0-9] digita   [a] = 'auto' (replica count)   "
                 "[backspace] apaga   [enter] confirma   [esc] cancela",
+                style="dim cyan",
+            )
+            body = Group(input_line, Text(""), hint_line)
+        elif kind == "retention_prompt":
+            # ``options[0]`` é o buffer atual (número de dias).
+            buf = options[0] if options else ""
+            input_line = Text(f"› {buf}_", style="bold cyan")
+            hint_line = Text(
+                "[0-9] digita dias   [backspace] apaga   [enter] confirma   "
+                "[esc] cancela   (default 30d; aplica em claude-worker + cron)",
                 style="dim cyan",
             )
             body = Group(input_line, Text(""), hint_line)
@@ -5126,6 +5140,11 @@ class DispatchMatrixView(View):
         # --- [p] editar max_parallel ---------------------------------------
         if key == "p":
             return self._open_max_parallel_prompt()
+
+        # --- [J] editar retenção JSONL (issue #445) -------------------------
+        # Maiúsculo de propósito: 'j' minúsculo é navegação DOWN (vim).
+        if key == "J":
+            return self._open_retention_prompt()
 
         # --- navegação row ------------------------------------------------
         if key in ("UP", "k"):
@@ -6177,6 +6196,8 @@ class DispatchMatrixView(View):
             return self._handle_cleanup_confirm_key(key)
         if self.mode is not None and self.mode[0] == "max_parallel_prompt":
             return self._handle_max_parallel_prompt_key(key)
+        if self.mode is not None and self.mode[0] == "retention_prompt":
+            return self._handle_retention_prompt_key(key)
         if key == "ESC":
             self.mode = None
             self.picker_cursor = 0
@@ -6654,6 +6675,136 @@ class DispatchMatrixView(View):
                 self.last_ok = False
         except Exception as exc:  # noqa: BLE001
             self.last_msg = f"erro ao setar max_parallel: {exc}"
+            self.last_ok = False
+        return ActionResult.refresh()
+
+    # --- retenção JSONL (issue #445) ------------------------------------
+
+    def _read_retention_env(self) -> str:
+        """Lê DEILE_CLAUDE_JSONL_RETENTION_DAYS do Deployment claude-worker.
+
+        Retorna string vazia se não conseguir ler (kubectl indisponível,
+        deployment ausente, env não setada → default do código = 30).
+        """
+        if self.data is None:
+            return ""
+        ns = (self.data.context.namespace
+              if getattr(self.data, "context", None) is not None
+              else _NS_DEFAULT)
+        kubectl = kubectl_bin()
+        if kubectl is None:
+            return ""
+        try:
+            result = subprocess.run(
+                [kubectl, "-n", ns, "get", "deployment", "claude-worker",
+                 "-o",
+                 "jsonpath={.spec.template.spec.containers[0].env"
+                 "[?(@.name=='DEILE_CLAUDE_JSONL_RETENTION_DAYS')].value}"],
+                capture_output=True, text=True, timeout=8,
+            )
+            return result.stdout.strip()
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def _open_retention_prompt(self) -> ActionResult:
+        """Abre modal de edição numérica da retenção JSONL (dias)."""
+        current = self._read_retention_env() or ""
+        self.mode = ("retention_prompt", None, [current])
+        self.picker_cursor = 0
+        self.last_msg = ""
+        self.last_ok = None
+        return ActionResult.refresh()
+
+    def _handle_retention_prompt_key(self, key: str) -> ActionResult:
+        """Captura entrada numérica para DEILE_CLAUDE_JSONL_RETENTION_DAYS."""
+        _, stage, options = self.mode  # type: ignore[misc]
+        buf: str = options[0] if options else ""
+
+        if key == "ESC":
+            self.mode = None
+            self.picker_cursor = 0
+            self.last_msg = "edição de retenção JSONL cancelada"
+            self.last_ok = None
+            return ActionResult.refresh()
+
+        if key == "BACKSPACE" or key == "\x7f":
+            self.mode = ("retention_prompt", stage, [buf[:-1]])
+            return ActionResult.refresh()
+
+        if key in ("\r", "\n"):
+            self.mode = None
+            self.picker_cursor = 0
+            if buf.strip() == "":
+                return self._apply_retention(None)  # remove override → 30
+            return self._apply_retention(buf.strip())
+
+        if key.isdigit():
+            self.mode = ("retention_prompt", stage, [buf + key])
+            return ActionResult.refresh()
+
+        return ActionResult()
+
+    def _apply_retention(self, value: Optional[str]) -> ActionResult:
+        """Aplica DEILE_CLAUDE_JSONL_RETENTION_DAYS no Deployment claude-worker
+        E no CronJob claude-worker-cleanup (backstop diário) — mantém os dois
+        em sincronia para não criar inconsistência de poda.
+
+        ``value=None`` → remove o override (volta ao default do código = 30).
+        ``value="N"`` → seta valor numérico (dias).
+        """
+        ns = (self.data.context.namespace
+              if self.data is not None and getattr(self.data, "context", None)
+              else _NS_DEFAULT)
+        if self.data is None:
+            self.last_msg = f"[demo] retenção JSONL → {value!r} (sem cluster, no-op)"
+            self.last_ok = False
+            return ActionResult.refresh()
+
+        kubectl = kubectl_bin()
+        if kubectl is None:
+            self.last_msg = "kubectl não encontrado — retenção não alterada"
+            self.last_ok = False
+            return ActionResult.refresh()
+
+        if value is not None:
+            try:
+                n = int(value)
+                if n < 1:
+                    raise ValueError(f"valor deve ser >= 1, got {n}")
+            except ValueError as exc:
+                self.last_msg = f"valor inválido para retenção JSONL: {exc}"
+                self.last_ok = False
+                return ActionResult.refresh()
+
+        env_arg = ("DEILE_CLAUDE_JSONL_RETENTION_DAYS-"  # remove
+                   if value is None
+                   else f"DEILE_CLAUDE_JSONL_RETENTION_DAYS={value}")
+        targets = ("deployment/claude-worker", "cronjob/claude-worker-cleanup")
+        ok_targets, failed = [], []
+        for tgt in targets:
+            try:
+                result = subprocess.run(
+                    [kubectl, "-n", ns, "set", "env", tgt, env_arg],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if result.returncode == 0:
+                    ok_targets.append(tgt.split("/")[-1])
+                else:
+                    failed.append(f"{tgt}: {result.stderr.strip()[:80]}")
+            except Exception as exc:  # noqa: BLE001
+                failed.append(f"{tgt}: {exc}")
+
+        action = "removida (default: 30d)" if value is None else f"→ {value}d"
+        if ok_targets and not failed:
+            self.last_msg = (f"retenção JSONL {action} em {', '.join(ok_targets)} "
+                             "(claude-worker rollout em curso)")
+            self.last_ok = True
+        elif ok_targets:
+            self.last_msg = (f"retenção JSONL {action} parcial — ok: "
+                             f"{', '.join(ok_targets)}; falhou: {'; '.join(failed)}")
+            self.last_ok = False
+        else:
+            self.last_msg = f"set env falhou: {'; '.join(failed)}"
             self.last_ok = False
         return ActionResult.refresh()
 

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -6746,8 +6746,9 @@ class DispatchMatrixView(View):
 
     def _apply_retention(self, value: Optional[str]) -> ActionResult:
         """Aplica DEILE_CLAUDE_JSONL_RETENTION_DAYS no Deployment claude-worker
-        E no CronJob claude-worker-cleanup (backstop diário) — mantém os dois
-        em sincronia para não criar inconsistência de poda.
+        (alvo principal — o cleanup vivo roda no pod) E, se existir, no CronJob
+        claude-worker-cleanup (backstop opcional). O CronJob nem sempre está
+        aplicado (NotFound) — nesse caso é PULADO, não conta como falha.
 
         ``value=None`` → remove o override (volta ao default do código = 30).
         ``value="N"`` → seta valor numérico (dias).
@@ -6779,25 +6780,31 @@ class DispatchMatrixView(View):
         env_arg = ("DEILE_CLAUDE_JSONL_RETENTION_DAYS-"  # remove
                    if value is None
                    else f"DEILE_CLAUDE_JSONL_RETENTION_DAYS={value}")
-        targets = ("deployment/claude-worker", "cronjob/claude-worker-cleanup")
-        ok_targets, failed = [], []
-        for tgt in targets:
+        # (target, obrigatório?) — só o deployment é obrigatório.
+        targets = (("deployment/claude-worker", True),
+                   ("cronjob/claude-worker-cleanup", False))
+        ok_targets, failed, skipped = [], [], []
+        for tgt, required in targets:
             try:
                 result = subprocess.run(
                     [kubectl, "-n", ns, "set", "env", tgt, env_arg],
                     capture_output=True, text=True, timeout=15,
                 )
+                name = tgt.split("/")[-1]
                 if result.returncode == 0:
-                    ok_targets.append(tgt.split("/")[-1])
+                    ok_targets.append(name)
+                elif not required and "not found" in result.stderr.lower():
+                    skipped.append(name)  # CronJob ausente nesse namespace — ok
                 else:
                     failed.append(f"{tgt}: {result.stderr.strip()[:80]}")
             except Exception as exc:  # noqa: BLE001
                 failed.append(f"{tgt}: {exc}")
 
         action = "removida (default: 30d)" if value is None else f"→ {value}d"
+        skip_note = f" (cron pulado: {', '.join(skipped)})" if skipped else ""
         if ok_targets and not failed:
-            self.last_msg = (f"retenção JSONL {action} em {', '.join(ok_targets)} "
-                             "(claude-worker rollout em curso)")
+            self.last_msg = (f"retenção JSONL {action} em {', '.join(ok_targets)}"
+                             f"{skip_note} (claude-worker rollout em curso)")
             self.last_ok = True
         elif ok_targets:
             self.last_msg = (f"retenção JSONL {action} parcial — ok: "

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -52,9 +52,13 @@ import dispatch_logger as dlog
 try:
     # Sibling stdlib-puro (mesmo dir, no sys.path in-pod como dispatch_logger).
     # Fonte única da agregação de custo, usada pelo harvester do ledger (#445).
+    # ``summarize_jsonl`` é o extrator RICO (superset) que preserva tudo que a
+    # tela de tokens mostra (título/brief/tools/PR/erros), não só os tokens.
     from jsonl_cost import aggregate_jsonl as _aggregate_jsonl
+    from jsonl_cost import summarize_jsonl as _summarize_jsonl
 except Exception:  # pragma: no cover — sibling sempre presente in-pod
     _aggregate_jsonl = None
+    _summarize_jsonl = None
 
 logger = logging.getLogger("deile.claude_worker_server")
 
@@ -3001,11 +3005,25 @@ def _session_jsonl_exists_for_workdir(workdir: Path) -> bool:
 # lê o ledger para sessões já podadas + o JSONL vivo para as recentes.
 # --------------------------------------------------------------------------- #
 
-#: Grace period (default 1 h) — protege contra TOCTOU: um workdir recém
-#: removido pode ter um resume agendado; só colhemos/podamos JSONL cujo
-#: dir não foi modificado dentro dessa janela.
+#: Grace period (default 1 h) — piso TOCTOU absoluto: um workdir recém
+#: removido pode ter um resume agendado; nunca colhemos/podamos JSONL cujo
+#: dir foi modificado dentro dessa janela. NÃO é o gatilho principal de poda
+#: (esse é a retenção em dias abaixo) — só um piso de segurança.
 _JSONL_ORPHAN_GRACE_S: int = int(
     os.environ.get("DEILE_CLAUDE_JSONL_ORPHAN_GRACE_S", "3600"),
+)
+
+#: Retenção dos transcripts JSONL órfãos, em DIAS (default 30) — gatilho
+#: principal da poda. Um transcript órfão (workdir-pai já removido) só é
+#: colhido+podado depois de N dias SEM modificação. Configurável pelo Humano
+#: via env (manifest/painel) — o JSONL é minúsculo (~KB), então retenção longa
+#: é barata e preserva o histórico resumível + o detalhe completo na tela de
+#: tokens. Knob SEPARADO do workdir (``DEILE_CLAUDE_CLEANUP_RETENTION_DAYS``),
+#: que limpa os checkouts volumosos num ritmo mais curto.
+_JSONL_RETENTION_DAYS_ENV = "DEILE_CLAUDE_JSONL_RETENTION_DAYS"
+_JSONL_RETENTION_DAYS_DEFAULT = 30
+_JSONL_RETENTION_DAYS: int = int(
+    os.environ.get(_JSONL_RETENTION_DAYS_ENV, str(_JSONL_RETENTION_DAYS_DEFAULT)),
 )
 
 _PROJECT_MARKER = "-home-claude-work-"
@@ -3028,18 +3046,27 @@ def _cost_ledger_path() -> Path:
 
 def _orphan_jsonl_scan(
     work_root: Path, projects_dir: Path, grace_s: int, now: float,
+    retention_days: Optional[int] = None,
 ) -> tuple:
-    """Lista dirs de projeto JSONL órfãos (workdir-pai ausente, além do grace).
+    """Lista dirs de projeto JSONL órfãos elegíveis à poda.
 
-    Órfão = ``projects/-home-claude-work-<task_id>`` cujo
-    ``work_root/<task_id>`` não existe mais E cujo ``st_mtime`` é anterior a
-    ``now - grace_s``. Returns ``(list[Path], candidate_bytes)``.
+    Órfão elegível = ``projects/-home-claude-work-<task_id>`` cujo
+    ``work_root/<task_id>`` não existe mais (workdir-pai removido) E cujo
+    ``st_mtime`` é mais antigo que o cutoff. O cutoff é o MAIS conservador
+    entre a retenção em dias (gatilho principal, default 30d) e o grace TOCTOU
+    (piso de 1h) — ``now - max(retention_days*86400, grace_s)``. Assim, mesmo
+    uma retenção mal-configurada para 0 nunca ceifa dentro da janela TOCTOU.
+
+    Returns ``(list[Path], candidate_bytes)``.
     """
     orphans: list = []
     candidate_bytes = 0
     if not projects_dir.is_dir():
         return orphans, candidate_bytes
-    cutoff = now - grace_s
+    if retention_days is None:
+        retention_days = _JSONL_RETENTION_DAYS
+    retention_s = max(0, retention_days) * 86400
+    cutoff = now - max(retention_s, grace_s)
     try:
         children = list(projects_dir.iterdir())
     except OSError:
@@ -3053,7 +3080,7 @@ def _orphan_jsonl_scan(
         # Workdir-pai ainda existe → sessão viva/resumível, preservar.
         if (work_root / task_id).exists():
             continue
-        # Grace: protege contra TOCTOU (workdir recém-removido).
+        # Retenção + grace: só órfãos sem modificação além do cutoff.
         try:
             if pdir.stat().st_mtime > cutoff:
                 continue
@@ -3102,16 +3129,21 @@ def _harvest_and_prune_orphan_jsonl(
     projects_dir: Optional[Path] = None,
     ledger_path: Optional[Path] = None,
     grace_s: Optional[int] = None,
+    retention_days: Optional[int] = None,
     now: Optional[float] = None,
     dry_run: bool = False,
 ) -> dict:
-    """Colhe o custo de sessões JSONL órfãs para o ledger e poda os dirs.
+    """Colhe o RESUMO COMPLETO de sessões JSONL órfãs para o ledger e poda.
 
-    Para cada dir de projeto órfão (workdir-pai ausente, além do grace):
-      1. Agrega cada ``*.jsonl`` (tokens por modelo) e anexa ao ledger
+    Para cada dir de projeto órfão (workdir-pai ausente, além da retenção):
+      1. Resume cada ``*.jsonl`` (``summarize_jsonl`` — tokens por modelo +
+         título/brief/tools/PR/erros/stop reasons) + lê o ``session.json``
+         (model/effort/ultracode/stage) e anexa o registro RICO ao ledger
          durável — pulando ``session_id`` já colhidos (idempotente).
-      2. Remove o dir de projeto inteiro (transcript volumoso).
+      2. Remove o dir de projeto inteiro (transcript volumoso) só DEPOIS que
+         tudo foi contabilizado.
 
+    A sessão colhida fica idêntica à viva na tela de tokens (não uma casca).
     ``dry_run=True`` apenas reporta os candidatos sem colher nem podar.
     """
     if projects_dir is None:
@@ -3120,11 +3152,13 @@ def _harvest_and_prune_orphan_jsonl(
         ledger_path = _cost_ledger_path()
     if grace_s is None:
         grace_s = _JSONL_ORPHAN_GRACE_S
+    if retention_days is None:
+        retention_days = _JSONL_RETENTION_DAYS
     if now is None:
         now = time.time()
 
     orphans, candidate_bytes = _orphan_jsonl_scan(
-        work_root, projects_dir, grace_s, now)
+        work_root, projects_dir, grace_s, now, retention_days)
     result = {
         "orphan_jsonl_dirs": [str(p) for p in orphans],
         "sessions_harvested": 0,
@@ -3137,22 +3171,29 @@ def _harvest_and_prune_orphan_jsonl(
     if dry_run or not orphans:
         return result
 
-    # Fail-safe cardinal: NUNCA podar dados de custo não colhidos. Sem o
-    # agregador (ex.: jsonl_cost ausente da imagem) não há como preservar o
-    # custo antes de deletar — então aborta a poda e preserva tudo.
-    if _aggregate_jsonl is None:
+    # Fail-safe cardinal: NUNCA podar dados não colhidos. Sem o extrator
+    # (ex.: jsonl_cost ausente da imagem) não há como preservar o custo +
+    # detalhe antes de deletar — então aborta a poda e preserva tudo.
+    if _summarize_jsonl is None:
         result["errors"].append(
-            "aggregate_jsonl indisponível — poda abortada (fail-safe)")
+            "summarize_jsonl indisponível — poda abortada (fail-safe)")
         logger.error(
-            "cost-ledger harvest ABORTADO: jsonl_cost.aggregate_jsonl "
+            "cost-ledger harvest ABORTADO: jsonl_cost.summarize_jsonl "
             "indisponível; %d dirs órfãos preservados (sem poda) para não "
-            "perder custo", len(orphans),
+            "perder custo/detalhe", len(orphans),
         )
         return result
 
     harvested = _harvested_session_ids(ledger_path)
     for pdir in orphans:
         task_id = pdir.name.split(_PROJECT_MARKER)[-1]
+        # Metadata ground-truth do pipeline (model/effort/ultracode/stage),
+        # gravada em ~/.claude/tasks/<task_id>/session.json. Pode não existir
+        # (sessão antiga / dispatch externo) — degradamos para campos vazios.
+        try:
+            meta = _load_session_meta(task_id) or {}
+        except Exception:  # noqa: BLE001 — meta é best-effort, nunca bloqueia
+            meta = {}
         # Só podamos um dir DEPOIS que todo o seu conteúdo foi contabilizado
         # (colhido para o ledger, já presente nele, ou genuinamente sem
         # tokens). Qualquer falha de agregação/escrita preserva o dir inteiro.
@@ -3164,9 +3205,9 @@ def _harvest_and_prune_orphan_jsonl(
             continue
         for jsonl in jsonls:
             try:
-                data = _aggregate_jsonl(str(jsonl))
-            except Exception as exc:  # noqa: BLE001 — agregação falhou: preserva
-                result["errors"].append(f"aggregate {jsonl}: {exc}")
+                data = _summarize_jsonl(str(jsonl))
+            except Exception as exc:  # noqa: BLE001 — resumo falhou: preserva
+                result["errors"].append(f"summarize {jsonl}: {exc}")
                 dir_fully_accounted = False
                 continue
             sid = data.get("session_id") or jsonl.stem
@@ -3175,8 +3216,12 @@ def _harvest_and_prune_orphan_jsonl(
             if not data.get("models"):
                 continue  # zero tokens — nada a colher, nada a perder
             try:
+                source_mtime = jsonl.stat().st_mtime
+            except OSError:
+                source_mtime = now  # mtime real indisponível — usa harvest time
+            try:
                 written = _append_ledger(ledger_path, {
-                    "v": 1,
+                    "v": 2,
                     "session_id": sid,
                     "task_id": task_id,
                     "models": data["models"],
@@ -3184,6 +3229,29 @@ def _harvest_and_prune_orphan_jsonl(
                     "last_ts": data.get("last_ts"),
                     "assistant_rounds": data.get("assistant_rounds", 0),
                     "harvested_at": now,
+                    "source_mtime": source_mtime,
+                    # Detalhe rico (#445 parte 2) — preserva o que a tela
+                    # de tokens mostra além dos tokens.
+                    "tools": data.get("tools") or {},
+                    "user_msgs": data.get("user_msgs", 0),
+                    "tool_calls": data.get("tool_calls", 0),
+                    "cwd": data.get("cwd"),
+                    "git_branch": data.get("git_branch"),
+                    "version": data.get("version"),
+                    "permission_mode": data.get("permission_mode"),
+                    "entrypoint": data.get("entrypoint"),
+                    "ai_title": data.get("ai_title"),
+                    "pr_number": data.get("pr_number"),
+                    "pr_url": data.get("pr_url"),
+                    "pr_repo": data.get("pr_repo"),
+                    "brief": data.get("brief"),
+                    "errors": data.get("errors") or {},
+                    "stop_reasons": data.get("stop_reasons") or {},
+                    # Metadata ground-truth do pipeline (session.json).
+                    "meta_model": meta.get("model"),
+                    "reasoning_effort": meta.get("reasoning_effort"),
+                    "ultracode": meta.get("ultracode"),
+                    "stage": meta.get("stage"),
                 })
             except OSError as exc:
                 result["errors"].append(f"ledger write {jsonl}: {exc}")
@@ -3292,10 +3360,12 @@ def _cleanup_scan(
             candidate_bytes += _dir_size(workdir)
 
     # Check 5: JSONL órfão em ~/.claude/projects (issue #445) — dirs de
-    # projeto cujo workdir-pai já não existe. Preview do que o harvester
-    # vai colher para o ledger + podar.
+    # projeto cujo workdir-pai já não existe E mais antigos que a retenção
+    # JSONL (knob próprio, default 30d, SEPARADO do retention_days dos
+    # workdirs). Preview do que o harvester vai colher para o ledger + podar.
     orphan_dirs, orphan_bytes = _orphan_jsonl_scan(
-        root, _projects_dir(), _JSONL_ORPHAN_GRACE_S, now)
+        root, _projects_dir(), _JSONL_ORPHAN_GRACE_S, now,
+        _JSONL_RETENTION_DAYS)
     candidate_bytes += orphan_bytes
 
     return {

--- a/infra/k8s/jsonl_cost.py
+++ b/infra/k8s/jsonl_cost.py
@@ -94,24 +94,55 @@ def _empty_model() -> Dict[str, int]:
     return {"in": 0, "out": 0, "cc": 0, "cr": 0, "cc_5m": 0, "cc_1h": 0}
 
 
-def aggregate_jsonl(path: str) -> dict:
-    """Agrega UM arquivo JSONL de sessão ``claude -p`` nos tokens por modelo.
+#: Teto do brief capturado no resumo (mesmo do parser in-pod do audit). Mantém
+#: o registro do ledger em escala de KB mesmo preservando o comando completo.
+_BRIEF_CAP = 4000
 
-    Conta cada resposta da API uma única vez por ``(message.id, requestId)``
-    — o claude grava o mesmo registro assistant repetido (deltas de
-    streaming) com o ``usage`` final idêntico; sem dedup os totais inflam
-    13-32x. Respostas sem ``id``/``requestId`` recebem chave sintética.
+
+def _text_of(content) -> str:
+    """Extrai o texto de um ``content`` (string ou lista de blocos)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                parts.append(b.get("text", ""))
+        return "\n".join(parts)
+    return ""
+
+
+def summarize_jsonl(path: str) -> dict:
+    """Resumo COMPLETO de uma sessão ``claude -p`` — superset de :func:`aggregate_jsonl`.
+
+    Extrai os MESMOS campos que o parser in-pod do ``session_tokens_audit``
+    usa para renderizar a tabela e o detalhe — tokens por modelo, tools,
+    rodadas, mensagens, brief, título IA, PR, versão, erros, stop reasons —
+    EXCETO o git status (que depende do ``cwd`` vivo, já removido na poda).
+
+    É a fonte única do harvest rico do ledger de custo (issue #445): a sessão
+    colhida para o ledger antes da poda fica IDÊNTICA à viva na tela de tokens,
+    não uma casca só com tokens. A agregação de custo (dedup por
+    ``(message.id, requestId)`` + soma) é a mesma de :func:`aggregate_jsonl`.
 
     Returns:
-        dict com ``session_id`` (stem do arquivo), ``models`` (model ->
-        {in,out,cc,cr,cc_5m,cc_1h}), ``first_ts``, ``last_ts`` e
-        ``assistant_rounds``.
+        dict com ``session_id``, ``models`` (model -> {in,out,cc,cr,cc_5m,
+        cc_1h}), ``tools``, ``assistant_rounds``, ``user_msgs``, ``tool_calls``,
+        ``cwd``, ``git_branch``, ``version``, ``permission_mode``,
+        ``entrypoint``, ``ai_title``, ``pr_number``, ``pr_url``, ``pr_repo``,
+        ``first_ts``, ``last_ts``, ``brief``, ``errors`` e ``stop_reasons``.
     """
     session_id = os.path.splitext(os.path.basename(path))[0]
     models: Dict[str, Dict[str, int]] = {}
+    tools: Dict[str, int] = {}
+    stop_reasons: Dict[str, int] = {}
+    errors = {"synthetic": 0, "max_tokens": 0, "api_error": 0, "tool_error": 0}
     first_ts: Optional[str] = None
     last_ts: Optional[str] = None
-    rounds = 0
+    cwd = git_branch = version = permission_mode = entrypoint = None
+    ai_title = pr_number = pr_url = pr_repo = None
+    brief: Optional[str] = None
+    rounds = user_msgs = tool_calls = 0
     seen = set()
     noid = 0
 
@@ -130,8 +161,41 @@ def aggregate_jsonl(path: str) -> dict:
                     if first_ts is None:
                         first_ts = ts
                     last_ts = ts
+                if o.get("cwd") and not cwd:
+                    cwd = o.get("cwd")
+                if o.get("gitBranch") and not git_branch:
+                    git_branch = o.get("gitBranch")
+                if o.get("version"):
+                    version = o.get("version")
+                if o.get("permissionMode"):
+                    permission_mode = o.get("permissionMode")
+                if o.get("entrypoint"):
+                    entrypoint = o.get("entrypoint")
+                if o.get("aiTitle"):
+                    ai_title = o.get("aiTitle")
+                if o.get("prNumber"):
+                    pr_number = o.get("prNumber")
+                if o.get("prUrl"):
+                    pr_url = o.get("prUrl")
+                if o.get("prRepository"):
+                    pr_repo = o.get("prRepository")
+                if o.get("isApiErrorMessage"):
+                    errors["api_error"] += 1
+                tur = o.get("toolUseResult")
+                if isinstance(tur, dict) and tur.get("is_error"):
+                    errors["tool_error"] += 1
+
                 msg = o.get("message")
-                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                if not isinstance(msg, dict):
+                    continue
+                role = msg.get("role")
+                if role == "user" or o.get("type") == "user":
+                    user_msgs += 1
+                    if brief is None:
+                        t = _text_of(msg.get("content"))
+                        if t.strip():
+                            brief = t[:_BRIEF_CAP]
+                if role != "assistant":
                     continue
                 rkey = (msg.get("id"), o.get("requestId"))
                 if rkey == (None, None):
@@ -141,10 +205,26 @@ def aggregate_jsonl(path: str) -> dict:
                     continue
                 seen.add(rkey)
                 rounds += 1
+                model = msg.get("model") or "unknown"
+                sr = msg.get("stop_reason")
+                if sr:
+                    stop_reasons[sr] = stop_reasons.get(sr, 0) + 1
+                    if sr == "max_tokens":
+                        errors["max_tokens"] += 1
+                if model == "<synthetic>":
+                    errors["synthetic"] += 1
+                if "prompt is too long" in _text_of(msg.get("content")).lower():
+                    errors["api_error"] += 1
+                c = msg.get("content")
+                if isinstance(c, list):
+                    for b in c:
+                        if isinstance(b, dict) and b.get("type") == "tool_use":
+                            tool_calls += 1
+                            nm = b.get("name", "?")
+                            tools[nm] = tools.get(nm, 0) + 1
                 u = msg.get("usage")
                 if not isinstance(u, dict):
                     continue
-                model = msg.get("model") or "unknown"
                 mm = models.setdefault(model, _empty_model())
                 mm["in"] += u.get("input_tokens", 0) or 0
                 mm["out"] += u.get("output_tokens", 0) or 0
@@ -160,7 +240,45 @@ def aggregate_jsonl(path: str) -> dict:
     return {
         "session_id": session_id,
         "models": models,
+        "tools": tools,
+        "assistant_rounds": rounds,
+        "user_msgs": user_msgs,
+        "tool_calls": tool_calls,
+        "cwd": cwd,
+        "git_branch": git_branch,
+        "version": version,
+        "permission_mode": permission_mode,
+        "entrypoint": entrypoint,
+        "ai_title": ai_title,
+        "pr_number": pr_number,
+        "pr_url": pr_url,
+        "pr_repo": pr_repo,
         "first_ts": first_ts,
         "last_ts": last_ts,
-        "assistant_rounds": rounds,
+        "brief": brief,
+        "errors": errors,
+        "stop_reasons": stop_reasons,
+    }
+
+
+def aggregate_jsonl(path: str) -> dict:
+    """Subset de custo de :func:`summarize_jsonl` (back-compat + paridade #445).
+
+    Conta cada resposta da API uma única vez por ``(message.id, requestId)``
+    — o claude grava o mesmo registro assistant repetido (deltas de
+    streaming) com o ``usage`` final idêntico; sem dedup os totais inflam
+    13-32x. Respostas sem ``id``/``requestId`` recebem chave sintética.
+
+    Returns:
+        dict com ``session_id`` (stem do arquivo), ``models`` (model ->
+        {in,out,cc,cr,cc_5m,cc_1h}), ``first_ts``, ``last_ts`` e
+        ``assistant_rounds``.
+    """
+    s = summarize_jsonl(path)
+    return {
+        "session_id": s["session_id"],
+        "models": s["models"],
+        "first_ts": s["first_ts"],
+        "last_ts": s["last_ts"],
+        "assistant_rounds": s["assistant_rounds"],
     }

--- a/infra/k8s/manifests/50-claude-worker-deployment.yaml
+++ b/infra/k8s/manifests/50-claude-worker-deployment.yaml
@@ -140,6 +140,14 @@ spec:
             # atualização do lease. Ajustar conforme carga da workload.
             - { name: DEILE_CLAUDE_LEASE_TTL_S, value: "30" }
             - { name: DEILE_CLAUDE_LEASE_HEARTBEAT_S, value: "5" }
+            # Retenção dos transcripts JSONL órfãos, em DIAS (issue #445). O
+            # startup hook + a task periódica de cleanup só colhem+podam um
+            # transcript órfão (workdir-pai removido) após N dias SEM
+            # modificação. JSONL é minúsculo (~KB) — retenção longa preserva o
+            # histórico resumível + o detalhe completo na tela de tokens.
+            # Knob SEPARADO do workdir (CLEANUP_RETENTION_DAYS, mais curto).
+            # Editável pelo painel [d] (kubectl set env + rollout, sem rebuild).
+            - { name: DEILE_CLAUDE_JSONL_RETENTION_DAYS, value: "30" }
           ports:
             - { name: claude-api, containerPort: 8767, protocol: TCP }
           volumeMounts:

--- a/infra/k8s/manifests/52-claude-worker-cleanup-cron.yaml
+++ b/infra/k8s/manifests/52-claude-worker-cleanup-cron.yaml
@@ -9,7 +9,9 @@
 #   - workdir com last_modified anterior ao cutoff de retenção (default 7 dias)
 #
 # Variáveis relevantes:
-#   DEILE_CLAUDE_CLEANUP_RETENTION_DAYS   default: 7
+#   DEILE_CLAUDE_CLEANUP_RETENTION_DAYS   default: 7  (workdirs volumosos)
+#   DEILE_CLAUDE_JSONL_RETENTION_DAYS     default: 30 (transcripts JSONL órfãos
+#                                         — colhe p/ ledger + poda após N dias)
 #   DEILE_CLAUDE_WORKER_ROOT              default: /home/claude/work
 #   DEILE_CLAUDE_LEASE_TTL_S              default: 30
 apiVersion: batch/v1
@@ -74,6 +76,7 @@ spec:
               env:
                 - { name: DEILE_CLAUDE_WORKER_ROOT, value: "/home/claude/work" }
                 - { name: DEILE_CLAUDE_CLEANUP_RETENTION_DAYS, value: "7" }
+                - { name: DEILE_CLAUDE_JSONL_RETENTION_DAYS, value: "30" }
                 - { name: DEILE_CLAUDE_LEASE_TTL_S, value: "30" }
               volumeMounts:
                 - { name: claude-home, mountPath: /home/claude }

--- a/infra/k8s/session_tokens_audit.py
+++ b/infra/k8s/session_tokens_audit.py
@@ -316,10 +316,12 @@ for f in sorted(glob.glob(os.path.join(BASE, "**", "*.jsonl"), recursive=True)):
         sessions.append(rec)
 
 # Ledger de custo (issue #445): sessões já podadas do disco vivem só aqui.
-# O harvester do claude_worker_server colheu os tokens por modelo ANTES de
-# remover o JSONL volumoso. Emitimos um registro sintético por sessão colhida
-# (não duplicando session_ids que ainda têm JSONL vivo), com a MESMA estrutura
-# ``models`` — o cálculo de custo no host é idêntico.
+# O harvester do claude_worker_server colheu o RESUMO COMPLETO de cada sessão
+# (tokens + título/brief/tools/PR/erros/meta) ANTES de remover o JSONL
+# volumoso. Emitimos um registro sintético por sessão colhida (não duplicando
+# session_ids com JSONL vivo) com a MESMA estrutura — custo E detalhe idênticos
+# aos da sessão viva. Registros v:1 (legados, só tokens) degradam para vazio
+# nos campos de detalhe; v:2 carrega tudo.
 LEDGER = os.environ.get("DEILE_CLAUDE_COST_LEDGER_PATH") or os.path.join(
     os.path.expanduser("~"), ".claude", "cost-ledger.jsonl")
 live_ids = set()
@@ -344,42 +346,49 @@ try:
                 continue
             if not any((sum(v.values()) > 0) for v in models.values()):
                 continue
+            # "Última atividade" real = mtime do transcript colhido (source_mtime,
+            # v:2); v:1 cai para harvested_at. O filtro de recência (painel
+            # "custo hoje") usa o mesmo carimbo.
             harv = r.get("harvested_at") or 0
-            if SINCE_MTIME and harv and harv < SINCE_MTIME:
+            rec_mtime = r.get("source_mtime") or harv or 0
+            if SINCE_MTIME and rec_mtime and rec_mtime < SINCE_MTIME:
                 continue
             seen_led.add(sid)
             tid = r.get("task_id") or ""
+            errs = r.get("errors") or {}
             sessions.append({
                 "jsonl": "<ledger>",
                 "project_dir": os.path.join(BASE, "-home-claude-work-" + tid),
                 "session_file": sid + ".jsonl",
                 "models": models,
-                "tools": {},
+                "tools": r.get("tools") or {},
                 "assistant_rounds": r.get("assistant_rounds", 0) or 0,
-                "user_msgs": 0,
-                "tool_calls": 0,
-                "cwd": None,
-                "git_branch": None,
-                "version": None,
-                "permission_mode": None,
-                "entrypoint": None,
-                "ai_title": None,
-                "pr_number": None,
-                "pr_url": None,
-                "pr_repo": None,
+                "user_msgs": r.get("user_msgs", 0) or 0,
+                "tool_calls": r.get("tool_calls", 0) or 0,
+                "cwd": r.get("cwd"),
+                "git_branch": r.get("git_branch"),
+                "version": r.get("version"),
+                "permission_mode": r.get("permission_mode"),
+                "entrypoint": r.get("entrypoint"),
+                "ai_title": r.get("ai_title"),
+                "pr_number": r.get("pr_number"),
+                "pr_url": r.get("pr_url"),
+                "pr_repo": r.get("pr_repo"),
                 "first_ts": r.get("first_ts"),
                 "last_ts": r.get("last_ts"),
-                "brief": None,
-                "errors": {"synthetic": 0, "max_tokens": 0,
-                           "api_error": 0, "tool_error": 0},
-                "stop_reasons": {},
-                "mtime": harv or None,
+                "brief": r.get("brief"),
+                "errors": {"synthetic": errs.get("synthetic", 0) or 0,
+                           "max_tokens": errs.get("max_tokens", 0) or 0,
+                           "api_error": errs.get("api_error", 0) or 0,
+                           "tool_error": errs.get("tool_error", 0) or 0},
+                "stop_reasons": r.get("stop_reasons") or {},
+                "mtime": rec_mtime or None,
                 "git": {"state": "harvested", "modified": 0,
                         "untracked": 0, "staged": 0, "root": None},
-                "meta_model": None,
-                "reasoning_effort": None,
-                "ultracode": None,
-                "stage": "harvested",
+                "meta_model": r.get("meta_model"),
+                "reasoning_effort": r.get("reasoning_effort"),
+                "ultracode": r.get("ultracode"),
+                "stage": r.get("stage") or "harvested",
                 "harvested": True,
             })
 except Exception:


### PR DESCRIPTION
## Contexto

Continuação do #445. O harvest de custo do `claude-worker` tinha duas perdas reais que o Humano apontou após o incidente de poda:

1. **Período de poda absurdo (1h).** O gatilho era o grace TOCTOU de 1h. Como os workdirs são limpos de hora em hora, toda sessão **terminada** virava órfã e o transcript sumia em ~1h — muito antes de o Humano querer perder o histórico.
2. **Harvest pobre (casca).** O registro do ledger guardava só tokens/rounds/timestamps. Tudo que a tela de tokens mostra no **detalhe** — título IA, brief, tools, PR, versão, erros, stop reasons, stage, modelo/effort — se perdia na poda. Era o "só preservou Rnd, tokens, cache% e idade".

## O que muda

### 1. Retenção configurável (default 30d) — o Humano decide
- Novo env `DEILE_CLAUDE_JSONL_RETENTION_DAYS` (default **30**) vira o **gatilho principal** da poda; o grace de 1h vira só **piso de segurança** (`cutoff = now - max(retenção, grace)`).
- Um transcript órfão só é colhido+podado após N dias **sem modificação** — nunca mais ceifa sessões novas.
- **Knob separado** do workdir (`DEILE_CLAUDE_CLEANUP_RETENTION_DAYS`, segue 7d) — JSONL é minúsculo (~KB), retenção longa é barata.
- Editável no manifest **e** no painel: tela `[d]` → atalho **`[J]`** (prompt numérico) aplica em `deployment/claude-worker` + `cronjob/claude-worker-cleanup` via `kubectl set env`, sem rebuild.

### 2. Harvest rico (v:2) — sessão colhida = sessão viva
- Novo `jsonl_cost.summarize_jsonl` (superset de `aggregate_jsonl`, **mesma dedup de custo** → paridade preservada) colhe o resumo completo.
- O harvester anexa o registro **v:2** ao ledger somando a metadata ground-truth do `session.json` (model/effort/ultracode/stage) + `source_mtime` (última atividade real).
- `session_tokens_audit` lê os campos de volta — o **detalhe** da sessão colhida fica idêntico ao da viva. v:1 legado degrada para detalhe vazio sem quebrar.

### Fail-safe intacto
Agora ancorado em `summarize_jsonl`: sem o extrator (jsonl_cost ausente da imagem) a poda é **abortada** e tudo é preservado. Foi o bug que causou a perda original.

## Testes
- `test_jsonl_cost`: `summarize_jsonl` extrai todo o detalhe; `aggregate_jsonl` é subset (paridade de custo).
- `test_cost_ledger_harvest`: retenção protege órfão <Nd; poda >Nd; registro v:2 com detalhe completo + meta; fail-safe.
- `test_audit_ledger_read`: lê v:2 (detalhe rico) + back-compat v:1 (vazio).
- `test_dispatch_matrix_jsonl_retention`: `[J]` abre prompt, `j` segue navegação, aplica nos dois alvos, falha parcial.

Suíte completa **sem regressão** — as 24 falhas remanescentes são poluição de ordenação pré-existente (settings singleton), idênticas na `main` e fora dos arquivos tocados.

Closes #445.