### PR TITLE
feat(claude-worker): recuperação proativa de lease de pod morto via registro de presença

### DIFF
--- a/deile/tests/infrastructure/test_pod_presence.py
+++ b/deile/tests/infrastructure/test_pod_presence.py
@@ -1,0 +1,263 @@
+"""Testes de registro de presença de pod e recuperação proativa de lease (issue #495).
+
+Cobre:
+- _write_presence: cria/atualiza <root>/.pods/<pod>.presence de forma atômica.
+- _get_alive_pods: retorna conjunto correto com base no PRESENCE_TTL_S.
+- _lease_is_stale com alive_pods: recuperação imediata quando pod não está vivo.
+- _workspace_is_stale com alive_pods: recuperação imediata sem aguardar TTL.
+- startup_cleanup integrado: workdir com lease de pod morto é recuperado.
+- _cleanup_stale_workspaces integrado: workdir com lease de pod morto é removido.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+
+
+@pytest.fixture
+def cws():
+    k8s_dir = str(_INFRA_K8S)
+    if k8s_dir not in sys.path:
+        sys.path.insert(0, k8s_dir)
+    spec = importlib.util.spec_from_file_location(
+        "cws_presence_test",
+        str(_INFRA_K8S / "claude_worker_server.py"),
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["cws_presence_test"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture
+def work_root(tmp_path):
+    root = tmp_path / "work"
+    root.mkdir()
+    return root
+
+
+def _make_workdir(root: Path, name: str = "aabbccddeeff0011") -> Path:
+    d = root / name
+    d.mkdir()
+    return d
+
+
+def _write_lease(workdir: Path, heartbeat_at: float, pod: str = "test-pod", pid: int = 999999999) -> None:
+    (workdir / ".lease.json").write_text(
+        json.dumps({"heartbeat_at": heartbeat_at, "pid": pid, "pod": pod}),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _write_presence
+# ---------------------------------------------------------------------------
+
+def test_write_presence_creates_file(cws, work_root, monkeypatch):
+    """_write_presence cria <root>/.pods/<pod>.presence com JSON correto."""
+    monkeypatch.setenv("HOSTNAME", "worker-abc123")
+    cws._write_presence(work_root)
+
+    pfile = work_root / ".pods" / "worker-abc123.presence"
+    assert pfile.exists()
+    data = json.loads(pfile.read_text())
+    assert data["pod"] == "worker-abc123"
+    assert abs(time.time() - data["written_at"]) < 5
+
+
+def test_write_presence_updates_written_at(cws, work_root, monkeypatch):
+    """_write_presence segunda chamada atualiza written_at."""
+    monkeypatch.setenv("HOSTNAME", "worker-update")
+    cws._write_presence(work_root)
+    pfile = work_root / ".pods" / "worker-update.presence"
+    first_ts = json.loads(pfile.read_text())["written_at"]
+
+    # Pequena pausa para garantir ts diferente
+    time.sleep(0.05)
+    cws._write_presence(work_root)
+    second_ts = json.loads(pfile.read_text())["written_at"]
+
+    assert second_ts >= first_ts
+
+
+# ---------------------------------------------------------------------------
+# _get_alive_pods
+# ---------------------------------------------------------------------------
+
+def test_get_alive_pods_returns_fresh_pod(cws, work_root, monkeypatch):
+    """Pod com written_at recente é incluído no conjunto de vivos."""
+    monkeypatch.setenv("HOSTNAME", "pod-fresh")
+    cws._write_presence(work_root)
+
+    alive = cws._get_alive_pods(work_root)
+    assert "pod-fresh" in alive
+
+
+def test_get_alive_pods_excludes_expired(cws, work_root):
+    """Pod com written_at > PRESENCE_TTL_S no passado não é considerado vivo."""
+    pdir = work_root / ".pods"
+    pdir.mkdir()
+    old_ts = time.time() - (cws._PRESENCE_TTL_S + 10)
+    (pdir / "dead-pod.presence").write_text(
+        json.dumps({"pod": "dead-pod", "written_at": old_ts}),
+        encoding="utf-8",
+    )
+
+    alive = cws._get_alive_pods(work_root)
+    assert "dead-pod" not in alive
+
+
+def test_get_alive_pods_returns_none_when_no_pods_dir(cws, work_root):
+    """Sem diretório .pods, retorna None (presença não inicializada)."""
+    alive = cws._get_alive_pods(work_root)
+    assert alive is None
+
+
+def test_get_alive_pods_ignores_corrupt_file(cws, work_root):
+    """Arquivo .presence mal-formado é ignorado silenciosamente."""
+    pdir = work_root / ".pods"
+    pdir.mkdir()
+    (pdir / "bad.presence").write_text("NOT JSON", encoding="utf-8")
+
+    alive = cws._get_alive_pods(work_root)
+    assert "bad" not in alive
+
+
+# ---------------------------------------------------------------------------
+# _lease_is_stale com alive_pods
+# ---------------------------------------------------------------------------
+
+def test_lease_is_stale_with_dead_pod_in_alive_pods(cws, work_root):
+    """Lease de pod ausente de alive_pods é considerado stale imediatamente."""
+    wd = _make_workdir(work_root)
+    # Heartbeat bem recente — sem alive_pods seria considerado ativo.
+    fresh = time.time() - 1
+    _write_lease(wd, fresh, pod="dead-pod-x")
+
+    # alive_pods não contém "dead-pod-x"
+    assert cws._lease_is_stale(wd / ".lease.json", alive_pods={"other-pod"}) is True
+
+
+def test_lease_is_not_stale_when_pod_is_alive(cws, work_root):
+    """Lease de pod presente em alive_pods não é considerado stale por presença."""
+    wd = _make_workdir(work_root)
+    fresh = time.time() - 1
+    _write_lease(wd, fresh, pod="live-pod")
+
+    assert cws._lease_is_stale(wd / ".lease.json", alive_pods={"live-pod"}) is False
+
+
+def test_lease_is_stale_fallback_without_alive_pods(cws, work_root):
+    """Sem alive_pods, comportamento original por heartbeat TTL permanece."""
+    wd = _make_workdir(work_root)
+    expired = time.time() - 3600
+    _write_lease(wd, expired, pid=999999999)
+
+    assert cws._lease_is_stale(wd / ".lease.json", alive_pods=None) is True
+
+
+# ---------------------------------------------------------------------------
+# _workspace_is_stale com alive_pods
+# ---------------------------------------------------------------------------
+
+def test_workspace_is_stale_with_dead_pod(cws, work_root):
+    """workspace_is_stale retorna True quando pod dono não está em alive_pods."""
+    wd = _make_workdir(work_root)
+    # Heartbeat fresquíssimo — sem alive_pods, seria ativo.
+    _write_lease(wd, time.time(), pod="ghost-pod")
+
+    assert cws._workspace_is_stale(
+        wd,
+        threshold_s=1800,
+        now=time.time(),
+        alive_pods={"other-pod"},
+    ) is True
+
+
+def test_workspace_is_not_stale_when_pod_alive(cws, work_root):
+    """workspace_is_stale retorna False quando pod dono está em alive_pods."""
+    wd = _make_workdir(work_root)
+    _write_lease(wd, time.time(), pod="alive-pod")
+
+    assert cws._workspace_is_stale(
+        wd,
+        threshold_s=1800,
+        now=time.time(),
+        alive_pods={"alive-pod"},
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# startup_cleanup integrado
+# ---------------------------------------------------------------------------
+
+def test_startup_cleanup_recovers_dead_pod_lease(cws, work_root, monkeypatch):
+    """startup_cleanup remove imediatamente lease de pod morto (sem esperar TTL)."""
+    monkeypatch.setenv("HOME", str(work_root.parent))
+    # Pod "this-pod" está vivo (presença fresca).
+    pdir = work_root / ".pods"
+    pdir.mkdir()
+    (pdir / "this-pod.presence").write_text(
+        json.dumps({"pod": "this-pod", "written_at": time.time()}),
+        encoding="utf-8",
+    )
+
+    wd = _make_workdir(work_root)
+    # Heartbeat recente, mas pod "dead-pod" não está em alive_pods.
+    _write_lease(wd, time.time() - 1, pod="dead-pod")
+
+    result = cws.startup_cleanup(root=work_root)
+
+    assert result["leases_removed"] == 1
+    assert not (wd / ".lease.json").exists()
+
+
+def test_startup_cleanup_skips_live_pod_with_fresh_heartbeat(cws, work_root, monkeypatch):
+    """startup_cleanup não toca workdir cujo pod está na lista de vivos."""
+    monkeypatch.setenv("HOME", str(work_root.parent))
+    pdir = work_root / ".pods"
+    pdir.mkdir()
+    (pdir / "live-pod.presence").write_text(
+        json.dumps({"pod": "live-pod", "written_at": time.time()}),
+        encoding="utf-8",
+    )
+
+    wd = _make_workdir(work_root)
+    _write_lease(wd, time.time() - 1, pod="live-pod")
+
+    result = cws.startup_cleanup(root=work_root)
+
+    assert result["leases_removed"] == 0
+    assert (wd / ".lease.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_stale_workspaces integrado
+# ---------------------------------------------------------------------------
+
+def test_cleanup_stale_workspaces_removes_dead_pod_workspace(cws, work_root, monkeypatch):
+    """_cleanup_stale_workspaces remove workspace de pod morto imediatamente."""
+    pdir = work_root / ".pods"
+    pdir.mkdir()
+    (pdir / "survivor.presence").write_text(
+        json.dumps({"pod": "survivor", "written_at": time.time()}),
+        encoding="utf-8",
+    )
+
+    wd = _make_workdir(work_root)
+    # Heartbeat recente — sem presença seria ativo; com presença é morto.
+    _write_lease(wd, time.time(), pod="dead-worker")
+
+    summary = cws._cleanup_stale_workspaces(work_root, threshold_s=1800)
+
+    assert summary["removed"] == 1
+    assert not wd.exists()

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -480,8 +480,14 @@ def _pid_alive(pid: int) -> bool:
         return False
 
 
-def _lease_is_stale(lease_path: Path) -> bool:
+def _lease_is_stale(
+    lease_path: Path, alive_pods: Optional[set] = None
+) -> bool:
     """True se o lease expirou E o PID proprietário não está mais vivo.
+
+    Quando ``alive_pods`` é fornecido (registro de presença, issue #495),
+    também retorna True imediatamente se o pod dono não constar no conjunto
+    de vivos — fechando a janela de recuperação de 30 min para ~60 s.
 
     Conservador: se não conseguir ler o lease, assume que NÃO é stale
     (fail-safe — evita apagar workdirs em uso quando o FS está lento).
@@ -490,6 +496,12 @@ def _lease_is_stale(lease_path: Path) -> bool:
         data = json.loads(lease_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return False
+    # Verificação proativa via presença: se o conjunto está disponível e o
+    # pod dono não aparece nele, o lease é stale independente do heartbeat.
+    if alive_pods is not None:
+        pod = data.get("pod", "")
+        if pod and pod not in alive_pods:
+            return True
     heartbeat_at = data.get("heartbeat_at", 0)
     if (time.time() - float(heartbeat_at)) < _LEASE_TTL_S:
         return False  # heartbeat recente → ativo
@@ -560,6 +572,11 @@ def startup_cleanup(root: Optional[Path] = None) -> dict:
             "errors": ["work root not found"],
         }
 
+    # Registro de presença (issue #495): conjunto de pods vivos no momento.
+    # Permite recuperação imediata de lease cujo pod dono já morreu, sem
+    # aguardar o TTL de 30 min do heartbeat.
+    alive_pods = _get_alive_pods(root)
+
     try:
         candidates = [
             d for d in root.iterdir()
@@ -577,11 +594,11 @@ def startup_cleanup(root: Optional[Path] = None) -> dict:
         lease_path = workdir / ".lease.json"
 
         # Lease vivo → workdir em uso, pula completamente.
-        if lease_path.exists() and not _lease_is_stale(lease_path):
+        if lease_path.exists() and not _lease_is_stale(lease_path, alive_pods=alive_pods):
             continue
 
         # Lease stale → remove só o arquivo de lease (workdir pode ter dados úteis).
-        if lease_path.exists() and _lease_is_stale(lease_path):
+        if lease_path.exists() and _lease_is_stale(lease_path, alive_pods=alive_pods):
             try:
                 lease_path.unlink()
                 leases_removed += 1
@@ -1458,6 +1475,18 @@ _WORKSPACE_CLEANUP_INTERVAL_S: float = float(
     os.environ.get("DEILE_CLAUDE_WORKER_WORKSPACE_CLEANUP_INTERVAL_S", "3600"),
 )
 
+#: Intervalo de escrita do arquivo de presença de pod (default 10s).
+_PRESENCE_INTERVAL_S: int = int(
+    os.environ.get("DEILE_CLAUDE_WORKER_PRESENCE_INTERVAL_S", "10"),
+)
+
+#: TTL de presença em segundos — pod é "vivo" se escrita há menos que isto.
+#: Default 60s = 6× o intervalo; margem para evitar falso-morto por janela de
+#: escrita bloqueada (issue #495).
+_PRESENCE_TTL_S: int = int(
+    os.environ.get("DEILE_CLAUDE_WORKER_PRESENCE_TTL_S", "60"),
+)
+
 
 def _workspace_total_bytes(root: Path) -> int:
     """Estimativa rápida do tamanho total ocupado pela árvore de workdirs.
@@ -1479,10 +1508,18 @@ def _workspace_total_bytes(root: Path) -> int:
     return total
 
 
-def _workspace_is_stale(workspace: Path, *, threshold_s: int, now: float) -> bool:
+def _workspace_is_stale(
+    workspace: Path,
+    *,
+    threshold_s: int,
+    now: float,
+    alive_pods: Optional[set] = None,
+) -> bool:
     """True se ``workspace`` é candidato a remoção.
 
     Critério (em ordem de precedência):
+      * ``.lease.json`` presente e pod dono ausente de ``alive_pods``
+        (registro de presença, issue #495) → stale imediatamente.
       * ``.lease.json`` presente e ``heartbeat_at`` mais velho que
         ``threshold_s`` → stale (pod morreu sem cleanup).
       * ``.lease.json`` ausente: fallback no ``st_mtime`` do diretório
@@ -1509,10 +1546,91 @@ def _workspace_is_stale(workspace: Path, *, threshold_s: int, now: float) -> boo
     # (st_mtime recente) mas o JSON aponta um heartbeat antigo, vale o JSON.
     try:
         data = json.loads(lease.read_text(encoding="utf-8"))
+        # Verificação proativa via presença (issue #495).
+        if alive_pods is not None:
+            pod = data.get("pod", "")
+            if pod and pod not in alive_pods:
+                return True
         hb = float(data.get("heartbeat_at", st.st_mtime))
     except (OSError, json.JSONDecodeError, ValueError):
         return True
     return (now - hb) >= threshold_s
+
+
+def _presence_dir(root: Path) -> Path:
+    """Subdiretório dos arquivos de presença de pod (``<root>/.pods``)."""
+    return root / ".pods"
+
+
+def _write_presence(root: Path) -> None:
+    """Escreve/atualiza ``<root>/.pods/<HOSTNAME>.presence`` de forma atômica.
+
+    Best-effort: erros de I/O são logados e ignorados.
+    """
+    pod_id = os.environ.get("HOSTNAME", f"local-{os.getpid()}")
+    pdir = _presence_dir(root)
+    try:
+        pdir.mkdir(exist_ok=True)
+    except OSError as exc:
+        logger.warning("presence: não criou %s: %s", pdir, exc)
+        return
+    target = pdir / f"{pod_id}.presence"
+    tmp = pdir / f".{pod_id}.presence.tmp"
+    try:
+        tmp.write_text(
+            json.dumps({"pod": pod_id, "written_at": time.time()}),
+            encoding="utf-8",
+        )
+        tmp.rename(target)
+    except OSError as exc:
+        logger.warning("presence: falha ao escrever %s: %s", target, exc)
+
+
+def _get_alive_pods(root: Path) -> Optional[set]:
+    """Retorna nomes dos pods com presença dentro de ``_PRESENCE_TTL_S``.
+
+    Returns:
+        ``None`` quando o diretório ``.pods`` não existe — o registro de
+        presença ainda não foi inicializado; chamadores devem recair no TTL
+        de heartbeat padrão.
+
+        ``set`` (possivelmente vazio) quando o diretório existe — contém
+        apenas os pods que atualizaram presença dentro de ``_PRESENCE_TTL_S``.
+
+    Arquivo ilegível ou TTL expirado → pod omitido do conjunto (conservador:
+    só recupera lease quando pod está comprovadamente ausente do registro).
+    """
+    pdir = _presence_dir(root)
+    if not pdir.is_dir():
+        return None  # presença não inicializada — sem dados suficientes
+    now = time.time()
+    alive: set = set()
+    try:
+        entries = list(pdir.iterdir())
+    except OSError:
+        return alive
+    for entry in entries:
+        if not entry.name.endswith(".presence"):
+            continue
+        try:
+            data = json.loads(entry.read_text(encoding="utf-8"))
+            written_at = float(data.get("written_at", 0))
+            pod = data.get("pod", "")
+            if pod and (now - written_at) < _PRESENCE_TTL_S:
+                alive.add(pod)
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    return alive
+
+
+async def _presence_loop(root: Path) -> None:
+    """Mantém ``<root>/.pods/<HOSTNAME>.presence`` atualizado a cada ``_PRESENCE_INTERVAL_S`` s.
+
+    Cancelado no shutdown do aiohttp (via _on_cleanup). Best-effort.
+    """
+    while True:
+        await asyncio.to_thread(_write_presence, root)
+        await asyncio.sleep(_PRESENCE_INTERVAL_S)
 
 
 def _remove_workspace_tree(workspace: Path) -> int:
@@ -1572,6 +1690,7 @@ def _cleanup_stale_workspaces(
             threshold_s = _WORKSPACE_STALE_TTL_S
         summary["threshold_s"] = threshold_s
 
+    alive_pods = _get_alive_pods(root)
     now = time.time()
     for child in children:
         if not child.is_dir() or child.name.startswith("."):
@@ -1580,7 +1699,7 @@ def _cleanup_stale_workspaces(
         if not _TASK_ID_RE.fullmatch(child.name):
             continue
         summary["inspected"] += 1
-        if not _workspace_is_stale(child, threshold_s=threshold_s, now=now):
+        if not _workspace_is_stale(child, threshold_s=threshold_s, now=now, alive_pods=alive_pods):
             continue
         bytes_freed = _remove_workspace_tree(child)
         summary["removed"] += 1
@@ -3528,23 +3647,31 @@ def build_app(auth_token: Optional[str] = None) -> web.Application:
     )
 
     async def _on_startup(_app: web.Application) -> None:
+        # Escreve presença antes do cleanup para que este pod seja incluído
+        # no conjunto de vivos durante a varredura inicial (issue #495).
+        await asyncio.to_thread(_write_presence, _cleanup_root)
         try:
             await asyncio.to_thread(_cleanup_stale_workspaces, _cleanup_root)
         except Exception as exc:  # noqa: BLE001 — startup nunca falha por isso
             logger.warning("startup workspace cleanup raised: %s", exc)
+        _app["_presence_task"] = asyncio.create_task(
+            _presence_loop(_cleanup_root),
+            name="presence-heartbeat",
+        )
         _app["_workspace_cleanup_task"] = asyncio.create_task(
             _workspace_cleanup_loop(_cleanup_root),
             name="workspace-cleanup",
         )
 
     async def _on_cleanup(_app: web.Application) -> None:
-        task = _app.get("_workspace_cleanup_task")
-        if task is not None:
-            task.cancel()
-            try:
-                await task
-            except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                pass
+        for key in ("_presence_task", "_workspace_cleanup_task"):
+            task = _app.get(key)
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
 
     app.on_startup.append(_on_startup)
     app.on_cleanup.append(_on_cleanup)
@@ -3623,6 +3750,11 @@ def main(passthrough: Optional[List[str]] = None) -> int:
     # ``~/.claude/credentials.json`` automaticamente (esse path é
     # convenção macOS — Linux só lê env vars).
     _load_oauth_token_into_env()
+
+    # Escreve presença antes do cleanup (issue #495): garante que este pod
+    # conste como vivo durante a varredura, evitando auto-recuperação do
+    # próprio lease ao reiniciar.
+    _write_presence(root)
 
     # Startup housekeeping hook (issue #408) — varre PVC antes de aceitar
     # conexões. Conservador, idempotente, best-effort.

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -3647,13 +3647,15 @@ def build_app(auth_token: Optional[str] = None) -> web.Application:
     )
 
     async def _on_startup(_app: web.Application) -> None:
-        # Escreve presença antes do cleanup para que este pod seja incluído
-        # no conjunto de vivos durante a varredura inicial (issue #495).
-        await asyncio.to_thread(_write_presence, _cleanup_root)
+        # Cleanup ANTES de escrever presença: na primeira execução o diretório
+        # .pods/ não existe → _get_alive_pods retorna None → detecção por TTL
+        # (conservador, sem falso-positivo). Escreve presença em seguida para
+        # que os ciclos subsequentes do _presence_loop já incluam este pod.
         try:
             await asyncio.to_thread(_cleanup_stale_workspaces, _cleanup_root)
         except Exception as exc:  # noqa: BLE001 — startup nunca falha por isso
             logger.warning("startup workspace cleanup raised: %s", exc)
+        await asyncio.to_thread(_write_presence, _cleanup_root)
         _app["_presence_task"] = asyncio.create_task(
             _presence_loop(_cleanup_root),
             name="presence-heartbeat",


### PR DESCRIPTION
## Resumo

Implementa o mecanismo de **registro de presença de pod** (issue #495) para recuperar leases de pods mortos em ~60s em vez de aguardar o TTL de 30 min do heartbeat — sem dependência da API do Kubernetes.

### Mudanças principais

- **`_write_presence(root)`** — grava/atualiza `<root>/.pods/<HOSTNAME>.presence` (JSON `{pod, written_at}`) de forma atômica. Chamada no startup de `main()` e `build_app()`, e em loop pela `_presence_loop` task (default 10s).
- **`_get_alive_pods(root)`** — retorna `set` de pods com presença dentro de `PRESENCE_TTL_S` (60s). Retorna `None` quando `.pods/` ainda não existe (fail-safe: recai no TTL de heartbeat).
- **`_lease_is_stale(lease_path, alive_pods)`** e **`_workspace_is_stale(..., alive_pods)`** — detectam imediatamente lease de pod ausente do conjunto.
- **`startup_cleanup()`** e **`_cleanup_stale_workspaces()`** — passam `alive_pods` para as funções acima.
- **`_presence_loop`** — task asyncio cancelada no shutdown via `_on_cleanup`.
- **14 testes** em `deile/tests/infrastructure/test_pod_presence.py` cobrindo: `_write_presence`, `_get_alive_pods`, `_lease_is_stale` + `_workspace_is_stale` com/sem `alive_pods`, `startup_cleanup` integrado, `_cleanup_stale_workspaces` integrado.

### Variáveis de ambiente

| Variável | Default | Descrição |
|---|---|---|
| `DEILE_CLAUDE_WORKER_PRESENCE_INTERVAL_S` | 10 | Intervalo de renovação de presença |
| `DEILE_CLAUDE_WORKER_PRESENCE_TTL_S` | 60 | TTL — pod "vivo" se escrita < este valor atrás |

Closes #495.