### PR TITLE
refactor: versionar 5 timeouts per-stage no manifest deile-pipeline

### DIFF
--- a/deile/tests/infrastructure/test_k8s_manifest_consistency.py
+++ b/deile/tests/infrastructure/test_k8s_manifest_consistency.py
@@ -264,6 +264,84 @@ def test_apiserver_egress_selector_matches_runtime() -> None:
     )
 
 
+def _get_pipeline_container_env(docs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the env list of the first container in the deile-pipeline Deployment."""
+    for d in docs:
+        if d.get("kind") == "Deployment":
+            labels = (
+                (d.get("spec", {}) or {})
+                .get("template", {})
+                .get("metadata", {})
+                .get("labels", {})
+            ) or {}
+            if labels.get("app") == "deile-pipeline":
+                containers = (
+                    (d.get("spec", {}) or {})
+                    .get("template", {})
+                    .get("spec", {})
+                    .get("containers", [])
+                ) or []
+                if containers:
+                    return containers[0].get("env") or []
+    return []
+
+
+# Canonical values for the 5 per-stage timeout vars (issue #530).
+_EXPECTED_TIMEOUTS: dict[str, str] = {
+    "DEILE_PIPELINE_TIMEOUT_S_CLASSIFY": "600",
+    "DEILE_PIPELINE_TIMEOUT_S_REFINE": "1800",
+    "DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT": "2700",
+    "DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW": "3600",
+    "DEILE_PIPELINE_TIMEOUT_S_FOLLOW_UPS": "2700",
+}
+
+
+def test_pipeline_timeout_vars_present_with_exact_values(
+    docs: list[dict[str, Any]],
+) -> None:
+    """Issue #530 — 5 TIMEOUT_S_* vars must exist with canonical values.
+
+    Fails if any key is absent, has the wrong value, or is duplicated.
+    When a manifest re-apply drops these env vars the pipeline falls back to
+    the global pipeline_claude_timeout (1800 s) and silently kills
+    IMPLEMENT/PR_REVIEW/FOLLOW_UPS early.
+    """
+    env = _get_pipeline_container_env(docs)
+    assert env, (
+        "Nenhuma variável de ambiente encontrada no container 'deile-pipeline'. "
+        "Verificar que o Deployment 46-deile-pipeline-deployment.yaml carrega o env:."
+    )
+
+    # (a) + (b) presence and exact value
+    env_map: dict[str, str] = {e["name"]: e.get("value", "") for e in env if "name" in e}
+    errors: list[str] = []
+    for key, expected in _EXPECTED_TIMEOUTS.items():
+        if key not in env_map:
+            errors.append(f"  AUSENTE: {key} (esperado value={expected!r})")
+        elif env_map[key] != expected:
+            errors.append(
+                f"  VALOR ERRADO: {key}={env_map[key]!r} (esperado {expected!r})"
+            )
+    assert not errors, (
+        "Timeouts per-stage do manifest 46 divergem dos valores canônicos (issue #530):\n"
+        + "\n".join(errors)
+        + "\nNão altere o teste para passar — corrija o manifest."
+    )
+
+    # (c) no duplicate name in the full env list
+    names = [e["name"] for e in env if "name" in e]
+    seen: set[str] = set()
+    dupes: list[str] = []
+    for name in names:
+        if name in seen:
+            dupes.append(name)
+        seen.add(name)
+    assert not dupes, (
+        f"Entradas env: duplicadas no container deile-pipeline: {dupes}. "
+        "Kubernetes usa last-wins para duplicatas — remova as redundantes."
+    )
+
+
 def test_apiserver_egress_fallback_is_private() -> None:
     """Regra 5 — todo ipBlock do fallback estático está em range privado.
 

--- a/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
+++ b/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
@@ -214,6 +214,18 @@ spec:
             # réplicas, deile-worker 2 réplicas → ~5 dispatches reais
             # concorrentes antes da fila.
             - { name: DEILE_PIPELINE_MAX_PARALLEL,         value: "5" }
+            # Timeouts per-stage (issue #530). Sem estas entradas, um
+            # `kubectl apply` cru remove os overrides injetados via
+            # `kubectl set env` e cada stage cai para o fallback global
+            # (pipeline_claude_timeout=1800 ou BUILT_IN_TIMEOUT_S_DEILE=900),
+            # causando kill prematuro em IMPLEMENT/PR_REVIEW/FOLLOW_UPS.
+            # Valores canônicos desta issue; cluster inacessível no momento
+            # da implementação (verificação registrada no PR).
+            - { name: DEILE_PIPELINE_TIMEOUT_S_CLASSIFY,   value: "600"  }
+            - { name: DEILE_PIPELINE_TIMEOUT_S_REFINE,     value: "1800" }
+            - { name: DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT,  value: "2700" }
+            - { name: DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW,  value: "3600" }
+            - { name: DEILE_PIPELINE_TIMEOUT_S_FOLLOW_UPS, value: "2700" }
             # Redireciona kubectl para o apiserver na porta nativa do k3s
             # (6443) em vez do ClusterIP kube-proxy (10.43.0.1:443).
             # Em Rancher Desktop / Lima, o kube-proxy iptables DNAT não


### PR DESCRIPTION
## Resumo

Consolida no manifest versionado as 5 env vars de timeout per-stage do `deile-pipeline` que existiam **apenas** como override vivo (`kubectl set env`) — eliminando o drift silencioso que causava kill prematuro após qualquer `kubectl apply`.

### Mudanças

**`infra/k8s/manifests/46-deile-pipeline-deployment.yaml`**
Adiciona ao `env:` do container `deile-pipeline`, logo após `DEILE_PIPELINE_MAX_PARALLEL`:

| Var | Valor |
|-----|-------|
| `DEILE_PIPELINE_TIMEOUT_S_CLASSIFY`   | `600`  |
| `DEILE_PIPELINE_TIMEOUT_S_REFINE`     | `1800` |
| `DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT`  | `2700` |
| `DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW`  | `3600` |
| `DEILE_PIPELINE_TIMEOUT_S_FOLLOW_UPS` | `2700` |

`DEILE_PIPELINE_MAX_PARALLEL` permanece intocado (uma única ocorrência, linha 216). Nenhum outro manifest alterado.

**`deile/tests/infrastructure/test_k8s_manifest_consistency.py`**
Novo teste `test_pipeline_timeout_vars_present_with_exact_values` que assere:
- (a) as 5 chaves presentes no `env:` do container `deile-pipeline`;
- (b) cada uma com o valor exato esperado (`600/1800/2700/3600/2700`);
- (c) ausência de `name` duplicado em todo o `env:` do container.

### Verificação da fonte-da-verdade (cluster vivo)

Tentativa de verificação via `kubectl get deploy deile-pipeline -n <ns> -o json | jq ...` — **cluster inacessível** no ambiente de implementação. Prosseguindo com os 5 valores canônicos declarados na issue #530 conforme protocolo da seção "Estado Proposto".

### Impacto pré-fix (cruzando dispatchers `:185-190` × cadeia de fallback)

| Stage | Fallback sem as vars | Efeito |
|-------|----------------------|--------|
| IMPLEMENT  | 1800 s (global claude) | **−900 s → kill prematuro** |
| PR_REVIEW  | 1800 s                 | **−1800 s → kill prematuro** |
| FOLLOW_UPS | 1800 s                 | **−900 s → kill prematuro** |
| REFINE     | 1800 s                 | no-op |
| CLASSIFY   | 900 s (built-in deile) | inócuo (sobe) |

Closes #530.