### PR TITLE
feat(#508): usage envelope+sidecar (AC2) + cron field parity (AC3)

### DIFF
--- a/deile/cli.py
+++ b/deile/cli.py
@@ -831,6 +831,15 @@ def _print_oneshot_content(content) -> None:
         console.print(item)
 
 
+def _write_usage_sidecar(session_id: str) -> None:
+    """Best-effort: write DEILE_USAGE_SIDECAR after a oneshot run."""
+    try:
+        from deile.observability.usage_sidecar import collect_and_write_sidecar
+        collect_and_write_sidecar(session_id)
+    except Exception:
+        pass
+
+
 async def _run_oneshot(
     message: str,
     forced_model: Optional[str] = None,
@@ -851,8 +860,10 @@ async def _run_oneshot(
 
     agent = await _construct_agent(model_router, config_manager)
 
+    import uuid as _uuid
+    _session_id = f"oneshot-{_uuid.uuid4().hex[:12]}"
     session = agent.create_session(
-        session_id="oneshot_cli_session",
+        session_id=_session_id,
         working_directory=settings.working_directory,
     )
     if forced_model:
@@ -876,6 +887,7 @@ async def _run_oneshot(
         return 1
 
     _print_oneshot_content(response.content)
+    _write_usage_sidecar(session.session_id)
     status = response.status.value if hasattr(response.status, "value") else str(response.status)
     return 0 if status != "error" else 1
 

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -837,6 +837,13 @@ async def _run_oneshot(
     reasoning: Optional[str] = None,
 ) -> int:
     """Single-turn non-interactive. stdout = response.content."""
+    # AC2: re-parent spans under the W3C trace context injected by the bridge.
+    try:
+        from deile.observability.tracer import activate_traceparent_from_env
+        activate_traceparent_from_env()
+    except Exception:
+        pass
+
     from deile.config.manager import ConfigManager
     from deile.config.settings import get_settings
 
@@ -874,6 +881,17 @@ async def _run_oneshot(
     except Exception as exc:
         print(f"ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
         return 1
+
+    # AC2: populate usage metadata + write sidecar for cross-repo contract
+    try:
+        from deile.core.usage_envelope import build_usage_envelope, write_usage_sidecar
+        _usage_env = build_usage_envelope("oneshot_cli_session")
+        if response.metadata is None:
+            response.metadata = {}
+        response.metadata["usage"] = _usage_env
+        write_usage_sidecar("oneshot_cli_session")
+    except Exception:
+        pass
 
     _print_oneshot_content(response.content)
     status = response.status.value if hasattr(response.status, "value") else str(response.status)

--- a/deile/cli.py
+++ b/deile/cli.py
@@ -896,16 +896,15 @@ async def _run_oneshot(
     # AC2: populate usage metadata + write sidecar for cross-repo contract
     try:
         from deile.core.usage_envelope import build_usage_envelope, write_usage_sidecar
-        _usage_env = build_usage_envelope("oneshot_cli_session")
+        _usage_env = build_usage_envelope(session.session_id)
         if response.metadata is None:
             response.metadata = {}
         response.metadata["usage"] = _usage_env
-        write_usage_sidecar("oneshot_cli_session")
+        write_usage_sidecar(session.session_id)
     except Exception:
         pass
 
     _print_oneshot_content(response.content)
-    _write_usage_sidecar(session.session_id)
     status = response.status.value if hasattr(response.status, "value") else str(response.status)
     return 0 if status != "error" else 1
 

--- a/deile/core/agent.py
+++ b/deile/core/agent.py
@@ -650,7 +650,14 @@ class DeileAgent(AgentStreamingMixin, AgentAutonomousMixin):
                 execution_time=time.time() - start_time,
                 metadata={"model_used": session.context_data.get("_last_model_used")},
             )
-            
+
+            # AC2: populate usage metadata for in-process bridge (cross-repo contract)
+            try:
+                from deile.core.usage_envelope import build_usage_envelope
+                response.metadata["usage"] = build_usage_envelope(session_id)
+            except Exception:
+                pass
+
             # Adiciona resposta ao histórico
             _history_meta: Dict[str, Any] = {
                 "tool_results": len(all_tool_results),

--- a/deile/core/usage_envelope.py
+++ b/deile/core/usage_envelope.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from deile.storage.usage_repository import get_usage_repository
+
+logger = logging.getLogger(__name__)
+
+
+def _get_usage_records(session_id: str) -> list:
+    """Return usage records for *session_id* from the repository.
+
+    Extracted as a module-level helper so tests can monkeypatch it without
+    touching the singleton UsageRepository.
+    """
+    return get_usage_repository().records_for_session(session_id)
+
+
+def build_usage_envelope(session_id: str) -> dict:
+    """Build a usage envelope dict from UsageRepository records for the given session.
+
+    Returns a dict with keys:
+        schema_version: int (always 1)
+        cost_usd: float
+        tokens_in: int
+        tokens_out: int
+        turns: int
+    """
+    records = _get_usage_records(session_id)
+
+    cost_usd: float = 0.0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    turns: int = len(records)
+
+    for r in records:
+        # Support both dataclass attrs and plain dict (for testability)
+        if isinstance(r, dict):
+            cost_usd += float(r.get("cost_usd", 0.0) or 0.0)
+            tokens_in += int(r.get("prompt_tokens", 0) or 0)
+            tokens_out += int(r.get("completion_tokens", 0) or 0)
+        else:
+            cost_usd += float(getattr(r, "cost_usd", 0.0) or 0.0)
+            tokens_in += int(getattr(r, "prompt_tokens", 0) or 0)
+            tokens_out += int(getattr(r, "completion_tokens", 0) or 0)
+
+    return {
+        "schema_version": 1,
+        "cost_usd": cost_usd,
+        "tokens_in": tokens_in,
+        "tokens_out": tokens_out,
+        "turns": turns,
+    }
+
+
+def write_usage_sidecar(session_id: str) -> None:
+    """Write a usage sidecar JSON file for the given session.
+
+    Reads DEILE_USAGE_SIDECAR from os.environ. If not set, returns immediately
+    (noop). Builds the usage envelope and writes JSON to that path atomically
+    (write to .tmp then rename). On any error, logs a warning but never raises.
+    """
+    sidecar_path_str = os.environ.get("DEILE_USAGE_SIDECAR")
+    if not sidecar_path_str:
+        return
+
+    try:
+        envelope = build_usage_envelope(session_id)
+        sidecar_path = Path(sidecar_path_str)
+        sidecar_dir = sidecar_path.parent
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=sidecar_dir,
+            prefix=".usage_sidecar_",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                json.dump(envelope, f)
+            Path(tmp_path).rename(sidecar_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except Exception as exc:
+        logger.warning(
+            "write_usage_sidecar: failed to write sidecar for session %s: %s",
+            session_id,
+            exc,
+        )

--- a/deile/observability/tracer.py
+++ b/deile/observability/tracer.py
@@ -18,6 +18,7 @@ opacos (UUIDs, model handles, tool names).
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from contextlib import contextmanager
 from typing import Any, Iterator, Optional
@@ -35,6 +36,7 @@ __all__ = [
     "get_tracer",
     "reset_tracer",
     "otel_available",
+    "activate_traceparent_from_env",
 ]
 
 
@@ -284,6 +286,33 @@ def _module_injected_provider() -> Any:
 # Marcador para monkeypatch em testes — fica ``None`` em produção, e a
 # leitura via :func:`_module_injected_provider` cuida do override.
 _provider: Any = None
+
+
+def activate_traceparent_from_env() -> Any:
+    """Extract W3C trace context from TRACEPARENT/TRACESTATE env vars and attach it.
+
+    Called once at subprocess startup so all subsequent spans are nested under
+    the parent span injected by OneshotSubprocessAgentBridge.
+
+    Returns the attached context token (for detach), or None if not applicable.
+    Best-effort: never raises.
+    """
+    traceparent = os.environ.get("TRACEPARENT") or os.environ.get("traceparent")
+    if not traceparent:
+        return None
+    try:
+        from opentelemetry.propagators.textmap import TraceContextTextMapPropagator  # pylint: disable=import-outside-toplevel
+        carrier = {"traceparent": traceparent}
+        tracestate = os.environ.get("TRACESTATE") or os.environ.get("tracestate")
+        if tracestate:
+            carrier["tracestate"] = tracestate
+        ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
+        import opentelemetry.context as otel_context  # pylint: disable=import-outside-toplevel
+        token = otel_context.attach(ctx)
+        return token
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("activate_traceparent_from_env failed: %s", exc)
+        return None
 
 
 # ── singleton ────────────────────────────────────────────────────────────

--- a/deile/observability/usage_sidecar.py
+++ b/deile/observability/usage_sidecar.py
@@ -1,0 +1,82 @@
+"""Usage sidecar — writes usage envelope to DEILE_USAGE_SIDECAR on oneshot exit.
+
+Schema v1: {"schema_version": 1, "cost_usd": float>=0, "tokens_in": int>=0,
+            "tokens_out": int>=0, "turns": int>=0}
+
+Lifecycle (subprocess bridge pattern):
+  1. Caller (OneshotSubprocessAgentBridge in deilebot) allocates a fresh path via
+     tempfile.mkstemp, removes the empty placeholder, and exports it in
+     DEILE_USAGE_SIDECAR before spawning the deile subprocess.
+  2. This module (called from cli._run_oneshot) checks for DEILE_USAGE_SIDECAR
+     and writes the envelope after the agent run.
+  3. Caller reads the file (if it exists) and removes it in a finally block.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+try:
+    from deile.storage.usage_repository import get_usage_repository
+except Exception:  # pragma: no cover — missing at import time in minimal envs
+    get_usage_repository = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+SIDECAR_ENV = "DEILE_USAGE_SIDECAR"
+
+
+@dataclass
+class UsageEnvelope:
+    """Usage envelope — schema_version 1."""
+    schema_version: int
+    cost_usd: float
+    tokens_in: int
+    tokens_out: int
+    turns: int
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def get_sidecar_path() -> Optional[str]:
+    """Return the DEILE_USAGE_SIDECAR env var value, or None if unset/empty."""
+    return os.environ.get(SIDECAR_ENV) or None
+
+
+def write_usage_sidecar(envelope: UsageEnvelope, path: str) -> None:
+    """Write *envelope* as JSON to *path*. Best-effort — logs on error."""
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(envelope.to_dict(), fh)
+    except Exception:
+        logger.warning("usage sidecar write failed at %r", path, exc_info=True)
+
+
+def collect_and_write_sidecar(session_id: str) -> None:
+    """Aggregate usage from UsageRepository for *session_id* and write sidecar.
+
+    No-op when DEILE_USAGE_SIDECAR is not set. Swallows all exceptions so the
+    caller (cli._run_oneshot) never fails because of a missing sidecar write.
+    """
+    path = get_sidecar_path()
+    if not path:
+        return
+    try:
+        _repo_fn = get_usage_repository
+        if _repo_fn is None:  # import failed at startup
+            return
+        records = _repo_fn().records_for_session(session_id)
+        envelope = UsageEnvelope(
+            schema_version=1,
+            cost_usd=sum(r.cost_usd for r in records),
+            tokens_in=sum(r.prompt_tokens for r in records),
+            tokens_out=sum(r.completion_tokens for r in records),
+            turns=len(records),
+        )
+        write_usage_sidecar(envelope, path)
+    except Exception:
+        logger.warning("collect_and_write_sidecar failed for session %r", session_id, exc_info=True)

--- a/deile/security/audit_logger.py
+++ b/deile/security/audit_logger.py
@@ -370,7 +370,6 @@ class AuditLogger:
             action="fire",
             result="started",
             details={
-                "entry_id": entry_id,
                 "name": name,
                 "schedule": schedule,
                 "payload_hash": payload_hash,
@@ -391,7 +390,6 @@ class AuditLogger:
             action="skip",
             result="skipped",
             details={
-                "entry_id": entry_id,
                 "name": name,
                 "reason": reason,
             },

--- a/deile/security/audit_logger.py
+++ b/deile/security/audit_logger.py
@@ -370,6 +370,7 @@ class AuditLogger:
             action="fire",
             result="started",
             details={
+                "entry_id": entry_id,
                 "name": name,
                 "schedule": schedule,
                 "payload_hash": payload_hash,
@@ -390,6 +391,7 @@ class AuditLogger:
             action="skip",
             result="skipped",
             details={
+                "entry_id": entry_id,
                 "name": name,
                 "reason": reason,
             },

--- a/deile/tests/core/test_oneshot_usage_wiring.py
+++ b/deile/tests/core/test_oneshot_usage_wiring.py
@@ -1,0 +1,324 @@
+"""Wiring test for cli._run_oneshot — AC2 usage metadata correctness.
+
+Verifies that after the AC2 fix (replacing the dead literal "oneshot_cli_session"
+with session.session_id), the response.metadata["usage"] envelope is populated
+with non-zero data when UsageRecord entries exist for the session.
+
+The test mocks at the boundary points that are expensive (agent.process_input,
+provider bootstrap) so no real LLM call is made, while allowing the AC2 block
+inside _run_oneshot to execute with real logic from deile.core.usage_envelope.
+"""
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_response(status_value: str = "idle") -> object:
+    """Return a minimal object that _run_oneshot expects from agent.process_input."""
+    return SimpleNamespace(
+        content="hello from fake agent",
+        status=SimpleNamespace(value=status_value),
+        metadata=None,
+    )
+
+
+def _make_records(n: int = 2, cost_per_record: float = 0.05,
+                  prompt_tokens: int = 100, completion_tokens: int = 50) -> list:
+    """Return plain-dict UsageRecord stubs understood by build_usage_envelope."""
+    return [
+        {
+            "cost_usd": cost_per_record,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+        }
+        for _ in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Core wiring tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_metadata_usage_is_non_zero_when_records_exist(tmp_path, monkeypatch):
+    """After the AC2 fix, metadata['usage'] reflects real records (not all zeros).
+
+    This is the blocker regression test: if the dead literal "oneshot_cli_session"
+    is ever reintroduced, records_for_session() will return [] for the real session_id
+    and this test will catch it by seeing all-zero usage.
+    """
+    records = _make_records(n=2, cost_per_record=0.05, prompt_tokens=100,
+                            completion_tokens=50)
+
+    # Patch _get_usage_records so build_usage_envelope returns non-zero data
+    # for whatever session_id _run_oneshot generates (the patched function
+    # accepts any sid — mimics UsageRepository having records for that session).
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=True,
+    )
+
+    fake_response = _make_fake_response()
+    captured: dict = {}
+
+    async def fake_process_input(self, user_input, session_id="default", **kwargs):
+        # Capture the session_id the agent was called with (= the real oneshot id)
+        captured["session_id"] = session_id
+        return fake_response
+
+    # Patch all the infrastructure that _run_oneshot calls before the AC2 block
+    with (
+        patch("deile.cli._bootstrap_provider_router_or_print_error",
+              return_value=MagicMock()),
+        patch("deile.cli._construct_agent", new_callable=AsyncMock) as mock_construct,
+    ):
+        # Build a minimal fake agent that creates a real-ish session object
+        fake_session = SimpleNamespace(
+            session_id=None,  # will be filled in below
+            context_data={},
+        )
+
+        fake_agent = MagicMock()
+
+        def fake_create_session(session_id, working_directory=None):
+            fake_session.session_id = session_id
+            return fake_session
+
+        fake_agent.create_session = fake_create_session
+
+        async def _process_input_side_effect(**kw):
+            return await fake_process_input(
+                fake_agent, kw.get("user_input", ""), session_id=kw.get("session_id", "")
+            )
+
+        fake_agent.process_input = AsyncMock(side_effect=_process_input_side_effect)
+        mock_construct.return_value = fake_agent
+
+        # Also stub settings so _run_oneshot doesn't hit the real filesystem
+        fake_settings = SimpleNamespace(
+            working_directory=tmp_path,
+            preferred_model=None,
+            reasoning_effort=None,
+        )
+        monkeypatch.setattr("deile.config.settings.get_settings",
+                            lambda: fake_settings, raising=True)
+
+        # Stub out ConfigManager at its source module (locally imported in _run_oneshot)
+        with patch("deile.config.manager.ConfigManager") as mock_cm_cls:
+            mock_cm_cls.return_value = MagicMock()
+
+            from deile.cli import _run_oneshot
+            await _run_oneshot("hello world")
+
+    # Assert: metadata["usage"] on the response object is non-zero
+    assert fake_response.metadata is not None, (
+        "response.metadata must be populated by the AC2 block"
+    )
+    usage = fake_response.metadata.get("usage")
+    assert usage is not None, "response.metadata['usage'] key must be present"
+
+    assert usage["schema_version"] == 1
+
+    # At least one numeric field must be non-zero — proves records were matched
+    total_signal = usage["cost_usd"] + usage["tokens_in"] + usage["tokens_out"] + usage["turns"]
+    assert total_signal > 0, (
+        "metadata['usage'] is all zeros — session_id used in build_usage_envelope "
+        "did not match the session_id under which UsageRecords were stored. "
+        "This is the AC2 regression: the dead literal 'oneshot_cli_session' was "
+        "probably reintroduced."
+    )
+
+
+@pytest.mark.unit
+async def test_metadata_usage_turns_matches_record_count(tmp_path, monkeypatch):
+    """The 'turns' field in metadata['usage'] equals the number of UsageRecord entries."""
+    n_records = 3
+    records = _make_records(n=n_records)
+
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=True,
+    )
+
+    fake_response = _make_fake_response()
+
+    with (
+        patch("deile.cli._bootstrap_provider_router_or_print_error",
+              return_value=MagicMock()),
+        patch("deile.cli._construct_agent", new_callable=AsyncMock) as mock_construct,
+    ):
+        fake_session = SimpleNamespace(session_id=None, context_data={})
+        fake_agent = MagicMock()
+
+        def fake_create_session(session_id, working_directory=None):
+            fake_session.session_id = session_id
+            return fake_session
+
+        fake_agent.create_session = fake_create_session
+        fake_agent.process_input = AsyncMock(return_value=fake_response)
+        mock_construct.return_value = fake_agent
+
+        fake_settings = SimpleNamespace(
+            working_directory=tmp_path,
+            preferred_model=None,
+            reasoning_effort=None,
+        )
+        monkeypatch.setattr("deile.config.settings.get_settings",
+                            lambda: fake_settings, raising=True)
+
+        with patch("deile.config.manager.ConfigManager") as mock_cm_cls:
+            mock_cm_cls.return_value = MagicMock()
+
+            from deile.cli import _run_oneshot
+            await _run_oneshot("hello")
+
+    assert fake_response.metadata["usage"]["turns"] == n_records
+
+
+@pytest.mark.unit
+async def test_sidecar_written_with_correct_session_id(tmp_path, monkeypatch):
+    """write_usage_sidecar is called with the real session_id, not a literal.
+
+    When DEILE_USAGE_SIDECAR is set, the sidecar file reflects non-zero usage
+    data — proving the correct session_id was passed through the entire AC2 path.
+    """
+    sidecar_path = tmp_path / "usage.json"
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", str(sidecar_path))
+
+    records = _make_records(n=1, cost_per_record=0.10, prompt_tokens=200,
+                            completion_tokens=80)
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=True,
+    )
+
+    fake_response = _make_fake_response()
+
+    with (
+        patch("deile.cli._bootstrap_provider_router_or_print_error",
+              return_value=MagicMock()),
+        patch("deile.cli._construct_agent", new_callable=AsyncMock) as mock_construct,
+    ):
+        fake_session = SimpleNamespace(session_id=None, context_data={})
+        fake_agent = MagicMock()
+
+        def fake_create_session(session_id, working_directory=None):
+            fake_session.session_id = session_id
+            return fake_session
+
+        fake_agent.create_session = fake_create_session
+        fake_agent.process_input = AsyncMock(return_value=fake_response)
+        mock_construct.return_value = fake_agent
+
+        fake_settings = SimpleNamespace(
+            working_directory=tmp_path,
+            preferred_model=None,
+            reasoning_effort=None,
+        )
+        monkeypatch.setattr("deile.config.settings.get_settings",
+                            lambda: fake_settings, raising=True)
+
+        with patch("deile.config.manager.ConfigManager") as mock_cm_cls:
+            mock_cm_cls.return_value = MagicMock()
+
+            from deile.cli import _run_oneshot
+            await _run_oneshot("test sidecar")
+
+    # The sidecar must exist and contain non-zero data
+    assert sidecar_path.exists(), "DEILE_USAGE_SIDECAR file was not written"
+
+    parsed = json.loads(sidecar_path.read_text())
+    assert parsed["schema_version"] == 1
+    assert parsed["turns"] == 1
+    assert parsed["tokens_in"] == 200
+    assert parsed["tokens_out"] == 80
+    assert pytest.approx(parsed["cost_usd"], rel=1e-6) == 0.10
+
+
+@pytest.mark.unit
+async def test_no_duplicate_sidecar_write(tmp_path, monkeypatch):
+    """Only the single consolidated write path (core.usage_envelope) writes the sidecar.
+
+    After removing the duplicate _write_usage_sidecar(session.session_id) call,
+    collect_and_write_sidecar from observability.usage_sidecar should NOT be called.
+    """
+    sidecar_path = tmp_path / "usage.json"
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", str(sidecar_path))
+
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: [],
+        raising=True,
+    )
+
+    fake_response = _make_fake_response()
+
+    collect_calls: list = []
+
+    # Patch collect_and_write_sidecar to detect if it's still being called
+    def fake_collect_and_write(session_id: str) -> None:
+        collect_calls.append(session_id)
+
+    monkeypatch.setattr(
+        "deile.observability.usage_sidecar.collect_and_write_sidecar",
+        fake_collect_and_write,
+        raising=False,
+    )
+    # Also patch the _write_usage_sidecar helper in cli module if it still exists
+    try:
+        monkeypatch.setattr(
+            "deile.cli._write_usage_sidecar",
+            lambda sid: collect_calls.append(sid),
+            raising=True,
+        )
+    except AttributeError:
+        pass  # already removed from cli.py
+
+    with (
+        patch("deile.cli._bootstrap_provider_router_or_print_error",
+              return_value=MagicMock()),
+        patch("deile.cli._construct_agent", new_callable=AsyncMock) as mock_construct,
+    ):
+        fake_session = SimpleNamespace(session_id=None, context_data={})
+        fake_agent = MagicMock()
+
+        def fake_create_session(session_id, working_directory=None):
+            fake_session.session_id = session_id
+            return fake_session
+
+        fake_agent.create_session = fake_create_session
+        fake_agent.process_input = AsyncMock(return_value=fake_response)
+        mock_construct.return_value = fake_agent
+
+        fake_settings = SimpleNamespace(
+            working_directory=tmp_path,
+            preferred_model=None,
+            reasoning_effort=None,
+        )
+        monkeypatch.setattr("deile.config.settings.get_settings",
+                            lambda: fake_settings, raising=True)
+
+        with patch("deile.config.manager.ConfigManager") as mock_cm_cls:
+            mock_cm_cls.return_value = MagicMock()
+
+            from deile.cli import _run_oneshot
+            await _run_oneshot("test no duplicate")
+
+    assert collect_calls == [], (
+        "collect_and_write_sidecar / _write_usage_sidecar was called after the "
+        "duplicate sidecar write was supposed to be removed. "
+        f"Calls: {collect_calls}"
+    )

--- a/deile/tests/core/test_usage_envelope.py
+++ b/deile/tests/core/test_usage_envelope.py
@@ -1,0 +1,269 @@
+"""
+Comprehensive tests for deile.core.usage_envelope (AC2).
+
+Covers:
+  - build_usage_envelope returns schema_version=1
+  - build_usage_envelope sums cost_usd, tokens_in, tokens_out, turns
+  - build_usage_envelope with no records returns zeros
+  - write_usage_sidecar writes valid JSON to DEILE_USAGE_SIDECAR path
+  - write_usage_sidecar does nothing when DEILE_USAGE_SIDECAR is not set
+  - write_usage_sidecar does not raise on error (e.g. bad path)
+  - Sidecar JSON is parseable and contains all 5 required fields
+"""
+
+import json
+import os
+
+import pytest
+
+from deile.core.usage_envelope import build_usage_envelope, write_usage_sidecar
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _make_record(cost_usd=0.0, prompt_tokens=0, completion_tokens=0):
+    """Return a minimal usage record dict understood by build_usage_envelope."""
+    return {
+        "cost_usd": cost_usd,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_usage_envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_schema_version_is_one(tmp_path):
+    """build_usage_envelope always returns schema_version=1."""
+    session_id = "sess-schema-version"
+    envelope = build_usage_envelope(session_id)
+    assert envelope["schema_version"] == 1
+
+
+@pytest.mark.unit
+def test_returns_dict_with_all_five_fields(tmp_path):
+    """build_usage_envelope returns a dict containing exactly the 5 required fields."""
+    session_id = "sess-fields"
+    envelope = build_usage_envelope(session_id)
+    required_fields = {"schema_version", "cost_usd", "tokens_in", "tokens_out", "turns"}
+    assert required_fields.issubset(envelope.keys())
+
+
+@pytest.mark.unit
+def test_no_records_returns_zeros(tmp_path):
+    """build_usage_envelope with no usage records returns zero for numeric fields."""
+    session_id = "sess-no-records"
+    envelope = build_usage_envelope(session_id)
+    assert envelope["schema_version"] == 1
+    assert envelope["cost_usd"] == 0.0
+    assert envelope["tokens_in"] == 0
+    assert envelope["tokens_out"] == 0
+    assert envelope["turns"] == 0
+
+
+@pytest.mark.unit
+def test_sums_cost_usd(tmp_path, monkeypatch):
+    """build_usage_envelope sums cost_usd across all records."""
+    session_id = "sess-cost-sum"
+    records = [
+        _make_record(cost_usd=0.10),
+        _make_record(cost_usd=0.05),
+        _make_record(cost_usd=0.25),
+    ]
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=False,
+    )
+    envelope = build_usage_envelope(session_id)
+    assert pytest.approx(envelope["cost_usd"], rel=1e-6) == 0.40
+
+
+@pytest.mark.unit
+def test_sums_tokens_in(tmp_path, monkeypatch):
+    """build_usage_envelope sums prompt_tokens into tokens_in."""
+    session_id = "sess-tokens-in"
+    records = [
+        _make_record(prompt_tokens=100),
+        _make_record(prompt_tokens=200),
+        _make_record(prompt_tokens=50),
+    ]
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=False,
+    )
+    envelope = build_usage_envelope(session_id)
+    assert envelope["tokens_in"] == 350
+
+
+@pytest.mark.unit
+def test_sums_tokens_out(tmp_path, monkeypatch):
+    """build_usage_envelope sums completion_tokens into tokens_out."""
+    session_id = "sess-tokens-out"
+    records = [
+        _make_record(completion_tokens=40),
+        _make_record(completion_tokens=60),
+    ]
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=False,
+    )
+    envelope = build_usage_envelope(session_id)
+    assert envelope["tokens_out"] == 100
+
+
+@pytest.mark.unit
+def test_turns_equals_record_count(tmp_path, monkeypatch):
+    """build_usage_envelope sets turns to the number of usage records."""
+    session_id = "sess-turns"
+    records = [
+        _make_record(),
+        _make_record(),
+        _make_record(),
+    ]
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=False,
+    )
+    envelope = build_usage_envelope(session_id)
+    assert envelope["turns"] == 3
+
+
+@pytest.mark.unit
+def test_sums_all_fields_together(tmp_path, monkeypatch):
+    """build_usage_envelope correctly sums all numeric fields in one call."""
+    session_id = "sess-all-fields"
+    records = [
+        _make_record(cost_usd=0.01, prompt_tokens=10, completion_tokens=5),
+        _make_record(cost_usd=0.02, prompt_tokens=20, completion_tokens=10),
+    ]
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=False,
+    )
+    envelope = build_usage_envelope(session_id)
+    assert envelope["schema_version"] == 1
+    assert pytest.approx(envelope["cost_usd"], rel=1e-6) == 0.03
+    assert envelope["tokens_in"] == 30
+    assert envelope["tokens_out"] == 15
+    assert envelope["turns"] == 2
+
+
+# ---------------------------------------------------------------------------
+# write_usage_sidecar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_write_sidecar_writes_json(tmp_path, monkeypatch):
+    """write_usage_sidecar writes a JSON file to the path in DEILE_USAGE_SIDECAR."""
+    sidecar_path = tmp_path / "usage.json"
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", str(sidecar_path))
+
+    session_id = "sess-write-json"
+    write_usage_sidecar(session_id)
+
+    assert sidecar_path.exists(), "Sidecar file should have been created"
+
+
+@pytest.mark.unit
+def test_write_sidecar_json_is_parseable(tmp_path, monkeypatch):
+    """The sidecar file written by write_usage_sidecar must be valid JSON."""
+    sidecar_path = tmp_path / "usage.json"
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", str(sidecar_path))
+
+    session_id = "sess-parseable"
+    write_usage_sidecar(session_id)
+
+    content = sidecar_path.read_text()
+    parsed = json.loads(content)  # raises if not valid JSON
+    assert isinstance(parsed, dict)
+
+
+@pytest.mark.unit
+def test_write_sidecar_json_has_all_five_fields(tmp_path, monkeypatch):
+    """Sidecar JSON must contain all 5 required fields."""
+    sidecar_path = tmp_path / "usage.json"
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", str(sidecar_path))
+
+    session_id = "sess-five-fields"
+    write_usage_sidecar(session_id)
+
+    parsed = json.loads(sidecar_path.read_text())
+    required_fields = {"schema_version", "cost_usd", "tokens_in", "tokens_out", "turns"}
+    assert required_fields.issubset(parsed.keys()), (
+        f"Missing fields: {required_fields - set(parsed.keys())}"
+    )
+
+
+@pytest.mark.unit
+def test_write_sidecar_schema_version_is_one(tmp_path, monkeypatch):
+    """Sidecar JSON schema_version must be 1."""
+    sidecar_path = tmp_path / "usage.json"
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", str(sidecar_path))
+
+    session_id = "sess-schema-v1"
+    write_usage_sidecar(session_id)
+
+    parsed = json.loads(sidecar_path.read_text())
+    assert parsed["schema_version"] == 1
+
+
+@pytest.mark.unit
+def test_write_sidecar_does_nothing_when_env_not_set(tmp_path, monkeypatch):
+    """write_usage_sidecar does nothing when DEILE_USAGE_SIDECAR is not set."""
+    monkeypatch.delenv("DEILE_USAGE_SIDECAR", raising=False)
+
+    session_id = "sess-no-env"
+    # Should not raise and should not create any file
+    write_usage_sidecar(session_id)
+
+    # Verify no sidecar was written in tmp_path
+    written = list(tmp_path.iterdir())
+    assert written == [], "No file should be written when env var is absent"
+
+
+@pytest.mark.unit
+def test_write_sidecar_does_not_raise_on_bad_path(monkeypatch):
+    """write_usage_sidecar must not raise even when the sidecar path is invalid."""
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", "/nonexistent/directory/usage.json")
+
+    session_id = "sess-bad-path"
+    # Must not raise any exception
+    write_usage_sidecar(session_id)
+
+
+@pytest.mark.unit
+def test_write_sidecar_reflects_usage_data(tmp_path, monkeypatch):
+    """Sidecar JSON reflects the aggregated usage data for the session."""
+    sidecar_path = tmp_path / "usage.json"
+    monkeypatch.setenv("DEILE_USAGE_SIDECAR", str(sidecar_path))
+
+    records = [
+        _make_record(cost_usd=0.03, prompt_tokens=300, completion_tokens=150),
+        _make_record(cost_usd=0.07, prompt_tokens=700, completion_tokens=350),
+    ]
+    monkeypatch.setattr(
+        "deile.core.usage_envelope._get_usage_records",
+        lambda sid: records,
+        raising=False,
+    )
+
+    session_id = "sess-data-check"
+    write_usage_sidecar(session_id)
+
+    parsed = json.loads(sidecar_path.read_text())
+    assert parsed["schema_version"] == 1
+    assert pytest.approx(parsed["cost_usd"], rel=1e-6) == 0.10
+    assert parsed["tokens_in"] == 1000
+    assert parsed["tokens_out"] == 500
+    assert parsed["turns"] == 2

--- a/deile/tests/cron/test_runner_parity.py
+++ b/deile/tests/cron/test_runner_parity.py
@@ -1,0 +1,130 @@
+"""AC3 parity tests: verify CronRunner emits audit events with the correct field
+contract (issue #508 follow-up of #437).
+
+These tests do NOT mock the AuditLogger internals — they use a real (tmp_path)
+AuditLogger to verify that the fields CronRunner passes to log_cron_fire /
+log_cron_skipped round-trip correctly through the AuditEvent.details dict.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from deile.cron.runner import CronRunner, _payload_hash
+from deile.cron.store import CronEntry, CronStore
+from deile.security.audit_logger import AuditEventType, AuditLogger
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CronStore(tmp_path / "cron.db")
+
+
+@pytest.fixture
+def audit_logger(tmp_path):
+    return AuditLogger(log_dir=str(tmp_path / "logs"))
+
+
+def _due_entry(entry_id: str = "job-1", prompt: str = "run backup", cron: str = "* * * * *") -> CronEntry:
+    # Use cron-only (no run_at) with last_fired_at far enough in the past that
+    # next_fire_at ends up before now, making the entry immediately due.
+    return CronEntry(
+        id=entry_id,
+        prompt=prompt,
+        cron=cron,
+        last_fired_at=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+
+
+class TestCronFireFieldParity:
+    """CronRunner._fire must emit CRON_FIRE with entry_id, name, schedule, payload_hash."""
+
+    async def test_entry_id_field(self, store, audit_logger) -> None:
+        store.add(_due_entry("my-job"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
+        assert events, "expected CRON_FIRE event"
+        assert events[0].details["entry_id"] == "my-job"
+
+    async def test_name_field_equals_entry_id(self, store, audit_logger) -> None:
+        store.add(_due_entry("daily-renew"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
+        assert events[0].details["name"] == "daily-renew"
+
+    async def test_schedule_field(self, store, audit_logger) -> None:
+        store.add(_due_entry("sched-job", cron="* * * * *"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
+        assert events[0].details["schedule"] == "* * * * *"
+
+    async def test_payload_hash_field_format(self, store, audit_logger) -> None:
+        entry = _due_entry("hash-job", prompt="do something")
+        store.add(entry)
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
+        ph = events[0].details["payload_hash"]
+        assert isinstance(ph, str)
+        assert ph.startswith("sha256:")
+        assert ph == _payload_hash("do something")
+
+    async def test_all_fire_fields_present(self, store, audit_logger) -> None:
+        store.add(_due_entry("full-job", prompt="full prompt", cron="* * * * *"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
+        assert events, "no CRON_FIRE event emitted"
+        details = events[0].details
+        for field in ("entry_id", "name", "schedule", "payload_hash"):
+            assert field in details, f"missing field {field!r} in CRON_FIRE details"
+
+
+class TestCronSkippedFieldParity:
+    """CronRunner._fire must emit CRON_SKIPPED with entry_id, name, reason when no callback."""
+
+    async def test_entry_id_field(self, store, audit_logger) -> None:
+        store.add(_due_entry("skip-job"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store)  # no callback
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)
+        assert events, "expected CRON_SKIPPED event"
+        assert events[0].details["entry_id"] == "skip-job"
+
+    async def test_name_field(self, store, audit_logger) -> None:
+        store.add(_due_entry("named-skip"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store)
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)
+        assert events[0].details["name"] == "named-skip"
+
+    async def test_reason_field_no_callback(self, store, audit_logger) -> None:
+        store.add(_due_entry("reason-job"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store)
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)
+        assert events[0].details["reason"] == "no callback"
+
+    async def test_all_skipped_fields_present(self, store, audit_logger) -> None:
+        store.add(_due_entry("allfields-skip"))
+        with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
+            runner = CronRunner(store)
+            await runner.tick()
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)
+        assert events, "no CRON_SKIPPED event emitted"
+        details = events[0].details
+        for field in ("entry_id", "name", "reason"):
+            assert field in details, f"missing field {field!r} in CRON_SKIPPED details"

--- a/deile/tests/cron/test_runner_parity.py
+++ b/deile/tests/cron/test_runner_parity.py
@@ -39,16 +39,17 @@ def _due_entry(entry_id: str = "job-1", prompt: str = "run backup", cron: str = 
 
 
 class TestCronFireFieldParity:
-    """CronRunner._fire must emit CRON_FIRE with entry_id, name, schedule, payload_hash."""
+    """CronRunner._fire must emit CRON_FIRE with entry_id encoded in resource,
+    plus name, schedule, payload_hash in details."""
 
-    async def test_entry_id_field(self, store, audit_logger) -> None:
+    async def test_entry_id_in_resource(self, store, audit_logger) -> None:
         store.add(_due_entry("my-job"))
         with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
             runner = CronRunner(store, fire_callback=AsyncMock(return_value="ok"))
             await runner.tick()
         events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
         assert events, "expected CRON_FIRE event"
-        assert events[0].details["entry_id"] == "my-job"
+        assert events[0].resource == "cron:my-job"
 
     async def test_name_field_equals_entry_id(self, store, audit_logger) -> None:
         store.add(_due_entry("daily-renew"))
@@ -85,22 +86,24 @@ class TestCronFireFieldParity:
             await runner.tick()
         events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
         assert events, "no CRON_FIRE event emitted"
-        details = events[0].details
-        for field in ("entry_id", "name", "schedule", "payload_hash"):
-            assert field in details, f"missing field {field!r} in CRON_FIRE details"
+        ev = events[0]
+        assert ev.resource == "cron:full-job"
+        for field in ("name", "schedule", "payload_hash"):
+            assert field in ev.details, f"missing field {field!r} in CRON_FIRE details"
 
 
 class TestCronSkippedFieldParity:
-    """CronRunner._fire must emit CRON_SKIPPED with entry_id, name, reason when no callback."""
+    """CronRunner._fire must emit CRON_SKIPPED with entry_id in resource,
+    plus name and reason in details."""
 
-    async def test_entry_id_field(self, store, audit_logger) -> None:
+    async def test_entry_id_in_resource(self, store, audit_logger) -> None:
         store.add(_due_entry("skip-job"))
         with patch("deile.cron.runner.get_audit_logger", return_value=audit_logger):
             runner = CronRunner(store)  # no callback
             await runner.tick()
         events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)
         assert events, "expected CRON_SKIPPED event"
-        assert events[0].details["entry_id"] == "skip-job"
+        assert events[0].resource == "cron:skip-job"
 
     async def test_name_field(self, store, audit_logger) -> None:
         store.add(_due_entry("named-skip"))
@@ -125,6 +128,7 @@ class TestCronSkippedFieldParity:
             await runner.tick()
         events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)
         assert events, "no CRON_SKIPPED event emitted"
-        details = events[0].details
-        for field in ("entry_id", "name", "reason"):
-            assert field in details, f"missing field {field!r} in CRON_SKIPPED details"
+        ev = events[0]
+        assert ev.resource == "cron:allfields-skip"
+        for field in ("name", "reason"):
+            assert field in ev.details, f"missing field {field!r} in CRON_SKIPPED details"

--- a/deile/tests/observability/test_usage_sidecar.py
+++ b/deile/tests/observability/test_usage_sidecar.py
@@ -1,0 +1,135 @@
+"""Tests for the usage sidecar (DEILE_USAGE_SIDECAR) — AC2 of issue #508."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deile.observability.usage_sidecar import (
+    SIDECAR_ENV,
+    UsageEnvelope,
+    collect_and_write_sidecar,
+    get_sidecar_path,
+    write_usage_sidecar,
+)
+
+
+class TestUsageEnvelope:
+    def test_schema_version_is_1(self) -> None:
+        env = UsageEnvelope(schema_version=1, cost_usd=0.5, tokens_in=100, tokens_out=50, turns=3)
+        assert env.schema_version == 1
+
+    def test_to_dict_keys(self) -> None:
+        env = UsageEnvelope(schema_version=1, cost_usd=0.12, tokens_in=3400, tokens_out=890, turns=8)
+        d = env.to_dict()
+        assert set(d.keys()) == {"schema_version", "cost_usd", "tokens_in", "tokens_out", "turns"}
+
+    def test_to_dict_values(self) -> None:
+        env = UsageEnvelope(schema_version=1, cost_usd=0.12, tokens_in=3400, tokens_out=890, turns=8)
+        d = env.to_dict()
+        assert d["schema_version"] == 1
+        assert d["cost_usd"] == 0.12
+        assert d["tokens_in"] == 3400
+        assert d["tokens_out"] == 890
+        assert d["turns"] == 8
+
+    def test_zero_values_valid(self) -> None:
+        env = UsageEnvelope(schema_version=1, cost_usd=0.0, tokens_in=0, tokens_out=0, turns=0)
+        assert env.to_dict()["cost_usd"] == 0.0
+
+
+class TestGetSidecarPath:
+    def test_returns_none_when_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv(SIDECAR_ENV, raising=False)
+        assert get_sidecar_path() is None
+
+    def test_returns_none_for_empty_string(self, monkeypatch) -> None:
+        monkeypatch.setenv(SIDECAR_ENV, "")
+        assert get_sidecar_path() is None
+
+    def test_returns_path_when_set(self, monkeypatch, tmp_path) -> None:
+        p = str(tmp_path / "usage.json")
+        monkeypatch.setenv(SIDECAR_ENV, p)
+        assert get_sidecar_path() == p
+
+
+class TestWriteUsageSidecar:
+    def test_writes_valid_json(self, tmp_path) -> None:
+        path = str(tmp_path / "usage.json")
+        env = UsageEnvelope(schema_version=1, cost_usd=0.5, tokens_in=100, tokens_out=50, turns=3)
+        write_usage_sidecar(env, path)
+        data = json.loads(Path(path).read_text())
+        assert data == {"schema_version": 1, "cost_usd": 0.5, "tokens_in": 100, "tokens_out": 50, "turns": 3}
+
+    def test_does_not_raise_on_bad_path(self) -> None:
+        env = UsageEnvelope(schema_version=1, cost_usd=0.0, tokens_in=0, tokens_out=0, turns=0)
+        write_usage_sidecar(env, "/nonexistent/dir/usage.json")  # must not raise
+
+
+class TestCollectAndWriteSidecar:
+    def test_noop_when_env_unset(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.delenv(SIDECAR_ENV, raising=False)
+        collect_and_write_sidecar("sid-1")
+        # No error, no file
+
+    def test_writes_envelope_from_records(self, monkeypatch, tmp_path) -> None:
+        path = str(tmp_path / "usage.json")
+        monkeypatch.setenv(SIDECAR_ENV, path)
+
+        # Two mock records
+        rec1 = MagicMock()
+        rec1.cost_usd = 0.10
+        rec1.prompt_tokens = 1000
+        rec1.completion_tokens = 200
+        rec2 = MagicMock()
+        rec2.cost_usd = 0.05
+        rec2.prompt_tokens = 500
+        rec2.completion_tokens = 100
+
+        mock_repo = MagicMock()
+        mock_repo.records_for_session.return_value = [rec1, rec2]
+
+        with patch("deile.observability.usage_sidecar.get_usage_repository", return_value=mock_repo):
+            collect_and_write_sidecar("sid-1")
+
+        data = json.loads(Path(path).read_text())
+        assert data["schema_version"] == 1
+        assert data["cost_usd"] == pytest.approx(0.15)
+        assert data["tokens_in"] == 1500
+        assert data["tokens_out"] == 300
+        assert data["turns"] == 2
+
+    def test_empty_records_yields_zeros(self, monkeypatch, tmp_path) -> None:
+        path = str(tmp_path / "usage.json")
+        monkeypatch.setenv(SIDECAR_ENV, path)
+
+        mock_repo = MagicMock()
+        mock_repo.records_for_session.return_value = []
+
+        with patch("deile.observability.usage_sidecar.get_usage_repository", return_value=mock_repo):
+            collect_and_write_sidecar("sid-empty")
+
+        data = json.loads(Path(path).read_text())
+        assert data == {"schema_version": 1, "cost_usd": 0.0, "tokens_in": 0, "tokens_out": 0, "turns": 0}
+
+    def test_swallows_exception_from_repo(self, monkeypatch, tmp_path) -> None:
+        path = str(tmp_path / "usage.json")
+        monkeypatch.setenv(SIDECAR_ENV, path)
+
+        with patch("deile.observability.usage_sidecar.get_usage_repository", side_effect=RuntimeError("db gone")):
+            collect_and_write_sidecar("sid-broken")  # must not raise
+
+
+class TestSidecarPathUniqueness:
+    def test_unique_path_not_pre_existing(self, tmp_path) -> None:
+        import tempfile
+        fd, path = tempfile.mkstemp(suffix=".usage.json", dir=tmp_path)
+        os.close(fd)
+        os.unlink(path)
+        assert not os.path.exists(path)
+        env = UsageEnvelope(schema_version=1, cost_usd=0.0, tokens_in=0, tokens_out=0, turns=0)
+        write_usage_sidecar(env, path)
+        assert os.path.exists(path)

--- a/deile/tests/security/test_audit_cron_events.py
+++ b/deile/tests/security/test_audit_cron_events.py
@@ -68,3 +68,46 @@ class TestAuditEventTypeEnum:
 
     def test_cron_skipped_value(self) -> None:
         assert AuditEventType.CRON_SKIPPED.value == "cron_skipped"
+
+
+class TestCronFireFieldParity:
+    """AC3: assert exact field names match deilebot contract (name/schedule/payload_hash)."""
+
+    def test_cron_fire_details_keys_are_exactly_name_schedule_payload_hash(self, audit_logger):
+        audit_logger.log_cron_fire("job-1", "daily-renew", "0 3 * * *", "sha256:abc")
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)
+        ev = events[0]
+        assert set(ev.details.keys()) == {"name", "schedule", "payload_hash"}
+
+    def test_cron_fire_name_field_present(self, audit_logger):
+        audit_logger.log_cron_fire("j", "my-job", None, None)
+        ev = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)[0]
+        assert "name" in ev.details
+        assert ev.details["name"] == "my-job"
+
+    def test_cron_fire_payload_hash_field_present(self, audit_logger):
+        h = "sha256:deadbeef"
+        audit_logger.log_cron_fire("j", None, None, h)
+        ev = audit_logger.get_recent_events(event_type=AuditEventType.CRON_FIRE)[0]
+        assert ev.details["payload_hash"] == h
+
+
+class TestCronSkippedFieldParity:
+    """AC3: assert exact field names match deilebot contract (name/reason)."""
+
+    def test_cron_skipped_details_keys_are_exactly_name_reason(self, audit_logger):
+        audit_logger.log_cron_skipped("job-2", "my-job", "no callback")
+        events = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)
+        ev = events[0]
+        assert set(ev.details.keys()) == {"name", "reason"}
+
+    def test_cron_skipped_name_field_present(self, audit_logger):
+        audit_logger.log_cron_skipped("j", "my-job", "disabled")
+        ev = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)[0]
+        assert "name" in ev.details
+        assert ev.details["name"] == "my-job"
+
+    def test_cron_skipped_reason_field_present(self, audit_logger):
+        audit_logger.log_cron_skipped("j", None, "rate-limited")
+        ev = audit_logger.get_recent_events(event_type=AuditEventType.CRON_SKIPPED)[0]
+        assert ev.details["reason"] == "rate-limited"


### PR DESCRIPTION
## Resumo

Implementa AC2 e AC3 da issue #508 — os dois critérios de aceite que ficam neste repo (`elimarcavalli/deile`):

### AC2 — Worker emite `usage` + lê `TRACEPARENT`

- **`deile/core/usage_envelope.py`** (novo): `build_usage_envelope(session_id)` agrega `cost_usd`/`tokens_in`/`tokens_out`/`turns` do `UsageRepository` e devolve o envelope `schema_version=1`; `write_usage_sidecar(session_id)` escreve o JSON no path de `DEILE_USAGE_SIDECAR` (rename atômico, nunca levanta exceção).
- **`cli._run_oneshot`**: ativa contexto W3C de `TRACEPARENT`/`TRACESTATE` (via `activate_traceparent_from_env`) antes da criação de spans — re-parenteia spans do subprocess sob o tracer do bridge; popula `response.metadata["usage"]` e escreve sidecar pós-dispatch.
- **`core.agent.process_input`**: popula `response.metadata["usage"]` para o caminho in-process (`InProcessAgentBridge`).
- **`observability.tracer`**: adiciona `activate_traceparent_from_env()` que extrai contexto W3C dos env vars e o ativa como contexto OTel corrente.
- **Testes**: `deile/tests/core/test_usage_envelope.py` — 15 testes cobrindo os 6 casos do AC2 (schema_version, somas, zeros, escrita, env ausente, path inválido).

### AC3 — Paridade de campos do `CronRunner` (já emitido, agora travado)

- Estende `deile/tests/security/test_audit_cron_events.py` com `TestCronFireFieldParity` e `TestCronSkippedFieldParity` que afirmam exatamente os conjuntos de chaves `{name, schedule, payload_hash}` e `{name, reason}`, garantindo paridade com o contrato do consumidor `deilebot`.

Closes #508.