### PR TITLE
feat(pipeline): GC de labels transitórias ao fechar issues/PRs

### DIFF
--- a/deile/orchestration/pipeline/gc.py
+++ b/deile/orchestration/pipeline/gc.py
@@ -1,0 +1,189 @@
+"""Terminal GC — removes transient pipeline labels from closed/merged items.
+
+Called when an issue transitions to 'closed' or a PR transitions to
+'closed'/'merged'. Eliminates label accumulation on terminal work items
+without touching priority or project-classification labels.
+
+Standalone module: importable without loading stages.py or the full
+pipeline graph.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, List, Literal, Tuple
+
+from deile.orchestration.pipeline.labels import (
+    BY_LABEL_PREFIX,
+    FOLLOW_UPS_PROCESSED,
+    MENTION_DONE,
+    REFINAR,
+    WORKFLOW_CONCLUDED,
+    WORKFLOW_DECOMPOSED,
+    is_attempt_label,
+    is_batch_label,
+    is_refine_attempt_label,
+)
+
+if TYPE_CHECKING:
+    from deile.orchestration.forge.base import ForgeClient
+
+logger = logging.getLogger(__name__)
+
+_WORKFLOW_PREFIX = "~workflow:"
+_REVIEW_PREFIX = "~review:"
+
+
+class GCOnOpenItemError(Exception):
+    """Raised when run_terminal_gc is called on an open item.
+
+    Zero API calls are made before this exception is raised.
+    """
+
+
+def _to_strip_issue(current_labels: Tuple[str, ...]) -> List[str]:
+    """Labels to remove from a closed issue."""
+    result = []
+    for lb in current_labels:
+        if lb.startswith(_WORKFLOW_PREFIX):
+            if lb not in (WORKFLOW_DECOMPOSED, WORKFLOW_CONCLUDED):
+                result.append(lb)
+        elif lb.startswith(BY_LABEL_PREFIX):
+            result.append(lb)
+        elif is_batch_label(lb):
+            result.append(lb)
+        elif is_attempt_label(lb):
+            result.append(lb)
+        elif is_refine_attempt_label(lb):
+            result.append(lb)
+        elif lb == MENTION_DONE:
+            result.append(lb)
+        elif lb == REFINAR:
+            result.append(lb)
+    return result
+
+
+def _to_strip_pr(current_labels: Tuple[str, ...]) -> List[str]:
+    """Labels to remove from a closed or merged PR."""
+    result = []
+    for lb in current_labels:
+        if lb.startswith(_REVIEW_PREFIX):
+            result.append(lb)
+        elif lb.startswith(BY_LABEL_PREFIX):
+            result.append(lb)
+        elif is_batch_label(lb):
+            result.append(lb)
+        elif is_attempt_label(lb):
+            result.append(lb)
+        elif lb.startswith(_WORKFLOW_PREFIX):
+            result.append(lb)
+        elif lb == FOLLOW_UPS_PROCESSED:
+            result.append(lb)
+    return result
+
+
+async def run_terminal_gc(
+    forge: "ForgeClient",
+    item_type: Literal["issue", "pr"],
+    item_number: int,
+    item_state: Literal["open", "closed", "merged"],
+    *,
+    api_timeout_s: float = 10.0,
+) -> Literal["success", "noop", "partial"]:
+    """Remove transient pipeline labels from a terminal item.
+
+    Returns:
+        'success'  — all planned mutations executed successfully
+        'noop'     — no mutations needed (item already GC'd or non-terminal)
+        'partial'  — at least one mutation failed; failures logged individually
+
+    Raises:
+        GCOnOpenItemError — if item_state == 'open' (zero API calls made)
+
+    Concurrency note: sequential invocations guarantee idempotency ('noop'
+    on second call). Concurrent invocations are safe — both complete without
+    unhandled exceptions — but the second returns 'success' rather than 'noop'
+    because its API calls receive silent 404s (github_forge.py:977-978).
+
+    ~prioridade:* labels are never removed regardless of item type or state.
+    """
+    if item_state == "open":
+        raise GCOnOpenItemError(
+            f"run_terminal_gc called on open {item_type} #{item_number}; "
+            "GC only applies to terminal items (closed/merged)"
+        )
+
+    if item_type == "issue":
+        ref = await asyncio.wait_for(
+            forge.get_issue(item_number), timeout=api_timeout_s
+        )
+        current: Tuple[str, ...] = ref.labels if ref is not None else ()
+    else:
+        ref = await asyncio.wait_for(
+            forge.get_pr(item_number), timeout=api_timeout_s
+        )
+        current = ref.labels if ref is not None else ()
+
+    if item_type == "issue":
+        to_remove = _to_strip_issue(current)
+        to_add = [] if WORKFLOW_CONCLUDED in current else [WORKFLOW_CONCLUDED]
+    else:
+        to_remove = _to_strip_pr(current)
+        to_add = []
+
+    if not to_remove and not to_add:
+        logger.debug(
+            "run_terminal_gc: %s #%d already clean — noop",
+            item_type,
+            item_number,
+        )
+        return "noop"
+
+    failures = 0
+
+    if to_remove:
+        try:
+            await asyncio.wait_for(
+                forge.remove_labels(item_type, item_number, to_remove),
+                timeout=api_timeout_s,
+            )
+            logger.debug(
+                "run_terminal_gc: removed %s from %s #%d",
+                to_remove,
+                item_type,
+                item_number,
+            )
+        except Exception as exc:
+            logger.warning(
+                "run_terminal_gc: remove_labels failed for %s #%d: %s",
+                item_type,
+                item_number,
+                exc,
+            )
+            failures += 1
+
+    if to_add:
+        try:
+            await asyncio.wait_for(
+                forge.add_labels(item_type, item_number, to_add),
+                timeout=api_timeout_s,
+            )
+            logger.debug(
+                "run_terminal_gc: added %s to %s #%d",
+                to_add,
+                item_type,
+                item_number,
+            )
+        except Exception as exc:
+            logger.warning(
+                "run_terminal_gc: add_labels failed for %s #%d: %s",
+                item_type,
+                item_number,
+                exc,
+            )
+            failures += 1
+
+    return "partial" if failures > 0 else "success"
+
+
+__all__ = ["GCOnOpenItemError", "run_terminal_gc"]

--- a/deile/orchestration/pipeline/labels.py
+++ b/deile/orchestration/pipeline/labels.py
@@ -88,6 +88,10 @@ WORKFLOW_DECOMPOSED = "~workflow:decomposta"
 # A human removes this label to unblock (which lets auto-resume pick it up
 # again on the next free tick).
 WORKFLOW_BLOCKED = "~workflow:bloqueada"
+# GC terminal state — applied by run_terminal_gc to closed issues (issue #587).
+# Signals that the GC sweep has run; preserved by all subsequent GC invocations
+# (idempotent). Applied automatically, never manually by the pipeline.
+WORKFLOW_CONCLUDED = "~workflow:concluida"
 
 # PR workflow -------------------------------------------------------------
 REVIEW_PENDING = "~review:pendente"
@@ -195,6 +199,8 @@ def title_prefix_for_type(issue_type: Optional[str]) -> str:
 # Distributed lock --------------------------------------------------------
 BATCH_LABEL_PREFIX = "~batch:"
 
+BY_LABEL_PREFIX = "~by:"
+
 WORKFLOW_LABELS = (
     WORKFLOW_NEW,
     WORKFLOW_REVIEWING,
@@ -206,6 +212,7 @@ WORKFLOW_LABELS = (
     WORKFLOW_PR,
     WORKFLOW_DECOMPOSED,
     WORKFLOW_BLOCKED,
+    WORKFLOW_CONCLUDED,
 )
 
 #: Comment-routing truth table (issue #442). A comment on an OPEN issue carrying
@@ -286,6 +293,7 @@ LABEL_COLORS = {
     WORKFLOW_PR: _COLOR_BLUE_PR,
     WORKFLOW_DECOMPOSED: _COLOR_BLUE_DECOMPOSED,
     WORKFLOW_BLOCKED: _COLOR_RED_BLOCKED,
+    WORKFLOW_CONCLUDED: "006b75",
     REVIEW_PENDING: _COLOR_GREEN_PROGRESS,
     REVIEW_IN_PROGRESS: _COLOR_YELLOW_LOCK,
     REVIEW_CONCLUDED: _COLOR_GREEN_PROGRESS,
@@ -308,6 +316,7 @@ LABEL_DESCRIPTIONS = {
     WORKFLOW_PR: "Pipeline: PR aberta",
     WORKFLOW_DECOMPOSED: "Pipeline: intent decomposta em issues derivadas (épico aberto) — humano fecha manualmente",
     WORKFLOW_BLOCKED: "Pipeline: bloqueada (sem progresso / impedimento / teto) — humano remove para desbloquear",
+    WORKFLOW_CONCLUDED: "Pipeline: issue concluída (GC aplicado ao fechar) — label permanente pós-fechamento",
     REVIEW_PENDING: "Pipeline: PR aguardando revisão",
     REVIEW_IN_PROGRESS: "Pipeline: PR em revisão (lock)",
     REVIEW_CONCLUDED: "Pipeline: PR revisada/mergeada",

--- a/deile/tests/orchestration/pipeline/test_gc.py
+++ b/deile/tests/orchestration/pipeline/test_gc.py
@@ -1,0 +1,381 @@
+"""Tests for deile.orchestration.pipeline.gc — terminal GC (issue #587)."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from deile.orchestration.forge.refs import IssueRef, PrRef
+from deile.orchestration.pipeline.gc import GCOnOpenItemError, run_terminal_gc
+from deile.orchestration.pipeline.labels import (
+    BATCH_LABEL_PREFIX,
+    FOLLOW_UPS_PROCESSED,
+    MENTION_DONE,
+    REFINAR,
+    WORKFLOW_BLOCKED,
+    WORKFLOW_CONCLUDED,
+    WORKFLOW_DECOMPOSED,
+    WORKFLOW_IMPLEMENTING,
+    WORKFLOW_NEW,
+    WORKFLOW_PR,
+    WORKFLOW_REVIEWING,
+    make_attempt_label,
+    make_batch_label,
+    make_refine_attempt_label,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake forge
+# ---------------------------------------------------------------------------
+
+
+class _FakeForge:
+    """Minimal forge double for GC tests."""
+
+    def __init__(self, labels):
+        self._labels = list(labels)
+        self.removed: list = []
+        self.added: list = []
+        self.remove_raises: Exception | None = None
+        self.add_raises: Exception | None = None
+
+    async def get_issue(self, number: int) -> IssueRef:
+        return IssueRef(
+            number=number, title="t", url="u", labels=tuple(self._labels)
+        )
+
+    async def get_pr(self, number: int) -> PrRef:
+        return PrRef(
+            number=number, title="t", url="u", labels=tuple(self._labels)
+        )
+
+    async def remove_labels(self, kind: str, number: int, labels) -> None:
+        if self.remove_raises:
+            raise self.remove_raises
+        self.removed.extend(labels)
+        for lb in labels:
+            if lb in self._labels:
+                self._labels.remove(lb)
+
+    async def add_labels(self, kind: str, number: int, labels) -> None:
+        if self.add_raises:
+            raise self.add_raises
+        self.added.extend(labels)
+        self._labels.extend(labels)
+
+
+# ---------------------------------------------------------------------------
+# GCOnOpenItemError
+# ---------------------------------------------------------------------------
+
+
+class TestGCOnOpenItemError:
+    def test_raises_for_open_issue(self):
+        forge = _FakeForge([WORKFLOW_NEW])
+        with pytest.raises(GCOnOpenItemError):
+            asyncio.run(
+                run_terminal_gc(forge, "issue", 1, "open")
+            )
+
+    def test_raises_for_open_pr(self):
+        forge = _FakeForge(["~review:pendente"])
+        with pytest.raises(GCOnOpenItemError):
+            asyncio.run(
+                run_terminal_gc(forge, "pr", 1, "open")
+            )
+
+    def test_no_api_calls_before_raise(self):
+        calls = []
+
+        class _TrackingForge(_FakeForge):
+            async def get_issue(self, number):
+                calls.append("get_issue")
+                return await super().get_issue(number)
+
+        forge = _TrackingForge([WORKFLOW_NEW])
+        with pytest.raises(GCOnOpenItemError):
+            asyncio.run(run_terminal_gc(forge, "issue", 1, "open"))
+
+        assert calls == [], "no API calls should occur before GCOnOpenItemError"
+
+
+# ---------------------------------------------------------------------------
+# Issue GC — basic
+# ---------------------------------------------------------------------------
+
+
+class TestIssueGC:
+    def _run(self, labels, state="closed"):
+        forge = _FakeForge(labels)
+        result = asyncio.run(
+            run_terminal_gc(forge, "issue", 42, state)
+        )
+        return forge, result
+
+    def test_strips_workflow_new_and_adds_concluded(self):
+        forge, result = self._run([WORKFLOW_NEW, "bug"])
+        assert result == "success"
+        assert WORKFLOW_NEW not in forge._labels
+        assert WORKFLOW_CONCLUDED in forge._labels
+
+    def test_strips_all_transitional_workflow_labels(self):
+        transitional = [
+            WORKFLOW_NEW,
+            WORKFLOW_REVIEWING,
+            WORKFLOW_IMPLEMENTING,
+            WORKFLOW_PR,
+            WORKFLOW_BLOCKED,
+            "~workflow:em_refinamento",
+            "~workflow:em_arquitetura",
+            "~workflow:revisada",
+            "~workflow:aguardando_stakeholder",
+        ]
+        forge, result = self._run(transitional)
+        assert result == "success"
+        for lb in transitional:
+            assert lb not in forge._labels, f"expected {lb!r} to be stripped"
+        assert WORKFLOW_CONCLUDED in forge._labels
+
+    def test_preserves_workflow_decomposed(self):
+        forge, result = self._run([WORKFLOW_DECOMPOSED, WORKFLOW_IMPLEMENTING])
+        assert result == "success"
+        assert WORKFLOW_DECOMPOSED in forge._labels
+
+    def test_preserves_workflow_concluded(self):
+        """Second invocation on already-GC'd issue returns noop."""
+        forge, result = self._run([WORKFLOW_CONCLUDED])
+        assert result == "noop"
+        assert forge.removed == []
+        assert forge.added == []
+
+    def test_strips_by_label(self):
+        forge, result = self._run([WORKFLOW_NEW, "~by:default"])
+        assert result == "success"
+        assert "~by:default" not in forge._labels
+
+    def test_strips_batch_label(self):
+        batch = make_batch_label("abc12345")
+        forge, result = self._run([WORKFLOW_NEW, batch])
+        assert result == "success"
+        assert batch not in forge._labels
+
+    def test_strips_attempt_labels(self):
+        attempt = make_attempt_label(2)
+        forge, result = self._run([WORKFLOW_NEW, attempt])
+        assert result == "success"
+        assert attempt not in forge._labels
+
+    def test_strips_refine_attempt_labels(self):
+        refine = make_refine_attempt_label(3)
+        forge, result = self._run([WORKFLOW_NEW, refine])
+        assert result == "success"
+        assert refine not in forge._labels
+
+    def test_strips_mention_done(self):
+        forge, result = self._run([WORKFLOW_NEW, MENTION_DONE])
+        assert result == "success"
+        assert MENTION_DONE not in forge._labels
+
+    def test_strips_refinar(self):
+        forge, result = self._run([WORKFLOW_IMPLEMENTING, REFINAR])
+        assert result == "success"
+        assert REFINAR not in forge._labels
+
+    def test_preserves_priority_labels(self):
+        forge, result = self._run([WORKFLOW_NEW, "~prioridade:1"])
+        assert result == "success"
+        assert "~prioridade:1" in forge._labels
+
+    def test_preserves_project_type_labels(self):
+        for label in ("bug", "feature", "intent", "refactor", "enhancement",
+                      "infra", "observability"):
+            forge, result = self._run([WORKFLOW_NEW, label])
+            assert result == "success", f"expected success stripping {label!r}"
+            assert label in forge._labels, f"expected {label!r} to be preserved"
+
+    def test_applies_concluded_even_when_no_strip_needed(self):
+        """Issue with no transitional labels still gets ~workflow:concluida."""
+        forge, result = self._run(["bug", "~prioridade:2"])
+        assert result == "success"
+        assert WORKFLOW_CONCLUDED in forge._labels
+
+    def test_noop_when_only_concluded_and_project_labels(self):
+        forge, result = self._run([WORKFLOW_CONCLUDED, "bug", "~prioridade:0"])
+        assert result == "noop"
+
+    def test_multiple_by_labels_all_stripped(self):
+        forge, result = self._run([WORKFLOW_NEW, "~by:a", "~by:b"])
+        assert result == "success"
+        assert "~by:a" not in forge._labels
+        assert "~by:b" not in forge._labels
+
+
+# ---------------------------------------------------------------------------
+# PR GC — basic
+# ---------------------------------------------------------------------------
+
+
+class TestPRGC:
+    def _run(self, labels, state="merged"):
+        forge = _FakeForge(labels)
+        result = asyncio.run(
+            run_terminal_gc(forge, "pr", 99, state)
+        )
+        return forge, result
+
+    def test_strips_review_labels(self):
+        forge, result = self._run(["~review:pendente"])
+        assert result == "success"
+        assert "~review:pendente" not in forge._labels
+
+    def test_strips_all_review_variants(self):
+        for lb in ("~review:pendente", "~review:em_andamento", "~review:concluida"):
+            forge, result = self._run([lb])
+            assert result == "success"
+            assert lb not in forge._labels
+
+    def test_strips_by_label(self):
+        forge, result = self._run(["~review:pendente", "~by:default"])
+        assert result == "success"
+        assert "~by:default" not in forge._labels
+
+    def test_strips_batch_label(self):
+        batch = make_batch_label("deadbeef")
+        forge, result = self._run(["~review:em_andamento", batch])
+        assert result == "success"
+        assert batch not in forge._labels
+
+    def test_strips_attempt_labels(self):
+        attempt = make_attempt_label(1)
+        forge, result = self._run(["~review:pendente", attempt])
+        assert result == "success"
+        assert attempt not in forge._labels
+
+    def test_strips_residual_workflow_labels(self):
+        forge, result = self._run(["~review:concluida", WORKFLOW_PR, WORKFLOW_IMPLEMENTING])
+        assert result == "success"
+        assert WORKFLOW_PR not in forge._labels
+        assert WORKFLOW_IMPLEMENTING not in forge._labels
+
+    def test_strips_follow_ups_processed(self):
+        forge, result = self._run(["~review:concluida", FOLLOW_UPS_PROCESSED])
+        assert result == "success"
+        assert FOLLOW_UPS_PROCESSED not in forge._labels
+
+    def test_does_not_add_concluded_to_pr(self):
+        """PRs never get ~workflow:concluida applied."""
+        forge, result = self._run(["~review:pendente"])
+        assert result == "success"
+        assert WORKFLOW_CONCLUDED not in forge._labels
+        assert forge.added == []
+
+    def test_preserves_priority_labels(self):
+        forge, result = self._run(["~review:pendente", "~prioridade:3"])
+        assert result == "success"
+        assert "~prioridade:3" in forge._labels
+
+    def test_noop_when_already_clean(self):
+        forge, result = self._run(["bug", "~prioridade:1"])
+        assert result == "noop"
+        assert forge.removed == []
+        assert forge.added == []
+
+    def test_closed_pr_same_as_merged(self):
+        forge, result = self._run(["~review:pendente"], state="closed")
+        assert result == "success"
+        assert "~review:pendente" not in forge._labels
+
+
+# ---------------------------------------------------------------------------
+# Partial failures
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailures:
+    def test_partial_when_remove_labels_raises(self):
+        forge = _FakeForge([WORKFLOW_NEW])
+        forge.remove_raises = RuntimeError("network error")
+        result = asyncio.run(
+            run_terminal_gc(forge, "issue", 1, "closed")
+        )
+        assert result == "partial"
+
+    def test_partial_when_add_labels_raises(self):
+        forge = _FakeForge(["bug"])
+        forge.add_raises = RuntimeError("network error")
+        result = asyncio.run(
+            run_terminal_gc(forge, "issue", 1, "closed")
+        )
+        assert result == "partial"
+
+    def test_partial_remove_still_attempts_add(self):
+        """Even when remove fails, we still attempt the add."""
+        forge = _FakeForge([WORKFLOW_NEW])
+        forge.remove_raises = RuntimeError("boom")
+        result = asyncio.run(
+            run_terminal_gc(forge, "issue", 1, "closed")
+        )
+        assert result == "partial"
+        # add was attempted despite remove failure
+        assert WORKFLOW_CONCLUDED in forge.added
+
+    def test_partial_when_both_fail(self):
+        forge = _FakeForge([WORKFLOW_NEW])
+        forge.remove_raises = RuntimeError("remove boom")
+        forge.add_raises = RuntimeError("add boom")
+        result = asyncio.run(
+            run_terminal_gc(forge, "issue", 1, "closed")
+        )
+        assert result == "partial"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_issue_gc_idempotent_sequential(self):
+        """Running GC twice on a closed issue: first success, then noop."""
+        forge = _FakeForge([WORKFLOW_NEW, "bug"])
+        r1 = asyncio.run(run_terminal_gc(forge, "issue", 1, "closed"))
+        assert r1 == "success"
+        r2 = asyncio.run(run_terminal_gc(forge, "issue", 1, "closed"))
+        assert r2 == "noop"
+
+    def test_pr_gc_idempotent_sequential(self):
+        """Running GC twice on a merged PR: first success, then noop."""
+        forge = _FakeForge(["~review:pendente", "~prioridade:1"])
+        r1 = asyncio.run(run_terminal_gc(forge, "pr", 1, "merged"))
+        assert r1 == "success"
+        r2 = asyncio.run(run_terminal_gc(forge, "pr", 1, "merged"))
+        assert r2 == "noop"
+
+
+# ---------------------------------------------------------------------------
+# Timeout parameter accepted (smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestApiTimeout:
+    def test_custom_timeout_accepted(self):
+        """api_timeout_s parameter is accepted without error."""
+        forge = _FakeForge([WORKFLOW_NEW])
+        result = asyncio.run(
+            run_terminal_gc(forge, "issue", 1, "closed", api_timeout_s=30.0)
+        )
+        assert result == "success"
+
+    def test_timeout_triggers_partial(self):
+        """Simulates asyncio.TimeoutError from forge call."""
+        import asyncio as _asyncio
+
+        class _SlowForge(_FakeForge):
+            async def get_issue(self, number):
+                raise _asyncio.TimeoutError()
+
+        forge = _SlowForge([WORKFLOW_NEW])
+        with pytest.raises(_asyncio.TimeoutError):
+            asyncio.run(
+                run_terminal_gc(forge, "issue", 1, "closed", api_timeout_s=0.001)
+            )


### PR DESCRIPTION
## Resumo

Implementa o mecanismo de garbage collection de labels transitórias do pipeline DEILE, eliminando o acúmulo de labels em issues e PRs após fechamento.

### Mudanças principais

**`deile/orchestration/pipeline/gc.py`** (novo)
- `run_terminal_gc(forge, item_type, item_number, item_state, *, api_timeout_s=10.0) -> Literal['success', 'noop', 'partial']`
- `GCOnOpenItemError` — levantada quando `item_state == 'open'` (zero chamadas de API)
- Issues fechadas: remove todos `~workflow:*` transitórios (exceto `~workflow:decomposta` e `~workflow:concluida`), `~by:*`, `~batch:*`, `~attempt:*`, `~refine:*`, `~mention:processado`, `refinar`; aplica `~workflow:concluida`
- PRs fechadas/mergeadas: remove `~review:*`, `~by:*`, `~batch:*`, `~attempt:*`, `~workflow:*` residual, `~follow_ups:processed`; sem adição de labels
- Idempotente para invocações sequenciais (segunda retorna `'noop'`)
- Wraps de API com `asyncio.wait_for(api_timeout_s)` para timeout configurável
- Módulo standalone: importável sem `stages.py` ou o grafo completo de stages

**`deile/orchestration/pipeline/labels.py`**
- Adiciona `WORKFLOW_CONCLUDED = "~workflow:concluida"` com cor e descrição registradas
- Adiciona `BY_LABEL_PREFIX = "~by:"` como constante explícita
- `WORKFLOW_CONCLUDED` inserido em `WORKFLOW_LABELS`, `LABEL_COLORS`, `LABEL_DESCRIPTIONS`

**`deile/tests/orchestration/pipeline/test_gc.py`** (novo)
- 37 testes: `GCOnOpenItemError`, issue GC, PR GC, preservação de labels, idempotência, falhas parciais, timeout

## Resultado dos testes

```
37 passed in 1.25s
```

Closes #587.