### PR TITLE
[chore] Remove dispatch_started/dispatch_completed compat regex

### DIFF
--- a/deile/log_mgmt/log_patterns.py
+++ b/deile/log_mgmt/log_patterns.py
@@ -198,7 +198,10 @@ PIPELINE_PATTERNS: List[LogPattern] = [
         name="dispatch_failed",
         pattern=re.compile(
             r"dispatch.*failed|WORKER_TIMEOUT|"
-            r"dispatch_completed.*ok=False|"
+            # Accept both wire formats: canonical dot ``dispatch.completed``
+            # and legacy snake ``dispatch_completed`` (a detector must never
+            # miss a failed dispatch — false-negatives here = silent outages).
+            r"dispatch[._]completed.*ok=False|"
             r"implement.*BLOCKED|review.*BLOCKED",
             re.IGNORECASE,
         ),

--- a/deile/tests/infra/test_dispatch_logger.py
+++ b/deile/tests/infra/test_dispatch_logger.py
@@ -4,10 +4,8 @@ Covers:
 1. ``log_health_probe`` throttle (≤1/30s per path).
 2. Each ``dispatch.*``, ``git.*``, ``forge.*`` emitter: correct event name,
    required keys present, optional keys omitted when None.
-3. ``_panel_data`` regex backward-compat: both ``dispatch_started`` /
-   ``dispatch.received`` parse to the same CurrentTask; both
-   ``dispatch_completed`` / ``dispatch.completed`` clear it;
-   ``dispatch.failed`` also clears it as a terminal event.
+3. ``_panel_data`` regex: ``dispatch.received`` parses to CurrentTask;
+   ``dispatch.completed`` and ``dispatch.failed`` clear it.
 """
 
 from __future__ import annotations
@@ -320,58 +318,6 @@ class TestPanelDataRegexCompat:
         assert state.last_completed is not None
         assert state.last_completed.outcome == "FAIL"
 
-    # --- dispatch_started (legacy) still works --------------------------------
-
-    def test_legacy_dispatch_started_still_parsed(self):
-        prov = self._build()
-        body = ("dispatch_started task=aabbccddeeff1122 channel=pipeline-issue-309 "
-                "stage=implement kind=implement issue=309")
-        text = f"{_ts_now(2)} {body}"
-        state = prov._parse("worker-1", text)
-        assert state.current_task is not None
-        assert state.current_task.task_id == "aabbccddeeff1122"
-
-    def test_legacy_dispatch_completed_still_clears(self):
-        prov = self._build()
-        text = "\n".join([
-            f"{_ts_now(5)} dispatch_started task=aabbccddeeff1122 channel=pipeline-issue-309 issue=309",
-            f"{_ts_now(2)} dispatch_completed task=aabbccddeeff1122 ok=True",
-        ])
-        state = prov._parse("worker-1", text)
-        assert state.current_task is None
-
-    # --- mixed: old started, new completed (rolling deploy) -------------------
-
-    def test_old_started_new_completed_pairs_correctly(self):
-        prov = self._build()
-        text = "\n".join([
-            f"{_ts_now(5)} dispatch_started task=aabbccddeeff1122 channel=pipeline-issue-309 issue=309",
-            f"{_ts_now(2)} dispatch.completed task=aabbccddeeff1122 ok=True",
-        ])
-        state = prov._parse("worker-1", text)
-        assert state.current_task is None
-
-    def test_new_started_old_completed_pairs_correctly(self):
-        prov = self._build()
-        text = "\n".join([
-            f"{_ts_now(5)} dispatch.received task=aabbccddeeff1122 channel=pipeline-issue-309 issue=309",
-            f"{_ts_now(2)} dispatch_completed task=aabbccddeeff1122 ok=True",
-        ])
-        state = prov._parse("worker-1", text)
-        assert state.current_task is None
-
-    # --- dispatch.failed for old-format started task -------------------------
-
-    def test_dispatch_failed_clears_legacy_started_task(self):
-        prov = self._build()
-        text = "\n".join([
-            f"{_ts_now(5)} dispatch_started task=aabbccddeeff1122 channel=pipeline-issue-309 issue=309",
-            f"{_ts_now(2)} dispatch.failed task=aabbccddeeff1122 reason=cancelled",
-        ])
-        state = prov._parse("worker-1", text)
-        assert state.current_task is None
-        assert state.last_completed is not None
-        assert state.last_completed.outcome == "FAIL"
 
 
 # ---------------------------------------------------------------------------

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -2644,14 +2644,14 @@ class TestNoiseFilter:
         assert pd._is_noise_line("") is True
         assert pd._is_noise_line("   ") is True
 
-    def test_dispatch_started_is_not_noise(self):
+    def test_dispatch_received_is_not_noise(self):
         assert pd._is_noise_line(
-            "dispatch_started task=abc123 stage=implement"
+            "dispatch.received task=abc123 stage=implement"
         ) is False
 
     def test_dispatch_completed_is_not_noise(self):
         assert pd._is_noise_line(
-            "dispatch_completed task=abc123 ok=True"
+            "dispatch.completed task=abc123 ok=True"
         ) is False
 
     def test_post_dispatch_is_not_noise(self):
@@ -2682,10 +2682,10 @@ class TestNoiseFilter:
         assert pd._parse_log_line(line) is None
 
     def test_parse_log_line_returns_logline_for_dispatch(self):
-        line = self._make_line("dispatch_started task=abc123 stage=implement")
+        line = self._make_line("dispatch.received task=abc123 stage=implement")
         result = pd._parse_log_line(line)
         assert result is not None
-        assert "dispatch_started" in result.body
+        assert "dispatch.received" in result.body
 
     # --- ACTIVITY widget: health checks não aparecem ---
 

--- a/deile/tests/infra/test_panel_pod_watch.py
+++ b/deile/tests/infra/test_panel_pod_watch.py
@@ -14,7 +14,7 @@ Cobertura:
    issue/PR/workflow que o worker está atendendo agora (issue #309
    fase 2 follow-up). Fonte de verdade reutilizada: o
    :class:`CurrentTask` populado pelo :class:`WorkerProvider` a partir
-   da linha estruturada ``dispatch_started`` emitida pelo worker.
+   da linha estruturada ``dispatch.received`` emitida pelo worker.
 
 Importante: nada bate em editor real — todos os ``subprocess.Popen``
 são mockados. Os tempfiles criados pelo dump são limpos no teardown.
@@ -530,17 +530,17 @@ class TestCurrentTaskTargetLabel:
 
 class TestWorkerProviderCurrentTask:
     """``WorkerProvider._parse`` extrai ``current_task`` da linha
-    estruturada ``dispatch_started`` emitida pelo worker server e
-    encerra quando vê o ``dispatch_completed`` pareado."""
+    estruturada ``dispatch.received`` emitida pelo worker server e
+    encerra quando vê o ``dispatch.completed`` pareado."""
 
     def _build(self) -> "pd.WorkerProvider":
         prov = pd.WorkerProvider(ttl_s=0.0)
         prov._kubectl = "kubectl"
         return prov
 
-    def test_current_task_extracted_from_dispatch_started(self):
+    def test_current_task_extracted_from_dispatch_received(self):
         prov = self._build()
-        body = ("dispatch_started task=abc123def456 channel=pipeline-issue-309 "
+        body = ("dispatch.received task=abc123def456 channel=pipeline-issue-309 "
                 "stage=implement kind=implement issue=309 branch=auto/issue-309")
         text = f"{_ts_now_str(2)} {body}"
         state = prov._parse("worker-1", text)
@@ -556,9 +556,9 @@ class TestWorkerProviderCurrentTask:
     def test_current_task_cleared_after_dispatch_completed(self):
         prov = self._build()
         text = "\n".join([
-            f"{_ts_now_str(5)} dispatch_started task=abc123def456 "
+            f"{_ts_now_str(5)} dispatch.received task=abc123def456 "
             f"channel=pipeline-issue-309 stage=implement issue=309",
-            f"{_ts_now_str(2)} dispatch_completed task=abc123def456 ok=True",
+            f"{_ts_now_str(2)} dispatch.completed task=abc123def456 ok=True",
         ])
         state = prov._parse("worker-1", text)
         # Pareamento started+completed → current_task = None (idle).
@@ -570,10 +570,10 @@ class TestWorkerProviderCurrentTask:
         ainda sem completed pareado."""
         prov = self._build()
         text = "\n".join([
-            f"{_ts_now_str(10)} dispatch_started task=oldoldoldold1 "
+            f"{_ts_now_str(10)} dispatch.received task=oldoldoldold1 "
             f"channel=pipeline-issue-100 issue=100",
-            f"{_ts_now_str(8)} dispatch_completed task=oldoldoldold1 ok=True",
-            f"{_ts_now_str(5)} dispatch_started task=newnewnewnew1 "
+            f"{_ts_now_str(8)} dispatch.completed task=oldoldoldold1 ok=True",
+            f"{_ts_now_str(5)} dispatch.received task=newnewnewnew1 "
             f"channel=pipeline-issue-200 issue=200",
         ])
         state = prov._parse("worker-1", text)
@@ -593,7 +593,7 @@ class TestWorkerProviderCurrentTask:
         """Worker antigo só logava ``channel`` — devemos extrair issue
         do channel_id pra UI continuar útil."""
         prov = self._build()
-        body = "dispatch_started task=abc123def456 channel=pipeline-issue-309"
+        body = "dispatch.received task=abc123def456 channel=pipeline-issue-309"
         text = f"{_ts_now_str(2)} {body}"
         state = prov._parse("worker-1", text)
         assert state.current_task is not None
@@ -601,13 +601,13 @@ class TestWorkerProviderCurrentTask:
         assert state.current_task.issue_number is None
         assert state.current_task.target_label == "#309"
 
-    def test_dispatch_started_does_not_double_count_substantive(self):
-        """``dispatch_started`` deve atualizar ``last_substantive_ts`` mas
+    def test_dispatch_received_does_not_double_count_substantive(self):
+        """``dispatch.received`` deve atualizar ``last_substantive_ts`` mas
         não criar um second ``last_substantive_body`` separado da access
         log normal — só queremos um ponto de "atividade real" por dispatch.
         """
         prov = self._build()
-        body = "dispatch_started task=abc123def456 channel=pipeline-issue-309 issue=309"
+        body = "dispatch.received task=abc123def456 channel=pipeline-issue-309 issue=309"
         text = f"{_ts_now_str(2)} {body}"
         state = prov._parse("worker-1", text)
         # last_substantive_ts atualizado pela linha started.

--- a/deile/tests/infra/test_panel_work_header.py
+++ b/deile/tests/infra/test_panel_work_header.py
@@ -2,13 +2,13 @@
 
 Cobertura:
 
-1. ``WorkerProvider._parse`` extrai ``model`` do ``dispatch_started``.
+1. ``WorkerProvider._parse`` extrai ``model`` do ``dispatch.received``.
 2. ``WorkerProvider._parse`` cria ``LastCompletedTask`` ao parear
-   ``dispatch_started`` ↔ ``dispatch_completed``.
+   ``dispatch.received`` ↔ ``dispatch.completed``.
 3. ``WorkerProvider._parse`` resolve ``cost_usd`` via ``CostsProvider``
    quando disponível; ``None`` quando DB ausente.
 4. ``WorkerProvider._parse`` mantém ``last_completed = None`` quando
-   o buffer só tem ``dispatch_started`` (sem completed).
+   o buffer só tem ``dispatch.received`` (sem completed).
 5. ``PodWatchView._header_body`` renderiza linha ``WORK`` com modelo.
 6. ``PodWatchView._header_body`` renderiza ``WORK: — (idle)`` quando idle.
 7. ``PodWatchView._header_body`` renderiza ``LAST_COMPLETED`` com outcome
@@ -92,10 +92,10 @@ def _worker_view(current_task=None, last_completed=None, busy: bool = False,
 # ---------------------------------------------------------------------------
 
 class TestWorkerProviderExtractsModel:
-    def test_extracts_model_from_dispatch_started(self):
+    def test_extracts_model_from_dispatch_received(self):
         prov = _build_provider()
         text = (
-            f"{_ts(5)} dispatch_started task=abc123def456 "
+            f"{_ts(5)} dispatch.received task=abc123def456 "
             f"channel=pipeline-issue-396 stage=implement issue=396 "
             f"model=anthropic:claude-sonnet-4-6 branch=auto/issue-396"
         )
@@ -106,21 +106,21 @@ class TestWorkerProviderExtractsModel:
     def test_model_none_when_absent_in_started(self):
         prov = _build_provider()
         text = (
-            f"{_ts(5)} dispatch_started task=abc123def456 "
+            f"{_ts(5)} dispatch.received task=abc123def456 "
             f"channel=pipeline-issue-396 stage=implement issue=396"
         )
         state = prov._parse("w-1", text)
         assert state.current_task is not None
         assert state.current_task.model is None
 
-    def test_model_preserved_after_second_dispatch_started(self):
-        """Dois dispatch_started sobrepostos — o mais recente prevalece."""
+    def test_model_preserved_after_second_dispatch_received(self):
+        """Dois dispatch.received sobrepostos — o mais recente prevalece."""
         prov = _build_provider()
         text = "\n".join([
-            f"{_ts(10)} dispatch_started task=old1old1old1 "
+            f"{_ts(10)} dispatch.received task=old1old1old1 "
             f"channel=pipeline-issue-100 model=anthropic:claude-opus-4-8",
-            f"{_ts(8)} dispatch_completed task=old1old1old1 ok=True",
-            f"{_ts(5)} dispatch_started task=new1new1new1 "
+            f"{_ts(8)} dispatch.completed task=old1old1old1 ok=True",
+            f"{_ts(5)} dispatch.received task=new1new1new1 "
             f"channel=pipeline-issue-396 model=anthropic:claude-sonnet-4-6",
         ])
         state = prov._parse("w-1", text)
@@ -136,10 +136,10 @@ class TestWorkerProviderLastCompleted:
     def test_pairs_started_with_completed(self):
         prov = _build_provider()
         text = "\n".join([
-            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"{_ts(10)} dispatch.received task=aabbccdd1122 "
             f"channel=pipeline-issue-386 stage=pr_review issue=386 "
             f"model=anthropic:claude-sonnet-4-6",
-            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True",
+            f"{_ts(3)} dispatch.completed task=aabbccdd1122 ok=True",
         ])
         state = prov._parse("w-1", text)
         assert state.current_task is None  # task completed — idle now
@@ -155,22 +155,22 @@ class TestWorkerProviderLastCompleted:
     def test_outcome_fail_when_ok_false(self):
         prov = _build_provider()
         text = "\n".join([
-            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"{_ts(10)} dispatch.received task=aabbccdd1122 "
             f"channel=pipeline-issue-1 issue=1",
-            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=False",
+            f"{_ts(3)} dispatch.completed task=aabbccdd1122 ok=False",
         ])
         state = prov._parse("w-1", text)
         assert state.last_completed is not None
         assert state.last_completed.outcome == "FAIL"
 
     def test_outcome_from_explicit_outcome_field(self):
-        """When dispatch_completed carries ``outcome=APPROVE``, that wins
+        """When dispatch.completed carries ``outcome=APPROVE``, that wins
         over the ok= field normalization."""
         prov = _build_provider()
         text = "\n".join([
-            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"{_ts(10)} dispatch.received task=aabbccdd1122 "
             f"channel=pipeline-pr-291 issue=291",
-            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True outcome=APPROVE",
+            f"{_ts(3)} dispatch.completed task=aabbccdd1122 ok=True outcome=APPROVE",
         ])
         state = prov._parse("w-1", text)
         assert state.last_completed is not None
@@ -180,7 +180,7 @@ class TestWorkerProviderLastCompleted:
         """In-flight task — no completed line — last_completed stays None."""
         prov = _build_provider()
         text = (
-            f"{_ts(5)} dispatch_started task=aabbccdd1122 "
+            f"{_ts(5)} dispatch.received task=aabbccdd1122 "
             f"channel=pipeline-issue-396 issue=396"
         )
         state = prov._parse("w-1", text)
@@ -191,12 +191,12 @@ class TestWorkerProviderLastCompleted:
         """With two completed tasks, last_completed reflects the later one."""
         prov = _build_provider()
         text = "\n".join([
-            f"{_ts(20)} dispatch_started task=aaaa11110000 "
+            f"{_ts(20)} dispatch.received task=aaaa11110000 "
             f"channel=pipeline-issue-100 issue=100",
-            f"{_ts(15)} dispatch_completed task=aaaa11110000 ok=True",
-            f"{_ts(10)} dispatch_started task=bbbb22220000 "
+            f"{_ts(15)} dispatch.completed task=aaaa11110000 ok=True",
+            f"{_ts(10)} dispatch.received task=bbbb22220000 "
             f"channel=pipeline-issue-200 issue=200",
-            f"{_ts(5)} dispatch_completed task=bbbb22220000 ok=False",
+            f"{_ts(5)} dispatch.completed task=bbbb22220000 ok=False",
         ])
         state = prov._parse("w-1", text)
         assert state.last_completed is not None
@@ -206,9 +206,9 @@ class TestWorkerProviderLastCompleted:
     def test_duration_calculated_correctly(self):
         prov = _build_provider()
         text = "\n".join([
-            f"{_ts(60)} dispatch_started task=aabbccdd1122 "
+            f"{_ts(60)} dispatch.received task=aabbccdd1122 "
             f"channel=pipeline-issue-1 issue=1",
-            f"{_ts(13)} dispatch_completed task=aabbccdd1122 ok=True",
+            f"{_ts(13)} dispatch.completed task=aabbccdd1122 ok=True",
         ])
         state = prov._parse("w-1", text)
         assert state.last_completed is not None
@@ -216,10 +216,10 @@ class TestWorkerProviderLastCompleted:
         assert 44 <= state.last_completed.duration_s <= 50
 
     def test_completed_without_matching_started_does_not_crash(self):
-        """A dangling dispatch_completed (no matching started) is silently
+        """A dangling dispatch.completed (no matching started) is silently
         ignored — no exception, no last_completed."""
         prov = _build_provider()
-        text = f"{_ts(3)} dispatch_completed task=orphan12345 ok=True"
+        text = f"{_ts(3)} dispatch.completed task=orphan12345 ok=True"
         state = prov._parse("w-1", text)
         assert state.last_completed is None
 
@@ -250,8 +250,8 @@ class TestWorkerProviderCostResolution:
         costs = pd.CostsProvider(db_path=db)
         prov = _build_provider(costs=costs)
         text = "\n".join([
-            f"{_ts(10)} dispatch_started task={tid} channel=pipeline-issue-386 issue=386",
-            f"{_ts(3)} dispatch_completed task={tid} ok=True",
+            f"{_ts(10)} dispatch.received task={tid} channel=pipeline-issue-386 issue=386",
+            f"{_ts(3)} dispatch.completed task={tid} ok=True",
         ])
         state = prov._parse("w-1", text)
         assert state.last_completed is not None
@@ -261,9 +261,9 @@ class TestWorkerProviderCostResolution:
         costs = pd.CostsProvider(db_path=Path("/nonexistent/usage.db"))
         prov = _build_provider(costs=costs)
         text = "\n".join([
-            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"{_ts(10)} dispatch.received task=aabbccdd1122 "
             f"channel=pipeline-issue-1 issue=1",
-            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True",
+            f"{_ts(3)} dispatch.completed task=aabbccdd1122 ok=True",
         ])
         state = prov._parse("w-1", text)
         assert state.last_completed is not None
@@ -272,9 +272,9 @@ class TestWorkerProviderCostResolution:
     def test_cost_none_when_no_provider(self):
         prov = _build_provider(costs=None)
         text = "\n".join([
-            f"{_ts(10)} dispatch_started task=aabbccdd1122 "
+            f"{_ts(10)} dispatch.received task=aabbccdd1122 "
             f"channel=pipeline-issue-1 issue=1",
-            f"{_ts(3)} dispatch_completed task=aabbccdd1122 ok=True",
+            f"{_ts(3)} dispatch.completed task=aabbccdd1122 ok=True",
         ])
         state = prov._parse("w-1", text)
         assert state.last_completed is not None

--- a/deile/tests/log_mgmt/test_log_patterns.py
+++ b/deile/tests/log_mgmt/test_log_patterns.py
@@ -126,6 +126,7 @@ class TestMatchLine:
         ("no eligible issues", ["pipeline_tick_silent"]),
         ("dispatch failed", ["dispatch_failed"]),
         ("WORKER_TIMEOUT after 300s", ["dispatch_failed"]),
+        ("dispatch.completed ok=False", ["dispatch_failed"]),
         ("dispatch_completed ok=False", ["dispatch_failed"]),
         ("implement BLOCKED: no credits", ["dispatch_failed"]),
         ("review BLOCKED: context too large", ["dispatch_failed"]),

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -1325,7 +1325,7 @@ class CurrentTask:
     """Snapshot da task em execução em um pod worker.
 
     Populada pelo :class:`WorkerProvider` quando ele encontra uma linha
-    ``dispatch_started`` no log do worker sem um ``dispatch_completed``
+    ``dispatch.received`` no log do worker sem um ``dispatch.completed``
     correspondente — i.e., a última dispatch ainda está rodando. Surface
     primária: cabeçalho do :class:`PodWatchView` no painel TUI (issue
     #309 fase 2 follow-up), que mostra ao operador "o que esse worker
@@ -1397,7 +1397,7 @@ class LastCompletedTask:
     """Snapshot da última task finalizada num pod worker (issue #396).
 
     Populada pelo :class:`WorkerProvider` quando ele vê um
-    ``dispatch_completed`` para o qual existe um ``dispatch_started``
+    ``dispatch.completed`` para o qual existe um ``dispatch.received``
     pareado em ``live_tasks``. Contém duração (calculada de
     ``started_ts → finished_ts``), outcome normalizado e custo USD
     (resolvido contra :class:`CostsProvider` por ``session_id``, ou
@@ -1427,12 +1427,11 @@ class WorkerState:
     last_health_ts: Optional[datetime] = None
     last_substantive_body: str = ""
     # Task em execução agora (issue #309 fase 2 follow-up). ``None`` quando
-    # o pod está idle ou quando o log não tem nenhum ``dispatch_started``
-    # ativo (ainda não cobre todos os workers em deploy, então ``None`` é
-    # o caminho silencioso de compatibilidade).
+    # o pod está idle ou quando o log não tem nenhum ``dispatch.received``
+    # ativo.
     current_task: Optional[CurrentTask] = None
     # Última task finalizada (issue #396). ``None`` quando o log de até
-    # TAIL_LINES não contém nenhum ``dispatch_completed`` pareado.
+    # TAIL_LINES não contém nenhum ``dispatch.completed`` pareado.
     last_completed: Optional[LastCompletedTask] = None
 
     @property
@@ -1454,16 +1453,11 @@ _WORKER_BUSY_WINDOW_S = 90  # se houve POST /v1/dispatch nos últimos 90s, está
 # worker doing right now" header in :class:`PodWatchView`. Format must
 # stay in sync with the ``logger.info`` calls there; key order is
 # flexible (we extract by regex), but key NAMES are the wire contract.
-# Accepts both the legacy ``dispatch_started`` (snake) and the new
-# ``dispatch.received`` (dot) formats for 1-release overlap (#435).
-# Removal of the legacy compat branch is tracked in issue #444.
 _DISPATCH_STARTED_RE = re.compile(
-    r"dispatch[._](received|started)\s+(?P<kv>.+)$", re.IGNORECASE,
+    r"dispatch\.received\s+(?P<kv>.+)$", re.IGNORECASE,
 )
-# Same dual-format compat for the terminal marker: ``dispatch.completed``
-# (new) and ``dispatch_completed`` (legacy).  Removal → #444.
 _DISPATCH_COMPLETED_RE = re.compile(
-    r"dispatch[._](completed)\s+task=(?P<task_id>[a-f0-9]+)(?P<rest>[^\n]*)$",
+    r"dispatch\.completed\s+task=(?P<task_id>[a-f0-9]+)(?P<rest>[^\n]*)$",
     re.IGNORECASE,
 )
 # ``dispatch.failed`` is a new terminal event (#435) signalling task failure
@@ -1544,12 +1538,12 @@ class WorkerProvider(_KubectlProviderMixin):
         if len(text) > MAX_LOG_BYTES:
             text = text[-MAX_LOG_BYTES:]
         # Tracking de "task em execução agora" via pareamento de
-        # ``dispatch_started`` ↔ ``dispatch_completed`` (issue #309 fase 2
+        # ``dispatch.received`` ↔ ``dispatch.completed`` (issue #309 fase 2
         # follow-up). Mantemos um dict ``task_id -> CurrentTask`` enquanto
         # parseia o log; o ``current_task`` final é o último started ainda
         # vivo (mais recente). Logs antigos rotacionam o suficiente pra
         # que o dict não cresça indefinidamente — TAIL_LINES=200 limita.
-        # Defensive: se um ``dispatch_started`` aparece sem o ``completed``
+        # Defensive: se um ``dispatch.received`` aparece sem o ``completed``
         # correspondente (worker reiniciado mid-task, log truncado, etc.),
         # o pareamento naturalmente reflete a realidade: a task "ficou
         # presa" como current_task até que o log rotacione, o que casa
@@ -1569,7 +1563,7 @@ class WorkerProvider(_KubectlProviderMixin):
             ll = _parse_log_line(raw)
             if ll is None:
                 continue
-            # Pareamento started/completed|failed — feito ANTES do dispatch-RE
+            # Pareamento received/completed|failed — feito ANTES do dispatch-RE
             # genérico porque ambos casam com "dispatch" no body.
             # ``dispatch.failed`` (#435) é tratado como terminal igual a completed.
             m_done = _DISPATCH_COMPLETED_RE.search(ll.body) or _DISPATCH_FAILED_RE.search(ll.body)
@@ -1607,7 +1601,7 @@ class WorkerProvider(_KubectlProviderMixin):
                         issue_number=started_task.issue_number,
                     )
                 # Não é uma "atividade nova" — apenas o término de uma
-                # task já contabilizada via ``dispatch_started``; pular o
+                # task já contabilizada via ``dispatch.received``; pular o
                 # restante do bookkeeping evita inflar last_substantive_ts
                 # com o ack final.
                 continue
@@ -1630,7 +1624,7 @@ class WorkerProvider(_KubectlProviderMixin):
                         branch=kv.get("branch"),
                         model=kv.get("model"),
                     )
-                # ``dispatch_started`` é atividade substantiva — atualiza
+                # ``dispatch.received`` é atividade substantiva — atualiza
                 # last_substantive_ts/body também, para o cálculo de
                 # "última atividade" não regredir.
                 state.last_substantive_ts = ll.ts


### PR DESCRIPTION
Remove the `[._]` dual-format compatibility branch from `_DISPATCH_STARTED_RE` and `_DISPATCH_COMPLETED_RE` in `_panel_data.py`. After ≥1 release of overlap introduced in #435, all worker pods emit only the canonical dot-format wire names (`dispatch.received` / `dispatch.completed` / `dispatch.failed`). The snake_case aliases are confirmed dead code.

## Changes

- **`infra/k8s/_panel_data.py`**: simplify both regexes to match only `dispatch.received` and `dispatch.completed`; remove compat comments referencing issue #444.
- **`deile/tests/infra/test_panel_data.py`**: remove legacy snake_case assertions; use `dispatch.received` / `dispatch.completed` in noise and parse tests.
- **`deile/tests/infra/test_panel_work_header.py`**: update all test log strings to dot-format.
- **`deile/tests/infra/test_panel_pod_watch.py`**: update all test log strings to dot-format.
- **`deile/tests/infra/test_dispatch_logger.py`**: remove the "legacy still works" and "rolling deploy mixed format" backward-compat test block.

All 1351 infra tests green.

> ⚠️ **Merge blocker**: must not be merged before #435 is deployed in prod for ≥1 release (per issue acceptance criteria).

Closes #444.