### PR TITLE
chore(k8s): consolidate live pipeline env drift into manifest 46

### DIFF
--- a/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
+++ b/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
@@ -183,7 +183,7 @@ spec:
             # `[d]` (DispatchMatrixView) — o `kubectl set env` aplica patch
             # incremental, mantém estes como base.
             - { name: DEILE_PIPELINE_DISPATCH_MODE,        value: "deile-worker" }
-            - { name: DEILE_PIPELINE_DISPATCH_CLASSIFY,    value: "deile-worker" }
+            - { name: DEILE_PIPELINE_DISPATCH_CLASSIFY,    value: "claude-worker" }
             - { name: DEILE_PIPELINE_DISPATCH_REFINE,      value: "claude-worker" }
             - { name: DEILE_PIPELINE_DISPATCH_IMPLEMENT,   value: "claude-worker" }
             - { name: DEILE_PIPELINE_DISPATCH_PR_REVIEW,   value: "claude-worker" }
@@ -193,10 +193,10 @@ spec:
             # painel e o dispatch usava o modelo default global do worker
             # (que pode não ser o ideal para o stage).
             - { name: DEILE_PREFERRED_MODEL,               value: "deepseek:deepseek-v4-pro" }
-            - { name: DEILE_PIPELINE_MODEL_CLASSIFY,       value: "deepseek:deepseek-v4-pro" }
+            - { name: DEILE_PIPELINE_MODEL_CLASSIFY,       value: "anthropic:claude-sonnet-4-6" }
             - { name: DEILE_PIPELINE_MODEL_REFINE,         value: "anthropic:claude-opus-4-8" }
             - { name: DEILE_PIPELINE_MODEL_IMPLEMENT,      value: "anthropic:claude-sonnet-4-6" }
-            - { name: DEILE_PIPELINE_MODEL_PR_REVIEW,      value: "anthropic:claude-sonnet-4-6" }
+            - { name: DEILE_PIPELINE_MODEL_PR_REVIEW,      value: "anthropic:claude-opus-4-8" }
             - { name: DEILE_PIPELINE_MODEL_FOLLOW_UPS,     value: "anthropic:claude-sonnet-4-6" }
             # Per-stage reasoning effort (mesma motivação dos models): baked
             # default flipável live pelo painel [d] (coluna Reasoning). Vocabulário
@@ -205,10 +205,10 @@ spec:
             # default da API anthropic (preserva comportamento); classify dialado
             # pra baixo por ser tarefa leve. Ver deile/core/models/reasoning.py.
             - { name: DEILE_REASONING_EFFORT,             value: "high" }
-            - { name: DEILE_PIPELINE_REASONING_CLASSIFY,   value: "low" }
+            - { name: DEILE_PIPELINE_REASONING_CLASSIFY,   value: "medium" }
             - { name: DEILE_PIPELINE_REASONING_REFINE,     value: "high" }
-            - { name: DEILE_PIPELINE_REASONING_IMPLEMENT,  value: "high" }
-            - { name: DEILE_PIPELINE_REASONING_PR_REVIEW,  value: "high" }
+            - { name: DEILE_PIPELINE_REASONING_IMPLEMENT,  value: "ultracode" }
+            - { name: DEILE_PIPELINE_REASONING_PR_REVIEW,  value: "medium" }
             - { name: DEILE_PIPELINE_REASONING_FOLLOW_UPS, value: "medium" }
             # Paralelismo: até 5 grupos simultâneos. claude-worker tem 3
             # réplicas, deile-worker 2 réplicas → ~5 dispatches reais
@@ -223,9 +223,27 @@ spec:
             # da implementação (verificação registrada no PR).
             - { name: DEILE_PIPELINE_TIMEOUT_S_CLASSIFY,   value: "600"  }
             - { name: DEILE_PIPELINE_TIMEOUT_S_REFINE,     value: "1800" }
+            # NOTA: o live chegou a divergir para IMPLEMENT=600 (drift de
+            # painel/tuning sem registro de intenção); mantido 2700 de
+            # propósito — 600 mataria implements reais (built-in claude=1800)
+            # e contradiz o racional de kill-prematuro acima.
             - { name: DEILE_PIPELINE_TIMEOUT_S_IMPLEMENT,  value: "2700" }
             - { name: DEILE_PIPELINE_TIMEOUT_S_PR_REVIEW,  value: "3600" }
             - { name: DEILE_PIPELINE_TIMEOUT_S_FOLLOW_UPS, value: "2700" }
+            # Cost cap per-stage (issue #392): teto de custo estimado antes do
+            # POST; StageCostCapExceeded aborta o dispatch acima do cap.
+            - { name: DEILE_PIPELINE_COST_CAP_USD_CLASSIFY,   value: "1.00" }
+            - { name: DEILE_PIPELINE_COST_CAP_USD_REFINE,     value: "5.00" }
+            - { name: DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT,  value: "5.00" }
+            - { name: DEILE_PIPELINE_COST_CAP_USD_PR_REVIEW,  value: "5.00" }
+            - { name: DEILE_PIPELINE_COST_CAP_USD_FOLLOW_UPS, value: "5.00" }
+            # Retries per-stage (issue #391): tentativas antes de marcar a
+            # etapa como falha; espelha o que o painel injeta via set env.
+            - { name: DEILE_PIPELINE_RETRIES_CLASSIFY,   value: "2" }
+            - { name: DEILE_PIPELINE_RETRIES_REFINE,     value: "1" }
+            - { name: DEILE_PIPELINE_RETRIES_IMPLEMENT,  value: "4" }
+            - { name: DEILE_PIPELINE_RETRIES_PR_REVIEW,  value: "3" }
+            - { name: DEILE_PIPELINE_RETRIES_FOLLOW_UPS, value: "5" }
             # Redireciona kubectl para o apiserver na porta nativa do k3s
             # (6443) em vez do ClusterIP kube-proxy (10.43.0.1:443).
             # Em Rancher Desktop / Lima, o kube-proxy iptables DNAT não


### PR DESCRIPTION
## Contexto

Durante a vigília autônoma, ao verificar um rollout do pod `deile-pipeline` (rollout pontual via `kubectl set env`, **não** crash), comparei os env vars **live** do Deployment contra o manifest 46 versionado e encontrei drift acumulado de tuning aplicado pelo painel TUI fora do git.

Esta PR consolida o estado live no manifest, para que um `k8s up` futuro não zere os ajustes.

## Mudanças (live → manifest)

| var | antes (git) | depois |
|---|---|---|
| `DISPATCH_CLASSIFY` | deile-worker | claude-worker |
| `MODEL_CLASSIFY` | deepseek-v4-pro | anthropic:claude-sonnet-4-6 |
| `MODEL_PR_REVIEW` | claude-sonnet-4-6 | claude-opus-4-8 |
| `REASONING_CLASSIFY` | low | medium |
| `REASONING_IMPLEMENT` | high | ultracode |
| `REASONING_PR_REVIEW` | high | medium |
| `COST_CAP_USD_*` (5) | ausente | 1.00 / 5.00×4 |
| `RETRIES_*` (5) | ausente | 2/1/4/3/5 |

`MODEL_CLASSIFY` vira anthropic de forma **coerente** com `DISPATCH_CLASSIFY=claude-worker` (claude-worker só roda `claude`, não deepseek).

## Desvio deliberado: `TIMEOUT_S_IMPLEMENT`

O live havia derivado para **600s**, mas **mantive 2700s** no manifest de propósito:

- `timeout_s` viaja no payload e é o timeout do subprocess `claude -p` no claude-worker (issue #391).
- O built-in para claude-worker é **1800**; 600 seria o **menor de todos os stages**, apesar de IMPLEMENT ser tipicamente o mais longo.
- O próprio comentário do manifest documenta que timeout baixo causa *"kill prematuro em IMPLEMENT"*.
- **Nenhum commit registra intenção** de 600 — é drift acidental, não config que resolveu problema.

Para forçar 600, basta editar a linha.

## Verificação

- `python3 -c "import yaml; ..."` → YAML OK
- `pytest deile/tests/infrastructure/test_k8s_manifest_consistency.py` → **7 passed**