### PR TITLE
feat: notify via deilebot (Discord DM) when reaper blocks issue/PR

### DIFF
--- a/deile/orchestration/pipeline/notifier.py
+++ b/deile/orchestration/pipeline/notifier.py
@@ -165,6 +165,29 @@ class DiscordNotifier:
             f"`{WORKFLOW_BLOCKED}`."
         )
 
+    async def reaper_blocked(
+        self,
+        number: int,
+        url: str,
+        *,
+        kind: str,
+        attempt: int,
+        max_attempts: int,
+        age_seconds: int,
+    ) -> None:
+        """Fired when the reaper exhausts retries and blocks an item (issue #522).
+
+        The item gains ``~workflow:bloqueada`` and is removed from the reaper's
+        candidate set — so this DM fires exactly once per blocking event (dedup
+        by label transition, AC3). The GitHub comment is the durable channel;
+        the DM is best-effort notification so the operator can act promptly.
+        """
+        age_minutes = age_seconds // 60
+        await self._send(
+            f"⛔ **Reaper bloqueou** {kind} #{number} após {attempt}/{max_attempts} tentativas "
+            f"(idade: {age_minutes} min)\n🔗 {url}"
+        )
+
     async def pr_picked_up(self, number: int, title: str, url: str) -> None:
         await self._send(
             f"🔎 **Pipeline pegou para revisar** PR #{number}: {title}\n🔗 {url}"

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -3212,6 +3212,7 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
             from_label=REVIEW_IN_PROGRESS, to_label=REVIEW_PENDING,
             max_attempts=max_attempts, age_seconds=age,
             description=f"PR #{pr.number} review stuck há {age // 60}min",
+            url=pr.url,
         )
 
     # Issues com ~workflow:em_implementacao (stuck no implement).
@@ -3240,6 +3241,7 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
             from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_REVIEWED,
             max_attempts=max_attempts, age_seconds=age,
             description=f"issue #{issue.number} implement stuck há {age // 60}min",
+            url=issue.url,
         )
 
     # Issues com ~workflow:em_revisao (crítica de escopo interrompida por restart
@@ -3269,6 +3271,7 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
             from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_NEW,
             max_attempts=max_attempts, age_seconds=age,
             description=f"issue #{issue.number} em_revisao stuck há {age // 60}min",
+            url=issue.url,
         )
 
     # Issues com ~workflow:em_refinamento / ~workflow:em_arquitetura travadas por
@@ -3306,6 +3309,7 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
                     from_label=refine_state, to_label=WORKFLOW_NEW,
                     max_attempts=max_attempts, age_seconds=age,
                     description=f"issue #{issue.number} {refine_state} stuck há {age // 60}min",
+                    url=issue.url,
                 )
                 # Lock liberado → o dispatch em voo morreu; limpa o ledger pra
                 # não consultar resume-info de uma task abandonada.
@@ -3323,6 +3327,7 @@ async def _reap_one(
     max_attempts: int,
     age_seconds: int,
     description: str,
+    url: str,
 ) -> None:
     """Reaper helper — libera UM claim órfão.
 
@@ -3378,6 +3383,16 @@ async def _reap_one(
             "reaper BLOCKED %s #%d after %d attempts (age=%ds)",
             kind, number, next_attempt, age_seconds,
         )
+        try:
+            await monitor.notifier.reaper_blocked(
+                number, url,
+                kind=kind,
+                attempt=next_attempt,
+                max_attempts=max_attempts,
+                age_seconds=age_seconds,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort DM
+            logger.warning("reaper #%d: discord notify failed: %s", number, exc)
         return
 
     # Libera: remove labels stale, adiciona ~attempt:(N+1) + label de retorno.

--- a/deile/tests/orchestration/pipeline/test_reaper.py
+++ b/deile/tests/orchestration/pipeline/test_reaper.py
@@ -107,6 +107,9 @@ def _make_monitor_for_reaper(
     github.comment_on_pr = AsyncMock()
     github.comment_on_issue = AsyncMock()
     notifier = MagicMock()
+    # reaper_blocked is awaited — must be an AsyncMock so existing tests don't
+    # fail with "object MagicMock can't be used in 'await' expression".
+    notifier.reaper_blocked = AsyncMock()
     worktrees = MagicMock()
     claude = MagicMock()
     monitor = PipelineMonitor(
@@ -411,3 +414,120 @@ async def test_reaper_em_revisao_without_ownership_skipped():
 
     github.remove_labels.assert_not_awaited()
     github.add_labels.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Issue #522 — Discord notification via deilebot when reaper blocks
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reaper_block_sends_discord_notification():
+    """Quando o reaper bloqueia um item (next_attempt >= max_attempts),
+    notifier.reaper_blocked deve ser chamado com os dados corretos: número,
+    url, kind, attempt/max e age_seconds."""
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=60, reaper_max_attempts=3,
+    )
+    own = monitor.identity.ownership_label()
+    # attempt:2 → next=3 >= max_attempts=3 → bloqueia
+    pr = _make_pr(1000, labels=[
+        "~review:em_andamento", own, "~attempt:2",
+    ])
+    github.list_open_prs = AsyncMock(return_value=[pr])
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    monitor.notifier.reaper_blocked = AsyncMock()
+
+    await reap_orphan_claims(monitor)
+
+    monitor.notifier.reaper_blocked.assert_awaited_once()
+    call_kwargs = monitor.notifier.reaper_blocked.await_args
+    args, kwargs = call_kwargs.args, call_kwargs.kwargs
+    # Posicionais: number, url
+    assert args[0] == 1000
+    assert args[1] == pr.url
+    # Keyword-only
+    assert kwargs["kind"] == "pr"
+    assert kwargs["attempt"] == 3
+    assert kwargs["max_attempts"] == 3
+    assert kwargs["age_seconds"] >= 200
+
+
+@pytest.mark.asyncio
+async def test_reaper_already_blocked_item_not_renotified():
+    """Item com ~workflow:bloqueada já removido do conjunto de candidatos
+    de reap_orphan_claims — reaper_blocked NÃO deve ser chamado de novo."""
+    monitor, github = _make_monitor_for_reaper(reaper_stale_seconds=60)
+    own = monitor.identity.ownership_label()
+    # Item JÁ tem ~workflow:bloqueada — não tem ~review:em_andamento,
+    # portanto não entra no laço do reaper.
+    pr = _make_pr(1001, labels=["~workflow:bloqueada", own, "~attempt:3"])
+    github.list_open_prs = AsyncMock(return_value=[pr])
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 9999)
+
+    monitor.notifier.reaper_blocked = AsyncMock()
+
+    await reap_orphan_claims(monitor)
+
+    # Nada foi tocado (o item não tem ~review:em_andamento).
+    github.remove_labels.assert_not_awaited()
+    github.add_labels.assert_not_awaited()
+    monitor.notifier.reaper_blocked.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reaper_block_notification_failure_is_best_effort():
+    """Se reaper_blocked lança, o bloqueio, comentário GitHub e stats já foram
+    registrados — a falha na DM NÃO deve propagar nem impedir o return normal."""
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=60, reaper_max_attempts=3,
+    )
+    own = monitor.identity.ownership_label()
+    pr = _make_pr(1002, labels=[
+        "~review:em_andamento", own, "~attempt:2",
+    ])
+    github.list_open_prs = AsyncMock(return_value=[pr])
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    # Simula falha no envio da DM — _send já captura Exception internamente,
+    # mas testamos que o chamador também não propaga.
+    monitor.notifier.reaper_blocked = AsyncMock(
+        side_effect=Exception("discord unavailable"),
+    )
+
+    # Não deve levantar.
+    await reap_orphan_claims(monitor)
+
+    # Bloqueio e stats já registrados antes da DM.
+    added = list(github.add_labels.await_args_list[0].args[2])
+    assert "~workflow:bloqueada" in added
+    assert monitor._stats.issues_blocked >= 1
+    github.comment_on_pr.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reaper_block_disabled_notifier_is_noop():
+    """Com notifier.enabled == False (sem user_id), a chamada a reaper_blocked
+    é no-op: sem exceção, sem DM, comportamento de bloqueio normal."""
+    from deile.orchestration.pipeline.notifier import DiscordNotifier
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=60, reaper_max_attempts=3,
+    )
+    own = monitor.identity.ownership_label()
+    pr = _make_pr(1003, labels=[
+        "~review:em_andamento", own, "~attempt:2",
+    ])
+    github.list_open_prs = AsyncMock(return_value=[pr])
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    # Substitui o notifier por um real com enabled=False (sem user_id).
+    real_notifier = DiscordNotifier(user_id="")
+    monitor.notifier = real_notifier
+    assert real_notifier.enabled is False
+
+    # Não deve levantar; bloqueio acontece normalmente.
+    await reap_orphan_claims(monitor)
+
+    added = list(github.add_labels.await_args_list[0].args[2])
+    assert "~workflow:bloqueada" in added
+    github.comment_on_pr.assert_awaited_once()


### PR DESCRIPTION
Implements the notification path from the reaper blocking branch to DiscordNotifier.

## Changes
- `notifier.py`: adds `reaper_blocked` async helper (AC1) that sends a best-effort DM with number, url, attempt/max_attempts, and age in minutes
- `stages.py`: wires `monitor.notifier.reaper_blocked()` in the `_reap_one` blocking branch (AC2), after labels are applied and GitHub comment is posted — the DM is best-effort and never blocks the pipeline

## Behaviour
Fires exactly once per block transition: after the item receives `~workflow:bloqueada`, it no longer matches any of the four reaper sweeps, so `_reap_one` is not re-invoked for it.

Closes #522.