### PR TITLE
feat(pipeline): inject auth.fail/backoff/skip/recover structured logs (issue #559)

### DIFF
--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 import re
 import time
+from datetime import timedelta
 from dataclasses import replace
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -29,7 +30,10 @@ from deile.orchestration.forge import (CommentRef, GhCommandError, IssueRef,
                                        find_last_pr_url)
 from deile.orchestration.forge.refs import compute_batch_id_for_number
 from deile.orchestration.pipeline import pipeline_logger
-from deile.orchestration.pipeline._time_utils import now_utc
+from deile.orchestration.pipeline._time_utils import format_iso_utc, now_utc
+from deile.orchestration.pipeline.pipeline_logger import (
+    log_auth_backoff, log_auth_fail, log_auth_recover, log_auth_skip,
+)
 from deile.orchestration.pipeline.constants import PIPELINE_MSG_TRUNCATE_CHARS
 from deile.orchestration.pipeline.dispatch_ledger import DispatchLedger
 from deile.orchestration.pipeline.dispatch_resolver import \
@@ -2016,6 +2020,13 @@ async def implement_one_reviewed_issue(
         # curtos de ``WORKER_AUTH_EXPIRED``. O target será reavaliado no
         # próximo tick depois que a janela expirar.
         if is_target_auth_paused(monitor, "issue", target.number):
+            _paused_until = monitor._paused_until_ts.get(_auth_target_key("issue", target.number), 0.0)
+            _rem = max(0, int(_paused_until - _monotonic()))
+            log_auth_skip(
+                target=_auth_target_key("issue", target.number),
+                until_iso=format_iso_utc(now_utc() + timedelta(seconds=_rem)),
+                remaining_s=_rem,
+            )
             logger.debug(
                 "implement #%d: pausado por backoff de auth — skip este tick",
                 target.number,
@@ -2316,6 +2327,7 @@ async def _finalize_implement_outcome(
             )
         monitor._resume_tracker.clear(number)
         # Decisão #46 — sucesso real: reseta contadores de backoff de auth.
+        log_auth_recover(target=_auth_target_key("issue", number), reason='success')
         reset_auth_failures(monitor, "issue", number)
         monitor._stats.issues_implemented += 1
         await monitor.notifier.implementation_finished(number, pr_url)
@@ -2445,9 +2457,11 @@ def record_auth_failure_and_maybe_pause(
     key = _auth_target_key(kind, number)
     count = monitor._auth_failures_by_target.get(key, 0) + 1
     monitor._auth_failures_by_target[key] = count
+    log_auth_fail(target=key, attempts=count, threshold=_AUTH_BACKOFF_THRESHOLD, reason='WORKER_AUTH_EXPIRED')
     if count < _AUTH_BACKOFF_THRESHOLD:
         return count, 0.0
     backoff_s = min(_AUTH_BACKOFF_BASE_S * (2 ** count), _AUTH_BACKOFF_MAX_S)
+    log_auth_backoff(target=key, attempts=count, until_iso=format_iso_utc(now_utc() + timedelta(seconds=backoff_s)), backoff_s=int(backoff_s))
     monitor._paused_until_ts[key] = _monotonic() + backoff_s
     logger.warning(
         "auth backoff: target=%s count=%d pause_for=%.0fs",
@@ -2749,6 +2763,7 @@ async def reconcile_review_prs(monitor: "PipelineMonitor") -> None:
                 )
             await monitor.forge.clear_batch_label("pr", pr.number)
             monitor._resume_tracker.clear(pr.number)
+            log_auth_recover(target=_auth_target_key("pr", pr.number), reason='success')
             reset_auth_failures(monitor, "pr", pr.number)
             ledger.clear(key)
             monitor._stats.prs_reviewed += 1
@@ -2909,6 +2924,7 @@ async def _resume_review_one_pr(monitor: "PipelineMonitor", target, resume_enabl
             await monitor.forge.clear_batch_label("pr", target.number)
             monitor._resume_tracker.clear(target.number)
             # Decisão #46 — sucesso real: reseta contadores de backoff de auth.
+            log_auth_recover(target=_auth_target_key("pr", target.number), reason='success')
             reset_auth_failures(monitor, "pr", target.number)
             monitor._stats.prs_reviewed += 1
             await monitor.notifier.pr_reviewed(target.number, target.title, target.url, merged=True)
@@ -3084,13 +3100,22 @@ async def review_one_open_pr(monitor: "PipelineMonitor") -> None:
 
     # Sort by priority so the most urgent PR is reviewed first.
     # Decisão #46 — skip PRs em janela de pausa por backoff de auth.
-    target = next(
-        (
-            pr for pr in sort_by_priority(prs)
-            if _candidate(pr) and not is_target_auth_paused(monitor, "pr", pr.number)
-        ),
-        None,
-    )
+    target = None
+    for pr in sort_by_priority(prs):
+        if not _candidate(pr):
+            continue
+        if is_target_auth_paused(monitor, "pr", pr.number):
+            _key = _auth_target_key("pr", pr.number)
+            _paused_until = monitor._paused_until_ts.get(_key, 0.0)
+            _rem = max(0, int(_paused_until - _monotonic()))
+            log_auth_skip(
+                target=_key,
+                until_iso=format_iso_utc(now_utc() + timedelta(seconds=_rem)),
+                remaining_s=_rem,
+            )
+            continue
+        target = pr
+        break
     if target is None:
         return
     # Defensive guard (Mistério #4): if the head branch no longer exists on

--- a/deile/tests/orchestration/pipeline/test_auth_log_injection.py
+++ b/deile/tests/orchestration/pipeline/test_auth_log_injection.py
@@ -1,14 +1,9 @@
-"""AC2/AC10 — auth log injection in stages.py (issue #559).
-
-Tests that record_auth_failure_and_maybe_pause and the auth-skip paths emit
-the 4 structured log families: auth.fail, auth.backoff, auth.skip, auth.recover.
-"""
 from __future__ import annotations
 
 import logging
 import re
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,6 +13,7 @@ from deile.orchestration.pipeline.stages import (
     _AUTH_BACKOFF_THRESHOLD,
     _auth_target_key,
     record_auth_failure_and_maybe_pause,
+    reset_auth_failures,
 )
 
 
@@ -33,7 +29,7 @@ def _events(caplog):
 
 
 @pytest.fixture(autouse=True)
-def _reset_dedup(monkeypatch):
+def _reset(monkeypatch):
     monkeypatch.setattr(pl, "_DEDUP", pl._DedupCache())
 
 
@@ -42,7 +38,7 @@ def test_log_auth_fail_pattern(caplog):
     with caplog.at_level(logging.WARNING, logger="deile.pipeline.events"):
         record_auth_failure_and_maybe_pause(mon, "issue", 1)
     lines = _events(caplog)
-    assert lines, "No log line emitted for auth.fail"
+    assert lines, "No auth.fail line emitted"
     pattern = r"auth\.fail\s+target=\S+\s+attempts=\d+\s+threshold=3\s+reason=WORKER_AUTH_EXPIRED"
     assert any(re.search(pattern, line) for line in lines), f"No match in: {lines}"
 
@@ -61,7 +57,7 @@ def test_log_auth_skip_pattern(caplog):
     with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
         log_auth_skip(target="issue:99", until_iso="2023-11-14T22:21:20Z", remaining_s=480)
     lines = _events(caplog)
-    assert lines, "No log line emitted for auth.skip"
+    assert lines, "No auth.skip line emitted"
     pattern = r"auth\.skip\s+target=\S+\s+until_iso=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+remaining_s=\d+"
     assert any(re.search(pattern, line) for line in lines), f"No match in: {lines}"
 
@@ -70,7 +66,7 @@ def test_log_auth_recover_pattern(caplog):
     with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
         log_auth_recover(target="issue:1", reason="success")
     lines = _events(caplog)
-    assert lines, "No log line emitted for auth.recover"
+    assert lines, "No auth.recover line emitted"
     pattern = r"auth\.recover\s+target=\S+\s+reason=\S+"
     assert any(re.search(pattern, line) for line in lines), f"No match in: {lines}"
 
@@ -89,9 +85,7 @@ def test_auth_backoff_concrete_values(monkeypatch, caplog):
             record_auth_failure_and_maybe_pause(mon, "issue", 7)
 
     lines = _events(caplog)
-    # count=3, backoff_s = min(60 * 2**3, 1800) = min(480, 1800) = 480
-    # until_iso = now_utc + 480s = 2023-11-14T22:13:20Z + 480s = 2023-11-14T22:21:20Z
-    backoff_lines = [line for line in lines if "auth.backoff" in line]
+    backoff_lines = [l for l in lines if "auth.backoff" in l]
     assert backoff_lines, f"No auth.backoff line in: {lines}"
     line = backoff_lines[0]
     assert "backoff_s=480" in line, f"Expected backoff_s=480 in: {line!r}"

--- a/deile/tests/orchestration/pipeline/test_auth_log_injection.py
+++ b/deile/tests/orchestration/pipeline/test_auth_log_injection.py
@@ -1,0 +1,98 @@
+"""AC2/AC10 — auth log injection in stages.py (issue #559).
+
+Tests that record_auth_failure_and_maybe_pause and the auth-skip paths emit
+the 4 structured log families: auth.fail, auth.backoff, auth.skip, auth.recover.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+import deile.orchestration.pipeline.pipeline_logger as pl
+from deile.orchestration.pipeline.pipeline_logger import log_auth_recover, log_auth_skip
+from deile.orchestration.pipeline.stages import (
+    _AUTH_BACKOFF_THRESHOLD,
+    _auth_target_key,
+    record_auth_failure_and_maybe_pause,
+)
+
+
+def _make_monitor():
+    m = MagicMock()
+    m._auth_failures_by_target = {}
+    m._paused_until_ts = {}
+    return m
+
+
+def _events(caplog):
+    return [r.message for r in caplog.records if r.name == "deile.pipeline.events"]
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup(monkeypatch):
+    monkeypatch.setattr(pl, "_DEDUP", pl._DedupCache())
+
+
+def test_log_auth_fail_pattern(caplog):
+    mon = _make_monitor()
+    with caplog.at_level(logging.WARNING, logger="deile.pipeline.events"):
+        record_auth_failure_and_maybe_pause(mon, "issue", 1)
+    lines = _events(caplog)
+    assert lines, "No log line emitted for auth.fail"
+    pattern = r"auth\.fail\s+target=\S+\s+attempts=\d+\s+threshold=3\s+reason=WORKER_AUTH_EXPIRED"
+    assert any(re.search(pattern, line) for line in lines), f"No match in: {lines}"
+
+
+def test_log_auth_backoff_pattern(caplog):
+    mon = _make_monitor()
+    with caplog.at_level(logging.WARNING, logger="deile.pipeline.events"):
+        for _ in range(_AUTH_BACKOFF_THRESHOLD):
+            record_auth_failure_and_maybe_pause(mon, "issue", 42)
+    lines = _events(caplog)
+    pattern = r"auth\.backoff\s+target=\S+\s+attempts=\d+\s+until_iso=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+backoff_s=\d+"
+    assert any(re.search(pattern, line) for line in lines), f"No auth.backoff match in: {lines}"
+
+
+def test_log_auth_skip_pattern(caplog):
+    with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
+        log_auth_skip(target="issue:99", until_iso="2023-11-14T22:21:20Z", remaining_s=480)
+    lines = _events(caplog)
+    assert lines, "No log line emitted for auth.skip"
+    pattern = r"auth\.skip\s+target=\S+\s+until_iso=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+remaining_s=\d+"
+    assert any(re.search(pattern, line) for line in lines), f"No match in: {lines}"
+
+
+def test_log_auth_recover_pattern(caplog):
+    with caplog.at_level(logging.INFO, logger="deile.pipeline.events"):
+        log_auth_recover(target="issue:1", reason="success")
+    lines = _events(caplog)
+    assert lines, "No log line emitted for auth.recover"
+    pattern = r"auth\.recover\s+target=\S+\s+reason=\S+"
+    assert any(re.search(pattern, line) for line in lines), f"No match in: {lines}"
+
+
+def test_auth_backoff_concrete_values(monkeypatch, caplog):
+    """AC10 — concrete values with mocked _monotonic and now_utc."""
+    import deile.orchestration.pipeline.stages as stages_mod
+
+    monkeypatch.setattr(stages_mod, "_monotonic", lambda: 0.0)
+    fixed_now = datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc)
+    monkeypatch.setattr(stages_mod, "now_utc", lambda: fixed_now)
+
+    mon = _make_monitor()
+    with caplog.at_level(logging.WARNING, logger="deile.pipeline.events"):
+        for _ in range(_AUTH_BACKOFF_THRESHOLD):
+            record_auth_failure_and_maybe_pause(mon, "issue", 7)
+
+    lines = _events(caplog)
+    # count=3, backoff_s = min(60 * 2**3, 1800) = min(480, 1800) = 480
+    # until_iso = now_utc + 480s = 2023-11-14T22:13:20Z + 480s = 2023-11-14T22:21:20Z
+    backoff_lines = [line for line in lines if "auth.backoff" in line]
+    assert backoff_lines, f"No auth.backoff line in: {lines}"
+    line = backoff_lines[0]
+    assert "backoff_s=480" in line, f"Expected backoff_s=480 in: {line!r}"
+    assert "until_iso=2023-11-14T22:21:20Z" in line, f"Expected until_iso=2023-11-14T22:21:20Z in: {line!r}"


### PR DESCRIPTION
## Resumo

Implementa issue #559 — injeta 4 famílias de log estruturado no ciclo de auth backoff em `stages.py`, tornando o ciclo visível em `kubectl logs deploy/deile-pipeline`.

### Mudanças em `stages.py`

| Família | Ponto de injeção |
|---|---|
| `auth.fail` | `record_auth_failure_and_maybe_pause` — após incrementar contador, antes do threshold check |
| `auth.backoff` | `record_auth_failure_and_maybe_pause` — após calcular `backoff_s`, antes de setar `_paused_until_ts` |
| `auth.skip` (issue) | Loop de issue — dentro do bloco `if is_target_auth_paused` |
| `auth.skip` (pr) | Generator `next(...)` expandido para for-loop explícito |
| `auth.recover` | 3 call-sites de `reset_auth_failures`: `~2299` (issue), `~2735` (pr), `~2896` (pr) |

### Imports adicionados
- `from datetime import timedelta`
- `format_iso_utc` no import de `_time_utils`
- `log_auth_backoff, log_auth_fail, log_auth_recover, log_auth_skip` de `pipeline_logger`

### Testes (`test_auth_log_injection.py`)
- **AC2**: 4 padrões regex (um por família) — `test_log_auth_{fail,backoff,skip,recover}_pattern`
- **AC10**: valores concretos com mock de `_monotonic` (→ `0.0`) e `now_utc` (→ `2023-11-14T22:13:20Z`), verificando `backoff_s=480` e `until_iso=2023-11-14T22:21:20Z`
- `test_pipeline_logger_schema.py` sem regressão (10/10 pass)

Closes #559.