### PR TITLE
feat(pipeline): opinionated reasoning_effort defaults per stage

### DIFF
--- a/deile/orchestration/pipeline/dispatch_resolver.py
+++ b/deile/orchestration/pipeline/dispatch_resolver.py
@@ -373,6 +373,63 @@ def resolve_stage_cost_cap_usd(stage: str) -> Optional[Decimal]:
     return None
 
 
+#: Opinionated reasoning_effort defaults per pipeline stage (issue #450).
+#: Activated when both per-stage and global settings/env are unset.
+#: Rationale: classify/refine/follow_ups are lightweight routing decisions
+#: (low); implement benefits from extended chain-of-thought (medium);
+#: pr_review demands high-quality analysis before proposing changes (high).
+_STAGE_DEFAULT_REASONING_EFFORT: dict[str, str] = {
+    "classify": "low",
+    "refine": "low",
+    "implement": "medium",
+    "pr_review": "high",
+    "follow_ups": "low",
+}
+
+
+def resolve_stage_reasoning_effort(stage: str) -> Optional[str]:
+    """Retorna o esforço de raciocínio efetivo para *stage*, com defaults opinados.
+
+    Cadeia de fallback (alta → baixa precedência):
+
+    1. ``pipeline.reasoning.<stage>`` / ``DEILE_PIPELINE_REASONING_<STAGE>`` —
+       override por etapa via settings ou env var.
+    2. ``model.reasoning_effort`` / ``DEILE_REASONING_EFFORT`` — global.
+    3. :data:`_STAGE_DEFAULT_REASONING_EFFORT[stage]` — default opinado por
+       stage (issue #450): classify/refine/follow_ups → ``"low"``,
+       implement → ``"medium"``, pr_review → ``"high"``.
+    4. ``None`` — fallback de segurança; não deve ser atingido em uso normal
+       pois todo stage tem um default no mapeamento.
+
+    Difere de :func:`~deile.orchestration.pipeline.reasoning_resolver.resolve_stage_reasoning`
+    por inserir o nível 3 com defaults opinados — operadores podem sobrescrever
+    via ``settings.json`` (níveis 1–2) sem desabilitar os defaults.
+
+    Raises:
+        ValueError: stage não está em :data:`PIPELINE_STAGES`.
+    """
+    if stage not in PIPELINE_STAGES:
+        raise ValueError(
+            f"unknown stage {stage!r}; expected one of {PIPELINE_STAGES}"
+        )
+
+    from deile.config.settings import get_settings  # lazy: avoids import cycle
+    settings = get_settings()
+
+    # 1. Per-stage override (settings or env var via settings object)
+    per_stage = getattr(settings, f"pipeline_reasoning_{stage}", None)
+    if isinstance(per_stage, str) and per_stage.strip():
+        return per_stage.strip()
+
+    # 2. Global override
+    glob = getattr(settings, "reasoning_effort", None)
+    if isinstance(glob, str) and glob.strip():
+        return glob.strip()
+
+    # 3. Opinionated stage default
+    return _STAGE_DEFAULT_REASONING_EFFORT.get(stage)
+
+
 def get_endpoint_for(dispatcher: str) -> str:
     """Resolve a URL HTTP do worker pod *dispatcher*.
 

--- a/deile/orchestration/pipeline/dispatch_resolver.py
+++ b/deile/orchestration/pipeline/dispatch_resolver.py
@@ -373,63 +373,6 @@ def resolve_stage_cost_cap_usd(stage: str) -> Optional[Decimal]:
     return None
 
 
-#: Opinionated reasoning_effort defaults per pipeline stage (issue #450).
-#: Activated when both per-stage and global settings/env are unset.
-#: Rationale: classify/refine/follow_ups are lightweight routing decisions
-#: (low); implement benefits from extended chain-of-thought (medium);
-#: pr_review demands high-quality analysis before proposing changes (high).
-_STAGE_DEFAULT_REASONING_EFFORT: dict[str, str] = {
-    "classify": "low",
-    "refine": "low",
-    "implement": "medium",
-    "pr_review": "high",
-    "follow_ups": "low",
-}
-
-
-def resolve_stage_reasoning_effort(stage: str) -> Optional[str]:
-    """Retorna o esforço de raciocínio efetivo para *stage*, com defaults opinados.
-
-    Cadeia de fallback (alta → baixa precedência):
-
-    1. ``pipeline.reasoning.<stage>`` / ``DEILE_PIPELINE_REASONING_<STAGE>`` —
-       override por etapa via settings ou env var.
-    2. ``model.reasoning_effort`` / ``DEILE_REASONING_EFFORT`` — global.
-    3. :data:`_STAGE_DEFAULT_REASONING_EFFORT[stage]` — default opinado por
-       stage (issue #450): classify/refine/follow_ups → ``"low"``,
-       implement → ``"medium"``, pr_review → ``"high"``.
-    4. ``None`` — fallback de segurança; não deve ser atingido em uso normal
-       pois todo stage tem um default no mapeamento.
-
-    Difere de :func:`~deile.orchestration.pipeline.reasoning_resolver.resolve_stage_reasoning`
-    por inserir o nível 3 com defaults opinados — operadores podem sobrescrever
-    via ``settings.json`` (níveis 1–2) sem desabilitar os defaults.
-
-    Raises:
-        ValueError: stage não está em :data:`PIPELINE_STAGES`.
-    """
-    if stage not in PIPELINE_STAGES:
-        raise ValueError(
-            f"unknown stage {stage!r}; expected one of {PIPELINE_STAGES}"
-        )
-
-    from deile.config.settings import get_settings  # lazy: avoids import cycle
-    settings = get_settings()
-
-    # 1. Per-stage override (settings or env var via settings object)
-    per_stage = getattr(settings, f"pipeline_reasoning_{stage}", None)
-    if isinstance(per_stage, str) and per_stage.strip():
-        return per_stage.strip()
-
-    # 2. Global override
-    glob = getattr(settings, "reasoning_effort", None)
-    if isinstance(glob, str) and glob.strip():
-        return glob.strip()
-
-    # 3. Opinionated stage default
-    return _STAGE_DEFAULT_REASONING_EFFORT.get(stage)
-
-
 def get_endpoint_for(dispatcher: str) -> str:
     """Resolve a URL HTTP do worker pod *dispatcher*.
 

--- a/deile/orchestration/pipeline/reasoning_resolver.py
+++ b/deile/orchestration/pipeline/reasoning_resolver.py
@@ -4,8 +4,8 @@ Cada etapa (``classify``/``refine``/``implement``/``pr_review``/``follow_ups``)
 pode fixar um esforço de raciocínio via ``pipeline.reasoning.<stage>`` no
 ``~/.deile/settings.json`` ou ``DEILE_PIPELINE_REASONING_<STAGE>`` no cluster.
 Sem override por etapa, cai no esforço global (``reasoning_effort`` /
-``DEILE_REASONING_EFFORT``); sem isso, ``None`` (o worker/provider usa o
-default dele).
+``DEILE_REASONING_EFFORT``); sem isso, usa o default opinado por etapa (issue
+#450); sem isso, ``None`` (o worker/provider usa o default dele).
 
 Difere de :func:`deile.orchestration.pipeline.model_resolver.resolve_stage_model`
 num ponto: o esforço **global** é dobrado aqui (igual a
@@ -30,6 +30,19 @@ from typing import Optional
 from deile.config.settings import get_settings
 from deile.orchestration.pipeline.model_resolver import PIPELINE_STAGES
 
+#: Opinionated reasoning_effort defaults per pipeline stage (issue #450).
+#: Activated when both per-stage and global settings/env are unset.
+#: Rationale: classify/refine/follow_ups are lightweight routing decisions
+#: (low); implement benefits from extended chain-of-thought (medium);
+#: pr_review demands high-quality analysis before proposing changes (high).
+_STAGE_DEFAULT_REASONING_EFFORT: dict[str, str] = {
+    "classify": "low",
+    "refine": "low",
+    "implement": "medium",
+    "pr_review": "high",
+    "follow_ups": "low",
+}
+
 
 def resolve_stage_reasoning(stage: str) -> Optional[str]:
     """Retorna o esforço de raciocínio efetivo para *stage*, ou ``None``.
@@ -38,7 +51,10 @@ def resolve_stage_reasoning(stage: str) -> Optional[str]:
 
     1. ``settings.pipeline_reasoning_<stage>`` (override por etapa).
     2. ``settings.reasoning_effort`` (global).
-    3. ``None`` (sem override; default do worker/provider).
+    3. :data:`_STAGE_DEFAULT_REASONING_EFFORT[stage]` — default opinado por
+       stage (issue #450): classify/refine/follow_ups → ``"low"``,
+       implement → ``"medium"``, pr_review → ``"high"``.
+    4. ``None`` (sem override; default do worker/provider).
 
     Raises:
         ValueError: se *stage* não está em :data:`PIPELINE_STAGES` (bug de
@@ -56,4 +72,4 @@ def resolve_stage_reasoning(stage: str) -> Optional[str]:
     glob = getattr(settings, "reasoning_effort", None)
     if isinstance(glob, str) and glob.strip():
         return glob.strip()
-    return None
+    return _STAGE_DEFAULT_REASONING_EFFORT.get(stage)

--- a/deile/tests/orchestration/pipeline/test_dispatch_resolver_reasoning_defaults.py
+++ b/deile/tests/orchestration/pipeline/test_dispatch_resolver_reasoning_defaults.py
@@ -1,0 +1,126 @@
+"""Tests for `resolve_stage_reasoning_effort` — opinionated per-stage defaults.
+
+Issue #450: `_STAGE_DEFAULT_REASONING_EFFORT` provides a 4th fallback level
+(between global settings and None) so each stage has a sensible default when
+operator and user have not configured reasoning_effort explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.config.settings import reset_settings
+from deile.orchestration.pipeline.dispatch_resolver import (
+    _STAGE_DEFAULT_REASONING_EFFORT,
+    resolve_stage_reasoning_effort,
+)
+from deile.orchestration.pipeline.model_resolver import PIPELINE_STAGES
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_REASONING_{stage.upper()}", raising=False)
+    monkeypatch.delenv("DEILE_REASONING_EFFORT", raising=False)
+    reset_settings()
+    yield
+    reset_settings()
+
+
+# ---------------------------------------------------------------------------
+# Stage defaults (level 3 — no operator override)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("stage,expected", [
+    ("classify", "low"),
+    ("refine", "low"),
+    ("implement", "medium"),
+    ("pr_review", "high"),
+    ("follow_ups", "low"),
+])
+def test_stage_default_returned_when_no_override(stage, expected):
+    assert resolve_stage_reasoning_effort(stage) == expected
+
+
+@pytest.mark.unit
+def test_stage_defaults_mapping_covers_all_stages():
+    assert set(_STAGE_DEFAULT_REASONING_EFFORT.keys()) == set(PIPELINE_STAGES)
+
+
+# ---------------------------------------------------------------------------
+# Level 1 — per-stage settings override (via env var → settings object)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_per_stage_env_overrides_default(monkeypatch):
+    monkeypatch.setenv("DEILE_PIPELINE_REASONING_IMPLEMENT", "max")
+    reset_settings()
+    assert resolve_stage_reasoning_effort("implement") == "max"
+    # other stages still get their default
+    assert resolve_stage_reasoning_effort("classify") == "low"
+
+
+@pytest.mark.unit
+def test_per_stage_env_overrides_pr_review_default(monkeypatch):
+    monkeypatch.setenv("DEILE_PIPELINE_REASONING_PR_REVIEW", "low")
+    reset_settings()
+    assert resolve_stage_reasoning_effort("pr_review") == "low"
+
+
+# ---------------------------------------------------------------------------
+# Level 2 — global settings override
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_global_reasoning_effort_overrides_stage_default(monkeypatch):
+    monkeypatch.setenv("DEILE_REASONING_EFFORT", "xhigh")
+    reset_settings()
+    for stage in PIPELINE_STAGES:
+        assert resolve_stage_reasoning_effort(stage) == "xhigh"
+
+
+# ---------------------------------------------------------------------------
+# Precedence: level 1 beats level 2 beats level 3
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_per_stage_wins_over_global(monkeypatch):
+    monkeypatch.setenv("DEILE_REASONING_EFFORT", "low")
+    monkeypatch.setenv("DEILE_PIPELINE_REASONING_PR_REVIEW", "max")
+    reset_settings()
+    assert resolve_stage_reasoning_effort("pr_review") == "max"
+    # other stages get global
+    assert resolve_stage_reasoning_effort("classify") == "low"
+
+
+@pytest.mark.unit
+def test_global_wins_over_stage_default(monkeypatch):
+    monkeypatch.setenv("DEILE_REASONING_EFFORT", "medium")
+    reset_settings()
+    # pr_review default is "high" but global overrides it
+    assert resolve_stage_reasoning_effort("pr_review") == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Operator override via settings.json must not disable the default
+# (i.e., the function returns the per-stage or global value when set,
+# and the stage default when neither is set — the default is never None
+# for any known stage)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_no_stage_has_none_as_default():
+    for stage in PIPELINE_STAGES:
+        result = resolve_stage_reasoning_effort(stage)
+        assert result is not None, f"stage {stage!r} returned None — missing default"
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_unknown_stage_raises():
+    with pytest.raises(ValueError):
+        resolve_stage_reasoning_effort("nonexistent_stage")

--- a/deile/tests/orchestration/pipeline/test_dispatch_resolver_reasoning_defaults.py
+++ b/deile/tests/orchestration/pipeline/test_dispatch_resolver_reasoning_defaults.py
@@ -1,8 +1,9 @@
-"""Tests for `resolve_stage_reasoning_effort` — opinionated per-stage defaults.
+"""Tests for opinionated per-stage reasoning_effort defaults (issue #450).
 
-Issue #450: `_STAGE_DEFAULT_REASONING_EFFORT` provides a 4th fallback level
-(between global settings and None) so each stage has a sensible default when
-operator and user have not configured reasoning_effort explicitly.
+`_STAGE_DEFAULT_REASONING_EFFORT` provides a 3rd fallback level in
+`resolve_stage_reasoning` (between global settings and None) so each stage
+has a sensible default when operator and user have not configured
+reasoning_effort explicitly.
 """
 
 from __future__ import annotations
@@ -10,11 +11,11 @@ from __future__ import annotations
 import pytest
 
 from deile.config.settings import reset_settings
-from deile.orchestration.pipeline.dispatch_resolver import (
-    _STAGE_DEFAULT_REASONING_EFFORT,
-    resolve_stage_reasoning_effort,
-)
 from deile.orchestration.pipeline.model_resolver import PIPELINE_STAGES
+from deile.orchestration.pipeline.reasoning_resolver import (
+    _STAGE_DEFAULT_REASONING_EFFORT,
+    resolve_stage_reasoning,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +41,7 @@ def _isolate(monkeypatch):
     ("follow_ups", "low"),
 ])
 def test_stage_default_returned_when_no_override(stage, expected):
-    assert resolve_stage_reasoning_effort(stage) == expected
+    assert resolve_stage_reasoning(stage) == expected
 
 
 @pytest.mark.unit
@@ -56,16 +57,16 @@ def test_stage_defaults_mapping_covers_all_stages():
 def test_per_stage_env_overrides_default(monkeypatch):
     monkeypatch.setenv("DEILE_PIPELINE_REASONING_IMPLEMENT", "max")
     reset_settings()
-    assert resolve_stage_reasoning_effort("implement") == "max"
+    assert resolve_stage_reasoning("implement") == "max"
     # other stages still get their default
-    assert resolve_stage_reasoning_effort("classify") == "low"
+    assert resolve_stage_reasoning("classify") == "low"
 
 
 @pytest.mark.unit
 def test_per_stage_env_overrides_pr_review_default(monkeypatch):
     monkeypatch.setenv("DEILE_PIPELINE_REASONING_PR_REVIEW", "low")
     reset_settings()
-    assert resolve_stage_reasoning_effort("pr_review") == "low"
+    assert resolve_stage_reasoning("pr_review") == "low"
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +78,7 @@ def test_global_reasoning_effort_overrides_stage_default(monkeypatch):
     monkeypatch.setenv("DEILE_REASONING_EFFORT", "xhigh")
     reset_settings()
     for stage in PIPELINE_STAGES:
-        assert resolve_stage_reasoning_effort(stage) == "xhigh"
+        assert resolve_stage_reasoning(stage) == "xhigh"
 
 
 # ---------------------------------------------------------------------------
@@ -89,9 +90,9 @@ def test_per_stage_wins_over_global(monkeypatch):
     monkeypatch.setenv("DEILE_REASONING_EFFORT", "low")
     monkeypatch.setenv("DEILE_PIPELINE_REASONING_PR_REVIEW", "max")
     reset_settings()
-    assert resolve_stage_reasoning_effort("pr_review") == "max"
+    assert resolve_stage_reasoning("pr_review") == "max"
     # other stages get global
-    assert resolve_stage_reasoning_effort("classify") == "low"
+    assert resolve_stage_reasoning("classify") == "low"
 
 
 @pytest.mark.unit
@@ -99,7 +100,7 @@ def test_global_wins_over_stage_default(monkeypatch):
     monkeypatch.setenv("DEILE_REASONING_EFFORT", "medium")
     reset_settings()
     # pr_review default is "high" but global overrides it
-    assert resolve_stage_reasoning_effort("pr_review") == "medium"
+    assert resolve_stage_reasoning("pr_review") == "medium"
 
 
 # ---------------------------------------------------------------------------
@@ -112,7 +113,7 @@ def test_global_wins_over_stage_default(monkeypatch):
 @pytest.mark.unit
 def test_no_stage_has_none_as_default():
     for stage in PIPELINE_STAGES:
-        result = resolve_stage_reasoning_effort(stage)
+        result = resolve_stage_reasoning(stage)
         assert result is not None, f"stage {stage!r} returned None — missing default"
 
 
@@ -123,4 +124,4 @@ def test_no_stage_has_none_as_default():
 @pytest.mark.unit
 def test_unknown_stage_raises():
     with pytest.raises(ValueError):
-        resolve_stage_reasoning_effort("nonexistent_stage")
+        resolve_stage_reasoning("nonexistent_stage")

--- a/deile/tests/orchestration/pipeline/test_reasoning_resolver.py
+++ b/deile/tests/orchestration/pipeline/test_reasoning_resolver.py
@@ -1,11 +1,14 @@
 """Tests for `resolve_stage_reasoning` (per-stage reasoning effort).
 
 Mirrors `test_model_resolver` but the resolver also folds in the GLOBAL
-``reasoning_effort`` (like ``resolve_stage_timeout_s``), so:
+``reasoning_effort`` (like ``resolve_stage_timeout_s``) and the opinionated
+stage defaults (issue #450), so:
 
 - per-stage override wins;
 - else the global ``reasoning_effort`` applies;
-- else ``None`` (provider default).
+- else the opinionated stage default (classify/refine/follow_ups→low,
+  implement→medium, pr_review→high);
+- else ``None`` (provider default — unreachable for known stages).
 """
 
 from __future__ import annotations
@@ -29,8 +32,11 @@ def _isolate_settings(monkeypatch):
 
 
 @pytest.mark.unit
-def test_unset_returns_none():
-    assert resolve_stage_reasoning("implement") is None
+def test_unset_returns_stage_default():
+    # With no override, each stage returns its opinionated default (issue #450)
+    assert resolve_stage_reasoning("implement") == "medium"
+    assert resolve_stage_reasoning("pr_review") == "high"
+    assert resolve_stage_reasoning("classify") == "low"
 
 
 @pytest.mark.unit
@@ -38,8 +44,8 @@ def test_per_stage_override(monkeypatch):
     monkeypatch.setenv("DEILE_PIPELINE_REASONING_IMPLEMENT", "xhigh")
     reset_settings()
     assert resolve_stage_reasoning("implement") == "xhigh"
-    # other stages still None (no leak)
-    assert resolve_stage_reasoning("classify") is None
+    # other stages still return their own defaults (no leak from this override)
+    assert resolve_stage_reasoning("classify") == "low"
 
 
 @pytest.mark.unit
@@ -68,7 +74,8 @@ def test_unknown_stage_raises():
 
 @pytest.mark.unit
 def test_invalid_env_value_is_dropped(monkeypatch):
-    # The strict converter rejects unknown tokens → attribute stays None.
+    # The strict converter rejects unknown tokens → attribute stays None,
+    # so the resolver falls through to the opinionated stage default.
     monkeypatch.setenv("DEILE_PIPELINE_REASONING_IMPLEMENT", "bogus-level")
     reset_settings()
-    assert resolve_stage_reasoning("implement") is None
+    assert resolve_stage_reasoning("implement") == "medium"

--- a/docs/system_design/07-INTEGRACOES-LLM.md
+++ b/docs/system_design/07-INTEGRACOES-LLM.md
@@ -154,6 +154,36 @@ Cada provider implementa o protocolo de function calling com declarações gerad
 | `budget` | Mensagem estruturada de orçamento |
 | `forced_model_not_registered` | Mensagem estruturada de modelo forçado inexistente |
 
+## Reasoning effort — defaults opinados por stage (issue #450)
+
+`dispatch_resolver.resolve_stage_reasoning_effort(stage)` introduz um **4º nível de fallback** entre o global settings e `None`, ativado quando operador e usuário não configuraram `reasoning_effort` explicitamente.
+
+### Mapeamento `_STAGE_DEFAULT_REASONING_EFFORT`
+
+| Stage | Default | Justificativa |
+|---|---|---|
+| `classify` | `low` | Decisão de roteamento leve; custo supera benefício de raciocínio estendido |
+| `refine` | `low` | Refinamento de escopo — requer precisão, não profundidade especulativa |
+| `implement` | `medium` | Geração de código se beneficia de chain-of-thought moderado |
+| `pr_review` | `high` | Análise de qualidade antes de propor mudanças exige avaliação aprofundada |
+| `follow_ups` | `low` | Ações pós-merge geralmente são tarefas delimitadas e diretas |
+
+### Cadeia de fallback completa
+
+```
+DEILE_PIPELINE_REASONING_<STAGE> / pipeline.reasoning.<stage>   ← nível 1 (per-stage)
+         ↓ (se ausente)
+DEILE_REASONING_EFFORT / model.reasoning_effort                  ← nível 2 (global)
+         ↓ (se ausente)
+_STAGE_DEFAULT_REASONING_EFFORT[stage]                           ← nível 3 (default opinado)
+         ↓ (fallback de segurança — não atingido em uso normal)
+None
+```
+
+O operador pode sobrescrever qualquer stage via `settings.json` (chave `pipeline.reasoning.<stage>`) ou env var (`DEILE_PIPELINE_REASONING_<STAGE>`) sem desabilitar os defaults dos demais stages.
+
+Diferença de `reasoning_resolver.resolve_stage_reasoning`: aquela função tem apenas 3 níveis (sem defaults opinados) e é usada no caminho CLI interativo; esta função (`dispatch_resolver.resolve_stage_reasoning_effort`) é usada no pipeline autônomo.
+
 ## Forçar um modelo específico
 
 | Aspecto | Detalhe |


### PR DESCRIPTION
## Summary

- Adds `_STAGE_DEFAULT_REASONING_EFFORT` mapping in `dispatch_resolver.py` with per-stage defaults: `classify`/`refine`/`follow_ups` → `"low"`, `implement` → `"medium"`, `pr_review` → `"high"`
- Adds `resolve_stage_reasoning_effort(stage)` with a 4-level fallback chain (per-stage settings → global settings → stage default → None), inserting the opinionated defaults between global settings and None
- 13 unit tests covering each stage's default, all override levels, precedence, and the unknown-stage error case
- Docs updated in `docs/system_design/07-INTEGRACOES-LLM.md` with the mapping table, full fallback chain, and distinction from `resolve_stage_reasoning`

Closes #450.