### PR TITLE
feat(panel): export estruturado drill-down — path editável, overwrite atômico, txt, stdout, histórico

### DIFF
--- a/deile/tests/infra/test_panel_export_history.py
+++ b/deile/tests/infra/test_panel_export_history.py
@@ -1,0 +1,72 @@
+"""Tests: history ring buffer and dedup for LiveSessionView export (#547)."""
+from __future__ import annotations
+
+import json
+import sys
+from collections import deque
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel
+from deile.ui.panel.observability.screens import LiveSessionData
+
+
+class TestHistoryRingBuffer:
+    def test_maxlen_200(self):
+        v = panel.LiveSessionView()
+        assert v._history.maxlen == 200
+
+    def test_consecutive_dedup(self):
+        v = panel.LiveSessionView()
+        snap = {"polled_at": "2026-01-01T00:00:00Z",
+                "session": {"task_id": "t1"},
+                "command": None, "chat": None}
+        snap_key = json.dumps(snap, sort_keys=True, default=str)
+        # First add
+        if snap_key != v._history_last_key:
+            v._history.append(snap)
+            v._history_last_key = snap_key
+        # Second add same snap — should be deduped
+        if snap_key != v._history_last_key:
+            v._history.append(snap)
+            v._history_last_key = snap_key
+        assert len(v._history) == 1
+
+    def test_different_snaps_both_kept(self):
+        v = panel.LiveSessionView()
+        snaps = [
+            {"polled_at": "2026-01-01T00:00:00Z", "session": {"task_id": "t1"},
+             "command": None, "chat": None},
+            {"polled_at": "2026-01-01T00:00:01Z", "session": {"task_id": "t2"},
+             "command": None, "chat": None},
+        ]
+        for snap in snaps:
+            key = json.dumps(snap, sort_keys=True, default=str)
+            if key != v._history_last_key:
+                v._history.append(snap)
+                v._history_last_key = key
+        assert len(v._history) == 2
+
+    def test_history_in_export_v2(self):
+        history = [
+            {"polled_at": "2026-01-01T00:00:00Z", "session": None, "command": None, "chat": None}
+        ]
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout=None
+        )
+        obj = panel._build_live_session_json(data, history, redactor=None)
+        assert obj["schema_version"] == "deile.export.v2"
+        assert len(obj["history"]) == 1
+        assert obj["history"][0]["polled_at"] == "2026-01-01T00:00:00Z"
+
+    def test_empty_history_still_v2(self):
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout=None
+        )
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v2"
+        assert obj["history"] == []

--- a/deile/tests/infra/test_panel_export_overwrite.py
+++ b/deile/tests/infra/test_panel_export_overwrite.py
@@ -1,0 +1,101 @@
+"""Tests: atomic write and overwrite confirmation for panel export (#547)."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel
+
+
+def _make_live_view_with_data():
+    v = panel.LiveSessionView()
+    v._last_render = MagicMock(
+        session={"task_id": "t1"},
+        command={"cmd": ["cc"]},
+        chat={"turns": []},
+        api_errors=[],
+        stdout=None,
+    )
+    v.task_id = "t1"
+    return v
+
+
+class TestWriteAtomic:
+    def test_writes_content(self, tmp_path):
+        target = tmp_path / "out.json"
+        panel._write_atomic(b'{"test": 1}', target)
+        assert target.read_bytes() == b'{"test": 1}'
+
+    def test_uses_os_replace(self, tmp_path):
+        target = tmp_path / "out.json"
+        replaced = []
+        orig_replace = os.replace
+        def mock_replace(src, dst):
+            replaced.append((src, dst))
+            orig_replace(src, dst)
+        with patch.object(os, "replace", side_effect=mock_replace):
+            panel._write_atomic(b"hello", target)
+        assert len(replaced) == 1
+        assert Path(replaced[0][1]) == target
+
+    def test_tmp_in_same_dir(self, tmp_path):
+        target = tmp_path / "out.json"
+        tmp_paths = []
+        orig_mkstemp = __import__("tempfile").mkstemp
+        def mock_mkstemp(dir=None, **kw):
+            fd, path = orig_mkstemp(dir=dir, **kw)
+            tmp_paths.append(Path(path))
+            return fd, path
+        with patch("tempfile.mkstemp", side_effect=mock_mkstemp):
+            panel._write_atomic(b"data", target)
+        assert len(tmp_paths) == 1
+        assert tmp_paths[0].parent == target.parent
+
+    def test_new_file_no_confirmation(self, tmp_path):
+        v = _make_live_view_with_data()
+        target = tmp_path / "new.json"
+        v.handle_key("E", MagicMock())
+        v._export_path_buf = str(target)
+        v.handle_key("\r", MagicMock())
+        assert target.exists()
+        assert v._export_mode is None
+
+    def test_existing_file_triggers_overwrite_prompt(self, tmp_path):
+        v = _make_live_view_with_data()
+        target = tmp_path / "exists.json"
+        target.write_text("old content")
+        v.handle_key("E", MagicMock())
+        v._export_path_buf = str(target)
+        v.handle_key("\r", MagicMock())
+        assert v._export_mode == "overwrite"
+        assert v._export_target == target
+
+    def test_y_confirms_overwrite(self, tmp_path):
+        v = _make_live_view_with_data()
+        target = tmp_path / "exists.json"
+        target.write_text("old content")
+        v.handle_key("E", MagicMock())
+        v._export_path_buf = str(target)
+        v.handle_key("\r", MagicMock())
+        v.handle_key("y", MagicMock())
+        assert v._export_mode is None
+        content = target.read_bytes()
+        assert b"deile.export.v2" in content
+
+    def test_n_cancels_overwrite(self, tmp_path):
+        v = _make_live_view_with_data()
+        target = tmp_path / "exists.json"
+        target.write_text("old content")
+        v.handle_key("E", MagicMock())
+        v._export_path_buf = str(target)
+        v.handle_key("\r", MagicMock())
+        v.handle_key("n", MagicMock())
+        assert v._export_mode is None
+        assert target.read_text() == "old content"

--- a/deile/tests/infra/test_panel_export_path.py
+++ b/deile/tests/infra/test_panel_export_path.py
@@ -1,0 +1,103 @@
+"""Tests: path editing modal and path sanitization for panel export (#461/#547)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel
+
+
+def _make_view_with_data():
+    v = panel.LiveSessionView()
+    v._last_render = MagicMock()
+    v.task_id = "test-task-123"
+    return v
+
+
+class TestSafeIdSegment:
+    def test_normal_slug(self):
+        assert panel._safe_id_segment("abc-123") == "abc-123"
+
+    def test_slash_replaced(self):
+        seg = panel._safe_id_segment("claude-worker/7d:8c")
+        assert "/" not in seg
+        assert ":" not in seg
+        assert seg == "claude-worker_7d_8c"
+
+    def test_truncated_at_64(self):
+        long = "a" * 100
+        assert len(panel._safe_id_segment(long)) == 64
+
+    def test_empty_string(self):
+        seg = panel._safe_id_segment("")
+        assert seg == "unknown"
+
+
+class TestExportPathModal:
+    def test_E_opens_modal_when_data_ready(self):
+        v = _make_view_with_data()
+        result = v.handle_key("E", MagicMock())
+        assert v._export_mode == "path"
+        assert v._export_path_buf.endswith(".json")
+        assert "live_session" in v._export_path_buf
+
+    def test_E_no_data_shows_status(self):
+        v = panel.LiveSessionView()
+        v._last_render = None
+        result = v.handle_key("E", MagicMock())
+        assert v._export_mode is None
+        assert v._status_msg is not None
+
+    def test_printable_chars_append_to_buf(self):
+        v = _make_view_with_data()
+        v.handle_key("E", MagicMock())
+        original = v._export_path_buf
+        v.handle_key("x", MagicMock())
+        assert v._export_path_buf == original + "x"
+
+    def test_backspace_removes_last_char(self):
+        v = _make_view_with_data()
+        v.handle_key("E", MagicMock())
+        v._export_path_buf = "/tmp/test.json"
+        v.handle_key("\x7f", MagicMock())
+        assert v._export_path_buf == "/tmp/test.jso"
+
+    def test_esc_cancels_without_writing(self, tmp_path):
+        v = _make_view_with_data()
+        v.handle_key("E", MagicMock())
+        target = tmp_path / "should_not_exist.json"
+        v._export_path_buf = str(target)
+        v.handle_key("\x1b", MagicMock())
+        assert v._export_mode is None
+        assert not target.exists()
+
+    def test_enter_writes_file(self, tmp_path):
+        v = _make_view_with_data()
+        v._last_render = MagicMock(
+            session={"task_id": "t1"},
+            command={"cmd": ["python3"]},
+            chat={"turns": []},
+            api_errors=[],
+            stdout=None,
+        )
+        v._history.append({"polled_at": "2026-01-01T00:00:00Z",
+                           "session": None, "command": None, "chat": None})
+        v.handle_key("E", MagicMock())
+        target = tmp_path / "out.json"
+        v._export_path_buf = str(target)
+        v.handle_key("\r", MagicMock())
+        assert v._export_mode is None
+        assert target.exists()
+
+    def test_default_path_pre_filled(self):
+        v = _make_view_with_data()
+        v.handle_key("E", MagicMock())
+        buf = v._export_path_buf
+        assert "live_session" in buf
+        assert buf.endswith(".json")

--- a/deile/tests/infra/test_panel_export_stdout.py
+++ b/deile/tests/infra/test_panel_export_stdout.py
@@ -1,0 +1,57 @@
+"""Tests: stdout field in export (AC9/AC10/AC11, issue #547)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel
+from deile.ui.panel.observability.screens import LiveSessionData
+
+
+class TestSchemaV2WithStdout:
+    def test_stdout_present_yields_v2(self):
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout="some output"
+        )
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v2"
+        assert obj["payload"]["stdout"] == "some output"
+
+    def test_stdout_none_still_v2(self):
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout=None
+        )
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v2"
+        assert obj["payload"]["stdout"] is None
+
+    def test_stdout_redacted(self):
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "B" * 36
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout=f"token={secret}"
+        )
+        obj = panel._build_live_session_json(data, [], redactor=redactor)
+        import json
+        serialized = json.dumps(obj)
+        assert secret not in serialized
+
+
+class TestLiveSessionDataStdout:
+    def test_stdout_default_none(self):
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[]
+        )
+        assert data.stdout is None
+
+    def test_stdout_field_present(self):
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout="output"
+        )
+        assert data.stdout == "output"

--- a/deile/tests/infra/test_panel_export_txt.py
+++ b/deile/tests/infra/test_panel_export_txt.py
@@ -1,0 +1,116 @@
+"""Tests: plain-text export format for panel export (#547)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel
+
+
+def _make_session_data(stdout=None):
+    """Helper: create a realistic LiveSessionData-like object."""
+    from deile.ui.panel.observability.screens import LiveSessionData
+    return LiveSessionData(
+        session={"task_id": "t1", "stage": "implement", "alive": True},
+        command={"cmd": ["python3", "-m", "pytest"], "full_prompt": "run tests"},
+        chat={"turns": [
+            {"role": "user", "content": "implement feature", "ts": None},
+            {"role": "assistant", "content": "done", "ts": None},
+        ]},
+        api_errors=[],
+        stdout=stdout,
+    )
+
+
+class TestBuildLiveSessionTxt:
+    def test_not_valid_json(self):
+        data = _make_session_data()
+        txt = panel._build_live_session_txt(data, redactor=None)
+        try:
+            json.loads(txt)
+            assert False, "should not be valid JSON"
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    def test_has_schema_header(self):
+        data = _make_session_data()
+        txt = panel._build_live_session_txt(data, redactor=None)
+        assert "# deile export: live_session" in txt
+        assert "# schema: deile.export.v2" in txt
+
+    def test_has_session_section(self):
+        data = _make_session_data()
+        txt = panel._build_live_session_txt(data, redactor=None)
+        assert "[SESSION]" in txt
+        assert "task_id" in txt
+
+    def test_has_stdout_section(self):
+        data = _make_session_data(stdout="hello stdout\nline2")
+        txt = panel._build_live_session_txt(data, redactor=None)
+        assert "[STDOUT]" in txt
+        assert "hello stdout" in txt
+
+    def test_stdout_none_section(self):
+        data = _make_session_data(stdout=None)
+        txt = panel._build_live_session_txt(data, redactor=None)
+        assert "[STDOUT]" in txt
+        assert "(none)" in txt
+
+    def test_redaction_removes_secret(self):
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret_value = "ghp_" + "A" * 36
+        data = _make_session_data(stdout=f"token={secret_value}")
+        txt = panel._build_live_session_txt(data, redactor=redactor)
+        assert secret_value not in txt
+
+
+class TestBuildPodWatchTxt:
+    def test_not_valid_json(self):
+        txt = panel._build_pod_watch_txt("my-pod", "worker", ["log line 1"], redactor=None)
+        try:
+            json.loads(txt)
+            assert False, "should not be valid JSON"
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    def test_has_header(self):
+        txt = panel._build_pod_watch_txt("my-pod", "worker", ["line1", "line2"], redactor=None)
+        assert "# deile export: pod_watch" in txt
+        assert "# pod: my-pod" in txt
+        assert "# role: worker" in txt
+        assert "line1" in txt
+        assert "line2" in txt
+
+
+class TestTxtExtensionDetection:
+    def test_txt_extension_sets_export_txt(self, tmp_path):
+        v = panel.LiveSessionView()
+        v._last_render = MagicMock(
+            session={"task_id": "t1"}, command=None, chat=None,
+            api_errors=[], stdout=None,
+        )
+        v.handle_key("E", MagicMock())
+        target = tmp_path / "out.txt"
+        v._export_path_buf = str(target)
+        v.handle_key("\r", MagicMock())
+        assert v._export_txt is True
+
+    def test_json_extension_no_txt(self, tmp_path):
+        v = panel.LiveSessionView()
+        v._last_render = MagicMock(
+            session={"task_id": "t1"}, command=None, chat=None,
+            api_errors=[], stdout=None,
+        )
+        v.handle_key("E", MagicMock())
+        target = tmp_path / "out.json"
+        v._export_path_buf = str(target)
+        v.handle_key("\r", MagicMock())
+        assert v._export_txt is False

--- a/deile/ui/panel/observability/screens.py
+++ b/deile/ui/panel/observability/screens.py
@@ -212,6 +212,7 @@ class LiveSessionData:
     command: Optional[Dict[str, Any]]
     chat: Optional[Dict[str, Any]]
     api_errors: List[str]
+    stdout: Optional[str] = None
 
 
 class LiveSessionScreen:

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -2015,6 +2015,178 @@ class _LocalLogTailer:
         return list(self.buf)[-n:]
 
 
+# ---------------------------------------------------------------------------
+# Export helpers (issues #461 + #547)
+# ---------------------------------------------------------------------------
+
+def _deile_export_dir() -> Path:
+    """Return (and create) ~/.deile/exports/ with mode 0o700."""
+    d = Path(os.path.expanduser("~/.deile/exports"))
+    d.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return d
+
+
+def _safe_id_segment(s: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", s or "unknown")[:64]
+
+
+def _default_export_path(kind: str, id_or_pod: str, ext: str = ".json") -> Path:
+    safe = _safe_id_segment(id_or_pod)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return _deile_export_dir() / f"{kind}-{safe}-{ts}{ext}"
+
+
+def _write_atomic(content_bytes: bytes, target_path: Path) -> None:
+    """Write content_bytes to target_path atomically via tmp + os.replace."""
+    parent = target_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(dir=str(parent))
+    tmp_path = Path(tmp_str)
+    try:
+        os.write(fd, content_bytes)
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_path, target_path)
+        tmp_path = None
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+
+def _redact_for_export(value: Any, redactor: Any) -> Any:
+    """Recursively redact strings using redactor.redact_text."""
+    if redactor is None:
+        return value
+    if isinstance(value, str):
+        redacted, _ = redactor.redact_text(value)
+        return redacted
+    if isinstance(value, dict):
+        return {k: _redact_for_export(v, redactor) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_for_export(i, redactor) for i in value]
+    return value
+
+
+def _build_live_session_json(
+    data: Any,
+    history: List[Dict],
+    *,
+    redactor: Any,
+) -> Dict:
+    """Build deile.export.v2 JSON dict for live_session."""
+    payload = {
+        "session": _redact_for_export(data.session, redactor),
+        "command": _redact_for_export(data.command, redactor),
+        "chat": _redact_for_export(data.chat, redactor),
+        "api_errors": [_redact_for_export(e, redactor) for e in (data.api_errors or [])],
+        "stdout": _redact_for_export(data.stdout, redactor) if data.stdout is not None else None,
+    }
+    redacted_history = []
+    for snap in history:
+        redacted_history.append({
+            "polled_at": snap.get("polled_at"),
+            "session": _redact_for_export(snap.get("session"), redactor),
+            "command": _redact_for_export(snap.get("command"), redactor),
+            "chat": _redact_for_export(snap.get("chat"), redactor),
+        })
+    return {
+        "schema_version": "deile.export.v2",
+        "kind": "live_session",
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "payload": payload,
+        "history": redacted_history,
+    }
+
+
+def _build_live_session_txt(data: Any, *, redactor: Any) -> str:
+    """Build plain-text export for live_session (deile.export.v2)."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    task_id = (data.session or {}).get("task_id", "?") if data.session else "?"
+    parts = [
+        "# deile export: live_session",
+        "# schema: deile.export.v2",
+        f"# exported_at: {now_iso}",
+        f"# task_id: {task_id}",
+        "# " + "-" * 60,
+        "[SESSION]",
+    ]
+    if data.session:
+        for k, v in data.session.items():
+            parts.append(f"  {k}: {_redact_for_export(str(v), redactor)}")
+    else:
+        parts.append("  (none)")
+    parts.append("[COMMAND]")
+    if data.command:
+        cmd = data.command.get("cmd") or []
+        cmd_str = _redact_for_export(" ".join(str(c) for c in cmd), redactor)
+        parts.append(f"  cmd: {cmd_str}")
+        fp = _redact_for_export(str(data.command.get("full_prompt") or ""), redactor)
+        parts.append(f"  full_prompt: {fp}")
+    else:
+        parts.append("  (none)")
+    parts.append("[CHAT]")
+    if data.chat:
+        for turn in ((data.chat or {}).get("turns") or []):
+            role = turn.get("role") or turn.get("type") or "?"
+            content = _redact_for_export(
+                str(turn.get("content") or turn.get("summary") or ""), redactor
+            )
+            parts.append(f"  [{role}] {content}")
+    else:
+        parts.append("  (none)")
+    parts.append("[STDOUT]")
+    if data.stdout is not None:
+        for ln in _redact_for_export(data.stdout, redactor).splitlines():
+            parts.append(f"  {ln}")
+    else:
+        parts.append("  (none)")
+    if data.api_errors:
+        parts.append("[API ERRORS]")
+        for err in data.api_errors:
+            parts.append(f"  {_redact_for_export(err, redactor)}")
+    return "\n".join(parts) + "\n"
+
+
+def _build_pod_watch_json(
+    pod_name: str, pod_role: str, lines: List[str], *, redactor: Any
+) -> Dict:
+    """Build deile.export.v1 JSON dict for pod_watch."""
+    return {
+        "schema_version": "deile.export.v1",
+        "kind": "pod_watch",
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "payload": {
+            "pod": pod_name,
+            "role": pod_role,
+            "lines": [_redact_for_export(ln, redactor) for ln in lines],
+        },
+    }
+
+
+def _build_pod_watch_txt(
+    pod_name: str, pod_role: str, lines: List[str], *, redactor: Any
+) -> str:
+    """Build plain-text export for pod_watch (deile.export.v1)."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    parts = [
+        "# deile export: pod_watch",
+        "# schema: deile.export.v1",
+        f"# exported_at: {now_iso}",
+        f"# pod: {pod_name}",
+        f"# role: {pod_role}",
+        "# " + "-" * 60,
+    ] + [_redact_for_export(ln, redactor) for ln in lines]
+    return "\n".join(parts) + "\n"
+
+
 def _is_local_role(role: str) -> bool:
     """Helper compartilhado: identifica roles locais (`local-*`)."""
     return role.startswith("local-")
@@ -2034,7 +2206,7 @@ class PodWatchView(View):
     refresh_s = 1.0
 
     HOTKEYS = ("[f] follow on/off   [h] mostrar/esconder health   "
-               "[c] clear log   [.] abrir log   [t] resize /tmp   "
+               "[c] clear log   [.] abrir log   [E] export   [t] resize /tmp   "
                "[esc] volta   [q] sai")
 
     # Quantas linhas do buffer dumpamos no tempfile quando o usuário pede
@@ -2088,6 +2260,11 @@ class PodWatchView(View):
         # Modo "aguardando preset de /tmp" — quando True, próxima tecla 1-5
         # aplica o preset correspondente; qualquer outra cancela.
         self._awaiting_tmp_preset: bool = False
+        # Export state
+        self._export_mode: Optional[str] = None  # None | "path" | "overwrite"
+        self._export_txt: bool = False
+        self._export_path_buf: str = ""
+        self._export_target: Optional[Path] = None
 
     def on_mount(self, app: "PanelApp") -> None:
         # PodWatchView é singleton no registry — re-mount com pod diferente
@@ -2095,6 +2272,10 @@ class PodWatchView(View):
         # vazam entre pods, confundindo o operador.
         self.following = True
         self.hide_health = True
+        self._export_mode = None
+        self._export_txt = False
+        self._export_path_buf = ""
+        self._export_target = None
         if self.streamer is not None:
             self.streamer.stop()
             self.streamer = None
@@ -2448,22 +2629,34 @@ class PodWatchView(View):
         # + current task). claude-worker adiciona LEASE/DISK/QUOTA (até 3
         # linhas extra) → size=12. Outros pods mantêm 9.
         info_size = 12 if self.pod_role == "claude-worker" else 9
-        layout.split_column(
+        rows: List[Any] = [
             Layout(_head_panel(self.title, app), name="head", size=4),
             Layout(Panel(self._header_body(),
                          title="[bold]POD[/bold]", title_align="left",
                          border_style="cyan"),
                    name="info", size=info_size),
             Layout(self._log_panel(), name="log"),
-            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
-        )
+        ]
+        if self._export_mode == "path":
+            rows.append(Layout(self._render_export_path_panel(), name="modal", size=5))
+        elif self._export_mode == "overwrite":
+            rows.append(Layout(self._render_export_overwrite_panel(), name="modal", size=4))
+        rows.append(Layout(_footer_panel(self.HOTKEYS), name="footer", size=3))
+        layout.split_column(*rows)
         return layout
 
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        # Export mode takes priority.
+        if self._export_mode == "path":
+            return self._handle_pod_export_path_key(key)
+        if self._export_mode == "overwrite":
+            return self._handle_pod_export_overwrite_key(key)
         # Resolve preset de /tmp PRIMEIRO — outras teclas ficam mortas até o
         # operador escolher ou cancelar (mesmo padrão do PodPickerView).
         if self._awaiting_tmp_preset:
             return self._handle_tmp_preset_key(key)
+        if key == "E":
+            return self._start_pod_export()
         if key == "f":
             self.following = not self.following
             if self.following and self.streamer is None:
@@ -2588,6 +2781,111 @@ class PodWatchView(View):
                 "nenhum editor encontrado (cursor/code/notepad/open/xdg-open)"
             )
 
+    def _start_pod_export(self) -> ActionResult:
+        if self.streamer is None:
+            self._set_status("streamer não iniciado — nada para exportar")
+            return ActionResult.refresh()
+        self._export_txt = False
+        default_path = _default_export_path(
+            "pod_watch", self.pod_name or "pod", ".json"
+        )
+        self._export_mode = "path"
+        self._export_path_buf = str(default_path)
+        self._export_target = None
+        return ActionResult.refresh()
+
+    def _handle_pod_export_path_key(self, key: str) -> ActionResult:
+        if key in ("ESC", "\x1b"):
+            self._export_mode = None
+            self._set_status("export cancelado")
+            return ActionResult.refresh()
+        if key in ("BACKSPACE", "\x7f"):
+            self._export_path_buf = self._export_path_buf[:-1]
+            return ActionResult.refresh()
+        if key in ("\r", "\n"):
+            path_str = self._export_path_buf.strip()
+            if not path_str:
+                self._export_mode = None
+                return ActionResult.refresh()
+            path_str = os.path.expanduser(path_str)
+            target = Path(path_str)
+            if not target.is_absolute():
+                target = _deile_export_dir() / target
+            self._export_txt = target.suffix == ".txt"
+            if target.exists():
+                self._export_target = target
+                self._export_mode = "overwrite"
+            else:
+                self._export_mode = None
+                self._do_export_pod_watch(target)
+            return ActionResult.refresh()
+        if len(key) == 1 and key.isprintable():
+            self._export_path_buf += key
+            return ActionResult.refresh()
+        return ActionResult.refresh()
+
+    def _handle_pod_export_overwrite_key(self, key: str) -> ActionResult:
+        self._export_mode = None
+        if key in ("y", "Y"):
+            self._do_export_pod_watch(self._export_target)
+        else:
+            self._set_status("export cancelado")
+        self._export_target = None
+        return ActionResult.refresh()
+
+    def _render_export_path_panel(self) -> Panel:
+        return Panel(
+            Text.from_markup(
+                f"[bold]Path de destino:[/bold] {self._export_path_buf}[blink]█[/blink]\n\n"
+                "[dim]chars imprimíveis: editar   "
+                "[bold][backspace][/bold]: apagar   "
+                "[bold][esc][/bold]: cancelar   "
+                "[bold][enter][/bold]: confirmar[/dim]"
+            ),
+            title="[bold]EXPORT — editar path[/bold]",
+            title_align="left",
+            border_style="cyan",
+        )
+
+    def _render_export_overwrite_panel(self) -> Panel:
+        target = str(self._export_target or "?")
+        return Panel(
+            Text.from_markup(
+                f"Arquivo já existe: [bold]{target}[/bold]\n\n"
+                "[bold green][y][/bold green] sobrescrever  /  "
+                "qualquer outra tecla cancela"
+            ),
+            title="[bold]EXPORT — confirmar sobrescrita[/bold]",
+            title_align="left",
+            border_style="yellow",
+        )
+
+    def _do_export_pod_watch(self, target: Optional[Path]) -> None:
+        if target is None or self.streamer is None:
+            return
+        try:
+            from deile.security.secrets_scanner import SecretsScanner  # noqa: PLC0415
+            redactor = SecretsScanner()
+        except ImportError:
+            redactor = None
+        try:
+            lines = self.streamer.snapshot(n=self._DUMP_TAIL_LINES)
+            if self._export_txt:
+                content_bytes = _build_pod_watch_txt(
+                    self.pod_name or "", self.pod_role or "", lines, redactor=redactor
+                ).encode("utf-8")
+            else:
+                obj = _build_pod_watch_json(
+                    self.pod_name or "", self.pod_role or "", lines, redactor=redactor
+                )
+                content_bytes = json.dumps(
+                    obj, indent=2, ensure_ascii=False, default=str
+                ).encode("utf-8")
+            _write_atomic(content_bytes, target)
+            self._set_status(f"exportado: {target}")
+        except OSError as exc:
+            self._set_status(f"erro ao exportar: {exc}")
+
 
 class LiveSessionView(View):
     """Live view for a claude-worker session identified by task_id (issue #446).
@@ -2605,7 +2903,7 @@ class LiveSessionView(View):
     title = "Live Session"
     refresh_s = 2.0
 
-    HOTKEYS = "[esc] volta   [r] força refresh   [q] sai"
+    HOTKEYS = "[esc] volta   [r] força refresh   [E] export JSON/.txt   [q] sai"
 
     def __init__(self, data: Optional[PanelData] = None):
         self.data = data
@@ -2613,6 +2911,14 @@ class LiveSessionView(View):
         self.pod_name: str = ""
         self._last_render: Optional[Any] = None
         self._api_errors: List[str] = []
+        self._history: deque = deque(maxlen=200)
+        self._history_last_key: Optional[str] = None
+        self._export_mode: Optional[str] = None  # None | "path" | "overwrite"
+        self._export_txt: bool = False
+        self._export_path_buf: str = ""
+        self._export_target: Optional[Path] = None
+        self._status_msg: Optional[str] = None
+        self._status_until: float = 0.0
 
     def on_mount(self, app: "PanelApp") -> None:
         payload = getattr(app, "last_payload", {}) or {}
@@ -2620,6 +2926,14 @@ class LiveSessionView(View):
         self.pod_name = payload.get("pod_name", "")
         self._last_render = None
         self._api_errors = []
+        self._history.clear()
+        self._history_last_key = None
+        self._export_mode = None
+        self._export_txt = False
+        self._export_path_buf = ""
+        self._export_target = None
+        self._status_msg = None
+        self._status_until = 0.0
 
     def _fetch_data(self) -> Any:
         """Synchronously fetch session data via asyncio (called from render thread)."""
@@ -2660,10 +2974,11 @@ class LiveSessionView(View):
             # list_sessions + get_command + get_chat concurrently.
             # Reply = Union[dict/list, ApiError] — success is a dict/list,
             # failure is an ApiError instance (no .ok attribute).
-            sessions_reply, cmd_reply, chat_reply = await asyncio.gather(
+            sessions_reply, cmd_reply, chat_reply, stdout_reply = await asyncio.gather(
                 client.list_sessions(),
                 client.get_command(self.task_id),
                 client.get_chat(self.task_id, tail=50),
+                client.get_stdout(self.task_id),
                 return_exceptions=False,
             )
             # Filter sessions client-side by task_id.
@@ -2693,11 +3008,24 @@ class LiveSessionView(View):
             if not isinstance(chat_reply, (dict, list)):
                 errors.append(f"chat: {getattr(chat_reply, 'message', str(chat_reply))}")
 
+            stdout_text: Optional[str] = None
+            if isinstance(stdout_reply, dict):
+                raw = stdout_reply.get("stdout") or stdout_reply.get("content")
+                if isinstance(raw, str):
+                    stdout_text = raw
+            elif isinstance(stdout_reply, str):
+                stdout_text = stdout_reply
+            else:
+                errors.append(
+                    f"stdout: {getattr(stdout_reply, 'message', str(stdout_reply))}"
+                )
+
             return LiveSessionData(
                 session=session_row,
                 command=command_data,
                 chat=chat_data,
                 api_errors=errors,
+                stdout=stdout_text,
             )
 
         try:
@@ -2723,6 +3051,19 @@ class LiveSessionView(View):
             )
 
         live_data, errors = self._fetch_data()
+        if live_data is not None:
+            self._last_render = live_data
+            self._api_errors = live_data.api_errors
+            snap = {
+                "polled_at": datetime.now(timezone.utc).isoformat(),
+                "session": live_data.session,
+                "command": live_data.command,
+                "chat": live_data.chat,
+            }
+            snap_key = json.dumps(snap, sort_keys=True, default=str)
+            if snap_key != self._history_last_key:
+                self._history.append(snap)
+                self._history_last_key = snap_key
         if live_data is None:
             task_label = self.task_id[:16] if self.task_id else "?"
             errmsg = "; ".join(errors) if errors else "fetching…"
@@ -2732,21 +3073,149 @@ class LiveSessionView(View):
                 border_style="dim",
             )
 
-        layout = Layout()
-        layout.split_column(
+        # Clear expired status message before render.
+        if self._status_msg is not None and time.time() >= self._status_until:
+            self._status_msg = None
+
+        rows: List[Any] = [
             Layout(_head_panel(
                 f"LIVE SESSION {self.task_id[:16]}", app), name="head", size=4),
             Layout(LiveSessionScreen().render(live_data), name="body"),
-            Layout(_footer_panel(self.HOTKEYS), name="footer", size=3),
-        )
+        ]
+        if self._export_mode == "path":
+            rows.append(Layout(self._render_export_path_panel(), name="modal", size=5))
+        elif self._export_mode == "overwrite":
+            rows.append(Layout(self._render_export_overwrite_panel(), name="modal", size=4))
+        elif self._status_msg:
+            rows.append(Layout(
+                Panel(Text(self._status_msg, style="bold green"),
+                      border_style="green", title="export"),
+                name="status", size=3,
+            ))
+        rows.append(Layout(_footer_panel(self.HOTKEYS), name="footer", size=3))
+        layout = Layout()
+        layout.split_column(*rows)
         return layout
 
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        if self._export_mode == "path":
+            return self._handle_export_path_key(key)
+        if self._export_mode == "overwrite":
+            return self._handle_export_overwrite_key(key)
         if key in ("\x1b", "q"):
             return ActionResult.back()
         if key == "r":
             return ActionResult.refresh()
+        if key == "E":
+            return self._start_export()
         return ActionResult()
+
+    def _set_status(self, msg: str, ttl: float = 6.0) -> None:
+        self._status_msg = msg
+        self._status_until = time.time() + ttl
+
+    def _start_export(self) -> ActionResult:
+        if self._last_render is None:
+            self._set_status("nenhum dado ainda — aguarde o primeiro poll")
+            return ActionResult.refresh()
+        id_or_pod = self.task_id or self.pod_name or "unknown"
+        self._export_txt = False
+        default_path = _default_export_path("live_session", id_or_pod, ".json")
+        self._export_mode = "path"
+        self._export_path_buf = str(default_path)
+        self._export_target = None
+        return ActionResult.refresh()
+
+    def _handle_export_path_key(self, key: str) -> ActionResult:
+        if key in ("ESC", "\x1b"):
+            self._export_mode = None
+            self._set_status("export cancelado")
+            return ActionResult.refresh()
+        if key in ("BACKSPACE", "\x7f"):
+            self._export_path_buf = self._export_path_buf[:-1]
+            return ActionResult.refresh()
+        if key in ("\r", "\n"):
+            path_str = self._export_path_buf.strip()
+            if not path_str:
+                self._export_mode = None
+                return ActionResult.refresh()
+            path_str = os.path.expanduser(path_str)
+            target = Path(path_str)
+            if not target.is_absolute():
+                target = _deile_export_dir() / target
+            self._export_txt = target.suffix == ".txt"
+            if target.exists():
+                self._export_target = target
+                self._export_mode = "overwrite"
+            else:
+                self._export_mode = None
+                self._do_export_live_session(target)
+            return ActionResult.refresh()
+        if len(key) == 1 and key.isprintable():
+            self._export_path_buf += key
+            return ActionResult.refresh()
+        return ActionResult.refresh()
+
+    def _handle_export_overwrite_key(self, key: str) -> ActionResult:
+        self._export_mode = None
+        if key in ("y", "Y"):
+            self._do_export_live_session(self._export_target)
+        else:
+            self._set_status("export cancelado")
+        self._export_target = None
+        return ActionResult.refresh()
+
+    def _render_export_path_panel(self) -> "Panel":
+        return Panel(
+            Text.from_markup(
+                f"[bold]Path de destino:[/bold] {self._export_path_buf}[blink]█[/blink]\n\n"
+                "[dim]chars imprimíveis: editar   "
+                "[bold][backspace][/bold]: apagar   "
+                "[bold][esc][/bold]: cancelar   "
+                "[bold][enter][/bold]: confirmar[/dim]"
+            ),
+            title="[bold]EXPORT — editar path[/bold]",
+            title_align="left",
+            border_style="cyan",
+        )
+
+    def _render_export_overwrite_panel(self) -> "Panel":
+        target = str(self._export_target or "?")
+        return Panel(
+            Text.from_markup(
+                f"Arquivo já existe: [bold]{target}[/bold]\n\n"
+                "[bold green][y][/bold green] sobrescrever  /  "
+                "qualquer outra tecla cancela"
+            ),
+            title="[bold]EXPORT — confirmar sobrescrita[/bold]",
+            title_align="left",
+            border_style="yellow",
+        )
+
+    def _do_export_live_session(self, target: Optional[Path]) -> None:
+        if target is None or self._last_render is None:
+            return
+        try:
+            from deile.security.secrets_scanner import SecretsScanner  # noqa: PLC0415
+            redactor = SecretsScanner()
+        except ImportError:
+            redactor = None
+        try:
+            if self._export_txt:
+                content_bytes = _build_live_session_txt(
+                    self._last_render, redactor=redactor
+                ).encode("utf-8")
+            else:
+                obj = _build_live_session_json(
+                    self._last_render, list(self._history), redactor=redactor
+                )
+                content_bytes = json.dumps(
+                    obj, indent=2, ensure_ascii=False, default=str
+                ).encode("utf-8")
+            _write_atomic(content_bytes, target)
+            self._set_status(f"exportado: {target}")
+        except OSError as exc:
+            self._set_status(f"erro ao exportar: {exc}")
 
 
 class PipelineTimelineView(View):


### PR DESCRIPTION
## Summary

Implements the structured export feature for `LiveSessionView` and `PodWatchView` as specified in issues #461 and #547.

Since #461 (the base export) was never merged, this PR implements the complete feature:

- **Base export (#461)**: `[E]` hotkey in both views exports structured JSON (`deile.export.v1` for pod_watch, `deile.export.v2` for live_session)
- **Editable path**: before writing, opens an inline text modal pre-filled with the default path; `[esc]` cancels, `[enter]` confirms
- **Overwrite `[y]/[n]`**: when the path already exists, prompts for confirmation; write is always atomic via `tempfile` + `os.replace` (resolves TOCTOU)
- **Plain text export**: path extension `.txt` triggers a human-readable format; `.json` (default) writes the schema-versioned JSON
- **stdout in payload**: 4th fetch in `asyncio.gather` via `ClaudeWorkerSessionsClient.get_stdout`; `ApiError` → `stdout:null` + entry in `api_errors`; schema bumps to `deile.export.v2`
- **History ring buffer**: `deque(maxlen=200)` with consecutive dedup; included in v2 export
- **Redaction**: `SecretsScanner.redact_text` applied to all string values (imported, not copied)

## Test plan

- [ ] `python3 -m pytest deile/tests/infra/test_panel_export_path.py -p no:cov -q` — path modal, AC1/AC2/AC3
- [ ] `python3 -m pytest deile/tests/infra/test_panel_export_overwrite.py -p no:cov -q` — atomic write, overwrite confirm, AC4/AC5/AC6
- [ ] `python3 -m pytest deile/tests/infra/test_panel_export_txt.py -p no:cov -q` — text format, redaction, AC7/AC8
- [ ] `python3 -m pytest deile/tests/infra/test_panel_export_stdout.py -p no:cov -q` — stdout field, schema v2, AC9/AC10/AC11
- [ ] `python3 -m pytest deile/tests/infra/test_panel_export_history.py -p no:cov -q` — ring buffer, dedup, AC12/AC13/AC14
- [ ] `python3 -m pytest deile/tests/ui/test_observability_screens.py -p no:cov -q` — no regression in LiveSessionData

All 38 tests pass locally.

Closes #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)