### PR TITLE
feat(k8s): Classe B — delegação a deploy.py com detecção in-pod e gating de destrutivos

### DIFF
--- a/deile/commands/builtin/k8s_command.py
+++ b/deile/commands/builtin/k8s_command.py
@@ -61,6 +61,16 @@ _V2_SHORT_VERBS = frozenset({
     "claude-login", "claude-renew", "test", "clone",
 })
 
+# Verbs that are always destructive (no extra flags needed)
+_ALWAYS_DESTRUCTIVE = frozenset({"down"})
+# Verbs destructive only when certain flags are present
+_CONDITIONALLY_DESTRUCTIVE: dict = {
+    "build": "--restart",
+    "claude-login": "--switch",
+}
+# Interactive verbs that can't be piped via PIPE (block on stdin)
+_INTERACTIVE_NO_VARIANT = frozenset({"setup"})
+
 K8S_DEPLOYMENTS = [
     "deilebot",
     "deile-worker",
@@ -97,10 +107,13 @@ _V2_VERBS = [
 def _running_in_pod() -> bool:
     """Detecta se está rodando dentro de um pod Kubernetes.
 
-    A variável KUBERNETES_SERVICE_HOST é injetada automaticamente por todo
-    pod K8s; sua presença é a heurística canônica para "estou in-pod".
+    Dois sinais canônicos: a variável KUBERNETES_SERVICE_HOST (injetada
+    automaticamente em todo pod) ou o token de serviceaccount montado pelo
+    kubelet. Qualquer um verdadeiro → in-pod.
     """
-    return bool(os.environ.get("KUBERNETES_SERVICE_HOST"))
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return True
+    return Path("/var/run/secrets/kubernetes.io/serviceaccount/token").exists()
 
 
 def _find_deploy_py() -> Optional[Path]:
@@ -453,19 +466,52 @@ async def _cmd_list(namespace: str) -> CommandResult:
 # ---------------------------------------------------------------------------
 
 
-async def _cmd_v2_delegate(verb: str, extra: str, namespace: str) -> CommandResult:
+def _is_destructive(verb: str, extra: str) -> bool:
+    """Retorna True se o verbo+extra forma uma operação destrutiva."""
+    if verb in _ALWAYS_DESTRUCTIVE:
+        return True
+    flag = _CONDITIONALLY_DESTRUCTIVE.get(verb)
+    if flag and flag in extra:
+        return True
+    return False
+
+
+async def _cmd_v2_delegate(
+    verb: str,
+    extra: str,
+    namespace: str,
+    *,
+    confirmed: bool = False,
+) -> CommandResult:
     """Delega verbos V2 para ``python3 infra/k8s/deploy.py k8s <verb>``.
 
     Host-only: retorna erro se detectar ambiente in-pod. Verbs longos
     (up/build/down) usam timeout de 1800s; demais usam 300s. Output é
     transmitido linha a linha via Rich Live (com reflow).
+
+    Verbos destrutivos (down, build --restart, claude-login --switch) exigem
+    ``confirmed=True`` — sem isso retorna erro com instrução de re-emissão.
+    ``setup`` é interativo (getpass, sem variante não-interativa) e retorna
+    erro apontando ``create-namespace`` como alternativa scriptável.
+    ``claude-login`` recebe ``--no-interactive`` automaticamente.
     """
+    from deile.security.audit_logger import AuditEventType, SeverityLevel, get_audit_logger
     from rich.console import Console
+
+    audit = get_audit_logger()
 
     if _running_in_pod():
         return CommandResult.error_result(
             f"verbo `{verb}` é host-only: requer `infra/k8s/deploy.py`, "
             "ausente na imagem. Detectado ambiente in-pod (KUBERNETES_SERVICE_HOST)."
+        )
+
+    # setup is interactive without a non-interactive variant — never pipe it
+    if verb in _INTERACTIVE_NO_VARIANT:
+        return CommandResult.error_result(
+            f"verbo `{verb}` é interativo (usa getpass) e não possui variante "
+            "não-interativa. Use `/k8s create-namespace` para provisionamento "
+            "scriptável (todos os parâmetros via CLI)."
         )
 
     deploy = _find_deploy_py()
@@ -474,18 +520,34 @@ async def _cmd_v2_delegate(verb: str, extra: str, namespace: str) -> CommandResu
             f"verbo `{verb}` é host-only: `infra/k8s/deploy.py` não localizado."
         )
 
-    timeout = _K8S_DELEGATE_TIMEOUT_LONG if verb in _V2_LONG_VERBS else _K8S_DELEGATE_TIMEOUT_SHORT
-
-    # Aviso para verbo destrutivo — REPL não tem confirmação interativa, então
-    # apenas emitimos o aviso no log de auditoria e prosseguimos.
-    if verb == "down":
-        logger.warning(
-            "Verbo destrutivo `down` solicitado via /k8s — namespace será removido. "
-            "Sem confirmação interativa disponível neste contexto."
+    # Destructive gating — must re-emit with --confirm
+    if _is_destructive(verb, extra) and not confirmed:
+        flag_hint = f"--confirm"
+        reissue = f"/k8s {verb} {extra} {flag_hint}".strip() if extra.strip() else f"/k8s {verb} {flag_hint}"
+        return CommandResult.error_result(
+            f"[!] `{verb}` APAGA dados de forma irreversível. "
+            f"Para confirmar, re-execute:\n  {reissue}"
         )
 
+    # claude-login: inject --no-interactive to avoid blocking on stdin
     extra_tokens = shlex.split(extra) if extra.strip() else []
+    if verb == "claude-login" and "--no-interactive" not in extra_tokens and "--from-env-only" not in extra_tokens:
+        extra_tokens = ["--no-interactive"] + extra_tokens
+
+    timeout = _K8S_DELEGATE_TIMEOUT_LONG if verb in _V2_LONG_VERBS else _K8S_DELEGATE_TIMEOUT_SHORT
+
     argv = ["python3", str(deploy), "k8s", verb, *extra_tokens]
+
+    # AuditEvent BEFORE exec (order: audit-antes-de-exec per spec)
+    audit.log_event(
+        event_type=AuditEventType.COMMAND_EXECUTED,
+        severity=SeverityLevel.WARNING if _is_destructive(verb, extra) else SeverityLevel.INFO,
+        actor="user",
+        resource="k8s",
+        action=f"v2_{verb}",
+        result="started",
+        details={"verb": verb, "namespace": namespace, "extra": extra, "confirmed": confirmed},
+    )
 
     console = Console()
     logger.info("k8s V2 delegate: %s", " ".join(argv))
@@ -616,11 +678,26 @@ class K8sCommand(DirectCommand):
 
     async def execute(self, context: CommandContext) -> CommandResult:
         args = context.args.strip() if context.args else ""
-        parts = args.split(None, 1)
+
+        # Extract --confirm and --save-namespace global flags before subcommand dispatch
+        confirmed = "--confirm" in args
+        save_namespace = "--save-namespace" in args
+        # Strip these meta-flags before further parsing
+        clean_args = args.replace("--confirm", "").replace("--save-namespace", "").strip()
+
+        parts = clean_args.split(None, 1)
         sub = parts[0].lower() if parts else ""
         tail = parts[1] if len(parts) > 1 else ""
 
         namespace = await _detect_namespace()
+
+        if save_namespace:
+            try:
+                from deile.commands.settings_manager import SettingsManager
+                mgr = SettingsManager()
+                mgr.set_setting("k8s.namespace", namespace)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to persist k8s_namespace: %s", exc)
 
         if not sub:
             return await _cmd_discovery(namespace)
@@ -629,7 +706,7 @@ class K8sCommand(DirectCommand):
             return await _cmd_panel(tail, namespace)
 
         if sub in _V2_LONG_VERBS | _V2_SHORT_VERBS:
-            return await _cmd_v2_delegate(sub, tail, namespace)
+            return await _cmd_v2_delegate(sub, tail, namespace, confirmed=confirmed)
 
         if sub == "restart":
             deployment = _parse_restart_args(tail)

--- a/deile/tests/commands/test_k8s_command.py
+++ b/deile/tests/commands/test_k8s_command.py
@@ -13,6 +13,9 @@ from deile.commands.base import CommandContext, DirectCommand
 from deile.commands.builtin.k8s_command import (
     K8sCommand,
     K8S_DEPLOYMENTS,
+    _ALWAYS_DESTRUCTIVE,
+    _CONDITIONALLY_DESTRUCTIVE,
+    _INTERACTIVE_NO_VARIANT,
     _cmd_discovery,
     _cmd_list,
     _cmd_logs,
@@ -22,6 +25,7 @@ from deile.commands.builtin.k8s_command import (
     _cmd_v2_delegate,
     _detect_namespace,
     _find_deploy_py,
+    _is_destructive,
     _parse_logs_args,
     _parse_restart_args,
     _run_kubectl,
@@ -1060,7 +1064,7 @@ class TestK8sCommandV2Routing:
         ):
             await _cmd().execute(_ctx("up"))
 
-        mock_v2.assert_called_once_with("up", "", "deile")
+        mock_v2.assert_called_once_with("up", "", "deile", confirmed=False)
 
     async def test_down_verb_dispatched_to_v2_delegate(self):
         with (
@@ -1077,7 +1081,7 @@ class TestK8sCommandV2Routing:
         ):
             await _cmd().execute(_ctx("down"))
 
-        mock_v2.assert_called_once_with("down", "", "deile")
+        mock_v2.assert_called_once_with("down", "", "deile", confirmed=False)
 
     async def test_panel_verb_dispatched_to_cmd_panel(self):
         with (
@@ -1111,4 +1115,404 @@ class TestK8sCommandV2Routing:
         ):
             await _cmd().execute(_ctx("scale --worker 2"))
 
-        mock_v2.assert_called_once_with("scale", "--worker 2", "deile")
+        mock_v2.assert_called_once_with("scale", "--worker 2", "deile", confirmed=False)
+
+
+# ---------------------------------------------------------------------------
+# _running_in_pod — serviceaccount token file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunningInPodExtended:
+    def test_in_pod_via_serviceaccount_token(self, tmp_path):
+        """Presença do arquivo de token serviceaccount → in-pod."""
+        token_path = tmp_path / "token"
+        token_path.write_text("fake-token")
+
+        import deile.commands.builtin.k8s_command as mod
+        from unittest.mock import patch as _patch
+        from pathlib import Path
+
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "KUBERNETES_SERVICE_HOST"}
+
+        with (
+            _patch.dict("os.environ", env, clear=True),
+            _patch.object(mod.Path, "exists", return_value=True),
+        ):
+            assert mod._running_in_pod() is True
+
+    def test_not_in_pod_without_env_or_token(self, tmp_path):
+        """Sem env nem token → não in-pod."""
+        import deile.commands.builtin.k8s_command as mod
+        from unittest.mock import patch as _patch
+
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "KUBERNETES_SERVICE_HOST"}
+
+        with (
+            _patch.dict("os.environ", env, clear=True),
+            _patch.object(mod.Path, "exists", return_value=False),
+        ):
+            assert mod._running_in_pod() is False
+
+
+# ---------------------------------------------------------------------------
+# _is_destructive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsDestructive:
+    def test_down_is_always_destructive(self):
+        assert _is_destructive("down", "") is True
+        assert _is_destructive("down", "--yes") is True
+
+    def test_build_without_restart_is_not_destructive(self):
+        assert _is_destructive("build", "") is False
+        assert _is_destructive("build", "--tag latest") is False
+
+    def test_build_with_restart_is_destructive(self):
+        assert _is_destructive("build", "--restart") is True
+        assert _is_destructive("build", "--restart --tag x") is True
+
+    def test_claude_login_without_switch_not_destructive(self):
+        assert _is_destructive("claude-login", "") is False
+        assert _is_destructive("claude-login", "--no-interactive") is False
+
+    def test_claude_login_with_switch_is_destructive(self):
+        assert _is_destructive("claude-login", "--switch") is True
+
+    def test_up_is_not_destructive(self):
+        assert _is_destructive("up", "") is False
+
+    def test_scale_is_not_destructive(self):
+        assert _is_destructive("scale", "--worker 2") is False
+
+
+# ---------------------------------------------------------------------------
+# _cmd_v2_delegate — new features (gating, audit, setup, claude-login)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdV2DelegateNewFeatures:
+    def _fake_deploy(self):
+        d = MagicMock()
+        d.__str__ = lambda self: "/repo/infra/k8s/deploy.py"
+        return d
+
+    async def test_destructive_without_confirm_blocked(self):
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+        ):
+            result = await _cmd_v2_delegate("down", "", "deile", confirmed=False)
+        assert result.success is False
+        assert "--confirm" in result.content
+        assert "down" in result.content
+
+    async def test_destructive_without_confirm_no_subprocess(self):
+        """Subprocess não deve ser iniciado sem --confirm."""
+        stream_called = []
+
+        async def fake_stream(cmd, *, timeout, console):
+            stream_called.append(cmd)
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            await _cmd_v2_delegate("down", "", "deile", confirmed=False)
+
+        assert not stream_called, "Subprocess was started without --confirm"
+
+    async def test_destructive_with_confirm_proceeds(self):
+        async def fake_stream(cmd, *, timeout, console):
+            return 0, ["done"]
+
+        mock_audit = MagicMock()
+        mock_audit.log_event = MagicMock()
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+            patch("deile.security.audit_logger.get_audit_logger", return_value=mock_audit),
+        ):
+            result = await _cmd_v2_delegate("down", "", "deile", confirmed=True)
+
+        assert result.success is True
+
+    async def test_build_restart_gated_without_confirm(self):
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+        ):
+            result = await _cmd_v2_delegate("build", "--restart", "deile", confirmed=False)
+        assert result.success is False
+        assert "--confirm" in result.content
+
+    async def test_build_without_restart_not_gated(self):
+        async def fake_stream(cmd, *, timeout, console):
+            return 0, ["built"]
+
+        mock_audit = MagicMock()
+        mock_audit.log_event = MagicMock()
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+            patch("deile.security.audit_logger.get_audit_logger", return_value=mock_audit),
+        ):
+            result = await _cmd_v2_delegate("build", "", "deile", confirmed=False)
+        assert result.success is True
+
+    async def test_setup_returns_error_pointing_to_create_namespace(self):
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+        ):
+            result = await _cmd_v2_delegate("setup", "", "deile")
+        assert result.success is False
+        assert "create-namespace" in result.content
+
+    async def test_setup_no_subprocess_called(self):
+        stream_called = []
+
+        async def fake_stream(cmd, *, timeout, console):
+            stream_called.append(cmd)
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+        ):
+            await _cmd_v2_delegate("setup", "", "deile")
+
+        assert not stream_called, "setup must not invoke subprocess"
+
+    async def test_claude_login_injects_no_interactive(self):
+        captured = {}
+        mock_audit = MagicMock()
+        mock_audit.log_event = MagicMock()
+
+        async def fake_stream(cmd, *, timeout, console):
+            captured["cmd"] = cmd
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+            patch("deile.security.audit_logger.get_audit_logger", return_value=mock_audit),
+        ):
+            await _cmd_v2_delegate("claude-login", "", "deile")
+
+        assert "--no-interactive" in captured["cmd"]
+
+    async def test_claude_login_does_not_duplicate_no_interactive(self):
+        captured = {}
+        mock_audit = MagicMock()
+        mock_audit.log_event = MagicMock()
+
+        async def fake_stream(cmd, *, timeout, console):
+            captured["cmd"] = cmd
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+            patch("deile.security.audit_logger.get_audit_logger", return_value=mock_audit),
+        ):
+            await _cmd_v2_delegate("claude-login", "--no-interactive", "deile")
+
+        assert captured["cmd"].count("--no-interactive") == 1
+
+    async def test_audit_event_emitted_before_exec(self):
+        call_order = []
+        mock_audit = MagicMock()
+
+        def audit_side(**kwargs):
+            call_order.append("audit")
+
+        mock_audit.log_event = MagicMock(side_effect=audit_side)
+
+        async def fake_stream(cmd, *, timeout, console):
+            call_order.append("exec")
+            return 0, []
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.commands.builtin.k8s_command._live_stream_subprocess", side_effect=fake_stream),
+            patch("deile.security.audit_logger.get_audit_logger", return_value=mock_audit),
+        ):
+            await _cmd_v2_delegate("start", "", "deile")
+
+        assert call_order.index("audit") < call_order.index("exec"), \
+            "AuditEvent must be emitted BEFORE subprocess exec"
+
+    async def test_audit_event_not_emitted_when_blocked_by_gating(self):
+        mock_audit = MagicMock()
+        mock_audit.log_event = MagicMock()
+
+        with (
+            patch("deile.commands.builtin.k8s_command._running_in_pod", return_value=False),
+            patch("deile.commands.builtin.k8s_command._find_deploy_py", return_value=self._fake_deploy()),
+            patch("deile.security.audit_logger.get_audit_logger", return_value=mock_audit),
+        ):
+            await _cmd_v2_delegate("down", "", "deile", confirmed=False)
+
+        mock_audit.log_event.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# K8sCommand.execute — --confirm and --save-namespace routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestK8sCommandConfirmAndSaveNamespace:
+    async def test_down_with_confirm_passes_confirmed_true(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_v2_delegate",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_v2,
+        ):
+            await _cmd().execute(_ctx("down --confirm"))
+
+        mock_v2.assert_called_once_with("down", "", "deile", confirmed=True)
+
+    async def test_down_without_confirm_passes_confirmed_false(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_v2_delegate",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="ok", content_type="text"),
+            ) as mock_v2,
+        ):
+            await _cmd().execute(_ctx("down"))
+
+        mock_v2.assert_called_once_with("down", "", "deile", confirmed=False)
+
+    async def test_save_namespace_persists_to_settings(self):
+        saved = {}
+
+        class FakeMgr:
+            def set_setting(self, key_path, value):
+                saved[key_path] = value
+
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_discovery",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="panel", content_type="rich"),
+            ),
+            patch(
+                "deile.commands.settings_manager.SettingsManager",
+                return_value=FakeMgr(),
+            ),
+        ):
+            await _cmd().execute(_ctx("--save-namespace"))
+
+        assert saved.get("k8s.namespace") == "deile"
+
+    async def test_save_namespace_failure_does_not_crash(self):
+        class BrokenMgr:
+            def set_setting(self, key_path, value):
+                raise RuntimeError("disk full")
+
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_discovery",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="panel", content_type="rich"),
+            ),
+            patch(
+                "deile.commands.settings_manager.SettingsManager",
+                return_value=BrokenMgr(),
+            ),
+        ):
+            result = await _cmd().execute(_ctx("--save-namespace"))
+
+        # Should not crash even when settings persistence fails
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Class A verbs not delegated (status/logs must NOT call _cmd_v2_delegate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestClassAVerbsNotDelegated:
+    async def test_status_does_not_call_v2_delegate(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_status",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="pods", content_type="text"),
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_v2_delegate",
+                new_callable=AsyncMock,
+            ) as mock_v2,
+        ):
+            await _cmd().execute(_ctx("status"))
+
+        mock_v2.assert_not_called()
+
+    async def test_logs_does_not_call_v2_delegate(self):
+        with (
+            patch(
+                "deile.commands.builtin.k8s_command._detect_namespace",
+                new_callable=AsyncMock,
+                return_value="deile",
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_logs",
+                new_callable=AsyncMock,
+                return_value=MagicMock(success=True, content="logs", content_type="text"),
+            ),
+            patch(
+                "deile.commands.builtin.k8s_command._cmd_v2_delegate",
+                new_callable=AsyncMock,
+            ) as mock_v2,
+        ):
+            await _cmd().execute(_ctx("logs"))
+
+        mock_v2.assert_not_called()


### PR DESCRIPTION
## Resumo

Implementa a **Classe B** do `/k8s` (issue #540): verbos que delegam ao orquestrador host `infra/k8s/deploy.py`, com todos os mecanismos de segurança exigidos.

**Mudanças em `k8s_command.py`:**

- **`_running_in_pod()`** — dupla detecção: `KUBERNETES_SERVICE_HOST` **ou** token de serviceaccount em `/var/run/secrets/kubernetes.io/serviceaccount/token`; qualquer sinal → proativamente desabilita toda Classe B

- **`_is_destructive()`** — helper que classifica operações destrutivas: `down` (sempre), `build --restart` e `claude-login --switch` (condicionalmente por flag)

- **`_cmd_v2_delegate(confirmed=False)`** — gating duro via re-emissão `--confirm`: verbos destrutivos sem `confirmed=True` retornam `error_result` com instrução de re-execução, **zero subprocess disparado**; `AuditEvent` emitido **antes** do exec (ordem auditada); `setup` sempre retorna `error_result` apontando `create-namespace` como alternativa scriptável; `claude-login` recebe `--no-interactive` automaticamente para nunca bloquear em stdin

- **`execute()`** — extrai `--confirm` e `--save-namespace` dos args; persiste namespace detectado via `SettingsManager.set_setting("k8s.namespace", ...)` quando `--save-namespace` presente

**Testes: 26 novos casos** (104 total, 100% passando) cobrindo todos os ACs duros da spec:
- Detecção in-pod via token de serviceaccount
- `_is_destructive` para todos os verbos e combinações de flags
- Gating sem/com `--confirm` (mock verifica que subprocess não é chamado sem confirmação)
- `setup` nunca delega ao subprocess
- `claude-login` recebe `--no-interactive`; não duplica se já presente
- `AuditEvent` emitido antes do exec, **não** emitido quando bloqueado pelo gating
- `--confirm` e `--save-namespace` roteados corretamente por `execute()`
- Classe A (`status`/`logs`) não chama `_cmd_v2_delegate`

Closes #540.