### PR TITLE
refactor(export): align drill-down export to spec (AC6/AC7/AC14)

### DIFF
--- a/deile/tests/infra/test_panel_export_history.py
+++ b/deile/tests/infra/test_panel_export_history.py
@@ -58,7 +58,7 @@ class TestHistoryRingBuffer:
         data = LiveSessionData(
             session=None, command=None, chat=None, api_errors=[], stdout=None
         )
-        obj = panel._build_live_session_json(data, history, redactor=None)
+        obj = panel._build_live_session_json(data, history, redactor=None, include_history=True)
         assert obj["schema_version"] == "deile.export.v2"
         assert len(obj["history"]) == 1
         assert obj["history"][0]["polled_at"] == "2026-01-01T00:00:00Z"
@@ -67,6 +67,25 @@ class TestHistoryRingBuffer:
         data = LiveSessionData(
             session=None, command=None, chat=None, api_errors=[], stdout=None
         )
-        obj = panel._build_live_session_json(data, [], redactor=None)
+        obj = panel._build_live_session_json(data, [], redactor=None, include_history=True)
         assert obj["schema_version"] == "deile.export.v2"
         assert obj["history"] == []
+
+    def test_default_no_history_is_v1(self):
+        """AC14: default export (no include_history) must be v1 snapshot without history."""
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout=None
+        )
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v1"
+        assert "history" not in obj
+
+    def test_default_no_history_v1_with_payload(self):
+        """AC14: v1 snapshot still includes the payload field."""
+        data = LiveSessionData(
+            session={"task_id": "t1"}, command=None, chat=None, api_errors=[], stdout=None
+        )
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v1"
+        assert "payload" in obj
+        assert "history" not in obj

--- a/deile/tests/infra/test_panel_export_overwrite.py
+++ b/deile/tests/infra/test_panel_export_overwrite.py
@@ -87,7 +87,7 @@ class TestWriteAtomic:
         v.handle_key("y", MagicMock())
         assert v._export_mode is None
         content = target.read_bytes()
-        assert b"deile.export.v2" in content
+        assert b"deile.export.v1" in content
 
     def test_n_cancels_overwrite(self, tmp_path):
         v = _make_live_view_with_data()
@@ -99,3 +99,30 @@ class TestWriteAtomic:
         v.handle_key("n", MagicMock())
         assert v._export_mode is None
         assert target.read_text() == "old content"
+
+    def test_exclusive_raises_file_exists_error_on_toctou(self, tmp_path):
+        """AC6: exclusive=True must raise FileExistsError if file appears between
+        exists() check and _write_atomic call (TOCTOU race guard)."""
+        target = tmp_path / "raced.json"
+        # Simulate TOCTOU: target doesn't exist yet but os.open raises FileExistsError
+        # to model a concurrent creator.
+        real_os_open = os.open
+
+        def mock_os_open(path, flags, *args, **kwargs):
+            if (flags & os.O_EXCL) and str(path) == str(target):
+                raise FileExistsError(f"File appeared concurrently: {path}")
+            return real_os_open(path, flags, *args, **kwargs)
+
+        with patch.object(os, "open", side_effect=mock_os_open):
+            try:
+                panel._write_atomic(b"content", target, exclusive=True)
+                assert False, "should have raised FileExistsError"
+            except FileExistsError:
+                pass  # expected — no silent clobber
+
+    def test_exclusive_false_does_not_raise_on_existing(self, tmp_path):
+        """Without exclusive, _write_atomic overwrites silently (normal overwrite path)."""
+        target = tmp_path / "overwrite.json"
+        target.write_bytes(b"old")
+        panel._write_atomic(b"new", target, exclusive=False)
+        assert target.read_bytes() == b"new"

--- a/deile/tests/infra/test_panel_export_stdout.py
+++ b/deile/tests/infra/test_panel_export_stdout.py
@@ -18,7 +18,7 @@ class TestSchemaV2WithStdout:
         data = LiveSessionData(
             session=None, command=None, chat=None, api_errors=[], stdout="some output"
         )
-        obj = panel._build_live_session_json(data, [], redactor=None)
+        obj = panel._build_live_session_json(data, [], redactor=None, include_history=True)
         assert obj["schema_version"] == "deile.export.v2"
         assert obj["payload"]["stdout"] == "some output"
 
@@ -26,9 +26,19 @@ class TestSchemaV2WithStdout:
         data = LiveSessionData(
             session=None, command=None, chat=None, api_errors=[], stdout=None
         )
-        obj = panel._build_live_session_json(data, [], redactor=None)
+        obj = panel._build_live_session_json(data, [], redactor=None, include_history=True)
         assert obj["schema_version"] == "deile.export.v2"
         assert obj["payload"]["stdout"] is None
+
+    def test_stdout_present_default_is_v1(self):
+        """AC14: default export is v1 snapshot even when stdout is present."""
+        data = LiveSessionData(
+            session=None, command=None, chat=None, api_errors=[], stdout="some output"
+        )
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v1"
+        assert obj["payload"]["stdout"] == "some output"
+        assert "history" not in obj
 
     def test_stdout_redacted(self):
         from deile.security.secrets_scanner import SecretsScanner

--- a/deile/tests/infra/test_panel_export_txt.py
+++ b/deile/tests/infra/test_panel_export_txt.py
@@ -42,8 +42,15 @@ class TestBuildLiveSessionTxt:
     def test_has_schema_header(self):
         data = _make_session_data()
         txt = panel._build_live_session_txt(data, redactor=None)
-        assert "# deile export: live_session" in txt
+        assert "# deile export — kind=live_session" in txt
         assert "# schema: deile.export.v2" in txt
+
+    def test_header_em_dash_format(self):
+        """AC7: first line must match '# deile export — kind=live_session' with em-dash."""
+        data = _make_session_data()
+        txt = panel._build_live_session_txt(data, redactor=None)
+        first_line = txt.splitlines()[0]
+        assert first_line == "# deile export — kind=live_session"
 
     def test_has_session_section(self):
         data = _make_session_data()
@@ -83,11 +90,17 @@ class TestBuildPodWatchTxt:
 
     def test_has_header(self):
         txt = panel._build_pod_watch_txt("my-pod", "worker", ["line1", "line2"], redactor=None)
-        assert "# deile export: pod_watch" in txt
+        assert "# deile export — kind=pod_watch" in txt
         assert "# pod: my-pod" in txt
         assert "# role: worker" in txt
         assert "line1" in txt
         assert "line2" in txt
+
+    def test_pod_watch_header_em_dash_format(self):
+        """AC7: first line of pod_watch txt must use em-dash format."""
+        txt = panel._build_pod_watch_txt("my-pod", "worker", [], redactor=None)
+        first_line = txt.splitlines()[0]
+        assert first_line == "# deile export — kind=pod_watch"
 
 
 class TestTxtExtensionDetection:

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -2036,10 +2036,24 @@ def _default_export_path(kind: str, id_or_pod: str, ext: str = ".json") -> Path:
     return _deile_export_dir() / f"{kind}-{safe}-{ts}{ext}"
 
 
-def _write_atomic(content_bytes: bytes, target_path: Path) -> None:
-    """Write content_bytes to target_path atomically via tmp + os.replace."""
+def _write_atomic(content_bytes: bytes, target_path: Path, *, exclusive: bool = False) -> None:
+    """Write content_bytes to target_path atomically via tmp + os.replace.
+
+    When exclusive=True (new-file branch), a sentinel file is created with
+    O_CREAT|O_EXCL before the replace so that a concurrent creation between
+    the caller's exists()-check and this write raises FileExistsError instead
+    of silently overwriting.
+    """
     parent = target_path.parent
     parent.mkdir(parents=True, exist_ok=True)
+    if exclusive:
+        # Guard against TOCTOU: claim the target path before writing.
+        # If another process already created it between our exists() check
+        # and now, os.open with O_EXCL raises FileExistsError.
+        sentinel_fd = os.open(
+            str(target_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        )
+        os.close(sentinel_fd)
     fd, tmp_str = tempfile.mkstemp(dir=str(parent))
     tmp_path = Path(tmp_str)
     try:
@@ -2080,8 +2094,15 @@ def _build_live_session_json(
     history: List[Dict],
     *,
     redactor: Any,
+    include_history: bool = False,
 ) -> Dict:
-    """Build deile.export.v2 JSON dict for live_session."""
+    """Build JSON dict for live_session.
+
+    When include_history=False (default): schema_version="deile.export.v1",
+    no history field — snapshot export.
+    When include_history=True: schema_version="deile.export.v2", history
+    embedded.
+    """
     payload = {
         "session": _redact_for_export(data.session, redactor),
         "command": _redact_for_export(data.command, redactor),
@@ -2089,6 +2110,13 @@ def _build_live_session_json(
         "api_errors": [_redact_for_export(e, redactor) for e in (data.api_errors or [])],
         "stdout": _redact_for_export(data.stdout, redactor) if data.stdout is not None else None,
     }
+    if not include_history:
+        return {
+            "schema_version": "deile.export.v1",
+            "kind": "live_session",
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "payload": payload,
+        }
     redacted_history = []
     for snap in history:
         redacted_history.append({
@@ -2111,7 +2139,7 @@ def _build_live_session_txt(data: Any, *, redactor: Any) -> str:
     now_iso = datetime.now(timezone.utc).isoformat()
     task_id = (data.session or {}).get("task_id", "?") if data.session else "?"
     parts = [
-        "# deile export: live_session",
+        "# deile export — kind=live_session",
         "# schema: deile.export.v2",
         f"# exported_at: {now_iso}",
         f"# task_id: {task_id}",
@@ -2177,7 +2205,7 @@ def _build_pod_watch_txt(
     """Build plain-text export for pod_watch (deile.export.v1)."""
     now_iso = datetime.now(timezone.utc).isoformat()
     parts = [
-        "# deile export: pod_watch",
+        "# deile export — kind=pod_watch",
         "# schema: deile.export.v1",
         f"# exported_at: {now_iso}",
         f"# pod: {pod_name}",
@@ -2895,7 +2923,7 @@ class PodWatchView(View):
                 self._export_mode = "overwrite"
             else:
                 self._export_mode = None
-                self._do_export_pod_watch(target)
+                self._do_export_pod_watch(target, exclusive=True)
             return ActionResult.refresh()
         if len(key) == 1 and key.isprintable():
             self._export_path_buf += key
@@ -2938,7 +2966,7 @@ class PodWatchView(View):
             border_style="yellow",
         )
 
-    def _do_export_pod_watch(self, target: Optional[Path]) -> None:
+    def _do_export_pod_watch(self, target: Optional[Path], *, exclusive: bool = False) -> None:
         if target is None or self.streamer is None:
             return
         try:
@@ -2959,7 +2987,7 @@ class PodWatchView(View):
                 content_bytes = json.dumps(
                     obj, indent=2, ensure_ascii=False, default=str
                 ).encode("utf-8")
-            _write_atomic(content_bytes, target)
+            _write_atomic(content_bytes, target, exclusive=exclusive)
             self._set_status(f"exportado: {target}")
         except OSError as exc:
             self._set_status(f"erro ao exportar: {exc}")
@@ -3313,7 +3341,7 @@ class LiveSessionView(View):
                 self._export_mode = "overwrite"
             else:
                 self._export_mode = None
-                self._do_export_live_session(target)
+                self._do_export_live_session(target, exclusive=True)
             return ActionResult.refresh()
         if len(key) == 1 and key.isprintable():
             self._export_path_buf += key
@@ -3356,7 +3384,7 @@ class LiveSessionView(View):
             border_style="yellow",
         )
 
-    def _do_export_live_session(self, target: Optional[Path]) -> None:
+    def _do_export_live_session(self, target: Optional[Path], *, exclusive: bool = False) -> None:
         if target is None or self._last_render is None:
             return
         try:
@@ -3376,7 +3404,7 @@ class LiveSessionView(View):
                 content_bytes = json.dumps(
                     obj, indent=2, ensure_ascii=False, default=str
                 ).encode("utf-8")
-            _write_atomic(content_bytes, target)
+            _write_atomic(content_bytes, target, exclusive=exclusive)
             self._set_status(f"exportado: {target}")
         except OSError as exc:
             self._set_status(f"erro ao exportar: {exc}")


### PR DESCRIPTION
## Summary

Aligns the drill-down export implementation (merged in #548) to the letter of issue #547 ACs. Zero functional regression — all changes are spec-compliance fixes in `deile/infra/k8s/_panel.py`.

## Changes

### AC14 — Default export is v1 snapshot (no history)
- Default export: `schema_version="deile.export.v1"`, no `payload.history` field
- History variant: `schema_version="deile.export.v2"` with history (unchanged)

### AC7 — .txt header aligned to spec
- Header changed to match pattern `^# deile export — kind=<kind>`
- Example: `# deile export — kind=live_session`

### AC6 — TOCTOU fix in `_write_atomic` new-path branch
- New paths opened with `O_EXCL` flag to detect concurrent creation
- `FileExistsError` raised on race (no silent clobber)

## Tests
- AC14: asserts default schema is v1 and has no history
- AC7: asserts .txt first line matches em-dash pattern
- AC6: simulates concurrent creation and verifies `FileExistsError` is raised

Closes #549.