### PR TITLE
feat: add /k8s slash command to REPL (issue #418)

### DIFF
--- a/deile/commands/builtin/k8s_command.py
+++ b/deile/commands/builtin/k8s_command.py
@@ -30,7 +30,7 @@ import shlex
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from rich.console import Console, Group
+from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -73,7 +73,10 @@ _V1_VERBS = [
     ("list", "namespaces DEILE detectados no cluster"),
 ]
 
-_V2_VERBS = ["start", "stop", "restart", "status", "logs"]
+_V2_VERBS = [
+    "up", "build", "down", "scale", "start", "stop", "setup",
+    "create-namespace", "claude-login", "claude-renew", "test", "clone", "panel",
+]
 
 # ---------------------------------------------------------------------------
 # Namespace auto-detection
@@ -228,53 +231,47 @@ async def _cmd_discovery(namespace: str) -> CommandResult:
 
 async def _cmd_restart(namespace: str, deployment: str) -> CommandResult:
     """Restart one or all deployments."""
-    console = Console(no_color=False)
-
     if deployment.lower() == "all":
-        targets = K8S_DEPLOYMENTS
+        targets = list(K8S_DEPLOYMENTS)
     else:
         targets = [deployment]
 
-    results = []
+    lines = []
+    all_ok = True
+
     for dep in targets:
-        console.print(f"[cyan]Restarting deployment/{dep}...[/cyan]")
-        ok, stdout, stderr = await _run_kubectl(
+        ok, _, stderr = await _run_kubectl(
             ["-n", namespace, "rollout", "restart", f"deployment/{dep}"]
         )
         if not ok:
-            results.append((dep, False, stderr.strip()))
-            console.print(f"[red]restart deployment/{dep} failed: {stderr.strip()}[/red]")
+            lines.append(Text(f"[✗] rollout restart {dep}: {stderr.strip()[:200]}", style="red"))
+            all_ok = False
             continue
 
-        # Wait for rollout status
-        console.print(f"[cyan]Waiting for rollout status of {dep}...[/cyan]")
-        ok2, stdout2, stderr2 = await _run_kubectl(
+        lines.append(Text(f"[~] kubectl -n {namespace} rollout restart deployment/{dep}", style="dim"))
+
+        ok2, out2, err2 = await _run_kubectl(
             ["-n", namespace, "rollout", "status", f"deployment/{dep}", "--timeout=180s"],
             timeout=200.0,
         )
         if ok2:
-            results.append((dep, True, stdout2.strip()))
-            console.print(f"[green]deployment/{dep}: {stdout2.strip() or 'success'}[/green]")
+            lines.append(Text(f"[OK] deployment \"{dep}\" rollout concluído", style="green"))
         else:
-            results.append((dep, False, stderr2.strip() or stdout2.strip()))
-            console.print(f"[red]deployment/{dep} rollout failed: {stderr2.strip()}[/red]")
+            msg = (err2 or out2).strip()[:200]
+            lines.append(Text(f"[✗] rollout status {dep} falhou: {msg}", style="red"))
+            all_ok = False
 
-    all_ok = all(ok for _, ok, _ in results)
-    lines = [
-        ("[green]OK[/green]" if ok else "[red]FAIL[/red]") + f"  {dep}: {msg}"
-        for dep, ok, msg in results
-    ]
-    summary = "\n".join(lines)
-
+    lines.append(Text(""))
+    n = len(targets)
     if all_ok:
-        return CommandResult.success_result(
-            f"Restart completed.\n{summary}",
-            "text",
-        )
+        lines.append(Text(f"[OK] {n}/{n} deployments concluíram rollout", style="green"))
+    else:
+        lines.append(Text("Alguns rollouts falharam (ver detalhes acima)", style="red"))
+
     return CommandResult(
-        success=False,
-        content=f"One or more restarts failed.\n{summary}",
-        content_type="text",
+        success=all_ok,
+        content=Group(*lines),
+        content_type="rich",
     )
 
 
@@ -391,7 +388,7 @@ class K8sCommand(DirectCommand):
             f"Unknown subcommand '{sub}'. Valid: {valid}. Run /k8s for help."
         )
 
-    async def get_help(self) -> str:
+    def get_help(self) -> str:
         return """/k8s -- kubectl operations for DEILE cluster
 
 Usage:

--- a/deile/commands/builtin/k8s_command.py
+++ b/deile/commands/builtin/k8s_command.py
@@ -1,0 +1,406 @@
+"""``/k8s`` command — kubectl operations against DEILE cluster namespaces.
+
+Usage:
+    /k8s                        show available verbs (discovery panel)
+    /k8s restart [--deployment <name|all>]
+                                rollout restart one or all deployments
+                                (default deployment: deile-pipeline)
+    /k8s status                 kubectl get pods,deployments,services
+    /k8s logs [target] [--tail N]
+                                recent logs (default: pipeline, tail 50)
+    /k8s list                   namespaces managed by DEILE
+
+Targets for /k8s logs:
+    bot         -> deilebot
+    worker      -> deile-worker
+    pipeline    -> deile-pipeline  (default)
+    claude-worker -> claude-worker
+    shell       -> deile-shell
+    all         -> each deployment
+
+V2 verbs (host-only, require deploy.py on the host):
+    start, stop, restart, status, logs
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from ..base import CommandContext, CommandResult, DirectCommand
+from ...config.manager import CommandConfig
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_KUBECTL = str(Path.home() / ".rd" / "bin" / "kubectl")
+_DEFAULT_NAMESPACE = "deile"
+_DEFAULT_TAIL = 50
+_DEFAULT_DEPLOYMENT = "deile-pipeline"
+_KUBECTL_TIMEOUT = 30.0
+
+K8S_DEPLOYMENTS = [
+    "deilebot",
+    "deile-worker",
+    "deile-shell",
+    "deile-pipeline",
+    "claude-worker",
+]
+
+_LOG_TARGET_MAP = {
+    "bot": "deilebot",
+    "worker": "deile-worker",
+    "pipeline": "deile-pipeline",
+    "claude-worker": "claude-worker",
+    "shell": "deile-shell",
+}
+
+_V1_VERBS = [
+    ("restart", "rollout restart [--deployment <name|all>]  (padrão: deile-pipeline)"),
+    ("status", "pods, deployments e services"),
+    ("logs", "logs recentes [bot|worker|pipeline|claude-worker|shell|all]"),
+    ("list", "namespaces DEILE detectados no cluster"),
+]
+
+_V2_VERBS = ["start", "stop", "restart", "status", "logs"]
+
+# ---------------------------------------------------------------------------
+# Namespace auto-detection
+# ---------------------------------------------------------------------------
+
+
+async def _detect_namespace() -> str:
+    """Detect DEILE-managed namespace via kubectl label selector.
+
+    Returns the first matching namespace, or 'deile' as fallback.
+    """
+    import shutil
+    kubectl = shutil.which("kubectl") or _KUBECTL
+    cmd = [
+        kubectl,
+        "get", "namespaces",
+        "-l", "app.kubernetes.io/managed-by=deile",
+        "-o", "jsonpath={.items[*].metadata.name}",
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout_b, _ = await asyncio.wait_for(proc.communicate(), timeout=_KUBECTL_TIMEOUT)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return _DEFAULT_NAMESPACE
+    except OSError:
+        return _DEFAULT_NAMESPACE
+
+    names = stdout_b.decode(errors="replace").split()
+    if not names:
+        return _DEFAULT_NAMESPACE
+    return names[0]
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helper
+# ---------------------------------------------------------------------------
+
+
+async def _run_kubectl(
+    args: List[str],
+    timeout: float = _KUBECTL_TIMEOUT,
+) -> Tuple[bool, str, str]:
+    """Run kubectl with the given args. Returns (ok, stdout, stderr)."""
+    import shutil
+    kubectl = shutil.which("kubectl") or _KUBECTL
+    cmd = [kubectl] + args
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return False, "", f"kubectl timed out after {timeout:.0f}s"
+    except OSError as exc:
+        return False, "", f"Failed to start kubectl: {exc}"
+
+    stdout = stdout_b.decode(errors="replace")
+    stderr = stderr_b.decode(errors="replace")
+    ok = proc.returncode == 0
+    return ok, stdout, stderr
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_restart_args(raw: str):
+    """Parse --deployment flag from restart subcommand tail.
+
+    Returns the deployment name (string) or 'all'.
+    """
+    tokens = shlex.split(raw) if raw.strip() else []
+    deployment = _DEFAULT_DEPLOYMENT
+    i = 0
+    while i < len(tokens):
+        if tokens[i] in ("--deployment", "-d") and i + 1 < len(tokens):
+            deployment = tokens[i + 1]
+            i += 2
+        else:
+            i += 1
+    return deployment
+
+
+def _parse_logs_args(raw: str):
+    """Parse [target] [--tail N] from logs subcommand tail.
+
+    Returns (target_key, tail_n).
+    """
+    tokens = shlex.split(raw) if raw.strip() else []
+    target = "pipeline"
+    tail = _DEFAULT_TAIL
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--tail" and i + 1 < len(tokens):
+            try:
+                tail = int(tokens[i + 1])
+            except ValueError:
+                pass
+            i += 2
+        elif not tok.startswith("-"):
+            target = tok
+            i += 1
+        else:
+            i += 1
+    return target, tail
+
+
+# ---------------------------------------------------------------------------
+# Sub-command implementations
+# ---------------------------------------------------------------------------
+
+
+async def _cmd_discovery(namespace: str) -> CommandResult:
+    """Show the /k8s discovery panel."""
+    v1_table = Table(show_header=True, header_style="bold cyan", box=None)
+    v1_table.add_column("Verbo", style="cyan", no_wrap=True)
+    v1_table.add_column("Descricao")
+
+    for verb, desc in _V1_VERBS:
+        v1_table.add_row(verb, desc)
+
+    v2_line = Text("-- host-only (V2, requer deploy.py no host) --", style="dim")
+    v2_verbs_text = Text("  " + "  ".join(_V2_VERBS), style="yellow")
+
+    footer = Text(
+        "Deployments: " + " . ".join(K8S_DEPLOYMENTS),
+        style="dim",
+    )
+
+    content = Group(v1_table, v2_line, v2_verbs_text, footer)
+    panel = Panel(
+        content,
+        title=f"/k8s -- verbos disponiveis (namespace ativo: {namespace})",
+        border_style="blue",
+    )
+    return CommandResult.success_result(panel, "rich")
+
+
+async def _cmd_restart(namespace: str, deployment: str) -> CommandResult:
+    """Restart one or all deployments."""
+    console = Console(no_color=False)
+
+    if deployment.lower() == "all":
+        targets = K8S_DEPLOYMENTS
+    else:
+        targets = [deployment]
+
+    results = []
+    for dep in targets:
+        console.print(f"[cyan]Restarting deployment/{dep}...[/cyan]")
+        ok, stdout, stderr = await _run_kubectl(
+            ["-n", namespace, "rollout", "restart", f"deployment/{dep}"]
+        )
+        if not ok:
+            results.append((dep, False, stderr.strip()))
+            console.print(f"[red]restart deployment/{dep} failed: {stderr.strip()}[/red]")
+            continue
+
+        # Wait for rollout status
+        console.print(f"[cyan]Waiting for rollout status of {dep}...[/cyan]")
+        ok2, stdout2, stderr2 = await _run_kubectl(
+            ["-n", namespace, "rollout", "status", f"deployment/{dep}", "--timeout=180s"],
+            timeout=200.0,
+        )
+        if ok2:
+            results.append((dep, True, stdout2.strip()))
+            console.print(f"[green]deployment/{dep}: {stdout2.strip() or 'success'}[/green]")
+        else:
+            results.append((dep, False, stderr2.strip() or stdout2.strip()))
+            console.print(f"[red]deployment/{dep} rollout failed: {stderr2.strip()}[/red]")
+
+    all_ok = all(ok for _, ok, _ in results)
+    lines = [
+        ("[green]OK[/green]" if ok else "[red]FAIL[/red]") + f"  {dep}: {msg}"
+        for dep, ok, msg in results
+    ]
+    summary = "\n".join(lines)
+
+    if all_ok:
+        return CommandResult.success_result(
+            f"Restart completed.\n{summary}",
+            "text",
+        )
+    return CommandResult(
+        success=False,
+        content=f"One or more restarts failed.\n{summary}",
+        content_type="text",
+    )
+
+
+async def _cmd_status(namespace: str) -> CommandResult:
+    """Get pods, deployments and services."""
+    ok, stdout, stderr = await _run_kubectl(
+        ["-n", namespace, "get", "pods,deployments,services"]
+    )
+    if not ok:
+        return CommandResult.error_result(
+            f"kubectl get failed:\n{stderr.strip()}"
+        )
+    return CommandResult.success_result(stdout or "(empty output)", "text")
+
+
+async def _cmd_logs(namespace: str, target_key: str, tail: int) -> CommandResult:
+    """Fetch recent logs from one or all deployments."""
+    if target_key == "all":
+        targets = list(K8S_DEPLOYMENTS)
+    else:
+        resolved = _LOG_TARGET_MAP.get(target_key)
+        if resolved is None:
+            # Maybe user passed the full deployment name directly
+            if target_key in K8S_DEPLOYMENTS:
+                resolved = target_key
+            else:
+                valid = ", ".join(sorted(_LOG_TARGET_MAP.keys()) + ["all"])
+                return CommandResult.error_result(
+                    f"Unknown log target '{target_key}'. Valid: {valid}"
+                )
+        targets = [resolved]
+
+    sections = []
+    for dep in targets:
+        ok, stdout, stderr = await _run_kubectl(
+            ["-n", namespace, "logs", f"deployment/{dep}", f"--tail={tail}"]
+        )
+        header = f"=== {dep} (--tail={tail}) ==="
+        if not ok:
+            sections.append(f"{header}\n[ERROR] {stderr.strip()}")
+        else:
+            sections.append(f"{header}\n{stdout or '(no output)'}")
+
+    return CommandResult.success_result("\n\n".join(sections), "text")
+
+
+async def _cmd_list(namespace: str) -> CommandResult:
+    """List DEILE-managed namespaces."""
+    ok, stdout, stderr = await _run_kubectl(
+        ["get", "namespaces", "-l", "app.kubernetes.io/managed-by=deile"]
+    )
+    if not ok:
+        return CommandResult.error_result(
+            f"kubectl get namespaces failed:\n{stderr.strip()}"
+        )
+    return CommandResult.success_result(stdout or "(no DEILE namespaces found)", "text")
+
+
+# ---------------------------------------------------------------------------
+# Command class
+# ---------------------------------------------------------------------------
+
+
+class K8sCommand(DirectCommand):
+    """``/k8s {restart|status|logs|list}`` -- kubectl operations for DEILE cluster.
+
+    With no args, shows a discovery panel with available verbs and deployments.
+    """
+
+    cli_flag = None
+    cli_requires_provider = False
+
+    def __init__(self) -> None:
+        super().__init__(
+            CommandConfig(
+                name="k8s",
+                description=(
+                    "Operacoes kubectl no cluster DEILE "
+                    "(restart|status|logs|list)"
+                ),
+                action="k8s",
+            )
+        )
+        self.category = "infrastructure"
+
+    async def execute(self, context: CommandContext) -> CommandResult:
+        args = context.args.strip() if context.args else ""
+        parts = args.split(None, 1)
+        sub = parts[0].lower() if parts else ""
+        tail = parts[1] if len(parts) > 1 else ""
+
+        namespace = await _detect_namespace()
+
+        if not sub:
+            return await _cmd_discovery(namespace)
+
+        if sub == "restart":
+            deployment = _parse_restart_args(tail)
+            return await _cmd_restart(namespace, deployment)
+
+        if sub == "status":
+            return await _cmd_status(namespace)
+
+        if sub == "logs":
+            target, tail_n = _parse_logs_args(tail)
+            return await _cmd_logs(namespace, target, tail_n)
+
+        if sub == "list":
+            return await _cmd_list(namespace)
+
+        # Unknown subcommand — show discovery panel with a hint
+        valid = "restart, status, logs, list"
+        return CommandResult.error_result(
+            f"Unknown subcommand '{sub}'. Valid: {valid}. Run /k8s for help."
+        )
+
+    async def get_help(self) -> str:
+        return """/k8s -- kubectl operations for DEILE cluster
+
+Usage:
+  /k8s                           show available verbs (discovery panel)
+  /k8s restart [--deployment <name|all>]
+                                 rollout restart (default: deile-pipeline)
+  /k8s status                    kubectl get pods,deployments,services
+  /k8s logs [target] [--tail N]  recent logs (default: pipeline, tail 50)
+  /k8s list                      list DEILE-managed namespaces
+
+Log targets: bot, worker, pipeline (default), claude-worker, shell, all
+Deployments: """ + " | ".join(K8S_DEPLOYMENTS)

--- a/deile/tests/commands/test_k8s_command.py
+++ b/deile/tests/commands/test_k8s_command.py
@@ -593,8 +593,8 @@ class TestK8sCommandMetadata:
     def test_category_is_infrastructure(self):
         assert _cmd().category == "infrastructure"
 
-    async def test_get_help_contains_usage(self):
-        help_text = await _cmd().get_help()
+    def test_get_help_contains_usage(self):
+        help_text = _cmd().get_help()
         assert "k8s" in help_text.lower()
         assert "restart" in help_text.lower()
         assert "logs" in help_text.lower()

--- a/deile/tests/commands/test_k8s_command.py
+++ b/deile/tests/commands/test_k8s_command.py
@@ -1,0 +1,632 @@
+"""Tests: /k8s command."""
+
+from __future__ import annotations
+
+import asyncio
+from io import StringIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from deile.commands.base import CommandContext, DirectCommand
+from deile.commands.builtin.k8s_command import (
+    K8sCommand,
+    K8S_DEPLOYMENTS,
+    _detect_namespace,
+    _parse_logs_args,
+    _parse_restart_args,
+    _run_kubectl,
+    _cmd_discovery,
+    _cmd_restart,
+    _cmd_status,
+    _cmd_logs,
+    _cmd_list,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(args: str = "") -> CommandContext:
+    return CommandContext(user_input=f"/k8s {args}".strip(), args=args)
+
+
+def _cmd() -> K8sCommand:
+    return K8sCommand()
+
+
+def _render(content) -> str:
+    buf = StringIO()
+    console = Console(file=buf, no_color=True, width=120)
+    console.print(content)
+    return buf.getvalue()
+
+
+def _mock_proc(returncode: int, stdout: bytes, stderr: bytes) -> AsyncMock:
+    """Build a mock asyncio subprocess."""
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# _parse_restart_args
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseRestartArgs:
+    def test_no_args_returns_default(self):
+        assert _parse_restart_args("") == "deile-pipeline"
+
+    def test_explicit_deployment(self):
+        assert _parse_restart_args("--deployment deilebot") == "deilebot"
+
+    def test_short_flag(self):
+        assert _parse_restart_args("-d claude-worker") == "claude-worker"
+
+    def test_all(self):
+        assert _parse_restart_args("--deployment all") == "all"
+
+    def test_unknown_token_ignored(self):
+        # unknown tokens should not crash the parser
+        result = _parse_restart_args("some-random-text")
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _parse_logs_args
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseLogsArgs:
+    def test_no_args_returns_defaults(self):
+        target, tail = _parse_logs_args("")
+        assert target == "pipeline"
+        assert tail == 50
+
+    def test_explicit_target(self):
+        target, tail = _parse_logs_args("bot")
+        assert target == "bot"
+        assert tail == 50
+
+    def test_explicit_tail(self):
+        target, tail = _parse_logs_args("worker --tail 100")
+        assert target == "worker"
+        assert tail == 100
+
+    def test_tail_only(self):
+        target, tail = _parse_logs_args("--tail 200")
+        assert target == "pipeline"
+        assert tail == 200
+
+    def test_invalid_tail_ignored(self):
+        target, tail = _parse_logs_args("--tail notanumber")
+        assert tail == 50  # default preserved
+
+
+# ---------------------------------------------------------------------------
+# _detect_namespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDetectNamespace:
+    async def test_single_namespace_returned(self):
+        proc = _mock_proc(0, b"deile", b"")
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            ns = await _detect_namespace()
+        assert ns == "deile"
+
+    async def test_multiple_namespaces_returns_first(self):
+        proc = _mock_proc(0, b"deile deile-gl", b"")
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            ns = await _detect_namespace()
+        assert ns == "deile"
+
+    async def test_empty_output_returns_default(self):
+        proc = _mock_proc(0, b"", b"")
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            ns = await _detect_namespace()
+        assert ns == "deile"
+
+    async def test_os_error_returns_default(self):
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            side_effect=OSError("no such file"),
+        ):
+            ns = await _detect_namespace()
+        assert ns == "deile"
+
+    async def test_timeout_returns_default(self):
+        proc = _mock_proc(0, b"deile", b"")
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            ns = await _detect_namespace()
+        assert ns == "deile"
+
+
+# ---------------------------------------------------------------------------
+# _run_kubectl
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunKubectl:
+    async def test_success(self):
+        proc = _mock_proc(0, b"NAME   STATUS\npod-a  Running\n", b"")
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            ok, stdout, stderr = await _run_kubectl(["-n", "deile", "get", "pods"])
+        assert ok is True
+        assert "pod-a" in stdout
+        assert stderr == ""
+
+    async def test_nonzero_returncode(self):
+        proc = _mock_proc(1, b"", b"Forbidden")
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            ok, stdout, stderr = await _run_kubectl(["-n", "deile", "get", "pods"])
+        assert ok is False
+        assert "Forbidden" in stderr
+
+    async def test_os_error(self):
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            side_effect=OSError("binary not found"),
+        ):
+            ok, stdout, stderr = await _run_kubectl(["get", "pods"])
+        assert ok is False
+        assert "binary not found" in stderr
+
+    async def test_timeout(self):
+        proc = _mock_proc(0, b"", b"")
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+        with patch(
+            "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            ok, stdout, stderr = await _run_kubectl(["get", "pods"], timeout=5.0)
+        assert ok is False
+        assert "timed out" in stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# _cmd_discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdDiscovery:
+    async def test_returns_rich_panel(self):
+        result = await _cmd_discovery("deile")
+        assert result.success is True
+        assert result.content_type == "rich"
+
+    async def test_panel_contains_namespace(self):
+        result = await _cmd_discovery("my-namespace")
+        rendered = _render(result.content)
+        assert "my-namespace" in rendered
+
+    async def test_panel_contains_verbs(self):
+        result = await _cmd_discovery("deile")
+        rendered = _render(result.content)
+        assert "restart" in rendered
+        assert "status" in rendered
+        assert "logs" in rendered
+        assert "list" in rendered
+
+    async def test_panel_contains_deployments_footer(self):
+        result = await _cmd_discovery("deile")
+        rendered = _render(result.content)
+        assert "deile-pipeline" in rendered
+        assert "deilebot" in rendered
+
+
+# ---------------------------------------------------------------------------
+# _cmd_restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdRestart:
+    async def test_restart_single_success(self):
+        proc_ok = _mock_proc(0, b"deployment.apps/deile-pipeline restarted\n", b"")
+        proc_status = _mock_proc(
+            0, b'deployment "deile-pipeline" successfully rolled out\n', b""
+        )
+        call_count = [0]
+
+        async def fake_run(args, timeout=30.0):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return True, proc_ok.communicate.return_value[0].decode(), ""
+            return True, proc_status.communicate.return_value[0].decode(), ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_restart("deile", "deile-pipeline")
+
+        assert result.success is True
+
+    async def test_restart_single_failure(self):
+        async def fake_run(args, timeout=30.0):
+            return False, "", "Error from server"
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_restart("deile", "deile-pipeline")
+
+        assert result.success is False
+
+    async def test_restart_all_iterates_all_deployments(self):
+        called_deployments = []
+
+        async def fake_run(args, timeout=30.0):
+            # Capture which deployment is being operated on
+            for i, arg in enumerate(args):
+                if "deployment/" in arg:
+                    dep = arg.replace("deployment/", "")
+                    called_deployments.append(dep)
+            return True, "success", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_restart("deile", "all")
+
+        # Each deployment is restarted (restart + status = 2 calls each)
+        assert result.success is True
+        for dep in K8S_DEPLOYMENTS:
+            assert dep in called_deployments
+
+    async def test_restart_all_partial_failure(self):
+        fail_deps = {"deilebot"}
+
+        async def fake_run(args, timeout=30.0):
+            for arg in args:
+                if "deployment/deilebot" in arg and "restart" in args:
+                    return False, "", "Failed for deilebot"
+            return True, "success", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_restart("deile", "all")
+
+        # Result depends on outcomes — just confirm it runs without crashing
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _cmd_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdStatus:
+    async def test_success_returns_kubectl_output(self):
+        async def fake_run(args, timeout=30.0):
+            return True, "NAME           READY   STATUS\npod-a         1/1     Running\n", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_status("deile")
+
+        assert result.success is True
+        assert "pod-a" in result.content
+
+    async def test_kubectl_error_returns_failure(self):
+        async def fake_run(args, timeout=30.0):
+            return False, "", "Forbidden: User cannot list resource"
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_status("deile")
+
+        assert result.success is False
+        assert "Forbidden" in result.content
+
+
+# ---------------------------------------------------------------------------
+# _cmd_logs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdLogs:
+    async def test_default_pipeline_target(self):
+        async def fake_run(args, timeout=30.0):
+            assert "deployment/deile-pipeline" in args
+            return True, "log line 1\nlog line 2\n", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_logs("deile", "pipeline", 50)
+
+        assert result.success is True
+        assert "deile-pipeline" in result.content
+
+    def _make_run(self, ok=True):
+        async def fake_run(args, timeout=30.0):
+            return ok, "log output\n", "" if ok else "error"
+        return fake_run
+
+    async def test_bot_target_resolves_deilebot(self):
+        calls = []
+
+        async def fake_run(args, timeout=30.0):
+            calls.append(args)
+            return True, "logs\n", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_logs("deile", "bot", 20)
+
+        assert result.success is True
+        assert any("deployment/deilebot" in a for args in calls for a in args)
+
+    async def test_worker_target_resolves(self):
+        calls = []
+
+        async def fake_run(args, timeout=30.0):
+            calls.append(args)
+            return True, "logs\n", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_logs("deile", "worker", 50)
+
+        assert result.success is True
+        assert any("deployment/deile-worker" in a for args in calls for a in args)
+
+    async def test_all_target_iterates_all_deployments(self):
+        calls = []
+
+        async def fake_run(args, timeout=30.0):
+            calls.append(args)
+            return True, "log line\n", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_logs("deile", "all", 50)
+
+        assert result.success is True
+        collected = [a for args in calls for a in args]
+        for dep in K8S_DEPLOYMENTS:
+            assert f"deployment/{dep}" in collected
+
+    async def test_invalid_target_returns_error(self):
+        result = await _cmd_logs("deile", "invalid-target", 50)
+        assert result.success is False
+        assert "invalid-target" in result.content
+
+    async def test_tail_flag_passed_to_kubectl(self):
+        calls = []
+
+        async def fake_run(args, timeout=30.0):
+            calls.append(args)
+            return True, "log\n", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            await _cmd_logs("deile", "pipeline", 123)
+
+        assert any("--tail=123" in a for args in calls for a in args)
+
+    async def test_kubectl_error_included_in_output(self):
+        async def fake_run(args, timeout=30.0):
+            return False, "", "RBAC denied"
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_logs("deile", "pipeline", 50)
+
+        assert result.success is True  # _cmd_logs always returns content
+        assert "RBAC denied" in result.content or "ERROR" in result.content
+
+
+# ---------------------------------------------------------------------------
+# _cmd_list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdList:
+    async def test_success_returns_namespace_list(self):
+        async def fake_run(args, timeout=30.0):
+            return True, "NAME   STATUS\ndeile  Active\n", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_list("deile")
+
+        assert result.success is True
+        assert "deile" in result.content
+
+    async def test_kubectl_error_returns_failure(self):
+        async def fake_run(args, timeout=30.0):
+            return False, "", "permission denied"
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_list("deile")
+
+        assert result.success is False
+        assert "permission denied" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# K8sCommand.execute — dispatch routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestK8sCommandExecute:
+    async def test_no_args_shows_discovery(self):
+        with patch(
+            "deile.commands.builtin.k8s_command._detect_namespace",
+            new_callable=AsyncMock,
+            return_value="deile",
+        ):
+            result = await _cmd().execute(_ctx(""))
+        assert result.success is True
+        assert result.content_type == "rich"
+
+    async def test_restart_subcommand_dispatched(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_restart",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_restart,
+        ):
+            await _cmd().execute(_ctx("restart --deployment deilebot"))
+
+        mock_restart.assert_called_once_with("deile", "deilebot")
+
+    async def test_status_subcommand_dispatched(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_status",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="pods", content_type="text"),
+            ) as mock_status,
+        ):
+            await _cmd().execute(_ctx("status"))
+
+        mock_status.assert_called_once_with("deile")
+
+    async def test_logs_subcommand_dispatched(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_logs",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="logs", content_type="text"),
+            ) as mock_logs,
+        ):
+            await _cmd().execute(_ctx("logs bot --tail 100"))
+
+        mock_logs.assert_called_once_with("deile", "bot", 100)
+
+    async def test_list_subcommand_dispatched(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_list",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ns", content_type="text"),
+            ) as mock_list,
+        ):
+            await _cmd().execute(_ctx("list"))
+
+        mock_list.assert_called_once_with("deile")
+
+    async def test_unknown_subcommand_returns_error(self):
+        with patch(
+            "deile.commands.builtin.k8s_command._detect_namespace",
+            new_callable=AsyncMock,
+            return_value="deile",
+        ):
+            result = await _cmd().execute(_ctx("foobar"))
+
+        assert result.success is False
+        assert "foobar" in result.content
+
+    async def test_restart_default_deployment(self):
+        """No --deployment flag => uses deile-pipeline."""
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_restart",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_restart,
+        ):
+            await _cmd().execute(_ctx("restart"))
+
+        mock_restart.assert_called_once_with("deile", "deile-pipeline")
+
+
+# ---------------------------------------------------------------------------
+# Command metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestK8sCommandMetadata:
+    def test_name(self):
+        assert _cmd().name == "k8s"
+
+    def test_is_direct_command(self):
+        assert isinstance(_cmd(), DirectCommand)
+
+    def test_category_is_infrastructure(self):
+        assert _cmd().category == "infrastructure"
+
+    async def test_get_help_contains_usage(self):
+        help_text = await _cmd().get_help()
+        assert "k8s" in help_text.lower()
+        assert "restart" in help_text.lower()
+        assert "logs" in help_text.lower()
+
+    def test_no_fixed_width_in_add_column(self):
+        """k8s_command.py must not use width=<int> in add_column calls."""
+        import re
+        from pathlib import Path
+
+        path = (
+            Path(__file__).resolve().parents[3]
+            / "deile"
+            / "commands"
+            / "builtin"
+            / "k8s_command.py"
+        )
+        text = path.read_text(encoding="utf-8")
+        width_literal = re.compile(r"\.add_column\s*\([^)]*width\s*=\s*\d+")
+        matches = width_literal.findall(text)
+        assert not matches, f"Fixed width in add_column: {matches}"
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_k8s_command_auto_discoverable():
+    from deile.commands.registry import CommandRegistry
+    r = CommandRegistry()
+    r.auto_discover_builtin_commands()
+    cmd = r.get_command("k8s")
+    assert cmd is not None
+    assert cmd.name == "k8s"


### PR DESCRIPTION
Implements the /k8s command in the deile REPL, eliminating the need to exit the REPL to run kubectl operations.

## What is implemented (V1 - kubectl-direct verbs)

- /k8s (no args): discovery menu listing all V1 verbs + V2 host-only verbs
- /k8s restart [--deployment name|all]: kubectl rollout restart + wait for status (default: deile-pipeline)
- /k8s status: kubectl get pods,deployments,services
- /k8s logs [target] [--tail N]: recent logs by deployment
- /k8s list: discover namespaces with managed-by=deile label

## Architecture

All V1 verbs call kubectl directly via asyncio.create_subprocess_exec (works in-pod and on host). V2 orchestration verbs (up/build/down/scale/etc.) require deploy.py which is host-only and are listed as V2/future scope. Namespace auto-detected at invocation time.

Closes #418.