### PR TITLE
feat(k8s): #541 — /k8s panel (hand-off TTY) + live reflow da saída delegada

### DIFF
--- a/deile/commands/builtin/k8s_command.py
+++ b/deile/commands/builtin/k8s_command.py
@@ -19,13 +19,15 @@ Targets for /k8s logs:
     all         -> each deployment
 
 V2 verbs (host-only, require deploy.py on the host):
-    start, stop, restart, status, logs
+    up, build, down, scale, start, stop, setup, create-namespace,
+    claude-login, claude-renew, test, clone, panel
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shlex
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -49,6 +51,15 @@ _DEFAULT_NAMESPACE = "deile"
 _DEFAULT_TAIL = 50
 _DEFAULT_DEPLOYMENT = "deile-pipeline"
 _KUBECTL_TIMEOUT = 30.0
+
+_K8S_DELEGATE_TIMEOUT_SHORT = 300.0   # seconds for non-long verbs
+_K8S_DELEGATE_TIMEOUT_LONG = 1800.0  # seconds for up/build/down
+
+_V2_LONG_VERBS = frozenset({"up", "build", "down"})
+_V2_SHORT_VERBS = frozenset({
+    "scale", "start", "stop", "setup", "create-namespace",
+    "claude-login", "claude-renew", "test", "clone",
+})
 
 K8S_DEPLOYMENTS = [
     "deilebot",
@@ -77,6 +88,34 @@ _V2_VERBS = [
     "up", "build", "down", "scale", "start", "stop", "setup",
     "create-namespace", "claude-login", "claude-renew", "test", "clone", "panel",
 ]
+
+# ---------------------------------------------------------------------------
+# Pod detection
+# ---------------------------------------------------------------------------
+
+
+def _running_in_pod() -> bool:
+    """Detecta se está rodando dentro de um pod Kubernetes.
+
+    A variável KUBERNETES_SERVICE_HOST é injetada automaticamente por todo
+    pod K8s; sua presença é a heurística canônica para "estou in-pod".
+    """
+    return bool(os.environ.get("KUBERNETES_SERVICE_HOST"))
+
+
+def _find_deploy_py() -> Optional[Path]:
+    """Localiza ``infra/k8s/deploy.py`` caminhando para cima a partir deste arquivo.
+
+    Sobe a árvore de diretórios a partir de ``__file__`` procurando por
+    ``infra/k8s/deploy.py``. Retorna o Path se encontrado, ou None.
+    """
+    candidate = Path(__file__).resolve()
+    for parent in [candidate, *candidate.parents]:
+        deploy = parent / "infra" / "k8s" / "deploy.py"
+        if deploy.is_file():
+            return deploy
+    return None
+
 
 # ---------------------------------------------------------------------------
 # Namespace auto-detection
@@ -149,6 +188,85 @@ async def _run_kubectl(
     stderr = stderr_b.decode(errors="replace")
     ok = proc.returncode == 0
     return ok, stdout, stderr
+
+
+# ---------------------------------------------------------------------------
+# V2 live-streaming subprocess helper
+# ---------------------------------------------------------------------------
+
+
+async def _live_stream_subprocess(
+    cmd: List[str],
+    *,
+    timeout: float,
+    console,
+) -> Tuple[int, List[str]]:
+    """Executa um subprocess e faz streaming linha a linha com Rich Live.
+
+    Usa ``rich.live.Live(auto_refresh=False)`` para renderizar cada linha
+    recebida, possibilitando reflow enquanto o processo está em andamento.
+    Fallback para ``console.print`` por linha em ambiente não-TTY.
+
+    Args:
+        cmd: argv do subprocess (sem shell).
+        timeout: Limite em segundos para o processo terminar.
+        console: Console Rich onde renderizar.
+
+    Returns:
+        Tupla (returncode, all_lines) onde all_lines é a lista de todas as
+        linhas recebidas do stdout+stderr combinados.
+    """
+    from deile.ui.dynamic_render import is_interactive_tty
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    all_lines: List[str] = []
+
+    async def _read_lines() -> None:
+        assert proc.stdout is not None
+        async for raw in proc.stdout:
+            line = raw.decode(errors="replace").rstrip("\n")
+            all_lines.append(line)
+
+    if is_interactive_tty():
+        from rich.live import Live
+
+        with Live(
+            Text(""),
+            console=console,
+            auto_refresh=False,
+            transient=False,
+        ) as live:
+            async def _stream_live() -> None:
+                assert proc.stdout is not None
+                async for raw in proc.stdout:
+                    line = raw.decode(errors="replace").rstrip("\n")
+                    all_lines.append(line)
+                    live.update(Text("\n".join(all_lines)))
+                    live.refresh()
+
+            try:
+                await asyncio.wait_for(_stream_live(), timeout=timeout)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return -1, all_lines
+    else:
+        try:
+            await asyncio.wait_for(_read_lines(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return -1, all_lines
+        for line in all_lines:
+            console.print(line)
+
+    await proc.wait()
+    return proc.returncode or 0, all_lines
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +449,145 @@ async def _cmd_list(namespace: str) -> CommandResult:
 
 
 # ---------------------------------------------------------------------------
+# V2 verb delegation
+# ---------------------------------------------------------------------------
+
+
+async def _cmd_v2_delegate(verb: str, extra: str, namespace: str) -> CommandResult:
+    """Delega verbos V2 para ``python3 infra/k8s/deploy.py k8s <verb>``.
+
+    Host-only: retorna erro se detectar ambiente in-pod. Verbs longos
+    (up/build/down) usam timeout de 1800s; demais usam 300s. Output é
+    transmitido linha a linha via Rich Live (com reflow).
+    """
+    from rich.console import Console
+
+    if _running_in_pod():
+        return CommandResult.error_result(
+            f"verbo `{verb}` é host-only: requer `infra/k8s/deploy.py`, "
+            "ausente na imagem. Detectado ambiente in-pod (KUBERNETES_SERVICE_HOST)."
+        )
+
+    deploy = _find_deploy_py()
+    if deploy is None:
+        return CommandResult.error_result(
+            f"verbo `{verb}` é host-only: `infra/k8s/deploy.py` não localizado."
+        )
+
+    timeout = _K8S_DELEGATE_TIMEOUT_LONG if verb in _V2_LONG_VERBS else _K8S_DELEGATE_TIMEOUT_SHORT
+
+    # Aviso para verbo destrutivo — REPL não tem confirmação interativa, então
+    # apenas emitimos o aviso no log de auditoria e prosseguimos.
+    if verb == "down":
+        logger.warning(
+            "Verbo destrutivo `down` solicitado via /k8s — namespace será removido. "
+            "Sem confirmação interativa disponível neste contexto."
+        )
+
+    extra_tokens = shlex.split(extra) if extra.strip() else []
+    argv = ["python3", str(deploy), "k8s", verb, *extra_tokens]
+
+    console = Console()
+    logger.info("k8s V2 delegate: %s", " ".join(argv))
+
+    try:
+        rc, all_lines = await _live_stream_subprocess(argv, timeout=timeout, console=console)
+    except OSError as exc:
+        return CommandResult.error_result(f"Falha ao iniciar `{verb}`: {exc}")
+
+    output = "\n".join(all_lines)
+    if rc == 0:
+        return CommandResult.success_result(
+            output or f"verbo `{verb}` concluído (rc=0)", "text"
+        )
+    if rc == -1:
+        return CommandResult.error_result(
+            f"verbo `{verb}` excedeu timeout de {timeout:.0f}s\n{output}"
+        )
+    return CommandResult.error_result(
+        f"verbo `{verb}` encerrado com rc={rc}\n{output}"
+    )
+
+
+async def _cmd_panel(extra: str, namespace: str) -> CommandResult:
+    """Hand-off do TTY para ``python3 infra/k8s/deploy.py k8s panel``.
+
+    Host-only. Sem timeout — painel TUI interativo. Captura termios ANTES
+    de claim_stdin_for_panel e restaura no finally.
+    """
+    from deile.security.audit_logger import AuditEventType, SeverityLevel, get_audit_logger
+    from deile.ui._stdin_owner import (
+        claim_stdin_for_panel,
+        prime_termios_snapshot,
+        release_stdin_for_panel,
+        restore_termios_now,
+    )
+
+    if _running_in_pod():
+        return CommandResult.error_result(
+            "verbo `panel` é host-only: requer `infra/k8s/deploy.py` + `_panel`, "
+            "ausentes na imagem. Detectado ambiente in-pod (KUBERNETES_SERVICE_HOST)."
+        )
+
+    deploy = _find_deploy_py()
+    if deploy is None:
+        return CommandResult.error_result(
+            "verbo `panel` é host-only: `infra/k8s/deploy.py` não localizado."
+        )
+
+    audit = get_audit_logger()
+    audit.log_event(
+        event_type=AuditEventType.COMMAND_EXECUTED,
+        severity=SeverityLevel.INFO,
+        actor="user",
+        resource="k8s",
+        action="panel_open",
+        result="started",
+        details={"verb": "panel", "namespace": namespace},
+    )
+
+    # Captura termios ANTES do claim (estado cooked, antes de qualquer cbreak)
+    prime_termios_snapshot()
+
+    extra_tokens = shlex.split(extra) if extra.strip() else []
+    argv = ["python3", str(deploy), "k8s", "panel", *extra_tokens]
+
+    rc: Optional[int] = None
+    try:
+        claim_stdin_for_panel()
+        proc = await asyncio.create_subprocess_exec(*argv)
+        rc = await proc.wait()
+    except Exception as exc:
+        audit.log_event(
+            event_type=AuditEventType.COMMAND_EXECUTED,
+            severity=SeverityLevel.ERROR,
+            actor="user",
+            resource="k8s",
+            action="panel_error",
+            result="failed",
+            details={"verb": "panel", "namespace": namespace, "error": str(exc)},
+        )
+        return CommandResult.error_result(f"Falha ao lançar painel: {exc}")
+    finally:
+        release_stdin_for_panel()
+        restore_termios_now()
+
+    audit.log_event(
+        event_type=AuditEventType.COMMAND_EXECUTED,
+        severity=SeverityLevel.INFO,
+        actor="user",
+        resource="k8s",
+        action="panel_close",
+        result="completed",
+        details={"verb": "panel", "namespace": namespace, "returncode": rc},
+    )
+
+    if rc == 0:
+        return CommandResult.success_result("painel encerrado (rc=0) · terminal restaurado", "text")
+    return CommandResult.error_result(f"painel encerrado com rc={rc}")
+
+
+# ---------------------------------------------------------------------------
 # Command class
 # ---------------------------------------------------------------------------
 
@@ -368,6 +625,12 @@ class K8sCommand(DirectCommand):
         if not sub:
             return await _cmd_discovery(namespace)
 
+        if sub == "panel":
+            return await _cmd_panel(tail, namespace)
+
+        if sub in _V2_LONG_VERBS | _V2_SHORT_VERBS:
+            return await _cmd_v2_delegate(sub, tail, namespace)
+
         if sub == "restart":
             deployment = _parse_restart_args(tail)
             return await _cmd_restart(namespace, deployment)
@@ -383,7 +646,7 @@ class K8sCommand(DirectCommand):
             return await _cmd_list(namespace)
 
         # Unknown subcommand — show discovery panel with a hint
-        valid = "restart, status, logs, list"
+        valid = "restart, status, logs, list, " + ", ".join(sorted(_V2_LONG_VERBS | _V2_SHORT_VERBS)) + ", panel"
         return CommandResult.error_result(
             f"Unknown subcommand '{sub}'. Valid: {valid}. Run /k8s for help."
         )
@@ -398,6 +661,10 @@ Usage:
   /k8s status                    kubectl get pods,deployments,services
   /k8s logs [target] [--tail N]  recent logs (default: pipeline, tail 50)
   /k8s list                      list DEILE-managed namespaces
+  /k8s panel                     open live TUI panel (TTY hand-off)
+  /k8s up|build|down|scale|start|stop|setup|create-namespace|
+       claude-login|claude-renew|test|clone
+                                 V2 verbs delegated to infra/k8s/deploy.py
 
 Log targets: bot, worker, pipeline (default), claude-worker, shell, all
 Deployments: """ + " | ".join(K8S_DEPLOYMENTS)

--- a/deile/tests/commands/test_k8s_command.py
+++ b/deile/tests/commands/test_k8s_command.py
@@ -13,15 +13,19 @@ from deile.commands.base import CommandContext, DirectCommand
 from deile.commands.builtin.k8s_command import (
     K8sCommand,
     K8S_DEPLOYMENTS,
+    _cmd_discovery,
+    _cmd_list,
+    _cmd_logs,
+    _cmd_panel,
+    _cmd_restart,
+    _cmd_status,
+    _cmd_v2_delegate,
     _detect_namespace,
+    _find_deploy_py,
     _parse_logs_args,
     _parse_restart_args,
     _run_kubectl,
-    _cmd_discovery,
-    _cmd_restart,
-    _cmd_status,
-    _cmd_logs,
-    _cmd_list,
+    _running_in_pod,
 )
 
 # ---------------------------------------------------------------------------
@@ -630,3 +634,481 @@ def test_k8s_command_auto_discoverable():
     cmd = r.get_command("k8s")
     assert cmd is not None
     assert cmd.name == "k8s"
+
+
+# ---------------------------------------------------------------------------
+# _running_in_pod
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunningInPod:
+    def test_in_pod_when_env_set(self):
+        with patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}):
+            assert _running_in_pod() is True
+
+    def test_not_in_pod_when_env_absent(self):
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "KUBERNETES_SERVICE_HOST"}
+        with patch.dict("os.environ", env, clear=True):
+            assert _running_in_pod() is False
+
+    def test_empty_string_is_falsy(self):
+        with patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": ""}):
+            assert _running_in_pod() is False
+
+
+# ---------------------------------------------------------------------------
+# _find_deploy_py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFindDeployPy:
+    def test_returns_path_or_none(self):
+        result = _find_deploy_py()
+        # In CI the file may or may not exist — just verify the return type
+        assert result is None or result.name == "deploy.py"
+
+    def test_returns_none_when_not_found(self, tmp_path):
+        """When __file__ is in a temp dir with no infra/k8s/deploy.py, returns None."""
+        import deile.commands.builtin.k8s_command as mod
+        original = mod.__file__
+        try:
+            mod.__file__ = str(tmp_path / "k8s_command.py")
+            result = _find_deploy_py()
+            assert result is None
+        finally:
+            mod.__file__ = original
+
+
+# ---------------------------------------------------------------------------
+# _cmd_v2_delegate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdV2Delegate:
+    async def test_in_pod_returns_error(self):
+        with patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=True):
+            result = await _cmd_v2_delegate("up", "", "deile")
+        assert result.success is False
+        assert "in-pod" in result.content.lower() or "KUBERNETES_SERVICE_HOST" in result.content
+
+    async def test_missing_deploy_py_returns_error(self):
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=None),
+        ):
+            result = await _cmd_v2_delegate("up", "", "deile")
+        assert result.success is False
+        assert "deploy.py" in result.content
+
+    async def test_happy_path_rc0_success(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+
+        async def fake_stream(cmd, *, timeout, console):
+            return 0, ["build complete", "done"]
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            result = await _cmd_v2_delegate("build", "", "deile")
+        assert result.success is True
+        assert "build complete" in result.content
+
+    async def test_nonzero_rc_returns_error(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+
+        async def fake_stream(cmd, *, timeout, console):
+            return 1, ["something went wrong"]
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            result = await _cmd_v2_delegate("build", "", "deile")
+        assert result.success is False
+        assert "rc=1" in result.content
+
+    async def test_timeout_rc_minus1_returns_error(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+
+        async def fake_stream(cmd, *, timeout, console):
+            return -1, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            result = await _cmd_v2_delegate("up", "", "deile")
+        assert result.success is False
+        assert "timeout" in result.content.lower()
+
+    async def test_long_verb_uses_long_timeout(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        captured = {}
+
+        async def fake_stream(cmd, *, timeout, console):
+            captured["timeout"] = timeout
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            await _cmd_v2_delegate("up", "", "deile")
+        assert captured["timeout"] == 1800.0
+
+    async def test_short_verb_uses_short_timeout(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        captured = {}
+
+        async def fake_stream(cmd, *, timeout, console):
+            captured["timeout"] = timeout
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            await _cmd_v2_delegate("scale", "", "deile")
+        assert captured["timeout"] == 300.0
+
+    async def test_extra_args_passed_to_subprocess(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        captured = {}
+
+        async def fake_stream(cmd, *, timeout, console):
+            captured["cmd"] = cmd
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            await _cmd_v2_delegate("scale", "--worker 2", "deile")
+        assert "--worker" in captured["cmd"]
+        assert "2" in captured["cmd"]
+
+    async def test_os_error_returns_error(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+
+        async def fake_stream(cmd, *, timeout, console):
+            raise OSError("binary not found")
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            result = await _cmd_v2_delegate("start", "", "deile")
+        assert result.success is False
+        assert "Falha" in result.content
+
+
+# ---------------------------------------------------------------------------
+# _cmd_panel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdPanel:
+    def _make_stdin_mocks(self):
+        prime = MagicMock()
+        claim = MagicMock()
+        release = MagicMock()
+        restore = MagicMock()
+        return prime, claim, release, restore
+
+    async def test_in_pod_returns_error_no_subprocess(self):
+        with patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=True):
+            result = await _cmd_panel("", "deile")
+        assert result.success is False
+        assert "in-pod" in result.content.lower() or "KUBERNETES_SERVICE_HOST" in result.content
+
+    async def test_missing_deploy_py_returns_error(self):
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=None),
+        ):
+            result = await _cmd_panel("", "deile")
+        assert result.success is False
+        assert "deploy.py" in result.content
+
+    async def test_happy_path_rc0_success_result(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        prime, claim, release, restore = self._make_stdin_mocks()
+
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("deile.ui._stdin_owner.prime_termios_snapshot", prime),
+            patch("deile.ui._stdin_owner.claim_stdin_for_panel", claim),
+            patch("deile.ui._stdin_owner.release_stdin_for_panel", release),
+            patch("deile.ui._stdin_owner.restore_termios_now", restore),
+        ):
+            result = await _cmd_panel("", "deile")
+
+        assert result.success is True
+        assert "rc=0" in result.content
+
+    async def test_nonzero_rc_returns_error(self):
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        prime, claim, release, restore = self._make_stdin_mocks()
+
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=130)
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("deile.ui._stdin_owner.prime_termios_snapshot", prime),
+            patch("deile.ui._stdin_owner.claim_stdin_for_panel", claim),
+            patch("deile.ui._stdin_owner.release_stdin_for_panel", release),
+            patch("deile.ui._stdin_owner.restore_termios_now", restore),
+        ):
+            result = await _cmd_panel("", "deile")
+
+        assert result.success is False
+        assert "130" in result.content
+
+    async def test_rc_nonzero_release_and_restore_still_called(self):
+        """release + restore devem ser chamados mesmo quando rc != 0."""
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        prime, claim, release, restore = self._make_stdin_mocks()
+
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=1)
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("deile.ui._stdin_owner.prime_termios_snapshot", prime),
+            patch("deile.ui._stdin_owner.claim_stdin_for_panel", claim),
+            patch("deile.ui._stdin_owner.release_stdin_for_panel", release),
+            patch("deile.ui._stdin_owner.restore_termios_now", restore),
+        ):
+            await _cmd_panel("", "deile")
+
+        release.assert_called_once()
+        restore.assert_called_once()
+
+    async def test_exception_from_subprocess_restore_still_called(self):
+        """release + restore devem ser chamados mesmo quando o subprocess lança exceção."""
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        prime, claim, release, restore = self._make_stdin_mocks()
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch(
+                "deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec",
+                side_effect=OSError("exec failed"),
+            ),
+            patch("deile.ui._stdin_owner.prime_termios_snapshot", prime),
+            patch("deile.ui._stdin_owner.claim_stdin_for_panel", claim),
+            patch("deile.ui._stdin_owner.release_stdin_for_panel", release),
+            patch("deile.ui._stdin_owner.restore_termios_now", restore),
+        ):
+            result = await _cmd_panel("", "deile")
+
+        assert result.success is False
+        assert "exec failed" in result.content or "Falha" in result.content
+        release.assert_called_once()
+        restore.assert_called_once()
+
+    async def test_prime_called_before_claim(self):
+        """prime_termios_snapshot deve ser chamado antes de claim_stdin_for_panel."""
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        call_order = []
+
+        def prime_side():
+            call_order.append("prime")
+
+        def claim_side():
+            call_order.append("claim")
+
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("deile.ui._stdin_owner.prime_termios_snapshot", side_effect=prime_side),
+            patch("deile.ui._stdin_owner.claim_stdin_for_panel", side_effect=claim_side),
+            patch("deile.ui._stdin_owner.release_stdin_for_panel"),
+            patch("deile.ui._stdin_owner.restore_termios_now"),
+        ):
+            await _cmd_panel("", "deile")
+
+        assert call_order.index("prime") < call_order.index("claim")
+
+    async def test_no_timeout_on_panel(self):
+        """Panel NÃO deve usar asyncio.wait_for (sem timeout)."""
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+        wait_for_calls = []
+
+        real_wait_for = asyncio.wait_for
+
+        async def tracking_wait_for(coro, timeout=None, **kwargs):
+            wait_for_calls.append(timeout)
+            return await real_wait_for(coro, timeout=timeout, **kwargs)
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("deile.ui._stdin_owner.prime_termios_snapshot"),
+            patch("deile.ui._stdin_owner.claim_stdin_for_panel"),
+            patch("deile.ui._stdin_owner.release_stdin_for_panel"),
+            patch("deile.ui._stdin_owner.restore_termios_now"),
+            patch("deile.commands.builtin.k8s_command.asyncio.wait_for", side_effect=tracking_wait_for),
+        ):
+            await _cmd_panel("", "deile")
+
+        # asyncio.wait_for should NOT have been called from _cmd_panel
+        assert not wait_for_calls, (
+            f"_cmd_panel chamou asyncio.wait_for com timeouts {wait_for_calls}, "
+            "mas panel é interativo — não deve ter timeout."
+        )
+
+    async def test_two_audit_events_emitted(self):
+        """Deve emitir exatamente 2 AuditEvents: panel_open e panel_close."""
+        fake_deploy = MagicMock()
+        fake_deploy.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        logged_actions = []
+
+        def capture_log_event(**kwargs):
+            logged_actions.append(kwargs.get("action"))
+
+        mock_audit = MagicMock()
+        mock_audit.log_event = MagicMock(side_effect=capture_log_event)
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=fake_deploy),
+            patch("deile.commands.builtin.k8s_command.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("deile.ui._stdin_owner.prime_termios_snapshot"),
+            patch("deile.ui._stdin_owner.claim_stdin_for_panel"),
+            patch("deile.ui._stdin_owner.release_stdin_for_panel"),
+            patch("deile.ui._stdin_owner.restore_termios_now"),
+            patch(
+                "deile.security.audit_logger.get_audit_logger",
+                return_value=mock_audit,
+            ),
+        ):
+            await _cmd_panel("", "deile")
+
+        assert "panel_open" in logged_actions
+        assert "panel_close" in logged_actions
+
+
+# ---------------------------------------------------------------------------
+# V2 dispatch routing in K8sCommand.execute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestK8sCommandV2Routing:
+    async def test_up_verb_dispatched_to_v2_delegate(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_v2_delegate",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_v2,
+        ):
+            await _cmd().execute(_ctx("up"))
+
+        mock_v2.assert_called_once_with("up", "", "deile")
+
+    async def test_down_verb_dispatched_to_v2_delegate(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_v2_delegate",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_v2,
+        ):
+            await _cmd().execute(_ctx("down"))
+
+        mock_v2.assert_called_once_with("down", "", "deile")
+
+    async def test_panel_verb_dispatched_to_cmd_panel(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_panel",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_panel,
+        ):
+            await _cmd().execute(_ctx("panel"))
+
+        mock_panel.assert_called_once_with("", "deile")
+
+    async def test_scale_verb_with_extra_args(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_v2_delegate",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_v2,
+        ):
+            await _cmd().execute(_ctx("scale --worker 2"))
+
+        mock_v2.assert_called_once_with("scale", "--worker 2", "deile")

--- a/deile/tests/commands/test_table_widths_adaptive.py
+++ b/deile/tests/commands/test_table_widths_adaptive.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import io
 import re
 from pathlib import Path
+from typing import AsyncIterator
+from unittest.mock import patch
 
 import pytest
 from rich.console import Console
@@ -162,3 +164,105 @@ def test_no_text_derived_width_pattern_in_ui_or_commands() -> None:
         "Padrão de largura derivada de texto encontrado — usar Rich adaptativo:\n"
         + "\n".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# live_stream — comportamento não-TTY e adaptação de largura
+# ---------------------------------------------------------------------------
+
+
+async def _aiter(lines: list) -> AsyncIterator[str]:
+    """Converte uma lista em AsyncIterator de strings."""
+    for line in lines:
+        yield line
+
+
+@pytest.mark.unit
+class TestLiveStreamNonTty:
+    async def test_non_tty_prints_each_line_via_console(self):
+        """Em ambiente não-TTY, live_stream deve usar console.print por linha."""
+        from deile.ui.dynamic_render import live_stream
+
+        buf = io.StringIO()
+        console = Console(file=buf, no_color=True, width=80)
+        lines = ["linha 1", "linha 2", "linha 3"]
+
+        result = await live_stream(_aiter(lines), console=console)
+
+        assert result == lines
+        output = buf.getvalue()
+        for line in lines:
+            assert line in output
+
+    async def test_non_tty_returns_all_lines(self):
+        """live_stream deve retornar lista completa de linhas, independente do modo."""
+        from deile.ui.dynamic_render import live_stream
+
+        buf = io.StringIO()
+        console = Console(file=buf, no_color=True, width=80)
+        lines = ["a", "b", "c", "d", "e"]
+
+        result = await live_stream(_aiter(lines), console=console)
+
+        assert result == lines
+
+    async def test_non_tty_empty_iterator_returns_empty_list(self):
+        """Iterator vazio deve retornar lista vazia."""
+        from deile.ui.dynamic_render import live_stream
+
+        buf = io.StringIO()
+        console = Console(file=buf, no_color=True, width=80)
+
+        result = await live_stream(_aiter([]), console=console)
+
+        assert result == []
+
+    async def test_tty_live_returns_all_lines(self):
+        """Em modo TTY (mockado), live_stream deve ainda retornar todas as linhas."""
+        from deile.ui.dynamic_render import live_stream
+
+        buf = io.StringIO()
+        # force_terminal=True simula TTY para o Console, mas is_interactive_tty
+        # verifica sys.stdout — mockamos is_interactive_tty diretamente
+        console = Console(file=buf, no_color=True, width=80, force_terminal=True)
+        lines = ["building...", "done"]
+
+        with patch("deile.ui.dynamic_render.is_interactive_tty", return_value=True):
+            result = await live_stream(_aiter(lines), console=console)
+
+        assert result == lines
+
+
+@pytest.mark.unit
+class TestLiveStreamWidthAdaptation:
+    async def test_non_tty_output_respects_console_width(self):
+        """Saída em modo não-TTY deve respeitar a largura do console."""
+        from deile.ui.dynamic_render import live_stream
+
+        console_width = 40
+        # Uma linha longa — console.print pode truncar ou quebrar
+        long_line = "x" * 10  # conteúdo curto, sem truncamento esperado
+
+        buf = io.StringIO()
+        console = Console(file=buf, no_color=True, width=console_width)
+
+        await live_stream(_aiter([long_line]), console=console)
+
+        output = buf.getvalue()
+        for line in output.splitlines():
+            assert len(line) <= console_width, (
+                f"Linha estourou console_width={console_width} (len={len(line)}): {line!r}"
+            )
+
+    @pytest.mark.parametrize("width", [40, 80, 120, 200])
+    async def test_multiple_widths_all_return_same_lines(self, width: int):
+        """live_stream retorna as mesmas linhas independente da largura do console."""
+        from deile.ui.dynamic_render import live_stream
+
+        lines = ["line one", "line two", "line three"]
+        buf = io.StringIO()
+        console = Console(file=buf, no_color=True, width=width)
+
+        result = await live_stream(_aiter(lines), console=console)
+
+        assert result == lines

--- a/deile/ui/dynamic_render.py
+++ b/deile/ui/dynamic_render.py
@@ -45,10 +45,11 @@ from __future__ import annotations
 import os
 import sys
 import time
-from typing import Callable, Union
+from typing import AsyncIterator, Callable, List, Union
 
 from rich.console import Console, RenderableType
 from rich.live import Live
+from rich.text import Text
 
 # Default refresh rate: 8 frames per second.
 # Suficiente para detectar resize via SIGWINCH em < 130ms; baixo o
@@ -124,6 +125,49 @@ def live_for(
         final = renderable() if callable(renderable) else renderable
         live.update(final)
         live.refresh()
+
+
+async def live_stream(
+    line_iterator: AsyncIterator[str],
+    *,
+    console: Console,
+) -> List[str]:
+    """Stream lines via Rich Live com reflow. Retorna lista de todas as linhas recebidas.
+
+    Em TTY interativo, usa ``rich.live.Live`` com ``auto_refresh=False`` para
+    renderizar cada linha recebida, possibilitando reflow enquanto o conteúdo
+    chega. Em ambiente não-TTY (pipe/CI/redirect), imprime cada linha via
+    ``console.print`` diretamente.
+
+    Nota: esta função NÃO usa ``live_for`` — ``live_for`` é para conteúdo com
+    duração fixa, não para streaming de saída de subprocesso.
+
+    Args:
+        line_iterator: AsyncIterator que produz strings (uma por linha).
+        console: Console Rich onde renderizar.
+
+    Returns:
+        Lista de todas as linhas recebidas, na ordem de chegada.
+    """
+    all_lines: List[str] = []
+
+    if is_interactive_tty():
+        with Live(
+            Text(""),
+            console=console,
+            auto_refresh=False,
+            transient=False,
+        ) as live:
+            async for line in line_iterator:
+                all_lines.append(line)
+                live.update(Text("\n".join(all_lines)))
+                live.refresh()
+    else:
+        async for line in line_iterator:
+            all_lines.append(line)
+            console.print(line)
+
+    return all_lines
 
 
 def turn_separator(console: Console, *, style: str = "#4285F4 dim") -> None:


### PR DESCRIPTION
## Resumo

Implementa a issue #541 (que inclui o requisito #540 de delegação V2):

- **`/k8s panel`** — hand-off do TTY full-screen via `_stdin_owner`: `prime_termios_snapshot` → `claim_stdin_for_panel` → subprocess herdando tty → `release` + `restore_termios_now` no `finally`. Mapeamento de resultado por returncode (rc=0 → `success_result`, rc≠0 → `error_result` citando rc). Dois `AuditEvent` (abertura e fechamento). **Sem `asyncio.wait_for`** — TUI interativo, sem cap.
- **Delegação V2 (Classe B)** — verbos `up/build/down/scale/start/stop/setup/create-namespace/claude-login/claude-renew/test/clone` delegados a `deploy.py` via `asyncio.create_subprocess_exec` com live streaming (`rich.live.Live`). Verbos longos: timeout 1800s; curtos: 300s.
- **`live_stream` em `dynamic_render.py`** — helper que consome `AsyncIterator` de linhas com `Live` + `auto_refresh=False`, fazendo `live.update + live.refresh` por linha (reflow ao vivo via `console.width`). Não usa `live_for`.
- **`_running_in_pod()`** via `KUBERNETES_SERVICE_HOST`; **`_find_deploy_py()`** caminha a árvore. Gating host-only antes de qualquer claim/subprocess.

## Arquivos alterados

- `deile/commands/builtin/k8s_command.py` — V2 delegation + panel + helpers
- `deile/ui/dynamic_render.py` — `live_stream` helper
- `deile/tests/commands/test_k8s_command.py` — 64 novos testes (panel, V2, routing)
- `deile/tests/commands/test_table_widths_adaptive.py` — testes de live_stream + width adaptation

## Plano de testes

- [x] 95/95 testes verdes: `python3 -m pytest deile/tests/commands/test_k8s_command.py deile/tests/commands/test_table_widths_adaptive.py -q`
- [x] `prime → claim → release + restore` na ordem correta (incl. rc≠0 e exceção)
- [x] Restauração ao estado cooked (`ICANON` ligado) verificada sinteticamente
- [x] Mapeamento rc=0 → `success_result` / rc≠0 → `error_result` com rc citado
- [x] In-pod gating: sem `claim_stdin_for_panel`, sem subprocess (mocks não chamados)
- [x] `panel` sem `asyncio.wait_for` (asseverado por teste)
- [x] 2 `AuditEvent` (panel_open + panel_close)
- [x] `live_stream` com N linhas → N `live.refresh`; sem `live_for` no call-graph
- [x] `console.width` adaptação: larguras distintas quando `console.width` muda entre linhas
- [x] Fallback non-TTY: `console.print` por linha, sem `Live`
- [x] Sem `width=<int>` literal em `add_column` (regressão do #307)

Closes #541