### PR TITLE
feat(pipeline-logger): batch.claim/release injection + ForgeClient on_label_change sink

### DIFF
--- a/deile/orchestration/forge/base.py
+++ b/deile/orchestration/forge/base.py
@@ -308,6 +308,7 @@ class ForgeClient(ABC):
 
     def __init__(self, config: ForgeConfig) -> None:
         self._config = config
+        self.on_label_change: Optional[Callable[[str, int, list[str], list[str]], None]] = None
 
     # ------------------------------------------------------------------
     # Introspection
@@ -563,17 +564,37 @@ class ForgeClient(ABC):
         self, number: int, *, from_label: Optional[str], to_label: str,
     ) -> None:
         """Swap a workflow label on an issue."""
-        if from_label is not None:
-            await self.remove_labels("issue", number, [from_label])
-        await self.add_labels("issue", number, [to_label])
+        cb = self.on_label_change
+        self.on_label_change = None
+        try:
+            if from_label is not None:
+                await self.remove_labels("issue", number, [from_label])
+            await self.add_labels("issue", number, [to_label])
+        finally:
+            self.on_label_change = cb
+        if cb is not None:
+            try:
+                cb("issue", number, [from_label] if from_label is not None else [], [to_label])
+            except Exception:
+                pass
 
     async def transition_pr(
         self, number: int, *, from_label: Optional[str], to_label: str,
     ) -> None:
         """Swap a workflow label on a PR/MR."""
-        if from_label is not None:
-            await self.remove_labels("pr", number, [from_label])
-        await self.add_labels("pr", number, [to_label])
+        cb = self.on_label_change
+        self.on_label_change = None
+        try:
+            if from_label is not None:
+                await self.remove_labels("pr", number, [from_label])
+            await self.add_labels("pr", number, [to_label])
+        finally:
+            self.on_label_change = cb
+        if cb is not None:
+            try:
+                cb("pr", number, [from_label] if from_label is not None else [], [to_label])
+            except Exception:
+                pass
 
     async def claim_with_batch(self, kind: str, number: int) -> Optional[str]:
         """Claim an issue/PR via the ``~batch:<sha>`` lock label.

--- a/deile/orchestration/forge/github_forge.py
+++ b/deile/orchestration/forge/github_forge.py
@@ -828,6 +828,11 @@ class GitHubForge(ForgeClient):
         for lb in labels_list:
             args += ["-f", f"labels[]={lb}"]
         await self._run_checked(*args)
+        if self.on_label_change is not None:
+            try:
+                self.on_label_change(kind, number, [], labels_list)
+            except Exception:
+                pass
 
     async def has_bot_activity_since(
         self,
@@ -975,6 +980,11 @@ class GitHubForge(ForgeClient):
                 raise ForgeCommandError(
                     ("gh", "api", "-X", "DELETE", path), rc, out, err,
                 )
+        if self.on_label_change is not None:
+            try:
+                self.on_label_change(kind, number, labels_list, [])
+            except Exception:
+                pass
 
     async def _ensure_label(self, name: str, *, color: str, description: str) -> None:
         rc, _, err = await self._run(

--- a/deile/orchestration/forge/gitlab_forge.py
+++ b/deile/orchestration/forge/gitlab_forge.py
@@ -999,6 +999,11 @@ class GitLabForge(ForgeClient):
             "api", "-X", "PUT", endpoint,
             "-f", f"add_labels={','.join(labels_list)}",
         )
+        if self.on_label_change is not None:
+            try:
+                self.on_label_change(kind, number, [], labels_list)
+            except Exception:
+                pass
 
     async def label_applied_at(
         self, kind: str, number: int, label: str,
@@ -1077,6 +1082,11 @@ class GitLabForge(ForgeClient):
             raise ForgeCommandError(
                 ("glab", "api", "-X", "PUT", endpoint), rc, out, err,
             )
+        if self.on_label_change is not None:
+            try:
+                self.on_label_change(kind, number, labels_list, [])
+            except Exception:
+                pass
 
     def _label_target_endpoint(self, kind: str, number: int) -> str:
         if kind == "issue":

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -50,6 +50,7 @@ from deile.orchestration.pipeline.lockfile import LockHeldError
 from deile.orchestration.pipeline.lockfile import acquire as acquire_lock
 from deile.orchestration.pipeline.lockfile import release as release_lock
 from deile.orchestration.pipeline.notifier import DiscordNotifier
+from deile.orchestration.pipeline import pipeline_logger
 from deile.orchestration.pipeline.resume_state import ResumeTracker
 from deile.orchestration.pipeline.scheduler import PendingRun, ScheduleStore
 from deile.orchestration.pipeline.stages import (_extract_pr_url,
@@ -358,6 +359,8 @@ class PipelineMonitor:
                 "PipelineMonitor: pass only one of forge=/github= (github= is deprecated)"
             )
         self.forge: ForgeClient = forge or github or build_forge(project_path=config.repo)
+        self.forge.on_label_change = lambda kind, num, rem, add: \
+            pipeline_logger.log_label_change(target_kind=kind, target=num, removed=rem, added=add)
         # WorktreeManager validates that base_repo_path is a git repo at
         # construction. The deile_worker strategy never creates local
         # worktrees (the worker Pod owns its own clone) and runs where

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 from deile.orchestration.forge import (CommentRef, GhCommandError, IssueRef,
                                        MentionTrigger, declared_hosts,
                                        find_last_pr_url)
+from deile.orchestration.forge.refs import compute_batch_id_for_number
+from deile.orchestration.pipeline import pipeline_logger
 from deile.orchestration.pipeline._time_utils import now_utc
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
 from deile.orchestration.pipeline.dispatch_ledger import DispatchLedger
@@ -247,6 +249,7 @@ async def _claim_for_classify(
     if batch is None:
         logger.debug("%s #%s already claimed by another monitor; skipping", kind, number)
         return False
+    pipeline_logger.log_batch_claim(sha=batch, issues=[number], reason=error_context)
     return True
 
 
@@ -260,6 +263,10 @@ async def _release_classify_claim(monitor: "PipelineMonitor", kind: str, number:
         return
     try:
         await monitor.forge.clear_batch_label(kind, number)
+        pipeline_logger.log_batch_release(
+            sha=compute_batch_id_for_number(kind, number),
+            reason="classify_released",
+        )
     except Exception as exc:  # noqa: BLE001 — label applied; clear is best-effort
         logger.warning("%s: could not clear batch on #%s: %s", kind, number, exc)
 

--- a/deile/tests/orchestration/forge/test_forge_label_sink.py
+++ b/deile/tests/orchestration/forge/test_forge_label_sink.py
@@ -1,0 +1,102 @@
+"""AC3b — ForgeClient on_label_change sink: no-op-safe + monitor wiring."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deile.orchestration.forge.base import ForgeConfig, ForgeKind
+from deile.orchestration.forge.github_forge import GitHubForge
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+
+
+def _github_forge() -> GitHubForge:
+    cfg = ForgeConfig(
+        project_path="owner/repo",
+        kind=ForgeKind.GITHUB,
+        host="github.com",
+        cli_path="/usr/bin/gh",
+    )
+    return GitHubForge(cfg)
+
+
+async def _fake_run_checked(*args):
+    return ""
+
+
+async def _fake_run(*args):
+    return (0, "", "")
+
+
+class TestForgeSinkNoopSafe:
+    """on_label_change = None → all label mutations complete without exception."""
+
+    async def test_add_labels_no_sink(self):
+        gh = _github_forge()
+        assert gh.on_label_change is None
+        with patch.object(gh, "_run_checked", side_effect=_fake_run_checked):
+            await gh.add_labels("issue", 1, ["~workflow:nova"])
+
+    async def test_remove_labels_no_sink(self):
+        gh = _github_forge()
+        assert gh.on_label_change is None
+        with patch.object(gh, "_run", side_effect=_fake_run):
+            await gh.remove_labels("issue", 1, ["~workflow:nova"])
+
+    async def test_transition_issue_no_sink(self):
+        gh = _github_forge()
+        assert gh.on_label_change is None
+        with patch.object(gh, "_run_checked", side_effect=_fake_run_checked), \
+             patch.object(gh, "_run", side_effect=_fake_run):
+            await gh.transition_issue(1, from_label="~workflow:nova", to_label="~workflow:em_revisao")
+
+
+def _boom(kind, num, rem, add):
+    raise RuntimeError("boom — sink must not propagate")
+
+
+class TestForgeSinkExceptionSwallowed:
+    """Sink raising RuntimeError → mutation completes (exception swallowed)."""
+
+    async def test_add_labels_sink_raises_swallowed(self):
+        gh = _github_forge()
+        gh.on_label_change = _boom
+        with patch.object(gh, "_run_checked", side_effect=_fake_run_checked):
+            await gh.add_labels("issue", 1, ["~workflow:nova"])
+
+    async def test_remove_labels_sink_raises_swallowed(self):
+        gh = _github_forge()
+        gh.on_label_change = _boom
+        with patch.object(gh, "_run", side_effect=_fake_run):
+            await gh.remove_labels("issue", 1, ["~workflow:nova"])
+
+    async def test_transition_issue_sink_raises_swallowed(self):
+        gh = _github_forge()
+        gh.on_label_change = _boom
+        with patch.object(gh, "_run_checked", side_effect=_fake_run_checked), \
+             patch.object(gh, "_run", side_effect=_fake_run):
+            await gh.transition_issue(1, from_label="~workflow:nova", to_label="~workflow:em_revisao")
+
+
+class TestMonitorWiresOnLabelChange:
+    """PipelineMonitor.__init__ assigns forge.on_label_change (AC3b scenario iii)."""
+
+    def test_monitor_wires_on_label_change_after_init(self):
+        cfg = PipelineConfig(
+            repo="owner/repo",
+            base_repo_path=Path("/tmp/fake"),
+            notify_user_id="42",
+        )
+        forge = MagicMock()
+        forge.on_label_change = None
+        monitor = PipelineMonitor(
+            cfg,
+            forge=forge,
+            worktrees=MagicMock(),
+            claude=MagicMock(),
+        )
+        assert monitor.forge.on_label_change is not None, (
+            "PipelineMonitor.__init__ must wire forge.on_label_change"
+        )

--- a/deile/tests/orchestration/pipeline/test_batch_logging.py
+++ b/deile/tests/orchestration/pipeline/test_batch_logging.py
@@ -1,0 +1,123 @@
+"""AC8 + AC2 — batch.claim / batch.release logging via pipeline_logger."""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import deile.orchestration.pipeline.pipeline_logger as pl
+from deile.orchestration.pipeline import stages
+from deile.orchestration.pipeline.identity import MonitorIdentity
+from deile.orchestration.pipeline.monitor import PipelineConfig, PipelineMonitor
+
+_CANON_PATTERN = re.compile(
+    r"^(refinement|decomposition|batch|label|reaper|auth|routing)\.[a-z_]+"
+    r"  ([a-z_]+=('[^']*'|[^ ]+) ?)+$"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup(monkeypatch):
+    monkeypatch.setattr(pl, "_DEDUP", pl._DedupCache())
+
+
+def _batch_lines(caplog):
+    return [
+        r.message for r in caplog.records
+        if r.name == "deile.pipeline.events" and r.message.startswith("batch.")
+    ]
+
+
+def _make_monitor(shard_count: int, claim_returns: object = "abc12345"):
+    cfg = PipelineConfig(
+        repo="owner/name",
+        base_repo_path=Path("/tmp/fake"),
+        notify_user_id="42",
+    )
+    forge = MagicMock()
+    forge.ensure_pipeline_labels = AsyncMock()
+    forge.claim_with_batch = AsyncMock(return_value=claim_returns)
+    forge.clear_batch_label = AsyncMock()
+    forge.add_labels = AsyncMock()
+    forge.remove_labels = AsyncMock()
+    forge.on_label_change = None
+
+    monitor = PipelineMonitor(
+        cfg,
+        forge=forge,
+        worktrees=MagicMock(),
+        claude=MagicMock(),
+    )
+    monitor.identity = MonitorIdentity(
+        monitor_id="default", shard_index=0, shard_count=shard_count,
+    )
+    return monitor
+
+
+class TestBatchLoggingAC8:
+    """AC8 — 0 batch.* lines for shard_count=1, exactly 2 for shard_count=2."""
+
+    async def test_single_monitor_emits_no_batch_lines(self, caplog):
+        monitor = _make_monitor(shard_count=1)
+        with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
+            await stages._claim_for_classify(monitor, "issue", 42, error_context="test")
+            await stages._release_classify_claim(monitor, "issue", 42)
+        lines = _batch_lines(caplog)
+        assert lines == [], f"shard_count=1 must emit 0 batch.* lines, got: {lines}"
+
+    async def test_multi_monitor_emits_exactly_two_batch_lines(self, caplog):
+        monitor = _make_monitor(shard_count=2, claim_returns="abc12345")
+        with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
+            claimed = await stages._claim_for_classify(
+                monitor, "issue", 42, error_context="test_context",
+            )
+            await stages._release_classify_claim(monitor, "issue", 42)
+        assert claimed is True
+        lines = _batch_lines(caplog)
+        assert len(lines) == 2, (
+            f"shard_count=2 must emit exactly 2 batch.* lines, got: {lines}"
+        )
+        assert any(ln.startswith("batch.claim") for ln in lines)
+        assert any(ln.startswith("batch.release") for ln in lines)
+
+    async def test_claim_returns_none_emits_no_batch_lines(self, caplog):
+        monitor = _make_monitor(shard_count=2, claim_returns=None)
+        with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
+            claimed = await stages._claim_for_classify(monitor, "issue", 42, error_context="test")
+        assert claimed is False
+        lines = _batch_lines(caplog)
+        assert lines == [], f"claim=None must emit 0 batch.* lines, got: {lines}"
+
+
+class TestBatchLoggingAC2:
+    """AC2 (partial) — batch.* lines match canonical format regex."""
+
+    async def test_batch_claim_matches_canonical_pattern(self, caplog):
+        monitor = _make_monitor(shard_count=2, claim_returns="abc12345")
+        with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
+            await stages._claim_for_classify(
+                monitor, "issue", 42, error_context="classify",
+            )
+        lines = _batch_lines(caplog)
+        claim_lines = [ln for ln in lines if ln.startswith("batch.claim")]
+        assert claim_lines, "No batch.claim line emitted"
+        for line in claim_lines:
+            assert _CANON_PATTERN.match(line), (
+                f"batch.claim does not match canonical pattern: {line!r}"
+            )
+
+    async def test_batch_release_matches_canonical_pattern(self, caplog):
+        monitor = _make_monitor(shard_count=2, claim_returns="abc12345")
+        with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
+            await stages._claim_for_classify(monitor, "issue", 42, error_context="classify")
+            await stages._release_classify_claim(monitor, "issue", 42)
+        lines = _batch_lines(caplog)
+        release_lines = [ln for ln in lines if ln.startswith("batch.release")]
+        assert release_lines, "No batch.release line emitted"
+        for line in release_lines:
+            assert _CANON_PATTERN.match(line), (
+                f"batch.release does not match canonical pattern: {line!r}"
+            )


### PR DESCRIPTION
## Summary

Implements issue #557 (3/7 sub-issue of #438):

- **`stages.py`**: injects `log_batch_claim` / `log_batch_release` in `_claim_for_classify` / `_release_classify_claim` — guarded by `shard_count > 1` gate (AC8: 0 lines for single monitor, exactly 2 for multi-monitor)
- **`forge/base.py`**: adds optional `on_label_change: Callable | None = None` attribute + consolidated callback in `transition_issue` / `transition_pr` (suppresses sub-call callbacks to emit exactly 1 `label.change` line per transition — AC11)
- **`github_forge.py`** + **`gitlab_forge.py`**: no-op-safe callback in `add_labels` / `remove_labels`
- **`monitor.py`**: wires `forge.on_label_change = lambda ... pipeline_logger.log_label_change(...)` in `__init__`
- **`test_batch_logging.py`**: AC8 (0 vs 2 lines) + AC2 canonical-regex checks
- **`test_forge_label_sink.py`**: AC3b — null-sink safety, exception-swallowing, monitor wiring

All 217 forge tests and 65 targeted pipeline tests green.

Closes #557.