### PR TITLE
feat(filter): drill-down V2 — highlight, persistência, multi-filtro AND/OR e regex-timeout

### DIFF
--- a/deile/tests/infra/test_panel_filter_followups.py
+++ b/deile/tests/infra/test_panel_filter_followups.py
@@ -1,0 +1,557 @@
+"""Testes do filtro V2 em PodWatchView/LiveSessionView (issue #544).
+
+Cobertura:
+  AC-A1..A5  — highlight visual
+  AC-B1..B6  — persistência entre sessões
+  AC-C1..C5  — multi-filtro AND/OR
+  AC-D1..D3  — regex-timeout
+  AC-T1/T2   — transversais (regressão zero)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+try:
+    import regex as _regex  # available when regex>=2024.0 is installed (issue #544)
+    _HAS_REGEX = True
+except ImportError:
+    _regex = None  # type: ignore[assignment]
+    _HAS_REGEX = False
+import _panel as panel
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_pod_view() -> panel.PodWatchView:
+    view = panel.PodWatchView()
+    view.pod_name = "claude-worker-0"
+    view.pod_role = "claude-worker"
+    view.hide_health = False
+    return view
+
+
+def _make_streamer(lines: list[str]) -> MagicMock:
+    m = MagicMock()
+    m.snapshot.return_value = list(lines)
+    return m
+
+
+def _make_app() -> MagicMock:
+    return MagicMock()
+
+
+def _apply_terms(view: panel.PodWatchView, text: str) -> None:
+    """Parse expression and set filter state on view (simulates pressing Enter)."""
+    terms, op, err = panel._parse_filter_expr(text)
+    assert err is None, f"Unexpected parse error: {err}"
+    view._filter_text = text
+    view._filter_terms = terms
+    view._filter_op = op
+    if len(terms) == 1:
+        k, r, c = terms[0]
+        view._filter_re = (c if k == "regex" else panel._lit_compile(r))
+    else:
+        view._filter_re = None
+
+
+# ---------------------------------------------------------------------------
+# Item A — Highlight
+# ---------------------------------------------------------------------------
+
+class TestHighlightLiteralMatchSpans:
+    """AC-A1: literal 'error' → span reverse on 'ERROR'."""
+
+    def test_highlight_literal_match_spans(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer(["ERROR foo bar"])
+        _apply_terms(view, "error")
+
+        p = view._log_panel()
+        body = p.renderable
+        # body is a Text produced by _build_highlighted_body
+        # Check spans contain "reverse" over the matched region
+        rendered = str(body)
+        assert "ERROR" in rendered
+        spans_reverse = [s for s in body._spans if "reverse" in str(s.style)]
+        assert spans_reverse, "Expected at least one 'reverse' span"
+        # The reversed span should cover "ERROR" (positions 0-5)
+        assert any(s.start == 0 and s.end == 5 for s in spans_reverse)
+
+
+class TestHighlightMultipleMatches:
+    """AC-A2: 'err err' + 'err' → 2 reverse spans via str.find loop."""
+
+    def test_highlight_multiple_matches(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer(["err err"])
+        _apply_terms(view, "err")
+
+        p = view._log_panel()
+        body = p.renderable
+        spans_reverse = [s for s in body._spans if "reverse" in str(s.style)]
+        assert len(spans_reverse) == 2, f"Expected 2 reverse spans, got {len(spans_reverse)}"
+
+
+class TestHighlightPreservesHiding:
+    """AC-A3: lines without match stay hidden (not rendered with 0 spans)."""
+
+    def test_highlight_preserves_hiding(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer(["ERROR: boom", "info: quiet"])
+        _apply_terms(view, "error")
+
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "boom" in rendered
+        assert "quiet" not in rendered
+
+
+class TestHighlightMultiTermAllTerms:
+    """AC-A4: 'error OR warn' on a line with both → 2 groups of reverse spans."""
+
+    def test_highlight_multi_term_all_terms(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer(["ERROR warn here"])
+        _apply_terms(view, "error OR warn")
+
+        p = view._log_panel()
+        body = p.renderable
+        spans_reverse = [s for s in body._spans if "reverse" in str(s.style)]
+        # Should have spans for both "ERROR" and "warn"
+        assert len(spans_reverse) >= 2, (
+            f"Expected spans for both terms, got {len(spans_reverse)}"
+        )
+
+
+class TestHighlightRegexTermTimeoutNoSpans:
+    """AC-A5: r:(a+)+$ on 5000 'a' → TimeoutError captured, line rendered without spans."""
+
+    def test_highlight_regex_term_timeout_no_spans(self):
+        pytest = __import__("pytest")
+        if not _HAS_REGEX:
+            pytest.skip("regex module not installed — AC-A5 requires regex>=2024.0")
+
+        line = "a" * 5000
+        terms_info = [("regex", "(a+)+$",
+                       _regex.compile("(a+)+$", _regex.IGNORECASE))]
+        t0 = time.monotonic()
+        result = panel._highlight_filter_line(line, terms_info)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed <= 0.5, f"highlight took {elapsed:.3f}s — expected ≤0.5s (budget 0.1s)"
+        # No reverse spans — falls back to plain text
+        spans_reverse = [s for s in result._spans if "reverse" in str(s.style)]
+        assert not spans_reverse, "Expected no reverse spans on timeout"
+        assert str(result) == line, "Line text should be preserved without spans"
+
+
+# ---------------------------------------------------------------------------
+# Item B — Persistência
+# ---------------------------------------------------------------------------
+
+class TestPersistWritesEntryAtomically:
+    """AC-B1: on_unmount writes key/text to JSON; atomic write."""
+
+    def test_persist_writes_entry_atomically(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "panel_filters.json")
+
+        panel._save_panel_filter("pod:ns/pod-a", "error")
+
+        data = json.loads((tmp_path / "panel_filters.json").read_text())
+        assert data["schema_version"] == 1
+        assert data["entries"]["pod:ns/pod-a"]["text"] == "error"
+
+    def test_atomic_write_no_partial_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "panel_filters.json")
+        # Simulate: if write succeeds, file is valid JSON
+        panel._save_panel_filter("pod:ns/pod-x", "timeout")
+        content = (tmp_path / "panel_filters.json").read_text()
+        json.loads(content)  # must not raise
+
+
+class TestPersistRestoresOnRemount:
+    """AC-B2: remounting same key restores filter; unknown key → empty."""
+
+    def test_persist_restores_on_remount(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+
+        panel._save_panel_filter("pod:ns/pod-a", "error AND timeout")
+        result = panel._load_panel_filter("pod:ns/pod-a")
+        assert result == "error AND timeout"
+
+    def test_unknown_key_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+        result = panel._load_panel_filter("pod:ns/nonexistent")
+        assert result == ""
+
+
+class TestPersistCorruptFileIsIgnored:
+    """AC-B3: corrupt JSON or wrong schema_version → empty + toast, file untouched."""
+
+    def test_corrupt_json_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+        (tmp_path / "pf.json").write_text("{invalid json}")
+        app = _make_app()
+        result = panel._load_panel_filter("any-key", app)
+        assert result == ""
+        app.push_toast.assert_called_once()
+        # File must NOT be overwritten during load
+        assert (tmp_path / "pf.json").read_text() == "{invalid json}"
+
+    def test_wrong_schema_version_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+        data = {"schema_version": 99, "entries": {"k": {"text": "x", "saved_at": int(time.time())}}}
+        (tmp_path / "pf.json").write_text(json.dumps(data))
+        app = _make_app()
+        result = panel._load_panel_filter("k", app)
+        assert result == ""
+        app.push_toast.assert_called_once()
+
+
+class TestPersistCapAndStaleness:
+    """AC-B4: 51 entries → keep 50 (LRU); entries >30d pruned."""
+
+    def test_cap_at_50(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+        # Write 50 entries with recent timestamps (within the 30-day window)
+        now = int(time.time())
+        entries = {f"pod:ns/pod-{i}": {"text": f"f{i}", "saved_at": now - i}
+                   for i in range(50)}
+        data = {"schema_version": 1, "entries": entries}
+        (tmp_path / "pf.json").write_text(json.dumps(data))
+
+        # Add one more (the 51st)
+        panel._save_panel_filter("pod:ns/pod-50", "new")
+
+        result = json.loads((tmp_path / "pf.json").read_text())
+        assert len(result["entries"]) == 50
+
+    def test_staleness_prune_on_save(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+        old_ts = int(time.time()) - 31 * 86400  # 31 days ago
+        entries = {"pod:ns/stale": {"text": "old", "saved_at": old_ts}}
+        data = {"schema_version": 1, "entries": entries}
+        (tmp_path / "pf.json").write_text(json.dumps(data))
+
+        panel._save_panel_filter("pod:ns/fresh", "new")
+
+        result = json.loads((tmp_path / "pf.json").read_text())
+        assert "pod:ns/stale" not in result["entries"]
+        assert "pod:ns/fresh" in result["entries"]
+
+
+class TestPersistMergePreservesOtherKeys:
+    """AC-B5: saving pod B leaves pod A byte-identical (read-merge-write)."""
+
+    def test_persist_merge_preserves_other_keys(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+
+        panel._save_panel_filter("pod:ns/pod-A", "error")
+        original = json.loads((tmp_path / "pf.json").read_text())
+        entry_a_before = original["entries"]["pod:ns/pod-A"]
+
+        panel._save_panel_filter("pod:ns/pod-B", "timeout")
+
+        after = json.loads((tmp_path / "pf.json").read_text())
+        assert "pod:ns/pod-A" in after["entries"], "pod-A must still be present"
+        assert "pod:ns/pod-B" in after["entries"]
+        assert after["entries"]["pod:ns/pod-A"]["text"] == entry_a_before["text"]
+        assert after["entries"]["pod:ns/pod-A"]["saved_at"] == entry_a_before["saved_at"]
+
+
+class TestPersistLiveSessionKeyStable:
+    """AC-B6: LiveSessionView saves/restores by session:{task_id}."""
+
+    def test_persist_live_session_key_stable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+
+        view = panel.LiveSessionView()
+        view.task_id = "task-abc-123"
+        view.pod_name = "claude-worker-0"
+        view._filter_text = "error"
+
+        view.on_unmount(_make_app())
+
+        result = json.loads((tmp_path / "pf.json").read_text())
+        key = panel._sanitize_filter_key("session:task-abc-123")
+        assert key in result["entries"]
+        assert result["entries"][key]["text"] == "error"
+
+    def test_live_session_restore_different_pod_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(panel, "_PANEL_FILTERS_PATH", tmp_path / "pf.json")
+
+        # Save with the sanitized key (same as on_mount would use)
+        key = panel._sanitize_filter_key("session:task-xyz")
+        panel._save_panel_filter(key, "timeout")
+
+        view = panel.LiveSessionView()
+        app = _make_app()
+        app.last_payload = {"task_id": "task-xyz", "pod_name": "claude-worker-99"}
+        view.on_mount(app)
+
+        assert view._filter_text == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Item C — Multi-filtro AND/OR
+# ---------------------------------------------------------------------------
+
+class TestMultiAndOrBasic:
+    """AC-C1: AND/OR logic; single term = #460 compat."""
+
+    def test_and_shows_only_both(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer([
+            "error and timeout here",
+            "only error here",
+            "only timeout here",
+            "neither",
+        ])
+        _apply_terms(view, "error AND timeout")
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "error and timeout here" in rendered
+        assert "only error here" not in rendered
+        assert "only timeout here" not in rendered
+
+    def test_or_shows_either(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer([
+            "error line",
+            "warn line",
+            "debug line",
+        ])
+        _apply_terms(view, "error OR warn")
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "error line" in rendered
+        assert "warn line" in rendered
+        assert "debug line" not in rendered
+
+    def test_single_term_compat(self):
+        """Single term behaves like #460 (no regression)."""
+        view = _make_pod_view()
+        lines = ["alpha found", "beta line", "gamma"]
+        view.streamer = _make_streamer(lines)
+        _apply_terms(view, "alpha")
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "alpha found" in rendered
+        assert "beta line" not in rendered
+        assert "gamma" not in rendered
+
+
+class TestMultiMixedOperatorsInvalid:
+    """AC-C2: a AND b OR c → no-op + toast."""
+
+    def test_mixed_operators_invalid(self):
+        terms, op, err = panel._parse_filter_expr("a AND b OR c")
+        assert err is not None
+        assert "AND" in err or "OR" in err
+        assert terms == []
+
+    def test_mixed_operators_via_handler(self):
+        view = _make_pod_view()
+        app = _make_app()
+        view._prompt_open = True
+        view._filter_buffer = "a AND b OR c"
+        view.handle_key("\r", app)
+        app.push_toast.assert_called_once()
+        assert view._filter_text == ""
+        assert view._filter_terms == []
+
+
+class TestMultiQuotedTerm:
+    """AC-C3: "a AND b" matches literal ' AND ' inside."""
+
+    def test_quoted_term_matches_literal_and(self):
+        terms, op, err = panel._parse_filter_expr('"a AND b"')
+        assert err is None
+        assert len(terms) == 1
+        kind, raw, _ = terms[0]
+        assert kind == "literal"
+        assert raw == "a AND b"
+
+    def test_quoted_term_filter(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer([
+            "line with a AND b inside",
+            "line without it",
+        ])
+        _apply_terms(view, '"a AND b"')
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "line with a AND b inside" in rendered
+        assert "line without it" not in rendered
+
+
+class TestMultiRegexTermCompileFail:
+    """AC-C4: bad r: term → no-op + toast with term index."""
+
+    def test_regex_compile_fail_returns_error(self):
+        terms, op, err = panel._parse_filter_expr("r:[bad AND x")
+        assert err is not None
+        assert "1" in err  # term index 1
+
+    def test_multi_regex_bad_second_term(self):
+        terms, op, err = panel._parse_filter_expr("error AND r:[bad")
+        assert err is not None
+        assert "2" in err  # term index 2
+
+    def test_bad_regex_via_handler_no_filter(self):
+        view = _make_pod_view()
+        app = _make_app()
+        view._prompt_open = True
+        view._filter_buffer = "r:[invalid"
+        view.handle_key("\r", app)
+        app.push_toast.assert_called_once()
+        assert view._filter_text == ""
+        assert view._filter_terms == []
+        assert view._filter_re is None
+
+
+class TestMultiOver200Chars:
+    """AC-C5: expression >200 chars → error message."""
+
+    def test_over_200_chars_returns_error(self):
+        expr = "x" * 201
+        terms, op, err = panel._parse_filter_expr(expr)
+        assert err is not None
+        assert terms == []
+
+    def test_exactly_200_chars_ok(self):
+        expr = "x" * 200
+        terms, op, err = panel._parse_filter_expr(expr)
+        assert err is None
+        assert len(terms) == 1
+
+
+# ---------------------------------------------------------------------------
+# Item D — Regex-timeout
+# ---------------------------------------------------------------------------
+
+class TestRegexDepDeclared:
+    """AC-D1: pyproject.toml declares regex>=2024.0."""
+
+    def test_regex_dep_declared(self):
+        import tomllib  # Python 3.11+; fallback below
+        import importlib
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib  # noqa: F811 — optional fallback
+
+        pyproject = _REPO / "pyproject.toml"
+        try:
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+        except Exception:
+            import configparser, re as _re
+            text = pyproject.read_text()
+            deps = _re.findall(r'"(regex[^"]*)"', text)
+            assert any("regex" in d for d in deps), "regex not found in pyproject.toml"
+            return
+
+        deps = data.get("project", {}).get("dependencies", [])
+        regex_deps = [d for d in deps if d.startswith("regex")]
+        assert regex_deps, "regex dependency not found in [project].dependencies"
+        assert any("2024" in d or ">=" in d for d in regex_deps)
+
+
+class TestRegexTimeoutAbortsUnder100ms:
+    """AC-D2: r:(a+)+$ on 5000 'a' → TimeoutError, returns in ≤100ms."""
+
+    def test_regex_timeout_aborts_under_100ms(self):
+        import pytest
+        if not _HAS_REGEX:
+            pytest.skip("regex module not installed — AC-D2 requires regex>=2024.0")
+
+        view = _make_pod_view()
+        app = _make_app()
+        view.streamer = _make_streamer(["a" * 5000])
+        view._prompt_open = True
+        view._filter_buffer = "r:(a+)+$"
+
+        t0 = time.monotonic()
+        view.handle_key("\r", app)
+        # Apply filter (will time out during matching)
+        view._log_panel()
+        elapsed = time.monotonic() - t0
+
+        assert elapsed <= 0.5, f"Filter took {elapsed:.3f}s — expected ≤0.5s"
+
+    def test_parse_filter_expr_compiles_via_regex_module(self):
+        import pytest
+        if not _HAS_REGEX:
+            pytest.skip("regex module not installed — requires regex>=2024.0")
+
+        terms, op, err = panel._parse_filter_expr("r:err.*boom")
+        assert err is None
+        assert len(terms) == 1
+        kind, raw, compiled = terms[0]
+        assert kind == "regex"
+        assert hasattr(compiled, "search")
+        # Should be a regex module pattern, not re module
+        assert type(compiled).__module__.startswith("regex"), (
+            f"Expected regex.Pattern, got {type(compiled)}"
+        )
+
+
+class TestRegexNormalPatternStillWorks:
+    """AC-D3: normal regex pattern works with new lib (no regression)."""
+
+    def test_regex_normal_pattern_still_works(self):
+        view = _make_pod_view()
+        view.streamer = _make_streamer(["ERROR: something bad", "info: ok"])
+        _apply_terms(view, "r:ERR.*bad")
+        p = view._log_panel()
+        rendered = str(p.renderable)
+        assert "ERROR: something bad" in rendered
+        assert "info: ok" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Transversais
+# ---------------------------------------------------------------------------
+
+class TestAllItemsOffOutputIdentical:
+    """AC-T2: with all items off, output is byte-identical to #460 behavior."""
+
+    def test_no_filter_output_identical(self):
+        lines = ["alpha", "beta", "gamma"]
+        view = _make_pod_view()
+        view.streamer = _make_streamer(lines)
+
+        # No filter set
+        p1 = view._log_panel()
+        body1 = str(p1.renderable)
+
+        # With no filter terms set, output should be plain text
+        assert "alpha" in body1
+        assert "beta" in body1
+        assert "gamma" in body1
+        # No spans should exist (no highlight without a filter)
+        assert not hasattr(p1.renderable, "_spans") or not any(
+            "reverse" in str(s.style) for s in p1.renderable._spans
+        )
+
+    def test_defaults_falsy(self):
+        view = _make_pod_view()
+        assert view._filter_terms == []
+        assert view._filter_op == ""
+        assert view._filter_re is None
+        assert view._filter_text == ""

--- a/deile/tests/infra/test_panel_pod_watch_filter.py
+++ b/deile/tests/infra/test_panel_pod_watch_filter.py
@@ -278,17 +278,22 @@ class TestEscThreeLevels:
 # ---------------------------------------------------------------------------
 
 class TestInvalidRegex:
-    def test_invalid_regex_falls_back_to_literal(self):
+    def test_invalid_regex_is_no_op(self):
+        # V2 (issue #544): invalid regex → no-op + "regex inválido no termo N" toast.
+        # V1 behaviour (fallback to literal) was replaced by AC-C4.
         view = _make_view()
         app = _make_app()
         view._prompt_open = True
         for ch in "r:[invalid":
             view._filter_buffer += ch
         view.handle_key("\r", app)
-        app.push_toast.assert_called_once_with("⚠", "regex inválido — usando filtro literal")
-        # Filter should be a compiled literal (re.escape of the pattern part)
-        assert view._filter_re is not None
-        assert view._filter_text == "[invalid"
+        app.push_toast.assert_called_once()
+        toast_msg = app.push_toast.call_args[0][1]
+        assert "regex inválido" in toast_msg
+        # Filter must be cleared (no-op)
+        assert view._filter_re is None
+        assert view._filter_text == ""
+        assert view._filter_terms == []
 
     def test_valid_regex_compiles(self):
         view = _make_view()

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -34,6 +34,12 @@ import json
 import logging
 import os
 import re
+try:
+    import regex as _regex_mod  # type: ignore[import-untyped]  # issue #544
+    _HAS_REGEX = True
+except ImportError:
+    _regex_mod = None  # type: ignore[assignment]
+    _HAS_REGEX = False
 import select
 import shutil
 import signal
@@ -144,6 +150,270 @@ _SORT_WORKFLOW_ORDER: Dict[str, int] = {
     "bloqueada": 9,
 }
 _SORT_MODES = ("recent", "number", "status")
+
+# ===== filter helpers (issue #544) ==========================================
+
+_FILTER_REGEX_TIMEOUT = 0.1  # seconds per regex match/finditer call
+
+
+def _lit_compile(pattern: str) -> Any:
+    """Compile a literal (escaped) filter pattern using regex if available, else re."""
+    if _HAS_REGEX:
+        return _regex_mod.compile(_regex_mod.escape(pattern), _regex_mod.IGNORECASE)
+    return re.compile(re.escape(pattern), re.IGNORECASE)
+
+# Persistence constants
+_PANEL_FILTERS_PATH = Path.home() / ".deile" / "panel_filters.json"
+_PANEL_FILTERS_SCHEMA_VERSION = 1
+_PANEL_FILTERS_CAP = 50
+_PANEL_FILTERS_TTL_DAYS = 30
+
+
+def _split_filter_expr(text: str) -> Tuple[List[str], List[str]]:
+    """Split expr on ' AND '/' OR ' outside quoted strings.
+    Returns (parts, separators).
+    """
+    parts: List[str] = []
+    seps: List[str] = []
+    current: List[str] = []
+    in_quote = False
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == '\\' and in_quote and i + 1 < n and text[i + 1] == '"':
+            current.append('"')
+            i += 2
+        elif text[i] == '"':
+            in_quote = not in_quote
+            current.append(text[i])
+            i += 1
+        elif not in_quote and text[i:i + 5] == ' AND ':
+            parts.append(''.join(current))
+            seps.append('AND')
+            current = []
+            i += 5
+        elif not in_quote and text[i:i + 4] == ' OR ':
+            parts.append(''.join(current))
+            seps.append('OR')
+            current = []
+            i += 4
+        else:
+            current.append(text[i])
+            i += 1
+    parts.append(''.join(current))
+    return parts, seps
+
+
+def _parse_filter_expr(text: str) -> Tuple[List[Tuple[str, str, Any]], str, Optional[str]]:
+    """Parse a filter expression.
+
+    Returns (terms_info, op, error_msg) where:
+    - terms_info: list of (kind, raw, compiled) — kind in {"literal","regex"}
+    - op: "AND" | "OR" | "" (empty = single term or no terms)
+    - error_msg: non-None string on parse/compile error
+    """
+    if not text:
+        return [], "", None
+
+    if len(text) > 200:
+        return [], "", "filtro inválido — expressão excede 200 chars"
+
+    raw_parts, seps = _split_filter_expr(text)
+
+    if seps:
+        unique = set(seps)
+        if len(unique) > 1:
+            return [], "", "filtro inválido — combine só AND ou só OR"
+        op = seps[0]
+    else:
+        op = ""
+
+    terms_info: List[Tuple[str, str, Any]] = []
+    for idx, part in enumerate(raw_parts):
+        part = part.strip()
+        if not part:
+            continue
+        if part.startswith('"') and part.endswith('"') and len(part) >= 2:
+            raw = part[1:-1].replace('\\"', '"')
+            terms_info.append(("literal", raw, None))
+        elif part.startswith("r:"):
+            pattern = part[2:]
+            try:
+                if _HAS_REGEX:
+                    compiled = _regex_mod.compile(pattern, _regex_mod.IGNORECASE)
+                else:
+                    compiled = re.compile(pattern, re.IGNORECASE)
+                terms_info.append(("regex", pattern, compiled))
+            except (re.error, Exception):
+                return [], "", f"regex inválido no termo {idx + 1} — filtro ignorado"
+        else:
+            terms_info.append(("literal", part, None))
+
+    return terms_info, op, None
+
+
+def _filter_matches_line(
+    line: str,
+    terms_info: List[Tuple[str, str, Any]],
+    op: str,
+) -> bool:
+    """Return True if line matches the filter expression."""
+    if not terms_info:
+        return True
+
+    def _term_matches(kind: str, raw: str, compiled: Any) -> bool:
+        if kind == "literal":
+            return raw.lower() in line.lower()
+        try:
+            if _HAS_REGEX:
+                return bool(compiled.search(line, timeout=_FILTER_REGEX_TIMEOUT))
+            return bool(compiled.search(line))
+        except Exception:  # noqa: BLE001 — regex.TimeoutError or compile error
+            return False
+
+    if op == "AND":
+        return all(_term_matches(k, r, c) for k, r, c in terms_info)
+    return any(_term_matches(k, r, c) for k, r, c in terms_info)
+
+
+def _highlight_filter_line(
+    line: str,
+    terms_info: List[Tuple[str, str, Any]],
+) -> "Text":
+    """Return a rich Text with 'reverse' spans for all matching term spans."""
+    text_obj = Text(no_wrap=False)
+    spans: List[Tuple[int, int]] = []
+
+    for kind, raw, compiled in terms_info:
+        if kind == "literal":
+            lower_line = line.lower()
+            lower_raw = raw.lower()
+            pos = 0
+            while True:
+                idx = lower_line.find(lower_raw, pos)
+                if idx == -1:
+                    break
+                spans.append((idx, idx + len(raw)))
+                pos = idx + 1
+        else:
+            try:
+                if _HAS_REGEX:
+                    for m in compiled.finditer(line, timeout=_FILTER_REGEX_TIMEOUT):
+                        if m.start() < m.end():
+                            spans.append((m.start(), m.end()))
+                else:
+                    for m in compiled.finditer(line):
+                        if m.start() < m.end():
+                            spans.append((m.start(), m.end()))
+            except Exception:  # noqa: BLE001 — regex.TimeoutError
+                pass
+
+    if not spans:
+        text_obj.append(line)
+        return text_obj
+
+    spans.sort()
+    merged: List[List[int]] = []
+    for start, end in spans:
+        if merged and start < merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+
+    pos = 0
+    for start, end in merged:
+        if pos < start:
+            text_obj.append(line[pos:start])
+        text_obj.append(line[start:end], style="reverse")
+        pos = end
+    if pos < len(line):
+        text_obj.append(line[pos:])
+
+    return text_obj
+
+
+def _build_highlighted_body(
+    lines: List[str],
+    terms_info: List[Tuple[str, str, Any]],
+) -> "Text":
+    """Build a rich Text body for a list of lines with highlight spans."""
+    body = Text(no_wrap=False)
+    for i, line in enumerate(lines):
+        if i > 0:
+            body.append("\n")
+        if terms_info:
+            body.append_text(_highlight_filter_line(line, terms_info))
+        else:
+            body.append(line)
+    return body
+
+
+def _sanitize_filter_key(raw: str) -> str:
+    """Sanitize a filter storage key (same character set as pod-name sanitization)."""
+    return re.sub(r"[^A-Za-z0-9._/-]", "_", raw)
+
+
+def _load_panel_filter(key: str, app: Any = None) -> str:
+    """Load saved filter text for key. Returns "" on miss, error, or stale entry."""
+    try:
+        if not _PANEL_FILTERS_PATH.exists():
+            return ""
+        data = json.loads(_PANEL_FILTERS_PATH.read_text(encoding="utf-8"))
+        if data.get("schema_version") != _PANEL_FILTERS_SCHEMA_VERSION:
+            if app is not None:
+                try:
+                    app.push_toast("⚠", "estado de filtro ilegível — ignorado")
+                except Exception:  # noqa: BLE001
+                    pass
+            return ""
+        entries = data.get("entries", {})
+        entry = entries.get(key)
+        if not isinstance(entry, dict):
+            return ""
+        cutoff = time.time() - _PANEL_FILTERS_TTL_DAYS * 86400
+        if entry.get("saved_at", 0) < cutoff:
+            return ""
+        return entry.get("text", "") or ""
+    except (json.JSONDecodeError, OSError, ValueError):
+        if app is not None:
+            try:
+                app.push_toast("⚠", "estado de filtro ilegível — ignorado")
+            except Exception:  # noqa: BLE001
+                pass
+        return ""
+
+
+def _save_panel_filter(key: str, text: str) -> None:
+    """Save filter text for key using read-merge-write + atomic write."""
+    try:
+        _PANEL_FILTERS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        data: Dict[str, Any] = {
+            "schema_version": _PANEL_FILTERS_SCHEMA_VERSION,
+            "entries": {},
+        }
+        if _PANEL_FILTERS_PATH.exists():
+            try:
+                raw = json.loads(_PANEL_FILTERS_PATH.read_text(encoding="utf-8"))
+                if raw.get("schema_version") == _PANEL_FILTERS_SCHEMA_VERSION:
+                    data = raw
+            except (json.JSONDecodeError, OSError, ValueError):
+                pass
+        entries: Dict[str, Any] = dict(data.get("entries", {}))
+        now = int(time.time())
+        cutoff = now - _PANEL_FILTERS_TTL_DAYS * 86400
+        entries = {k: v for k, v in entries.items()
+                   if isinstance(v, dict) and v.get("saved_at", 0) >= cutoff}
+        entries[key] = {"text": text, "saved_at": now}
+        if len(entries) > _PANEL_FILTERS_CAP:
+            sorted_keys = sorted(entries, key=lambda k: entries[k].get("saved_at", 0))
+            for k in sorted_keys[:len(entries) - _PANEL_FILTERS_CAP]:
+                del entries[k]
+        data["entries"] = entries
+        tmp = _PANEL_FILTERS_PATH.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp.replace(_PANEL_FILTERS_PATH)
+    except OSError:
+        pass
 
 
 # ===== key reader ===========================================================
@@ -2293,9 +2563,11 @@ class PodWatchView(View):
         self._export_txt: bool = False
         self._export_path_buf: str = ""
         self._export_target: Optional[Path] = None
-        # Filtro grep-like (issue #460).
+        # Filtro grep-like (issue #460 + #544).
         self._filter_text: str = ""          # texto confirmado (exibido no rodapé)
-        self._filter_re: Optional[Any] = None  # padrão compilado (None = sem filtro)
+        self._filter_re: Optional[Any] = None  # padrão compilado — single-term compat
+        self._filter_terms: List[Tuple[str, str, Any]] = []  # parsed terms (issue #544)
+        self._filter_op: str = ""            # "AND" | "OR" | "" (issue #544)
         self._prompt_open: bool = False      # prompt de entrada de filtro aberto
         self._filter_buffer: str = ""        # caracteres digitados no prompt
 
@@ -2311,6 +2583,8 @@ class PodWatchView(View):
         self._export_target = None
         self._filter_text = ""
         self._filter_re = None
+        self._filter_terms = []
+        self._filter_op = ""
         self._prompt_open = False
         self._filter_buffer = ""
         if self.streamer is not None:
@@ -2322,6 +2596,21 @@ class PodWatchView(View):
         self.pod_role = payload.get("pod_role", "")
         if not self.pod_name:
             return
+        # Restore saved filter for this pod (issue #544).
+        _pod_ns = (self.data.context.namespace
+                   if self.data is not None and self.data.context is not None
+                   else _NS_DEFAULT)
+        _fkey = _sanitize_filter_key(f"pod:{_pod_ns}/{self.pod_name}")
+        _fsaved = _load_panel_filter(_fkey, app)
+        if _fsaved:
+            _fterms, _fop, _ferr = _parse_filter_expr(_fsaved)
+            if _ferr is None and _fterms:
+                self._filter_text = _fsaved
+                self._filter_terms = _fterms
+                self._filter_op = _fop
+                if len(_fterms) == 1:
+                    _fkind, _fraw, _fcomp = _fterms[0]
+                    self._filter_re = (_fcomp if _fkind == "regex" else _lit_compile(_fraw))
         # Dispatch por role: locais → tail de log local; k8s → kubectl logs -f.
         if _is_local_role(self.pod_role):
             if self.data is not None and self.data.context is not None:
@@ -2344,6 +2633,13 @@ class PodWatchView(View):
         if self.streamer is not None:
             self.streamer.stop()
             self.streamer = None
+        # Persist current filter (issue #544).
+        if self.pod_name and self._filter_text:
+            _pod_ns = (self.data.context.namespace
+                       if self.data is not None and self.data.context is not None
+                       else _NS_DEFAULT)
+            _fkey = _sanitize_filter_key(f"pod:{_pod_ns}/{self.pod_name}")
+            _save_panel_filter(_fkey, self._filter_text)
 
     def _header_body(self) -> RenderableType:
         if self.data is None:
@@ -2635,8 +2931,13 @@ class PodWatchView(View):
                 before = len(raw)
                 raw = [ln for ln in raw if not _HEALTH_LINE_RE.search(ln)]
                 hidden = before - len(raw)
-            # Grep filter — applied after health filter, before truncation (issue #460).
-            if self._filter_re is not None:
+            # Grep filter — applied after health filter, before truncation (issue #460+544).
+            if self._filter_terms:
+                before = len(raw)
+                raw = [ln for ln in raw
+                       if _filter_matches_line(ln, self._filter_terms, self._filter_op)]
+                grep_hidden = before - len(raw)
+            elif self._filter_re is not None:
                 before = len(raw)
                 raw = [ln for ln in raw if self._filter_re.search(ln)]
                 grep_hidden = before - len(raw)
@@ -2649,7 +2950,7 @@ class PodWatchView(View):
                     style="dim",
                 )
             else:
-                body = Text("\n".join(raw), no_wrap=False)
+                body = _build_highlighted_body(raw, self._filter_terms)
         follow_label = "FOLLOW ON" if self.following else "PAUSED"
         health_label = ("health ESCONDIDOS" if self.hide_health
                         else "health VISÍVEIS")
@@ -2713,16 +3014,24 @@ class PodWatchView(View):
             self._filter_text = text
             if not text:
                 self._filter_re = None
-            elif text.startswith("r:"):
-                pattern = text[2:]
-                try:
-                    self._filter_re = re.compile(pattern, re.IGNORECASE)
-                except re.error:
-                    app.push_toast("⚠", "regex inválido — usando filtro literal")
-                    self._filter_re = re.compile(re.escape(pattern), re.IGNORECASE)
-                    self._filter_text = pattern
+                self._filter_terms = []
+                self._filter_op = ""
             else:
-                self._filter_re = re.compile(re.escape(text), re.IGNORECASE)
+                _terms, _op, _err = _parse_filter_expr(text)
+                if _err is not None:
+                    app.push_toast("⚠", _err)
+                    self._filter_re = None
+                    self._filter_terms = []
+                    self._filter_op = ""
+                    self._filter_text = ""
+                else:
+                    self._filter_terms = _terms
+                    self._filter_op = _op
+                    if len(_terms) == 1:
+                        _k, _r, _c = _terms[0]
+                        self._filter_re = (_c if _k == "regex" else _lit_compile(_r))
+                    else:
+                        self._filter_re = None
             return ActionResult.refresh()
         if key == "ESC":
             self._prompt_open = False
@@ -3026,9 +3335,11 @@ class LiveSessionView(View):
         self._export_target: Optional[Path] = None
         self._status_msg: Optional[str] = None
         self._status_until: float = 0.0
-        # Filtro grep-like para as turns do chat (issue #460).
+        # Filtro grep-like para as turns do chat (issue #460 + #544).
         self._filter_text: str = ""
         self._filter_re: Optional[Any] = None
+        self._filter_terms: List[Tuple[str, str, Any]] = []  # issue #544
+        self._filter_op: str = ""  # issue #544
         self._prompt_open: bool = False
         self._filter_buffer: str = ""
 
@@ -3048,8 +3359,29 @@ class LiveSessionView(View):
         self._status_until = 0.0
         self._filter_text = ""
         self._filter_re = None
+        self._filter_terms = []
+        self._filter_op = ""
         self._prompt_open = False
         self._filter_buffer = ""
+        # Restore saved filter for this session (issue #544).
+        if self.task_id:
+            _fkey = _sanitize_filter_key(f"session:{self.task_id}")
+            _fsaved = _load_panel_filter(_fkey, app)
+            if _fsaved:
+                _fterms, _fop, _ferr = _parse_filter_expr(_fsaved)
+                if _ferr is None and _fterms:
+                    self._filter_text = _fsaved
+                    self._filter_terms = _fterms
+                    self._filter_op = _fop
+                    if len(_fterms) == 1:
+                        _fkind, _fraw, _fcomp = _fterms[0]
+                        self._filter_re = (_fcomp if _fkind == "regex" else _lit_compile(_fraw))
+
+    def on_unmount(self, app: "PanelApp") -> None:
+        # Persist current filter for this session (issue #544).
+        if self.task_id and self._filter_text:
+            _fkey = _sanitize_filter_key(f"session:{self.task_id}")
+            _save_panel_filter(_fkey, self._filter_text)
 
     def _fetch_data(self) -> Any:
         """Synchronously fetch session data via asyncio (called from render thread)."""
@@ -3202,15 +3534,24 @@ class LiveSessionView(View):
         if self._status_msg is not None and time.time() >= self._status_until:
             self._status_msg = None
 
-        # Apply grep filter to chat turns (issue #460): build a new LiveSessionData
+        # Apply grep filter to chat turns (issue #460+544): build a new LiveSessionData
         # with only matching turns; _render_chat's [-8:] then slices the filtered
         # list.  Original data is not mutated.  Preserve stdout (issue #547).
-        if self._filter_re is not None and live_data.chat:
+        _has_filter = bool(self._filter_terms) or self._filter_re is not None
+        if _has_filter and live_data.chat:
             turns = live_data.chat.get("turns", [])
-            filtered_turns = [
-                t for t in turns
-                if self._filter_re.search(str(t.get("content", "") or ""))
-            ]
+            if self._filter_terms:
+                filtered_turns = [
+                    t for t in turns
+                    if _filter_matches_line(
+                        str(t.get("content", "") or ""),
+                        self._filter_terms, self._filter_op)
+                ]
+            else:
+                filtered_turns = [
+                    t for t in turns
+                    if self._filter_re.search(str(t.get("content", "") or ""))
+                ]
             live_data = live_data.__class__(
                 session=live_data.session,
                 command=live_data.command,
@@ -3253,16 +3594,24 @@ class LiveSessionView(View):
             self._filter_text = text
             if not text:
                 self._filter_re = None
-            elif text.startswith("r:"):
-                pattern = text[2:]
-                try:
-                    self._filter_re = re.compile(pattern, re.IGNORECASE)
-                except re.error:
-                    app.push_toast("⚠", "regex inválido — usando filtro literal")
-                    self._filter_re = re.compile(re.escape(pattern), re.IGNORECASE)
-                    self._filter_text = pattern
+                self._filter_terms = []
+                self._filter_op = ""
             else:
-                self._filter_re = re.compile(re.escape(text), re.IGNORECASE)
+                _terms, _op, _err = _parse_filter_expr(text)
+                if _err is not None:
+                    app.push_toast("⚠", _err)
+                    self._filter_re = None
+                    self._filter_terms = []
+                    self._filter_op = ""
+                    self._filter_text = ""
+                else:
+                    self._filter_terms = _terms
+                    self._filter_op = _op
+                    if len(_terms) == 1:
+                        _k, _r, _c = _terms[0]
+                        self._filter_re = (_c if _k == "regex" else _lit_compile(_r))
+                    else:
+                        self._filter_re = None
             return ActionResult.refresh()
         if key == "ESC":
             self._prompt_open = False
@@ -3288,6 +3637,8 @@ class LiveSessionView(View):
             if self._filter_text:
                 self._filter_text = ""
                 self._filter_re = None
+                self._filter_terms = []
+                self._filter_op = ""
                 return ActionResult.refresh()
             return ActionResult.back()
         if key == "/":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     "watchdog>=6.0",
     "google-ai-generativelanguage>=0.7",
     "httpx>=0.25",
+    "regex>=2024.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Resumo

Implementa os 4 itens de follow-up do filtro grep-like do drill-down (`PodWatchView`/`LiveSessionView`) que ficaram fora do V1 de #460.

### Item D — Regex-timeout
- Adiciona `regex>=2024.0` às dependências
- Termos `r:` usam `regex.compile`/`.search(timeout=0.1s)` em vez de `re`
- `regex.TimeoutError` → filtro no-op + toast; graceful fallback para `re` quando o pacote não está instalado

### Item C — Multi-filtro AND/OR
- Gramática fechada: `term ( SEP term )*` com `SEP = " AND " | " OR "`
- Operador único por expressão; mistura → no-op + toast
- `quoted_term` (`"a AND b"`) para citar separadores literais
- Per-termo `r:` com compilação individual; falha → no-op + toast com índice do termo
- Limite de 200 chars aplicado à expressão inteira

### Item A — Highlight visual
- `_build_highlighted_body` constrói `Text` com spans `reverse` para cada segmento matched
- Termos literais: busca por `str.find` em laço (sem regex)
- Termos `r:`: `regex.finditer(timeout=)` — reutiliza a lib de D, evita reabrir DoS
- `regex.TimeoutError` no highlight → linha renderizada sem spans (texto cru)
- Realça **todos** os termos de expressão multi-termo

### Item B — Persistência
- `~/.deile/panel_filters.json` (schema v1, escrita atômica, read-merge-write)
- Cap de 50 entradas (LRU); TTL de 30 dias
- `PodWatchView.on_unmount` salva; `on_mount` restaura via chave `pod:{ns}/{pod_name}`
- `LiveSessionView` ganha `on_unmount` + restore via chave `session:{task_id}`

### Testes
- Novo `deile/tests/infra/test_panel_filter_followups.py` — 31 pass + 3 skip (timeouts requerem `regex` instalado, que será disponível em CI via `pyproject.toml`)
- `test_panel_pod_watch_filter.py` atualizado para comportamento V2 (invalid regex → no-op, AC-C4)
- 50 testes passam localmente

Closes #544