### PR TITLE
docs: add 4 claude-worker resume/ledger env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,6 +238,18 @@ DEILE_CLAUDE_WORKER_TASK_TIMEOUT_S=7200
 # Valor: nome da persona (ex: developer). Configurado nos manifests K8s.
 # DEILE_DEFAULT_PERSONA=developer
 
+# Override absoluto (tokens) do threshold resume→fresh; vazio ou 0 usa a fração abaixo.
+# DEILE_CLAUDE_RESUME_TOKEN_BUDGET=
+
+# Fração da janela do modelo usada como threshold de resume quando sem override absoluto. Default: 0.80.
+# DEILE_CLAUDE_RESUME_CONTEXT_FRACTION=0.80
+
+# Ledger append-only de custo por task. Default: ~/.claude/cost-ledger.jsonl.
+# DEILE_CLAUDE_COST_LEDGER_PATH=~/.claude/cost-ledger.jsonl
+
+# Grace period (s) para podar arquivos JSONL órfãos sem task associada. Default: 3600.
+# DEILE_CLAUDE_JSONL_ORPHAN_GRACE_S=3600
+
 # ----------------------------------------------------------------------------
 # 5. PIPELINE AUTÔNOMO  (deile-pipeline Pod)
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Adiciona as 4 variáveis de ambiente do gate de resume/ledger do claude-worker ao `.env.example`, cada uma com 1 linha de comentário (descrição + default), na seção do claude-worker — conforme especificado na issue.

**Variáveis adicionadas:**
- `DEILE_CLAUDE_RESUME_TOKEN_BUDGET` — override absoluto (tokens) do threshold resume→fresh; vazio/0 usa a fração abaixo
- `DEILE_CLAUDE_RESUME_CONTEXT_FRACTION` — fração da janela do modelo (default `0.80`) usada como threshold quando sem override absoluto
- `DEILE_CLAUDE_COST_LEDGER_PATH` — ledger append-only de custo (default `~/.claude/cost-ledger.jsonl`)
- `DEILE_CLAUDE_JSONL_ORPHAN_GRACE_S` — grace period (s) para podar JSONL órfão (default `3600`)

Nenhum outro arquivo foi alterado — mudança puramente documental.

Closes #533.