### PR TITLE
feat(audit): add --model SLUG flag to filter sessions by model

### DIFF
--- a/deile/tests/infrastructure/test_session_model_filter.py
+++ b/deile/tests/infrastructure/test_session_model_filter.py
@@ -1,0 +1,107 @@
+"""Testes da flag ``--model <SLUG>`` do ``session_tokens_audit`` (issue #532).
+
+O filtro ``filter_sessions_by_model`` é a única fonte da verdade do recorte por
+modelo: aplicado uma vez (antes de ``--top``/``--last``), vale para tabela,
+agregados, detail, export e loop interativo. Estes testes provam as decisões de
+design D1–D5 e os critérios de aceite AC2–AC7 sem precisar de cluster, carregando
+o módulo via o padrão ``importlib`` já usado em ``test_audit_ledger_read.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_INFRA_K8S = Path(__file__).resolve().parents[3] / "infra" / "k8s"
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, str(_INFRA_K8S / filename))
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture
+def audit():
+    if str(_INFRA_K8S) not in sys.path:
+        sys.path.insert(0, str(_INFRA_K8S))
+    return _load("audit_model_filter_test", "session_tokens_audit.py")
+
+
+def _sess(per_model_keys):
+    """Sessão mínima com as chaves de ``per_model`` dadas."""
+    return {"per_model": {k: {"input": 1, "output": 1} for k in per_model_keys}}
+
+
+def test_family_match(audit):
+    """D1/AC3: ``opus`` mantém um id opus completo; ``sonnet`` o descarta."""
+    s = _sess(["claude-opus-4-8-20250514"])
+    assert audit.filter_sessions_by_model([s], "opus") == [s]
+    assert audit.filter_sessions_by_model([s], "sonnet") == []
+
+
+def test_version_match(audit):
+    """D1: o slug versionado casa contra o id completo; versão errada descarta."""
+    s = _sess(["claude-opus-4-8-20250514"])
+    assert audit.filter_sessions_by_model([s], "opus-4-8") == [s]
+    assert audit.filter_sessions_by_model([s], "opus-4-7") == []
+
+
+def test_case_insensitive(audit):
+    """O match ignora caixa (``OPUS`` casa ``claude-opus-...``)."""
+    s = _sess(["claude-opus-4-8-20250514"])
+    assert audit.filter_sessions_by_model([s], "OPUS") == [s]
+
+
+def test_multimodel_any(audit):
+    """D2/AC4: sessão com ids opus+haiku é mantida por ``haiku`` E por ``opus``."""
+    s = _sess(["claude-opus-4-8-20250514", "claude-haiku-4-5-20251001"])
+    assert audit.filter_sessions_by_model([s], "opus") == [s]
+    assert audit.filter_sessions_by_model([s], "haiku") == [s]
+
+
+def test_synthetic_excluded(audit):
+    """A chave sentinela ``<synthetic>`` é excluída do match."""
+    s = _sess(["<synthetic>"])
+    assert audit.filter_sessions_by_model([s], "synthetic") == []
+
+
+def test_identity_no_slug(audit):
+    """AC7/AC2: ``None`` e ``""`` retornam a lista intacta (mesmos objetos, mesma ordem)."""
+    sessions = [_sess(["claude-opus-4-8-20250514"]), _sess(["claude-sonnet-4-6-20250101"])]
+    for slug in (None, ""):
+        out = audit.filter_sessions_by_model(sessions, slug)
+        assert out is sessions or out == sessions
+        assert len(out) == len(sessions)
+        for a, b in zip(out, sessions):
+            assert a is b  # identidade dos objetos-sessão
+
+
+def test_filter_precedes_top(audit):
+    """AC5: o corte ``[:N]`` aplicado APÓS o filtro devolve o top do recorte, não o global."""
+    opus_top = _sess(["claude-opus-4-8-20250514"])
+    sonnet = _sess(["claude-sonnet-4-6-20250101"])
+    opus_2 = _sess(["claude-opus-4-8-20250514"])
+    sessions = [sonnet, opus_top, opus_2]  # global top-1 seria a sonnet
+    filtered = audit.filter_sessions_by_model(sessions, "opus")
+    assert filtered[:1] == [opus_top]  # top-1 do recorte filtrado, não o global
+
+
+def test_zero_match_exit(audit, monkeypatch):
+    """AC6: no caminho não-interativo, filtro vazio chama ``sys.exit`` com code 1."""
+    monkeypatch.setattr(sys, "argv", ["session_tokens_audit.py", "--model", "gpt", "--no-interactive"])
+    monkeypatch.setattr(audit, "find_kubectl", lambda: "kubectl")
+    monkeypatch.setattr(audit, "resolve_pod", lambda *a, **k: "pod-x")
+    monkeypatch.setattr(audit, "resolve_pvc", lambda *a, **k: "pvc-x")
+    monkeypatch.setattr(audit, "_console", lambda *a, **k: None)
+    monkeypatch.setattr(audit, "fetch_sessions", lambda *a, **k: [_sess(["claude-opus-4-8-20250514"])])
+    monkeypatch.setattr(audit, "enrich", lambda sessions, pvc: sessions)
+    with pytest.raises(SystemExit) as exc:
+        audit.main()
+    assert exc.value.code == 1 or "Nenhuma sessão com modelo contendo 'gpt'." in str(exc.value.code)

--- a/infra/k8s/session_tokens_audit.py
+++ b/infra/k8s/session_tokens_audit.py
@@ -24,6 +24,7 @@ Uso
     python3 infra/k8s/session_tokens_audit.py --export ./out  # grava JSON + CSV
     python3 infra/k8s/session_tokens_audit.py -n deile-gl     # outro namespace
     python3 infra/k8s/session_tokens_audit.py --pod claude-worker-xxxx
+    python3 infra/k8s/session_tokens_audit.py --model opus-4-8
 
 No modo interativo: digite o NÚMERO de uma linha para ver os detalhes completos
 daquela sessão; ``a`` = agregados, ``e`` = exportar, ``q`` = sair.
@@ -659,6 +660,31 @@ def _short_model_slug(full: str) -> str:
     if m.startswith("claude-"):
         m = m[len("claude-"):]
     return re.sub(r"-\d{6,}.*$", "", m)  # tira o sufixo de data
+
+
+def filter_sessions_by_model(sessions: list, slug: str | None) -> list:
+    """Filtra sessões pelo modelo (substring case-insensitive).
+
+    Mantém uma sessão se QUALQUER chave de ``s["per_model"]`` (exceto
+    ``<synthetic>``) contém *slug* como substring (case-insensitive).
+    Se *slug* for ``None`` ou string vazia retorna a lista intacta.
+
+    Exemplos::
+
+        filter_sessions_by_model(sessions, "opus")    # mantém só sessões com opus
+        filter_sessions_by_model(sessions, None)      # retorna sessions sem alteração
+    """
+    if not slug:
+        return sessions
+    needle = slug.lower()
+    return [
+        s for s in sessions
+        if any(
+            needle in model_id.lower()
+            for model_id in s.get("per_model", {})
+            if model_id != "<synthetic>"
+        )
+    ]
 
 
 # Assinatura do preâmbulo ultracode injetado pelo claude_worker_server (fallback
@@ -1601,6 +1627,10 @@ def main():
     ap.add_argument("--last", nargs="?", type=int, const=-1, default=None, metavar="N",
                     help="ordena por última atividade ↓ (em vez de custo); "
                          "com N, mostra só as N sessões mais recentes")
+    ap.add_argument("--model", default=None, metavar="SLUG",
+                    help="filtra sessões cujo per_model contém SLUG como substring "
+                         "(case-insensitive) em pelo menos um model id completo, "
+                         "ex.: --model opus-4-8")
     args = ap.parse_args()
 
     kubectl = find_kubectl()
@@ -1615,6 +1645,9 @@ def main():
     if not sessions:
         sys.exit("Nenhuma sessão com tokens encontrada no PVC.")
     sessions = enrich(sessions, pvc)
+    sessions = filter_sessions_by_model(sessions, args.model)
+    if args.model and not sessions:
+        sys.exit(f"Nenhuma sessão com modelo contendo '{args.model}'.")
     last_requested = args.last is not None
     last_n = args.last if (last_requested and args.last and args.last > 0) else 0
     if last_requested:
@@ -1646,6 +1679,9 @@ def main():
         try:
             p = resolve_pod(kubectl, ns, args.pod)
             data = enrich(fetch_sessions(kubectl, ns, p, args.no_git), pvc)
+            data = filter_sessions_by_model(data, args.model)
+            if args.model and not data:
+                return None
             if last_n:  # preserva o corte das N mais recentes no refresh
                 data.sort(key=lambda x: x.get("mtime") or 0, reverse=True)
                 data = data[:last_n]


### PR DESCRIPTION
## Summary

Add `--model <SLUG>` flag to `infra/k8s/session_tokens_audit.py` to filter audit sessions by model (substring, case-insensitive).

### Changes
- New `filter_sessions_by_model(sessions, slug) -> list` pure function
- `--model <SLUG>` argparse flag (after `--last`, metavar=SLUG, default=None)
- Filter applied once in `main()` after `enrich()`, before `--top`/`--last` cuts
- Filter applied once in `refetch()` after its `enrich()` call
- Zero-match guard: `sys.exit(1)` with clear message in non-interactive mode
- `refetch()` returns `None` on zero matches (preserves prior data in loop)
- Stderr session count reflects filtered result

### Design Decisions
- Match target: full model IDs in `per_model` keys (e.g. `claude-opus-4-8-20250514`), not lossy derived fields
- Multi-model: session kept if ANY model ID matches (OR semantics)
- `<synthetic>` sentinel excluded from match
- Same filter instance covers table, aggregates, detail, export and interactive loop

### Usage
```
session_tokens_audit.py --model opus            # all sessions using any opus
session_tokens_audit.py --model opus-4-8        # specific version
session_tokens_audit.py --model haiku --top 10  # filter then take top 10
session_tokens_audit.py --model sonnet --export ./out  # export only sonnet
```

Closes #532.