### PR TITLE
fix(pipeline): 10 medium/low audit findings — robustness, DX, security-defensive

### DIFF
--- a/deile/orchestration/forge/github_forge.py
+++ b/deile/orchestration/forge/github_forge.py
@@ -859,6 +859,14 @@ class GitHubForge(ForgeClient):
     async def _has_bot_activity_impl(
         self, kind: str, number: int, bot_login: str, since_ts: int,
     ) -> bool:
+        # Defense-in-depth: validate before interpolating into the jq filter,
+        # matching the invariant held by every other login surface in the forge.
+        if not _GH_LOGIN_RE.fullmatch(bot_login or ""):
+            logger.warning(
+                "_has_bot_activity_impl #%d: bot_login %r rejected by _GH_LOGIN_RE",
+                number, bot_login,
+            )
+            return False
         # Comments — issues + PRs compartilham endpoint.
         rc_c, out_c, _ = await self._run(
             "api", "--paginate",

--- a/deile/orchestration/pipeline/dispatch_ledger.py
+++ b/deile/orchestration/pipeline/dispatch_ledger.py
@@ -83,7 +83,15 @@ class DispatchLedger:
     # ----------------------------------------------------------------- #
 
     def _load(self) -> Dict[str, Any]:
-        """Lê o ledger do disco. None → empty (file ausente/malformed)."""
+        """Lê o ledger do disco. None → empty (file ausente/malformed).
+
+        **Single-instance invariant**: ``_cache`` is populated once on the
+        first access and only invalidated explicitly via ``invalidate_cache()``.
+        Multi-instance usage (e.g. a second ``DispatchLedger()`` pointing to the
+        same path) sees a stale snapshot for the lifetime of the second instance.
+        All production code uses the singleton on ``PipelineMonitor``; never
+        instantiate a second ``DispatchLedger`` for the same path.
+        """
         if self._cache is not None:
             return self._cache
         if not self._path.exists():

--- a/deile/orchestration/pipeline/dispatch_resolver.py
+++ b/deile/orchestration/pipeline/dispatch_resolver.py
@@ -217,10 +217,14 @@ def resolve_stage_timeout_s(stage: str) -> int:
         try:
             v = int(raw_env.strip())
             if v <= 0:
-                raise ValueError(f"timeout must be > 0, got {v}")
+                raise ValueError(
+                    f"DEILE_PIPELINE_TIMEOUT_S_{stage.upper()} must be > 0, got {v!r}"
+                )
             return v
-        except ValueError:
-            raise
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid DEILE_PIPELINE_TIMEOUT_S_{stage.upper()}={raw_env!r}: {exc}"
+            ) from exc
 
     # 2. Per-stage settings (graceful)
     from deile.config.settings import get_settings  # lazy: avoids import cycle
@@ -268,10 +272,14 @@ def resolve_stage_max_retries(stage: str) -> int:
         try:
             v = int(raw_env.strip())
             if v < 0:
-                raise ValueError(f"retries must be >= 0, got {v}")
+                raise ValueError(
+                    f"DEILE_PIPELINE_RETRIES_{stage.upper()} must be >= 0, got {v!r}"
+                )
             return v
-        except ValueError:
-            raise
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid DEILE_PIPELINE_RETRIES_{stage.upper()}={raw_env!r}: {exc}"
+            ) from exc
 
     # 2. Per-stage settings (graceful)
     from deile.config.settings import get_settings  # lazy: avoids import cycle

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -873,7 +873,7 @@ async def review_one_new_issue(monitor: "PipelineMonitor") -> None:
         # paralelismo pelos workers em vez de uma issue por tick. ``available``
         # = max_parallel menos o total já em voo (crítica/refino/implement/PR).
         in_flight = await _count_total_in_flight(monitor)
-        available = max(0, max(1, monitor.config.max_parallel) - in_flight)
+        available = max(0, monitor.config.max_parallel - in_flight)
         if available <= 0:
             logger.debug(
                 "critique: todos os %d slots ocupados (%d em voo); skip novos claims",
@@ -979,7 +979,15 @@ async def _critique_one_issue(monitor: "PipelineMonitor", target) -> None:
         if await monitor.forge.claim_with_batch("issue", number) is None:
             return
     # Ownership tag lets the implement stage accept this issue without a batch.
-    await monitor.forge.add_labels("issue", number, [monitor.identity.ownership_label()])
+    try:
+        await monitor.forge.add_labels("issue", number, [monitor.identity.ownership_label()])
+    except GhCommandError as exc:
+        await _record_forge_error(
+            monitor, f"could not add ownership label to #{number} for critique", exc,
+        )
+        if multi:
+            await monitor.forge.clear_batch_label("issue", number)
+        return
     await monitor.notifier.issue_picked_up(number, target.title, target.url)
     try:
         await monitor.forge.transition_issue(
@@ -1174,7 +1182,7 @@ async def refine_one_issue(monitor: "PipelineMonitor") -> None:
     from deile.orchestration.pipeline.dispatch_ledger import DispatchLedger
     ledger = getattr(monitor.implementer, "_ledger", None)
     in_flight = await _count_total_in_flight(monitor)
-    available = max(0, max(1, monitor.config.max_parallel) - in_flight)
+    available = max(0, monitor.config.max_parallel - in_flight)
     if available <= 0:
         logger.debug(
             "refine: todos os %d slots ocupados (%d em voo); skip novos dispatches",
@@ -1775,7 +1783,14 @@ async def _count_in_flight_issues(monitor: "PipelineMonitor") -> int:
     for i in issues:
         if WORKFLOW_BLOCKED in i.labels or WORKFLOW_PR in i.labels:
             continue
-        if monitor._this_monitor_owns(i) or ownership_label in i.labels:
+        # Mirror the same predicate used by implement_one_reviewed_issue so
+        # in-flight count and dispatch eligibility are always consistent.
+        # Using OR here would count issues this monitor can never pick up
+        # (e.g. orphaned ~by:B labels after a shard migration), inflating
+        # in_flight and starving available_slots.
+        if monitor._this_monitor_owns(i) and (
+            i.batch_id is not None or ownership_label in i.labels
+        ):
             count += 1
     return count
 
@@ -1876,7 +1891,7 @@ async def implement_one_reviewed_issue(
     # that this monitor owns and that are not blocked / already with a PR.
     # These represent workers currently busy — subtract from max_parallel.
     in_flight = await _count_in_flight_issues(monitor)
-    available_slots = max(0, max(1, monitor.config.max_parallel) - in_flight)
+    available_slots = max(0, monitor.config.max_parallel - in_flight)
     if available_slots <= 0:
         logger.debug(
             "implement: all %d slots busy (%d in-flight); skipping new claims",
@@ -2674,7 +2689,9 @@ async def review_one_open_pr(monitor: "PipelineMonitor") -> None:
 
     # --- Pre-processing: invalidate ~review:concluida on PRs with new commits
     #     (issue #351 — invalidate-on-new-commit). Runs BEFORE candidate
-    #     selection so a freshly invalidated PR can be picked up this tick.
+    #     selection; the freshly invalidated PR will be picked up on the NEXT
+    #     tick because _candidate() checks pr.labels on the same in-memory
+    #     snapshot (which still carries REVIEW_CONCLUDED until the next fetch).
     for pr in prs:
         if (
             REVIEW_CONCLUDED in pr.labels
@@ -3364,10 +3381,17 @@ async def _reap_one(
         return
 
     # Libera: remove labels stale, adiciona ~attempt:(N+1) + label de retorno.
+    # If remove fails, skip add: applying to_label while from_label persists
+    # would leave the issue wearing two ~workflow: state labels simultaneously,
+    # violating the single-state invariant. Let the reaper retry next tick.
     try:
         await monitor.forge.remove_labels(kind, number, to_remove)
     except GhCommandError as exc:
-        logger.warning("reaper #%d: remove_labels failed: %s", number, exc)
+        logger.warning(
+            "reaper #%d: remove_labels failed: %s — skipping add_labels to preserve "
+            "label-state invariant; will retry next tick", number, exc,
+        )
+        return
     try:
         await monitor.forge.add_labels(
             kind, number, [to_label, make_attempt_label(next_attempt)],

--- a/deile/tests/orchestration/forge/test_has_bot_activity_login_validation.py
+++ b/deile/tests/orchestration/forge/test_has_bot_activity_login_validation.py
@@ -1,0 +1,70 @@
+"""Tests for login validation in ``_has_bot_activity_impl`` (issue #478 finding #4).
+
+Ensures that ``bot_login`` values that would inject into the jq filter are
+rejected via ``_GH_LOGIN_RE`` before any subprocess is invoked, and that a
+valid login follows the normal execution path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from deile.orchestration.forge.github_forge import GitHubForge
+
+
+@pytest.fixture
+def forge(github_config):
+    return GitHubForge(github_config)
+
+
+# ---------------------------------------------------------------------------
+# Malicious / invalid logins are short-circuited before subprocess execution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_login", [
+    'x") | true | select(true',      # jq injection
+    "",                               # empty string
+    "-startwithhyphen",              # invalid GitHub username (leading hyphen)
+    "endswithhyphen-",               # invalid GitHub username (trailing hyphen)
+    "a" * 40,                        # too long (>39 chars)
+    "has space",                     # space not allowed
+    "has@symbol",                    # @ not allowed
+])
+async def test_invalid_login_returns_false_without_subprocess(forge, bad_login):
+    """Malicious or invalid logins must return False without calling gh."""
+    with patch.object(forge, "_run", new_callable=AsyncMock) as mock_run:
+        result = await forge._has_bot_activity_impl("issue", 42, bad_login, 0)
+    assert result is False, f"Expected False for bad_login={bad_login!r}"
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Valid login follows the normal path (subprocess IS called)
+# ---------------------------------------------------------------------------
+
+async def test_valid_login_calls_subprocess(forge):
+    """A well-formed login must reach the subprocess layer."""
+    with patch.object(forge, "_run", new_callable=AsyncMock) as mock_run:
+        # Return (rc=1, "", "") so the function bottoms out as False
+        mock_run.return_value = (1, "", "")
+        result = await forge._has_bot_activity_impl("issue", 42, "deile-one", 0)
+    assert mock_run.called, "Expected subprocess to be invoked for a valid login"
+    assert result is False  # rc=1 → no match
+
+
+async def test_valid_login_with_activity_returns_true(forge):
+    """A login that matches activity timestamps returns True."""
+    import time
+    since = int(time.time()) - 100  # 100 seconds ago
+
+    async def _run_side_effect(*args, **kwargs):
+        # Simulate a comment created NOW (after since_ts)
+        import datetime
+        now_iso = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        return (0, now_iso, "")
+
+    with patch.object(forge, "_run", new_callable=AsyncMock, side_effect=_run_side_effect):
+        result = await forge._has_bot_activity_impl("issue", 42, "deile-one", since)
+    assert result is True

--- a/deile/tests/orchestration/pipeline/test_dispatch_resolver.py
+++ b/deile/tests/orchestration/pipeline/test_dispatch_resolver.py
@@ -288,3 +288,45 @@ def test_retries_settings_per_stage(monkeypatch):
     assert resolve_stage_max_retries("implement") == 5
     # Cleanup
     s.pipeline_retries_implement = None
+
+
+# ===== Error message context (issue #478 finding #5) =========================
+
+def test_timeout_env_invalid_message_contains_env_var_name(monkeypatch):
+    """ValueError message must include the env var name for traceability."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW", "foo")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    with pytest.raises(ValueError, match="DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW"):
+        resolve_stage_timeout_s("pr_review")
+
+
+def test_timeout_env_invalid_message_contains_raw_value(monkeypatch):
+    """ValueError message must include the raw value that caused the failure."""
+    _clear_timeout_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_TIMEOUT_S_CLASSIFY", "foo")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    with pytest.raises(ValueError, match="foo"):
+        resolve_stage_timeout_s("classify")
+
+
+def test_retries_env_invalid_message_contains_env_var_name(monkeypatch):
+    """ValueError message must include the env var name for traceability."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_IMPLEMENT", "bar")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    with pytest.raises(ValueError, match="DEILE_PIPELINE_RETRIES_IMPLEMENT"):
+        resolve_stage_max_retries("implement")
+
+
+def test_retries_env_invalid_message_contains_raw_value(monkeypatch):
+    """ValueError message must include the raw value that caused the failure."""
+    _clear_retries_env(monkeypatch)
+    monkeypatch.setenv("DEILE_PIPELINE_RETRIES_FOLLOW_UPS", "bar")
+    from deile.config.settings import reset_settings
+    reset_settings()
+    with pytest.raises(ValueError, match="bar"):
+        resolve_stage_max_retries("follow_ups")

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -3022,10 +3022,14 @@ async def sessions_command_handler(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": f"task_id {task_id} not found"}, status=404,
         )
+    from deile.security.secrets_scanner import SecretsScanner  # lazy: heavy import
+    _scanner = SecretsScanner()
+    raw_prompt = meta.get("full_prompt") or ""
+    redacted_prompt, _ = _scanner.redact_text(raw_prompt)
     return web.json_response({
         "task_id": task_id,
         "cmd": meta.get("command") or [],
-        "full_prompt": meta.get("full_prompt") or "",
+        "full_prompt": redacted_prompt,
         "stage": meta.get("stage"),
         "branch": meta.get("branch"),
         "model": meta.get("model"),

--- a/infra/k8s/worker_server.py
+++ b/infra/k8s/worker_server.py
@@ -116,7 +116,10 @@ def _read_auth_token() -> str:
 # é None) preservando todas as tasks em execução.
 _TASKS: Dict[str, Dict[str, Any]] = {}
 _TASKS_MAX: int = int(os.environ.get("DEILE_WORKER_MAX_INMEM_TASKS", "500"))
-_TASK_LOCK = asyncio.Lock()  # MVP: serialize CWD-coupled work
+# MVP: serialize CWD-coupled work within a single replica.
+# Real parallelism (max_parallel>1 in the pipeline) requires multiple
+# deile-worker replicas — one task runs at a time per replica.
+_TASK_LOCK = asyncio.Lock()
 _AGENT = None
 _AGENT_LOCK = asyncio.Lock()
 


### PR DESCRIPTION
Implements all 10 medium/low findings from `docs/audit/2026-05-29-pipeline-audit-findings.md` tracked in this issue.

## Changes

| Finding | File | Fix |
|---|---|---|
| **#4** `_has_bot_activity_impl` login validation absent | `github_forge.py` | Validate `bot_login` via `_GH_LOGIN_RE` before jq interpolation; return `False` on invalid |
| **#5** Timeout/retries env error loses context | `dispatch_resolver.py` | `ValueError` now includes the env var name and raw value |
| **#6** `max_parallel=0` silently becomes 1 | `stages.py` | Remove the inner `max(1, ...)` guard; `0` is now respected as "freeze dispatch" |
| **#7** Reaper applies `to_label` after `remove_labels` failure | `stages.py` | `return` early if `remove_labels` fails to preserve the single-state invariant |
| **#8** `_critique_one_issue` ownership label unguarded | `stages.py` | Wrap `add_labels(ownership)` in `try/except`; clear batch label on error |
| **#9** `_count_in_flight_issues` over-counts via OR predicate | `stages.py` | Align to AND predicate matching `implement_one_reviewed_issue` |
| **#10** Misleading comment "can be picked up this tick" | `stages.py` | Fix comment: invalidated PR is claimable on the **next** tick |
| **#11** `DispatchLedger._cache` never expires | `dispatch_ledger.py` | Document the single-instance invariant on `_load()` |
| **#12** `_TASK_LOCK` serialization hides `max_parallel` contract | `worker_server.py` | Expand comment: real parallelism requires multiple replicas |
| **#13** `full_prompt` exposed raw in sessions endpoint | `claude_worker_server.py` | Run through `SecretsScanner.redact_text` before returning |

## Tests

- New `test_has_bot_activity_login_validation.py` — 9 parametrized cases for #4
- Extended `test_dispatch_resolver.py` — 4 AC assertions verifying #5 error message content

All pre-existing tests pass (53 reaper/ledger/concurrency, 90 refinement/reconcile/regressions, 61 issue351/implementer).

Closes #478.