### PR TITLE
test(pipeline): AC0/AC13 no-regression suite para linhas de tick-log (issue #561, 7/7)

### DIFF
--- a/deile/tests/orchestration/pipeline/test_pipeline_logs_no_regression_existing_lines.py
+++ b/deile/tests/orchestration/pipeline/test_pipeline_logs_no_regression_existing_lines.py
@@ -1,0 +1,58 @@
+"""AC0/AC13 — Regressão: linhas de tick-log pré-existentes em monitor.py.
+
+Verifica que as duas linhas de tick-log históricas (DEBUG "pipeline tick #%d"
+e INFO "tick #%d done in %.2fs:") não foram removidas nem alteradas por
+nenhuma sub-issue upstream (#555–#560).
+
+Referência canônica: issue #438 §Baseline, revalidado contra main@96eee7e.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_MONITOR_PY = (
+    Path(__file__).resolve().parents[4]
+    / "deile"
+    / "orchestration"
+    / "pipeline"
+    / "monitor.py"
+)
+
+
+def _lines_with_numbers() -> list[tuple[int, str]]:
+    text = _MONITOR_PY.read_text(encoding="utf-8")
+    return [(i + 1, ln) for i, ln in enumerate(text.splitlines())]
+
+
+def test_pipeline_tick_debug_line_present() -> None:
+    """monitor.py deve conter logger.debug("pipeline tick #%d") — não-regressão AC13."""
+    lines = _lines_with_numbers()
+    matches = [
+        (lineno, ln)
+        for lineno, ln in lines
+        if 'pipeline tick #' in ln
+    ]
+    assert matches, (
+        "Regressão AC13: nenhuma linha com 'pipeline tick #' em monitor.py. "
+        "A linha logger.debug(\"pipeline tick #%d\") foi removida ou alterada."
+    )
+    assert any(
+        'logger.debug("pipeline tick #%d"' in ln for _, ln in matches
+    ), (
+        f"Regressão AC13: formato da linha DEBUG de tick alterado. "
+        f"Matches encontrados: {matches}"
+    )
+
+
+def test_tick_done_info_line_present() -> None:
+    """monitor.py deve conter logger.info("tick #%d done in %.2fs:") — não-regressão AC13."""
+    lines = _lines_with_numbers()
+    matches = [
+        (lineno, ln)
+        for lineno, ln in lines
+        if '"tick #%d done in %.2fs:' in ln
+    ]
+    assert matches, (
+        "Regressão AC13: nenhuma linha com 'tick #%d done in %.2fs:' em monitor.py. "
+        "A linha logger.info(\"tick #%d done in ...\") foi removida ou alterada."
+    )


### PR DESCRIPTION
## Resumo

Cria `deile/tests/orchestration/pipeline/test_pipeline_logs_no_regression_existing_lines.py` com 2 testes de snapshot que verificam que as linhas de tick-log pré-existentes em `monitor.py` não foram perturbadas pelas injeções upstream (#555–#560).

### Entregável (AC0)

Arquivo criado com ≥ 1 teste coletado:
```
pytest deile/tests/orchestration/pipeline/test_pipeline_logs_no_regression_existing_lines.py \
  -v --collect-only → 2 tests collected ✓
```

### Testes

- `test_pipeline_tick_debug_line_present` — verifica presença de `logger.debug("pipeline tick #%d")` (AC13 linha ~682)
- `test_tick_done_info_line_present` — verifica presença de `logger.info("tick #%d done in %.2fs:")` (AC13 linha ~831)

### AC13 — Snapshot das linhas de tick-log

```
grep -n 'pipeline tick #\|tick #%d done' deile/orchestration/pipeline/monitor.py
682:        logger.debug("pipeline tick #%d", self._stats.ticks)
831:                "tick #%d done in %.2fs: classified=%d reviewed=%d "
839:                "tick #%d done in %.2fs: classified=%d reviewed=%d "
```
Linhas inalteradas (diff vazio em relação ao baseline). ✓

### AC3 — Status das 15 funções injetadas

10/15 funções wired (issues #555, #556, #557, #559 mergeados):
- ✅ `log_refinement_critique`, `log_refinement_refine`, `log_decomposition_fanout` (issue #556)
- ✅ `log_batch_claim`, `log_batch_release`, `log_label_change` (issue #557)
- ✅ `log_auth_fail`, `log_auth_backoff`, `log_auth_skip`, `log_auth_recover` (issue #559)
- ⏳ `log_reaper_unblock`, `log_reaper_block` — aguardando merge de PR #574 (issue #558)
- ⏳ `log_routing_mention`, `log_routing_pr_unified`, `log_routing_dropped` — aguardando merge de PR #576 (issue #560)

Per gate de scope creep: correções de reaper/routing requerem mais de 1 linha por call-site → responsabilidade das sub-issues #558 e #560, não desta sub-issue.

### AC14/AC15 — Smoke-test in-cluster

SKIP automático em CI sem `kubectl`. Executar manualmente no namespace `deile` antes de fechar #438.

Closes #561.