### PR TITLE
refactor: migrate panel consumer to routing.* family, retire _MENTION_RE

### DIFF
--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -626,7 +626,6 @@ async def _dispatch_mention_group(
     number = primary.target_number
     has = set(trigger_types)
     sticky = bool(has & _STICKY_TRIGGER_TYPES)
-    logger.info("mention group %s: triggers=%s", dedup_key, trigger_types)
 
     # Issue work → inject into the pipeline (handles its own dispatch).
     if kind == "issue" and ("assignee" in has or "body" in has):

--- a/deile/tests/infra/test_panel_classify_canonical.py
+++ b/deile/tests/infra/test_panel_classify_canonical.py
@@ -71,11 +71,11 @@ _CANONICAL_FIXTURES = [
      "auth.skip", "worker-abc"),
     ("auth.recover target=worker-abc reason=renewed",
      "auth.recover", "worker-abc"),
-    ("routing.mention target_kind=issue target=42 action=injected_nova",
+    ("routing.mention target_kind=issue target=42 action=inject_workflow_nova",
      "routing.mention", "#42"),
     ("routing.pr_unified target=99 role=assignee",
      "routing.pr_unified", "PR#99"),
-    ("routing.dropped target_kind=issue target=42 reason=eco",
+    ("routing.dropped target_kind=issue target=42 reason=self_mention",
      "routing.dropped", "#42"),
 ]
 
@@ -279,7 +279,7 @@ class TestAC7Latency:
             "refinement.refine issue=42 round=1 persona=analyst body_chars=100 verdict=CLARO",
             "batch.claim sha=abc1234ef issues=[1,2] reason=shard",
             "auth.fail target=worker-1 attempts=3 thr=3 reason=expired",
-            "routing.mention target_kind=issue target=10 action=injected_nova",
+            "routing.mention target_kind=issue target=10 action=inject_workflow_nova",
         ]
         legacy = [
             "mention group issue:5: triggers=['nova']",

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -240,21 +240,24 @@ class TestPipelineClassifier:
         return pd.LogLine(ts=datetime(2026, 5, 23, 14, 0, tzinfo=timezone.utc),
                           body=body)
 
-    def test_mention_issue(self):
+    def test_mention_group_legacy_stages_fallback(self):
+        # Legacy "mention group" log lines are no longer emitted by stages.py
+        # (_MENTION_RE was retired). A line with the full module prefix still
+        # matches _STAGES_RE and returns action="stages".
         ev = pd._classify_pipeline_line(self._line(
             "deile.orchestration.pipeline.stages mention group issue:278: "
             "triggers=['assignee']"
         ))
         assert ev is not None
-        assert ev.action == "mention"
-        assert ev.target == "#278"
-        assert "assignee" in ev.detail
+        assert ev.action == "stages"
 
-    def test_mention_pr(self):
+    def test_mention_pr_legacy_returns_none(self):
+        # Legacy "mention group pr:..." without the full module prefix no longer
+        # matches any pattern and returns None.
         ev = pd._classify_pipeline_line(self._line(
             "stages mention group pr:291: triggers=['reviewer']"
         ))
-        assert ev is not None and ev.target == "PR291"
+        assert ev is None
 
     def test_dispatch_starting(self):
         ev = pd._classify_pipeline_line(self._line(
@@ -462,23 +465,21 @@ class TestPipelineClassifierCanonical:
         assert "backoff_s=120" in ev.detail
         assert "until=2026-05-31T11:00:00Z" in ev.detail
 
-    # ── AC10: zero regression on 6 legacy patterns ────────────────────────
-    def test_legacy_mention_issue(self):
+    # ── AC10: legacy patterns (mention retired, others unchanged) ─────────
+    def test_legacy_mention_issue_stages_fallback(self):
+        # _MENTION_RE retired — line with full module prefix matches _STAGES_RE.
         ev = pd._classify_pipeline_line(self._line(
             "deile.orchestration.pipeline.stages mention group issue:278: triggers=['assignee']"
         ))
         assert ev is not None
-        assert ev.action == "mention"
-        assert ev.target == "#278"
-        assert "assignee" in ev.detail
+        assert ev.action == "stages"
 
-    def test_legacy_mention_pr(self):
+    def test_legacy_mention_pr_returns_none(self):
+        # _MENTION_RE retired — short form without module prefix returns None.
         ev = pd._classify_pipeline_line(self._line(
             "stages mention group pr:291: triggers=['reviewer']"
         ))
-        assert ev is not None
-        assert ev.action == "mention"
-        assert ev.target == "PR291"
+        assert ev is None
 
     def test_legacy_dispatch_starting(self):
         ev = pd._classify_pipeline_line(self._line(

--- a/deile/tests/infra/test_panel_multi_source_activity.py
+++ b/deile/tests/infra/test_panel_multi_source_activity.py
@@ -162,12 +162,18 @@ class TestClassifySourceLine:
         assert ev.action == "dispatch"
 
     def test_legacy_actor_overridden_with_role(self):
+        # _MENTION_RE was removed in issue #485. Short-form "mention group"
+        # lines (without the full module prefix) no longer match any pattern.
+        # A line with the full deile.orchestration.pipeline.stages prefix still
+        # matches _STAGES_RE and the actor is overridden with the supplied role.
         ll = _make_logline(
-            "mention group issue:360: triggers=[implement,review]"
+            "deile.orchestration.pipeline.stages mention group issue:360: "
+            "triggers=[implement,review]"
         )
         ev = pd._classify_source_line(ll, "bot")
         assert ev is not None
         assert ev.actor == "bot"
+        assert ev.action == "stages"
 
     def test_returns_none_when_no_parser_matches(self):
         ll = _make_logline("INFO arbitrary unstructured line with no pattern")

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -875,9 +875,6 @@ _DISPATCH_DONE_RE = re.compile(r"worker dispatch completed", re.IGNORECASE)
 _HTTP_POST_RE = re.compile(
     r'HTTP Request: POST .*?/v1/dispatch.*?"HTTP/[\d.]+ (\d+)', re.IGNORECASE
 )
-_MENTION_RE = re.compile(
-    r"mention group (issue|pr):(\d+): triggers=\[(.*?)\]", re.IGNORECASE
-)
 _STAGES_RE = re.compile(
     r"deile\.orchestration\.pipeline\.stages\s+(.*)$", re.IGNORECASE
 )
@@ -1138,16 +1135,6 @@ def _classify_pipeline_line(ll: LogLine) -> Optional[ActivityEvent]:
         )
     # --- legacy vocabulary ---
 
-    m = _MENTION_RE.search(body)
-    if m:
-        kind = m.group(1).lower()
-        num = m.group(2)
-        triggers = m.group(3).replace("'", "").replace('"', "")
-        target = f"{'PR' if kind == 'pr' else '#'}{num}"
-        return ActivityEvent(
-            ts=ll.ts, actor="pipeline", action="mention",
-            target=target, detail=f"triggers={triggers}",
-        )
     if _DISPATCH_START_RE.search(body):
         return ActivityEvent(
             ts=ll.ts, actor="pipeline", action="dispatch", target="",


### PR DESCRIPTION
## Summary

- Remove legacy `_MENTION_RE` regex and associated `ActivityEvent(action="mention")` emission from `infra/k8s/_panel_data.py`
- Remove legacy `logger.info("mention group ...")` from `deile/orchestration/pipeline/stages.py`
- Establish canonical routing enum source-of-truth in `pipeline_logger.py`
- Align `_panel_data.py` consumer and test fixtures to canonical values

The canonical `routing.*` consumer paths (routing.mention/routing.pr_unified/routing.dropped) at lines :1091/:1105/:1117 are preserved; only the legacy _MENTION_RE fallback path is removed.

Closes #485.