### PR TITLE
feat(monitor): atualizar consumidores de monitor-audit.log para schema estruturado

### DIFF
--- a/deile/tests/infrastructure/test_panel_monitor_view.py
+++ b/deile/tests/infrastructure/test_panel_monitor_view.py
@@ -293,3 +293,73 @@ def test_models_fallback_no_stale_slugs(pm):
     present = set(pm._MODELS_FALLBACK)
     overlap = stale & present
     assert not overlap, f"Slugs desatualizados ainda em _MODELS_FALLBACK: {overlap}"
+
+
+# ---------------------------------------------------------------------------
+# Testes AC1/AC2/AC3 — parser schema novo + compatibilidade schema antigo (#440)
+# ---------------------------------------------------------------------------
+
+def test_parse_vigias_new_schema_action(pm):
+    """monitor.action com kind=oauth_renew → V1 has_action=True (AC1)."""
+    lines = [
+        "2026-06-01T10:00:00Z monitor.action kind=oauth_renew V1 ok=true",
+    ]
+    vigias = {v.number: v for v in pm.MonitorDataProvider._parse_vigias(None, lines)}
+    assert vigias[1].has_action is True, "V1 deveria ter has_action=True"
+    assert vigias[1].has_warn is False
+
+
+def test_parse_vigias_new_schema_ok_false(pm):
+    """monitor.vigia.check ok=false → has_warn=True (AC1)."""
+    lines = [
+        "2026-06-01T10:01:00Z monitor.vigia.check V2 ok=false",
+    ]
+    vigias = {v.number: v for v in pm.MonitorDataProvider._parse_vigias(None, lines)}
+    assert vigias[2].has_warn is True, "V2 deveria ter has_warn=True por ok=false"
+
+
+def test_parse_vigias_new_schema_vigia_skip(pm):
+    """monitor.vigia.skip → has_warn=True mesmo sem ok=false (AC1)."""
+    lines = [
+        "2026-06-01T10:02:00Z monitor.vigia.skip V3 reason=no_anomalies",
+    ]
+    vigias = {v.number: v for v in pm.MonitorDataProvider._parse_vigias(None, lines)}
+    assert vigias[3].has_warn is True, "V3 deveria ter has_warn=True por vigia.skip"
+
+
+def test_parse_vigias_new_schema_kind_fallback(pm):
+    """monitor.action kind=delete_pod sem V<n> explícito → V2 via _KIND_TO_VIGIA (AC1)."""
+    lines = [
+        "2026-06-01T10:03:00Z monitor.action kind=delete_pod ok=true",
+    ]
+    vigias = {v.number: v for v in pm.MonitorDataProvider._parse_vigias(None, lines)}
+    assert vigias[2].has_action is True, "V2 deveria ter has_action=True via kind=delete_pod"
+
+
+def test_parse_vigias_old_schema_fallback(pm):
+    """Schema antigo: ACTION + V1 → has_action=True (AC2)."""
+    lines = [
+        "2026-06-01T09:00:00Z ACTION abc123 V1 renovando oauth",
+    ]
+    vigias = {v.number: v for v in pm.MonitorDataProvider._parse_vigias(None, lines)}
+    assert vigias[1].has_action is True, "V1 deveria ter has_action=True (schema antigo)"
+
+
+def test_parse_vigias_malformed_line(pm):
+    """Linha malformada não levanta exceção; todos os vigias ficam sem dados (AC3)."""
+    lines = [
+        "isso nao eh uma linha valida do audit log !!!",
+    ]
+    vigias = pm.MonitorDataProvider._parse_vigias(None, lines)
+    # Não deve levantar exceção; vigias com last_seen_ts=None
+    assert all(v.last_seen_ts is None for v in vigias)
+
+
+def test_parse_vigias_last_seen_ts(pm):
+    """last_seen_ts é preenchido corretamente a partir do timestamp ISO (AC3)."""
+    lines = [
+        "2026-06-01T10:05:00Z monitor.action kind=oauth_renew V1 ok=true",
+    ]
+    vigias = {v.number: v for v in pm.MonitorDataProvider._parse_vigias(None, lines)}
+    assert vigias[1].last_seen_ts is not None, "last_seen_ts deveria ser preenchido"
+    assert vigias[1].last_seen_ts.year == 2026

--- a/infra/k8s/_panel_monitor.py
+++ b/infra/k8s/_panel_monitor.py
@@ -56,10 +56,20 @@ from rich.text import Text
 import _panel_data as pd_mod
 
 # Regex para extrair marcadores de vigia do audit log.
-# Formato esperado pela persona: "<ts> ACTION/SKIP/NOTIFY <fingerprint> <detalhe>"
-# e presença de "V1"..."V7" no body da linha.
+# Formato novo (schema estruturado, downstream de #439):
+#   "<ts> monitor.<familia>[.<subtipo>] k=v..."
+# Formato antigo (fallback para pods pré-rollout):
+#   "<ts> ACTION/SKIP/NOTIFY <fingerprint> <detalhe>" com token V1..V7
 _VIGIA_RE = re.compile(r"\bV([1-7])\b")
 _AUDIT_TS_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s]*)\s+(.*)$")
+_MONITOR_FAMILY_RE = re.compile(r"^monitor\.(\S+)")
+_MONITOR_KV_RE = re.compile(r"(\w+)=([^\s]+)")
+
+# Mapeamento kind= → vigia (schema novo: monitor.action kind=<valor>)
+_KIND_TO_VIGIA: Dict[str, int] = {
+    "oauth_renew": 1,
+    "delete_pod": 2,
+}
 
 _VIGIA_NAMES = {
     1: "OAuth expirado",
@@ -376,7 +386,6 @@ class MonitorDataProvider(pd_mod._KubectlProviderMixin):
         V<n> de forma garantida (gap documentado — ver relatório final).
         Procuramos "V1" ... "V7" no texto da linha e classificamos.
         """
-        # Status inicial: todas desconhecidas (sem dado no log).
         vigias: Dict[int, VigiaStatus] = {
             n: VigiaStatus(number=n, name=_VIGIA_NAMES[n])
             for n in range(1, 8)
@@ -388,18 +397,45 @@ class MonitorDataProvider(pd_mod._KubectlProviderMixin):
             ts: Optional[datetime] = None
             if ts_str:
                 ts = pd_mod._parse_k8s_ts(ts_str)
-            for vm in _VIGIA_RE.finditer(body):
-                vn = int(vm.group(1))
-                if vn not in vigias:
-                    continue
-                v = vigias[vn]
-                # Atualiza com linha mais recente (audit está em ordem cronológica).
-                if ts is not None:
-                    v.last_seen_ts = ts
-                v.last_line = body[:80]
+
+            fm = _MONITOR_FAMILY_RE.match(body)
+            if fm:
+                # --- Schema novo: monitor.<familia>[.<subtipo>] k=v... ---
+                family = fm.group(1)
+                kv = dict(_MONITOR_KV_RE.findall(body))
+                has_action = family.startswith("action")
+                has_warn = kv.get("ok", "true").lower() == "false" or family.startswith("vigia.skip")
+
+                # Prioridade 1: token V<n> explícito no body
+                vn_hits = [int(vm.group(1)) for vm in _VIGIA_RE.finditer(body) if int(vm.group(1)) in vigias]
+                # Prioridade 2: kind= mapeado para vigia conhecida
+                if not vn_hits:
+                    kind_vn = _KIND_TO_VIGIA.get(kv.get("kind", ""))
+                    if kind_vn:
+                        vn_hits = [kind_vn]
+
+                for vn in vn_hits:
+                    v = vigias[vn]
+                    if ts is not None:
+                        v.last_seen_ts = ts
+                    v.last_line = body[:80]
+                    if has_warn:
+                        v.has_warn = True
+                    if has_action:
+                        v.has_action = True
+            else:
+                # --- Fallback: schema antigo (pods pré-rollout) ---
                 upper = body.upper()
-                v.has_warn = any(kw in upper for kw in ("FAIL", "ERROR", "⚠", "URGENTE"))
-                v.has_action = "ACTION" in upper
+                for vm in _VIGIA_RE.finditer(body):
+                    vn = int(vm.group(1))
+                    if vn not in vigias:
+                        continue
+                    v = vigias[vn]
+                    if ts is not None:
+                        v.last_seen_ts = ts
+                    v.last_line = body[:80]
+                    v.has_warn = any(kw in upper for kw in ("FAIL", "ERROR", "⚠", "URGENTE"))
+                    v.has_action = "ACTION" in upper
         return list(vigias.values())
 
 
@@ -858,7 +894,26 @@ class MonitorView:
 
     def _render_log_tail(self) -> RenderableType:
         lines = list(self._log_tail_lines[-40:])
-        body = Text("\n".join(lines) if lines else "· aguardando log...", style="dim")
+        if not lines:
+            body: RenderableType = Text("· aguardando log...", style="dim")
+        else:
+            text = Text()
+            for i, line in enumerate(lines):
+                if i:
+                    text.append("\n")
+                stripped = line.lstrip()
+                if stripped.startswith("monitor.action"):
+                    text.append(line, style="bold green")
+                elif stripped.startswith("monitor."):
+                    text.append(line, style="cyan")
+                else:
+                    # Schema antigo: highlight palavras-chave em CAIXA ALTA
+                    upper = line.upper()
+                    if "ACTION" in upper or "URGENTE" in upper:
+                        text.append(line, style="bold yellow")
+                    else:
+                        text.append(line, style="dim")
+            body = text
         return Panel(
             body,
             title="[bold]AUDIT LOG — tail (live)[/bold]",


### PR DESCRIPTION
## Resumo

Atualiza os dois consumidores de `/state/monitor-audit.log` em `infra/k8s/_panel_monitor.py` para o schema estruturado publicado em #439 (`monitor.<familia>[.<subtipo>] k=v...`), mantendo compatibilidade com o schema antigo durante a janela de transição.

### Mudanças

**`_parse_vigias` (AC1 + AC2):**
- Reconhece linhas `monitor.*`: `monitor.action` → `has_action=True`; `ok=false` ou `monitor.vigia.skip` → `has_warn=True`
- Associação vigia↔linha: prioridade 1) token `V<n>` no body; prioridade 2) campo `kind=` mapeado via `_KIND_TO_VIGIA` (`oauth_renew→V1`, `delete_pod→V2`)
- Linhas sem prefixo `monitor.` continuam usando heurística antiga (`ACTION` in upper + `\bV<n>\b`) como fallback — pods pré-rollout continuam funcionando

**`_render_log_tail` (AC2 + highlighting):**
- `monitor.action` → `bold green`
- `monitor.*` → `cyan`
- Schema antigo com `ACTION`/`URGENTE` → `bold yellow`

**Testes (`test_panel_monitor_view.py`, AC3):**
- 7 novos casos: `monitor.action kind=oauth_renew` → V1 `has_action`, `ok=false` → `has_warn`, `vigia.skip` → `has_warn`, `kind=delete_pod` sem token V<n> → V2 via `_KIND_TO_VIGIA`, schema antigo fallback, linha malformada sem exceção, `last_seen_ts` preenchido
- 19 testes passando no total

Closes #440.