### PR TITLE
ci: add no-bot guardrails to install-smoke (AC-CI-1 + AC-CI-2)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        extra: ["", "bot"]
+        extra: ["", "test", "bot"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -34,10 +34,18 @@ jobs:
           /tmp/v/bin/pip install --upgrade pip
           if [ "${{ matrix.extra }}" = "" ]; then
             /tmp/v/bin/pip install -e .
+          elif [ "${{ matrix.extra }}" = "test" ]; then
+            /tmp/v/bin/pip install -e ".[test]"
           else
             /tmp/v/bin/pip install -e ".[${{ matrix.extra }}]"
           fi
           /tmp/v/bin/python -c "import deile; print(deile.__file__)"
+          if [ "${{ matrix.extra }}" = "" ]; then
+            /tmp/v/bin/python -c "import deile; from deile.tools.registry import ToolRegistry; r=ToolRegistry(); r.auto_discover(); bad=[t.name for t in r if t.name.startswith(('discord_','whatsapp_'))]; assert not bad, f'messaging tools leaked without deilebot: {bad}'; print('no-bot OK')"
+          fi
+          if [ "${{ matrix.extra }}" = "test" ]; then
+            /tmp/v/bin/pytest --collect-only -q tests/
+          fi
           if [ "${{ matrix.extra }}" = "bot" ]; then
             /tmp/v/bin/python -c "import deilebot; print(deilebot.__file__)"
             /tmp/v/bin/python -c "import deilebot_client; print(deilebot_client.__file__)"


### PR DESCRIPTION
## Summary

- **AC-CI-1**: Extends the bare `extra: ""` smoke-test leg to assert that no `discord_*` / `whatsapp_*` tools register in `ToolRegistry` when `deilebot` is absent. Verifies `deile/tools/messaging/auto_discover.py` correctly short-circuits at `BOT_CLIENT_AVAILABLE=False`.
- **AC-CI-2**: Adds a new `extra: "test"` matrix leg that installs `.[test]` (pytest without deilebot — the two extras are disjoint in `pyproject.toml`) and runs `pytest --collect-only -q tests/`, proving the full test suite collects with exit 0 when deilebot is not installed.

Both ACs are independent of issue #531. AC-CI-3 (docker build with `--build-arg WITH_BOT=0`) and AC-DOC-1 (README + runbook for `claude-only` profile) remain blocked on #531 and are not included here.

## Test plan

- [ ] Verify `install-smoke` workflow runs all three matrix legs: `""`, `"test"`, `"bot"`
- [ ] Confirm the `""` leg exits 0 and prints `no-bot OK`
- [ ] Confirm the `"test"` leg exits 0 on `pytest --collect-only -q tests/`
- [ ] Confirm the `"bot"` leg behaviour is unchanged (still requires `BOT_REPO_TOKEN`)

Closes #536