### PR TITLE
feat: grep-like filter in PodWatchView and LiveSessionView

### DIFF
--- a/deile/tests/infra/test_panel_pod_watch_filter.py
+++ b/deile/tests/infra/test_panel_pod_watch_filter.py
@@ -1,0 +1,393 @@
+"""Testes do filtro grep-like em PodWatchView e LiveSessionView (issue #460).
+
+Cobertura dos ACs:
+
+AC1  — filtro literal case-insensitive; linhas sem match ficam ocultas.
+AC2  — limite de 200 chars no buffer; prefixo `r:` ativa regex.
+AC3  — filtro aplicado APÓS health filter e ANTES do truncamento [-30:].
+AC4  — `[/]` abre o prompt inline; teclas viram texto no buffer.
+AC5  — `[ESC]` em 3 níveis: fecha prompt → limpa filtro → pop view (global).
+AC6  — LiveSessionView filtra `data.chat["turns"]` antes de renderizar.
+AC7  — regex inválido cai para filtro literal + toast.
+AC8  — filtro vazio `""` = saída idêntica (nenhuma linha oculta).
+AC9  — contador `grep_hidden` é separado de `health hidden`.
+AC10 — regex compilado 1× no [enter], nunca por render.
+AC11 — hotkeys `f`/`c`/`h` ficam mortas enquanto o prompt está aberto.
+AC12 — `[ESC]` dentro do prompt fecha sem aplicar o filtro.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_view() -> panel.PodWatchView:
+    view = panel.PodWatchView()
+    view.pod_name = "claude-worker-0"
+    view.pod_role = "claude-worker"
+    view.hide_health = False
+    return view
+
+
+def _make_streamer(lines: list[str]) -> MagicMock:
+    mock = MagicMock()
+    mock.snapshot.return_value = list(lines)
+    return mock
+
+
+def _make_app() -> MagicMock:
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# AC1 — filtro literal case-insensitive
+# ---------------------------------------------------------------------------
+
+class TestLiteralFilter:
+    def test_filter_literal_case_insensitive(self):
+        view = _make_view()
+        view.streamer = _make_streamer(["ERROR: boom", "info: ok", "Error: another"])
+        view._filter_re = re.compile(re.escape("error"), re.IGNORECASE)
+        view._filter_text = "error"
+
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "boom" in rendered
+        assert "another" in rendered
+        assert "info: ok" not in rendered
+
+    def test_filter_persists_across_renders(self):
+        view = _make_view()
+        lines = ["match_line", "skip_line"]
+        view.streamer = _make_streamer(lines)
+        view._filter_re = re.compile(re.escape("match"), re.IGNORECASE)
+        view._filter_text = "match"
+
+        # first render
+        p1 = view._log_panel()
+        # second render — same filter object, not recompiled
+        p2 = view._log_panel()
+        assert str(p1.renderable) == str(p2.renderable)
+
+
+# ---------------------------------------------------------------------------
+# AC8 — filtro vazio = saída idêntica
+# ---------------------------------------------------------------------------
+
+class TestEmptyFilter:
+    def test_empty_filter_no_change(self):
+        lines = ["alpha", "beta", "gamma"]
+        view = _make_view()
+        view.streamer = _make_streamer(lines)
+        # no filter
+        panel_no_filter = view._log_panel()
+
+        view._filter_re = None
+        view._filter_text = ""
+        panel_with_empty = view._log_panel()
+
+        assert str(panel_no_filter.renderable) == str(panel_with_empty.renderable)
+
+
+# ---------------------------------------------------------------------------
+# AC3 — filtro antes do truncamento [-30:]
+# ---------------------------------------------------------------------------
+
+class TestFilterBeforeTruncation:
+    def test_filter_applied_before_truncation(self):
+        # 40 lines: first 35 contain "target", last 5 do not.
+        # Without pre-truncation filtering, only last 30 lines are visible
+        # and none contain "target" → result would be empty.
+        # With correct ordering (filter before truncation), we see matches.
+        lines = [f"target line {i}" for i in range(35)] + [
+            f"noise line {i}" for i in range(5)
+        ]
+        view = _make_view()
+        view.streamer = _make_streamer(lines)
+        view._filter_re = re.compile(re.escape("target"), re.IGNORECASE)
+        view._filter_text = "target"
+
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "target" in rendered, (
+            "filter must be applied to full 200-line buffer before [-30:] truncation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC9 — grep_hidden separado do health hidden
+# ---------------------------------------------------------------------------
+
+class TestSeparateCounters:
+    def test_grep_hidden_count_separate_from_health(self):
+        # 3 health lines (to be hidden by hide_health) + 3 normal lines,
+        # 1 matching the grep filter.
+        lines = [
+            "GET /health 200",
+            "GET /healthz 200",
+            "GET /ready 200",
+            "ERROR: boom",
+            "info: ok",
+            "WARNING: watch",
+        ]
+        view = _make_view()
+        view.hide_health = True
+        view.streamer = _make_streamer(lines)
+        view._filter_re = re.compile(re.escape("error"), re.IGNORECASE)
+        view._filter_text = "error"
+
+        with patch("_panel._HEALTH_LINE_RE") as mock_re:
+            mock_re.search.side_effect = lambda ln: (
+                True if "health" in ln.lower() or "healthz" in ln.lower()
+                or "ready" in ln.lower() else False
+            )
+            p = view._log_panel()
+
+        title = p.title
+        # Both counters must appear with their respective labels.
+        assert "health filtrados" in title
+        assert "filtro grep" in title
+        # They must be on separate labels, not merged.
+        assert title.count("health filtrados") == 1
+        assert title.count("filtro grep") == 1
+
+
+# ---------------------------------------------------------------------------
+# AC4 — [/] abre prompt, teclas viram buffer
+# ---------------------------------------------------------------------------
+
+class TestPromptOpen:
+    def test_slash_opens_prompt(self):
+        view = _make_view()
+        app = _make_app()
+        assert not view._prompt_open
+        result = view.handle_key("/", app)
+        assert view._prompt_open
+        assert view._filter_buffer == ""
+        assert result.kind == panel.Action.REFRESH
+
+    def test_characters_go_to_buffer_when_prompt_open(self):
+        view = _make_view()
+        app = _make_app()
+        view._prompt_open = True
+        for ch in "hello":
+            view.handle_key(ch, app)
+        assert view._filter_buffer == "hello"
+
+
+# ---------------------------------------------------------------------------
+# AC11 — hotkeys f/c/h ficam mortas enquanto o prompt está aberto
+# ---------------------------------------------------------------------------
+
+class TestHotkeysDeadWhilePromptOpen:
+    def test_f_goes_to_buffer_not_follow_toggle(self):
+        view = _make_view()
+        app = _make_app()
+        view._prompt_open = True
+        initial_following = view.following
+        view.handle_key("f", app)
+        assert view.following == initial_following, "follow must NOT toggle while prompt is open"
+        assert "f" in view._filter_buffer
+
+    def test_c_goes_to_buffer_not_clear(self):
+        view = _make_view()
+        app = _make_app()
+        mock_streamer = _make_streamer(["line"])
+        view.streamer = mock_streamer
+        view._prompt_open = True
+        view.handle_key("c", app)
+        mock_streamer.buf.clear.assert_not_called()
+        assert "c" in view._filter_buffer
+
+    def test_h_goes_to_buffer_not_hide_toggle(self):
+        view = _make_view()
+        app = _make_app()
+        view._prompt_open = True
+        initial_hide = view.hide_health
+        view.handle_key("h", app)
+        assert view.hide_health == initial_hide, "hide_health must NOT toggle while prompt is open"
+        assert "h" in view._filter_buffer
+
+
+# ---------------------------------------------------------------------------
+# AC12 — ESC dentro do prompt fecha sem aplicar filtro
+# ---------------------------------------------------------------------------
+
+class TestEscInPrompt:
+    def test_esc_closes_prompt_without_applying_filter(self):
+        view = _make_view()
+        app = _make_app()
+        view._prompt_open = True
+        view._filter_buffer = "partial"
+        result = view.handle_key("ESC", app)
+        assert not view._prompt_open
+        assert view._filter_buffer == ""
+        assert view._filter_text == ""
+        assert view._filter_re is None
+        assert result.kind == panel.Action.REFRESH
+
+
+# ---------------------------------------------------------------------------
+# AC5 — ESC em 3 níveis via intercepts_key
+# ---------------------------------------------------------------------------
+
+class TestEscThreeLevels:
+    def test_level1_esc_closes_prompt(self):
+        view = _make_view()
+        view._prompt_open = True
+        assert view.intercepts_key("ESC")
+        app = _make_app()
+        view.handle_key("ESC", app)
+        assert not view._prompt_open
+
+    def test_level2_esc_clears_filter(self):
+        view = _make_view()
+        view._filter_text = "error"
+        view._filter_re = re.compile(re.escape("error"), re.IGNORECASE)
+        assert view.intercepts_key("ESC")
+        app = _make_app()
+        result = view.handle_key("ESC", app)
+        assert view._filter_text == ""
+        assert view._filter_re is None
+        assert result.kind == panel.Action.REFRESH
+
+    def test_level3_esc_not_intercepted(self):
+        view = _make_view()
+        view._filter_text = ""
+        view._prompt_open = False
+        assert not view.intercepts_key("ESC")
+
+
+# ---------------------------------------------------------------------------
+# AC7 — regex inválido cai para literal + toast
+# ---------------------------------------------------------------------------
+
+class TestInvalidRegex:
+    def test_invalid_regex_falls_back_to_literal(self):
+        view = _make_view()
+        app = _make_app()
+        view._prompt_open = True
+        for ch in "r:[invalid":
+            view._filter_buffer += ch
+        view.handle_key("\r", app)
+        app.push_toast.assert_called_once_with("⚠", "regex inválido — usando filtro literal")
+        # Filter should be a compiled literal (re.escape of the pattern part)
+        assert view._filter_re is not None
+        assert view._filter_text == "[invalid"
+
+    def test_valid_regex_compiles(self):
+        view = _make_view()
+        app = _make_app()
+        view._prompt_open = True
+        for ch in "r:err.*boom":
+            view._filter_buffer += ch
+        view.handle_key("\r", app)
+        app.push_toast.assert_not_called()
+        assert view._filter_re is not None
+        assert view._filter_re.search("error boom")
+
+
+# ---------------------------------------------------------------------------
+# AC2 — limite de 200 chars
+# ---------------------------------------------------------------------------
+
+class TestMaxLength:
+    def test_filter_text_capped_at_200_chars(self):
+        view = _make_view()
+        app = _make_app()
+        view._prompt_open = True
+        view._filter_buffer = "x" * 250
+        view.handle_key("\r", app)
+        assert len(view._filter_text) == 200
+
+
+# ---------------------------------------------------------------------------
+# AC10 — regex compilado 1× (não por render)
+# ---------------------------------------------------------------------------
+
+class TestCompileOnce:
+    def test_regex_not_recompiled_on_render(self):
+        view = _make_view()
+        view.streamer = _make_streamer(["line1", "line2"])
+        compiled = re.compile(re.escape("line"), re.IGNORECASE)
+        view._filter_re = compiled
+        view._filter_text = "line"
+
+        view._log_panel()
+        view._log_panel()
+        view._log_panel()
+
+        # The exact same object must still be there (not a new compile each time).
+        assert view._filter_re is compiled
+
+
+# ---------------------------------------------------------------------------
+# AC6 — LiveSessionView filtra chat["turns"]
+# ---------------------------------------------------------------------------
+
+class TestLiveSessionViewFilter:
+    def test_filter_turns_before_render(self):
+        from deile.ui.panel.observability.screens import LiveSessionData  # type: ignore
+
+        view = panel.LiveSessionView()
+        view.task_id = "task-123"
+        view.pod_name = "claude-worker-0"
+
+        turns = [
+            {"role": "user", "content": "find the error"},
+            {"role": "assistant", "content": "looking good"},
+            {"role": "user", "content": "error found: boom"},
+        ]
+        live_data = LiveSessionData(
+            session={"task_id": "task-123", "status": "running"},
+            command={"cmd": "test"},
+            chat={"turns": turns},
+            api_errors=[],
+        )
+
+        view._filter_re = re.compile(re.escape("error"), re.IGNORECASE)
+        view._filter_text = "error"
+
+        # Patch _fetch_data to return our live_data
+        # and LiveSessionScreen.render to capture what it receives.
+        received = {}
+
+        class FakeScreen:
+            def render(self, data):
+                received["data"] = data
+                from rich.text import Text
+                return Text("ok")
+
+        with (
+            patch.object(view, "_fetch_data", return_value=(live_data, [])),
+            patch(
+                "deile.ui.panel.observability.screens.LiveSessionScreen",
+                new=lambda: FakeScreen(),
+            ),
+            patch("_panel._head_panel", return_value=MagicMock()),
+            patch("_panel._footer_panel", return_value=MagicMock()),
+        ):
+            view.render(_make_app())
+
+        assert "data" in received
+        filtered_turns = received["data"].chat["turns"]
+        # Only turns containing "error" should remain.
+        assert len(filtered_turns) == 2
+        assert all("error" in t["content"].lower() for t in filtered_turns)
+        # Original data must be unchanged.
+        assert len(turns) == 3

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -2035,7 +2035,7 @@ class PodWatchView(View):
 
     HOTKEYS = ("[f] follow on/off   [h] mostrar/esconder health   "
                "[c] clear log   [.] abrir log   [t] resize /tmp   "
-               "[esc] volta   [q] sai")
+               "[/] filtro grep   [esc] volta   [q] sai")
 
     # Quantas linhas do buffer dumpamos no tempfile quando o usuário pede
     # "abrir log" num pod k8s. Suficiente pra contexto, sem inflar o disco.
@@ -2088,6 +2088,11 @@ class PodWatchView(View):
         # Modo "aguardando preset de /tmp" — quando True, próxima tecla 1-5
         # aplica o preset correspondente; qualquer outra cancela.
         self._awaiting_tmp_preset: bool = False
+        # Filtro grep-like (issue #460).
+        self._filter_text: str = ""          # texto confirmado (exibido no rodapé)
+        self._filter_re: Optional[Any] = None  # padrão compilado (None = sem filtro)
+        self._prompt_open: bool = False      # prompt de entrada de filtro aberto
+        self._filter_buffer: str = ""        # caracteres digitados no prompt
 
     def on_mount(self, app: "PanelApp") -> None:
         # PodWatchView é singleton no registry — re-mount com pod diferente
@@ -2095,6 +2100,10 @@ class PodWatchView(View):
         # vazam entre pods, confundindo o operador.
         self.following = True
         self.hide_health = True
+        self._filter_text = ""
+        self._filter_re = None
+        self._prompt_open = False
+        self._filter_buffer = ""
         if self.streamer is not None:
             self.streamer.stop()
             self.streamer = None
@@ -2408,6 +2417,7 @@ class PodWatchView(View):
 
     def _log_panel(self) -> Panel:
         hidden = 0
+        grep_hidden = 0
         if self.streamer is None:
             body: RenderableType = Text("(streamer não iniciado)", style="dim")
         else:
@@ -2416,6 +2426,11 @@ class PodWatchView(View):
                 before = len(raw)
                 raw = [ln for ln in raw if not _HEALTH_LINE_RE.search(ln)]
                 hidden = before - len(raw)
+            # Grep filter — applied after health filter, before truncation (issue #460).
+            if self._filter_re is not None:
+                before = len(raw)
+                raw = [ln for ln in raw if self._filter_re.search(ln)]
+                grep_hidden = before - len(raw)
             raw = raw[-30:]
             if not raw:
                 body = Text(
@@ -2430,16 +2445,26 @@ class PodWatchView(View):
         health_label = ("health ESCONDIDOS" if self.hide_health
                         else "health VISÍVEIS")
         hidden_label = f"  ·  {hidden} health filtrados" if hidden else ""
+        grep_hidden_label = f"  ·  {grep_hidden} filtro grep" if grep_hidden else ""
         # Limpa status transitório expirado antes de compor o título.
         if self._status_msg is not None and time.time() >= self._status_until:
             self._status_msg = None
         status_label = (f"  ·  [yellow]{self._status_msg}[/yellow]"
                         if self._status_msg else "")
         title = (f"[bold]LIVE LOG[/bold]  ·  {follow_label}  ·  "
-                 f"{health_label}{hidden_label}  ·  "
+                 f"{health_label}{hidden_label}{grep_hidden_label}  ·  "
                  f"{self.pod_name}{status_label}")
         return Panel(body, title=title, title_align="left",
                      border_style="green" if self.following else "yellow")
+
+    def _footer_text(self) -> str:
+        """Dynamic footer: shows filter prompt, active filter indicator, or normal hotkeys."""
+        if self._prompt_open:
+            return (f"filtro: {self._filter_buffer}_"
+                    "   [enter] confirma   [esc] cancela   [backspace] apaga")
+        if self._filter_text:
+            return f'[filtro: "{self._filter_text}"]   ' + self.HOTKEYS
+        return self.HOTKEYS
 
     def render(self, app: "PanelApp") -> RenderableType:
         layout = Layout()
@@ -2455,15 +2480,68 @@ class PodWatchView(View):
                          border_style="cyan"),
                    name="info", size=info_size),
             Layout(self._log_panel(), name="log"),
-            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+            Layout(_footer_panel(self._footer_text()), name="footer", size=3),
         )
         return layout
 
+    def intercepts_key(self, key: str) -> bool:
+        # ESC em 3 níveis (issue #460): nível 1 fecha prompt, nível 2 limpa
+        # filtro, nível 3 passa para o handler global (pop view).
+        if key == "ESC" and (self._prompt_open or bool(self._filter_text)):
+            return True
+        return super().intercepts_key(key)
+
+    def _handle_filter_prompt_key(self, key: str, app: "PanelApp") -> ActionResult:
+        """Processa teclas enquanto o prompt de filtro está aberto."""
+        if key in ("\r", "\n"):
+            self._prompt_open = False
+            text = self._filter_buffer[:200]  # AC2: limite de 200 chars
+            self._filter_text = text
+            if not text:
+                self._filter_re = None
+            elif text.startswith("r:"):
+                pattern = text[2:]
+                try:
+                    self._filter_re = re.compile(pattern, re.IGNORECASE)
+                except re.error:
+                    app.push_toast("⚠", "regex inválido — usando filtro literal")
+                    self._filter_re = re.compile(re.escape(pattern), re.IGNORECASE)
+                    self._filter_text = pattern
+            else:
+                self._filter_re = re.compile(re.escape(text), re.IGNORECASE)
+            return ActionResult.refresh()
+        if key == "ESC":
+            self._prompt_open = False
+            self._filter_buffer = ""
+            return ActionResult.refresh()
+        if key in ("\x7f", "\b", "backspace"):
+            if self._filter_buffer:
+                self._filter_buffer = self._filter_buffer[:-1]
+            return ActionResult.refresh()
+        if len(key) == 1 and key.isprintable():
+            self._filter_buffer += key
+            return ActionResult.refresh()
+        return ActionResult.refresh()
+
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        # Modal: filtro grep — intercepts ALL keys including f/c/h/q (issue #460).
+        if self._prompt_open:
+            return self._handle_filter_prompt_key(key, app)
         # Resolve preset de /tmp PRIMEIRO — outras teclas ficam mortas até o
         # operador escolher ou cancelar (mesmo padrão do PodPickerView).
         if self._awaiting_tmp_preset:
             return self._handle_tmp_preset_key(key)
+        if key == "ESC":
+            # Nível 2: limpa filtro ativo (nível 3 = pop view via global handler).
+            if self._filter_text:
+                self._filter_text = ""
+                self._filter_re = None
+                return ActionResult.refresh()
+            return ActionResult()
+        if key == "/":
+            self._prompt_open = True
+            self._filter_buffer = ""
+            return ActionResult.refresh()
         if key == "f":
             self.following = not self.following
             if self.following and self.streamer is None:
@@ -2605,7 +2683,7 @@ class LiveSessionView(View):
     title = "Live Session"
     refresh_s = 2.0
 
-    HOTKEYS = "[esc] volta   [r] força refresh   [q] sai"
+    HOTKEYS = "[esc] volta   [r] força refresh   [/] filtro grep   [q] sai"
 
     def __init__(self, data: Optional[PanelData] = None):
         self.data = data
@@ -2613,6 +2691,11 @@ class LiveSessionView(View):
         self.pod_name: str = ""
         self._last_render: Optional[Any] = None
         self._api_errors: List[str] = []
+        # Filtro grep-like para as turns do chat (issue #460).
+        self._filter_text: str = ""
+        self._filter_re: Optional[Any] = None
+        self._prompt_open: bool = False
+        self._filter_buffer: str = ""
 
     def on_mount(self, app: "PanelApp") -> None:
         payload = getattr(app, "last_payload", {}) or {}
@@ -2620,6 +2703,10 @@ class LiveSessionView(View):
         self.pod_name = payload.get("pod_name", "")
         self._last_render = None
         self._api_errors = []
+        self._filter_text = ""
+        self._filter_re = None
+        self._prompt_open = False
+        self._filter_buffer = ""
 
     def _fetch_data(self) -> Any:
         """Synchronously fetch session data via asyncio (called from render thread)."""
@@ -2709,6 +2796,15 @@ class LiveSessionView(View):
         except Exception as exc:  # noqa: BLE001
             return None, [str(exc)]
 
+    def _live_session_footer_text(self) -> str:
+        """Dynamic footer for LiveSessionView."""
+        if self._prompt_open:
+            return (f"filtro: {self._filter_buffer}_"
+                    "   [enter] confirma   [esc] cancela   [backspace] apaga")
+        if self._filter_text:
+            return f'[filtro: "{self._filter_text}"]   ' + self.HOTKEYS
+        return self.HOTKEYS
+
     def render(self, app: "PanelApp") -> RenderableType:
         try:
             from deile.ui.panel.observability.screens import (  # noqa: PLC0415
@@ -2732,16 +2828,82 @@ class LiveSessionView(View):
                 border_style="dim",
             )
 
+        # Apply grep filter to chat turns (issue #460): build a new LiveSessionData
+        # with only matching turns; _render_chat's [-8:] then slices the filtered
+        # list.  Original data is not mutated.
+        if self._filter_re is not None and live_data.chat:
+            turns = live_data.chat.get("turns", [])
+            filtered_turns = [
+                t for t in turns
+                if self._filter_re.search(str(t.get("content", "") or ""))
+            ]
+            live_data = live_data.__class__(
+                session=live_data.session,
+                command=live_data.command,
+                chat={**live_data.chat, "turns": filtered_turns},
+                api_errors=live_data.api_errors,
+            )
+
         layout = Layout()
         layout.split_column(
             Layout(_head_panel(
                 f"LIVE SESSION {self.task_id[:16]}", app), name="head", size=4),
             Layout(LiveSessionScreen().render(live_data), name="body"),
-            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
+            Layout(_footer_panel(self._live_session_footer_text()),
+                   name="footer", size=3),
         )
         return layout
 
+    def intercepts_key(self, key: str) -> bool:
+        if key == "ESC" and (self._prompt_open or bool(self._filter_text)):
+            return True
+        return super().intercepts_key(key)
+
+    def _handle_filter_prompt_key(self, key: str, app: "PanelApp") -> ActionResult:
+        """Processa teclas enquanto o prompt de filtro está aberto."""
+        if key in ("\r", "\n"):
+            self._prompt_open = False
+            text = self._filter_buffer[:200]
+            self._filter_text = text
+            if not text:
+                self._filter_re = None
+            elif text.startswith("r:"):
+                pattern = text[2:]
+                try:
+                    self._filter_re = re.compile(pattern, re.IGNORECASE)
+                except re.error:
+                    app.push_toast("⚠", "regex inválido — usando filtro literal")
+                    self._filter_re = re.compile(re.escape(pattern), re.IGNORECASE)
+                    self._filter_text = pattern
+            else:
+                self._filter_re = re.compile(re.escape(text), re.IGNORECASE)
+            return ActionResult.refresh()
+        if key == "ESC":
+            self._prompt_open = False
+            self._filter_buffer = ""
+            return ActionResult.refresh()
+        if key in ("\x7f", "\b", "backspace"):
+            if self._filter_buffer:
+                self._filter_buffer = self._filter_buffer[:-1]
+            return ActionResult.refresh()
+        if len(key) == 1 and key.isprintable():
+            self._filter_buffer += key
+            return ActionResult.refresh()
+        return ActionResult.refresh()
+
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        if self._prompt_open:
+            return self._handle_filter_prompt_key(key, app)
+        if key == "ESC":
+            if self._filter_text:
+                self._filter_text = ""
+                self._filter_re = None
+                return ActionResult.refresh()
+            return ActionResult.back()
+        if key == "/":
+            self._prompt_open = True
+            self._filter_buffer = ""
+            return ActionResult.refresh()
         if key in ("\x1b", "q"):
             return ActionResult.back()
         if key == "r":


### PR DESCRIPTION
## Resumo

Implementa filtragem grep-like dentro das telas abertas pelo drill-down de #446:
- **`PodWatchView`** (logs): hotkey `[/]` abre prompt inline no rodapé; filtro literal (case-insensitive) ou regex com prefixo `r:`
- **`LiveSessionView`** (chat): mesmo mecanismo, filtra `chat["turns"]` antes de passar ao renderer

## Detalhes de implementação

- Filtro aplicado sobre o buffer de 200 linhas **após** o filtro de health e **antes** do truncamento `[-30:]` — garante que matches no histórico profundo sejam visíveis
- Contador `grep_hidden` separado do `health hidden` (title não mente sobre a origem das linhas omitidas)
- Regex compilado **uma vez** no `[enter]`, nunca por render
- Regex inválido (prefixo `r:`) cai para filtro literal + `push_toast`
- Máquina de estados `[esc]` em 3 níveis via `intercepts_key`: fecha prompt → limpa filtro → pop view (global)
- Teclas `f`/`c`/`h`/`q` ficam mortas enquanto o prompt está aberto (estado modal tem prioridade)
- 19 novos testes em `deile/tests/infra/test_panel_pod_watch_filter.py` (cobertura de todos os ACs)

## Testes

```
deile/tests/infra/test_panel_pod_watch_filter.py  19 passed
deile/tests/infra/test_panel_pod_watch.py         (regressão) passou
deile/tests/infra/test_panel_pod_actions.py       (regressão) passou
deile/tests/infra/test_panel_activity_drilldown.py (regressão) passou
Total: 134 passed
```

Closes #460.