### PR TITLE
fix(pipeline): elimina loop de refino por re-rebaixamento revisada→em_arquitetura (#418)

### DIFF
--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -408,6 +408,14 @@ class PipelineMonitor:
         # concorrente da mesma PR num tick subsequente).
         self._bg_tasks: set = set()
         self._resume_in_flight: set = set()
+        # Anti-loop (issue #418): números de issues promovidas a ``revisada`` no
+        # TICK corrente (por convergência de refino OU crítica CLARO). O índice
+        # de labels do GitHub tem eventual consistency, então uma issue promovida
+        # neste tick ainda reaparece sob ``refinar``/``em_arquitetura`` na
+        # listagem de ``refine_one_issue`` (mesmo tick) — sem este guard o
+        # rehydrate a rebaixaria de volta, criando loop infinito. Limpo no início
+        # de cada tick; consultado pelo candidate-filter do refino.
+        self._refine_promoted_this_tick: set = set()
         # Schedule store — when present, schedule entries drive when each
         # action fires (instead of the fixed poll interval). On startup the
         # monitor first drains any catch-up queue (entries whose run time
@@ -845,6 +853,9 @@ class PipelineMonitor:
         skip = skip or set()
         scheduled_mode = bool(skip)
         cfg = self.config
+        # Anti-loop (issue #418): zera o set de "promovidas a revisada neste tick"
+        # no começo do tick, antes do reconcile que o preenche e do refine que o lê.
+        self._refine_promoted_this_tick.clear()
 
         async def _scheduled(enabled: bool, key: str, handler) -> None:
             """Run a schedulable stage unless the scheduler already covered it."""

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -1142,9 +1142,15 @@ async def refine_one_issue(monitor: "PipelineMonitor") -> None:
 
     _excluded = (WORKFLOW_WAITING, WORKFLOW_BLOCKED, WORKFLOW_IMPLEMENTING,
                  WORKFLOW_PR, WORKFLOW_DECOMPOSED)
+    # Anti-loop (issue #418): pula issues promovidas a ``revisada`` NESTE tick.
+    # ``reconcile_refine_issues`` roda antes (mesmo tick) e, ao convergir, marca a
+    # issue aqui; o índice de labels do GitHub ainda a lista sob ``refinar`` por
+    # eventual consistency, então sem este guard o rehydrate a rebaixaria de volta.
+    _promoted = getattr(monitor, "_refine_promoted_this_tick", set())
     candidates = [
         i for i in sort_by_priority(issues)
         if not any(lb in i.labels for lb in _excluded)
+        and i.number not in _promoted
         and monitor.identity.owns(i.title)
     ]
     if not candidates:
@@ -1338,6 +1344,12 @@ async def _promote_refine_to_reviewed(
         await monitor.forge.remove_labels("issue", number, cleanup)
         await monitor.forge.comment_on_issue(number, comment)
         monitor._resume_tracker.clear(number)
+        # Anti-loop (issue #418): marca a issue como promovida NESTE tick para o
+        # candidate-filter de ``refine_one_issue`` (mesmo tick) pular o snapshot
+        # stale do índice do GitHub que ainda a lista sob ``refinar``.
+        promoted = getattr(monitor, "_refine_promoted_this_tick", None)
+        if promoted is not None:
+            promoted.add(number)
         monitor._stats.issues_reviewed += 1
         logger.info(log_msg)
     except GhCommandError as exc:

--- a/deile/tests/orchestration/pipeline/test_reconcile_fire_and_forget.py
+++ b/deile/tests/orchestration/pipeline/test_reconcile_fire_and_forget.py
@@ -529,3 +529,65 @@ class TestReaperRefineExtended:
             if c.args[1] == 51 for lb in c.args[2]
         ]
         assert WORKFLOW_NEW not in added
+
+
+# === Anti-loop same-tick (issue #418) =======================================
+class TestRefineAntiLoopSameTick:
+    """Regressão da causa-raiz do loop de #418. reconcile_refine_issues roda
+    ANTES de refine_one_issue no mesmo tick; ao convergir, promove a issue a
+    revisada e a marca em ``_refine_promoted_this_tick``. O índice de labels do
+    GitHub tem eventual consistency, então a issue ainda reaparece sob
+    ``refinar``/``em_arquitetura`` na listagem de refine_one_issue — sem o guard
+    same-tick o rehydrate a rebaixaria de volta (revisada→em_arquitetura) → loop.
+    """
+
+    async def test_refine_skips_issue_promoted_this_tick(self):
+        client = _Client(verdict="REFINO: OK")
+        # Snapshot STALE: índice ainda lista #6 sob em_arquitetura + refinar.
+        stale = _issue(6, "feature", REFINAR, WORKFLOW_ARCHITECTURE, body="b")
+        monitor, github, ledger = _make(
+            client,
+            label_map={REFINAR: [stale], WORKFLOW_REFINING: [],
+                       WORKFLOW_ARCHITECTURE: [stale]},
+        )
+        # Simula: reconcile já promoveu #6 a revisada NESTE tick.
+        monitor._refine_promoted_this_tick.add(6)
+        github.transition_issue.reset_mock()
+
+        await monitor._refine_one_issue()
+
+        # NÃO rebaixou (nenhuma transition) e NÃO re-dispatchou refino.
+        assert _transitions(github) == []
+        assert ledger.get(DispatchLedger.key_for_issue(6)) is None
+
+    async def test_refine_proceeds_when_not_promoted(self):
+        """Contraprova: set vazio → refino segue normal (fluxo não regrediu)."""
+        client = _Client(verdict="REFINO: OK")
+        stale = _issue(6, "feature", REFINAR, WORKFLOW_ARCHITECTURE, body="b")
+        monitor, github, ledger = _make(
+            client,
+            label_map={REFINAR: [stale], WORKFLOW_REFINING: [],
+                       WORKFLOW_ARCHITECTURE: [stale]},
+        )
+        assert 6 not in monitor._refine_promoted_this_tick
+        await monitor._refine_one_issue()
+        assert ledger.get(DispatchLedger.key_for_issue(6)) is not None
+
+    async def test_convergence_marks_promoted_set(self):
+        """A convergência (promoção a revisada) registra a issue no set same-tick."""
+        client = _Client(verdict="Pronto.\nREFINO: OK")
+        issue = _issue(6, "feature", REFINAR, WORKFLOW_ARCHITECTURE, body="estavel")
+        monitor, github, _ = _make(
+            client,
+            label_map={REFINAR: [issue], WORKFLOW_REFINING: [],
+                       WORKFLOW_ARCHITECTURE: [issue]},
+            get_issue_body="estavel",
+        )
+        await monitor._refine_one_issue()
+        own = monitor.identity.ownership_label()
+        seeded = _issue(6, "feature", WORKFLOW_ARCHITECTURE, REFINAR, own)
+        github.list_issues_with_label = AsyncMock(
+            side_effect=lambda label, **_: ([seeded] if label == WORKFLOW_ARCHITECTURE else [])
+        )
+        await monitor._reconcile_refine_issues()
+        assert 6 in monitor._refine_promoted_this_tick


### PR DESCRIPTION
## Causa-raiz (provada)

Loop infinito de refino observado na #418 (sangria de Opus ~\$0,6 a cada ~4 min). Timeline de labels do GitHub provou a mecânica:

```
18:35:02 +revisada -em_arquitetura -refinar   ← convergência promove (correto)
18:35:11 -revisada                            ← 9s depois ALGO remove
18:35:12 +em_arquitetura                      ← e re-adiciona → re-dispatch → loop
```

No **mesmo tick**: `reconcile_refine_issues` (roda antes) converge e promove a issue a `~workflow:revisada`; em seguida `refine_one_issue` lista candidatas por label — mas o **índice de labels do GitHub tem eventual consistency** e ainda retorna a issue sob `refinar`/`em_arquitetura` (snapshot stale). O rehydrate de `_refine_one_issue_dispatch` rebaixa `revisada → em_arquitetura`, desfazendo a promoção e realimentando o loop. Como a convergência limpa o tracker (não conta tentativa), o teto de 5 nunca mais segura — agravado quando uma issue bloqueada é reativada (o unblock reseta o contador).

## Fix

Determinístico, sem depender da consistência do índice: o monitor mantém `_refine_promoted_this_tick` (zerado no início de cada tick). A promoção a revisada marca a issue nesse set; o candidate-filter de `refine_one_issue` pula issues nele. Cobre a janela same-tick do bug e **preserva** o caso legítimo de `refinar` aplicado à mão numa issue revisada (tick futuro → set vazio → rehydrate normal).

## Testes
- `test_refine_skips_issue_promoted_this_tick` — pula issue promovida no tick mesmo com snapshot stale.
- `test_refine_proceeds_when_not_promoted` — contraprova (fluxo não regrediu).
- `test_convergence_marks_promoted_set` — a convergência registra no set.
- Suíte completa verde (7121 passed).

Branch `fix/*` (fora do pipeline) de propósito — o monitor não deve revisar o próprio fix.