### PR TITLE
feat(reaper): extend reap_orphan_claims for em_arquitetura/em_refinamento zombie issues (no-ledger path)

### DIFF
--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -151,13 +151,24 @@ class PipelineConfig:
     # ``reaper_stale_seconds`` sem progresso são re-claimed (com
     # ``~attempt:N`` incrementado) para próximo tick retomar via resume.
     # Default 45min: > timeout máximo do claude-worker (2h) seria over-cauteloso;
-    # 45min cobre o timeout antigo de 30min com folga. 0 desliga o reaper.
+    # 45min cobre o timeout antigo de 30min com folga. 0 desliga apenas o ramo PR.
     reaper_stale_seconds: int = 45 * 60
     # Quando attempt >= reaper_max_attempts, o reaper bloqueia em vez de
     # liberar. Espelha resume_max_attempts mas separado pq são caminhos
     # distintos (resume = continuar trabalho parado; reaper = trabalho
     # presumido morto). Default 3 = 3 ciclos de 45min = 2h15m max stuck.
     reaper_max_attempts: int = 3
+    # Hard-ceiling TTL para issues em ~workflow:em_arquitetura ou
+    # ~workflow:em_refinamento SEM ledger entry com task_id (zumbi real:
+    # dispatch em voo morreu sem gravar no ledger, ou ledger ausente).
+    # Default 2h: >> poll_interval (60s) garante que um item sadio em descanso
+    # entre passes seja re-selecionado em ~1-2 ticks (cada tick grava ledger
+    # entry com task_id), permanecendo muito aquém do hard-ceiling.
+    # 0 desliga apenas este ramo (sem afetar os outros ramos do reaper).
+    # Depende de AC8: o guard em monitor.py e o early-return em stages.py
+    # agora operam sobre OR dos três TTLs; cada ramo auto-pula quando seu
+    # próprio TTL é <= 0.
+    reaper_arch_hard_seconds: int = 2 * 60 * 60  # 2h
     # The refinement gate (critique → refine loop → decompose) is worker-only:
     # it dispatches type-specific personas (analyst/architect/debugger) to the
     # deile-worker. On the legacy Claude path it is OFF, so ``review`` keeps its
@@ -690,7 +701,13 @@ class PipelineMonitor:
         # ~workflow:em_implementacao com idade > threshold sem progresso e
         # libera (próximo tick re-claim via resume). Best-effort: erros
         # no reaper NÃO derrubam o tick (catch + log).
-        if self.config.reaper_stale_seconds > 0:
+        # AC8 (#427): guard via OR dos três TTLs — desligar um TTL individual
+        # (valor 0) não silencia os demais ramos do reaper.
+        _reaper_any_active = (
+            self.config.reaper_stale_seconds > 0
+            or self.config.reaper_arch_hard_seconds > 0
+        )
+        if _reaper_any_active:
             try:
                 await stages.reap_orphan_claims(self)
             except Exception as exc:  # noqa: BLE001

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -3561,103 +3561,116 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
     NOTA: ``em_arquitetura`` e ``em_refinamento`` são AMBÍGUOS — podem ser
     estado de DESCANSO entre passes (a issue aguarda o próximo tick, SEM
     dispatch em voo) OU lock de um refino fire-and-forget travado (issue #373,
-    COM ledger entry + task_id). O reaper só os reapa quando há **ledger
-    entry com task_id** (dispatch em voo travado), distinguindo do descanso.
+    COM ledger entry + task_id). O reaper cobre dois casos:
+    1. Com ledger entry com task_id: ramo com-ledger (TTL = reaper_stale_seconds).
+    2. Sem ledger entry / ledger ausente: ramo sem-ledger (TTL =
+       reaper_arch_hard_seconds, 2h default, muito maior que poll_interval 60s)
+       — um item sadio em descanso é re-selecionado em ~1-2 ticks e grava
+       ledger entry, permanecendo abaixo do hard-ceiling. Permanecer 2h sem
+       ledger = zumbi real.
     ``em_revisao`` (crítica fire-and-forget) é sempre lock transitório.
+
+    AC8 (#427): cada ramo auto-pula quando seu TTL é <= 0 (sem early-return
+    global) para que desligar um TTL não silencia os demais ramos.
     """
     threshold = monitor.config.reaper_stale_seconds
     max_attempts = monitor.config.reaper_max_attempts
-    if threshold <= 0:
-        return
+    arch_hard_threshold = monitor.config.reaper_arch_hard_seconds
     now_ts = int(time.time())
     own_label = monitor.identity.ownership_label()
 
     # PRs com ~review:em_andamento (stuck no review).
-    try:
-        prs = await monitor.forge.list_open_prs()
-    except GhCommandError as exc:
-        await _record_forge_error(monitor, "reaper: list_open_prs failed", exc)
-        return
-    for pr in sort_by_priority(prs):
-        if REVIEW_IN_PROGRESS not in pr.labels:
-            continue
-        # Só re-claim PRs deste monitor (ownership).
-        if own_label not in pr.labels:
-            continue
-        applied_at = await monitor.forge.label_applied_at(
-            "pr", pr.number, REVIEW_IN_PROGRESS,
-        )
-        if applied_at is None:
-            continue  # forge sem suporte ou label sem timestamp
-        age = now_ts - applied_at
-        if age < threshold:
-            continue
-        await _reap_one(
-            monitor, kind="pr", number=pr.number, labels=pr.labels,
-            from_label=REVIEW_IN_PROGRESS, to_label=REVIEW_PENDING,
-            max_attempts=max_attempts, age_seconds=age,
-            description=f"PR #{pr.number} review stuck há {age // 60}min",
-            url=pr.url,
-        )
+    # AC8 (#427): pula o ramo quando seu TTL específico é 0 (não early-return global).
+    if threshold > 0:
+        try:
+            prs = await monitor.forge.list_open_prs()
+        except GhCommandError as exc:
+            await _record_forge_error(monitor, "reaper: list_open_prs failed", exc)
+            return
+        for pr in sort_by_priority(prs):
+            if REVIEW_IN_PROGRESS not in pr.labels:
+                continue
+            # Só re-claim PRs deste monitor (ownership).
+            if own_label not in pr.labels:
+                continue
+            applied_at = await monitor.forge.label_applied_at(
+                "pr", pr.number, REVIEW_IN_PROGRESS,
+            )
+            if applied_at is None:
+                continue  # forge sem suporte ou label sem timestamp
+            age = now_ts - applied_at
+            if age < threshold:
+                continue
+            await _reap_one(
+                monitor, kind="pr", number=pr.number, labels=pr.labels,
+                from_label=REVIEW_IN_PROGRESS, to_label=REVIEW_PENDING,
+                max_attempts=max_attempts, age_seconds=age,
+                description=f"PR #{pr.number} review stuck há {age // 60}min",
+                url=pr.url,
+            )
 
     # Issues com ~workflow:em_implementacao (stuck no implement).
-    try:
-        impl_issues = await monitor.forge.list_issues_with_label(
-            WORKFLOW_IMPLEMENTING,
-        )
-    except GhCommandError as exc:
-        await _record_forge_error(
-            monitor, "reaper: list_issues_with_label failed", exc,
-        )
-        return
-    for issue in sort_by_priority(impl_issues):
-        if own_label not in issue.labels:
-            continue
-        applied_at = await monitor.forge.label_applied_at(
-            "issue", issue.number, WORKFLOW_IMPLEMENTING,
-        )
-        if applied_at is None:
-            continue
-        age = now_ts - applied_at
-        if age < threshold:
-            continue
-        await _reap_one(
-            monitor, kind="issue", number=issue.number, labels=issue.labels,
-            from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_REVIEWED,
-            max_attempts=max_attempts, age_seconds=age,
-            description=f"issue #{issue.number} implement stuck há {age // 60}min",
-            url=issue.url,
-        )
+    # AC8 (#427): mesma política — pula ramo quando threshold <= 0.
+    if threshold > 0:
+        try:
+            impl_issues = await monitor.forge.list_issues_with_label(
+                WORKFLOW_IMPLEMENTING,
+            )
+        except GhCommandError as exc:
+            await _record_forge_error(
+                monitor, "reaper: list_issues_with_label failed", exc,
+            )
+            return
+        for issue in sort_by_priority(impl_issues):
+            if own_label not in issue.labels:
+                continue
+            applied_at = await monitor.forge.label_applied_at(
+                "issue", issue.number, WORKFLOW_IMPLEMENTING,
+            )
+            if applied_at is None:
+                continue
+            age = now_ts - applied_at
+            if age < threshold:
+                continue
+            await _reap_one(
+                monitor, kind="issue", number=issue.number, labels=issue.labels,
+                from_label=WORKFLOW_IMPLEMENTING, to_label=WORKFLOW_REVIEWED,
+                max_attempts=max_attempts, age_seconds=age,
+                description=f"issue #{issue.number} implement stuck há {age // 60}min",
+                url=issue.url,
+            )
 
     # Issues com ~workflow:em_revisao (crítica de escopo interrompida por restart
     # de pod — lock transitório que nenhum stage reseleciona).
-    try:
-        reviewing_issues = await monitor.forge.list_issues_with_label(
-            WORKFLOW_REVIEWING,
-        )
-    except GhCommandError as exc:
-        await _record_forge_error(
-            monitor, "reaper: list_issues_with_label(em_revisao) failed", exc,
-        )
-        return
-    for issue in sort_by_priority(reviewing_issues):
-        if own_label not in issue.labels:
-            continue
-        applied_at = await monitor.forge.label_applied_at(
-            "issue", issue.number, WORKFLOW_REVIEWING,
-        )
-        if applied_at is None:
-            continue
-        age = now_ts - applied_at
-        if age < threshold:
-            continue
-        await _reap_one(
-            monitor, kind="issue", number=issue.number, labels=issue.labels,
-            from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_NEW,
-            max_attempts=max_attempts, age_seconds=age,
-            description=f"issue #{issue.number} em_revisao stuck há {age // 60}min",
-            url=issue.url,
-        )
+    # AC8 (#427): mesma política — pula ramo quando threshold <= 0.
+    if threshold > 0:
+        try:
+            reviewing_issues = await monitor.forge.list_issues_with_label(
+                WORKFLOW_REVIEWING,
+            )
+        except GhCommandError as exc:
+            await _record_forge_error(
+                monitor, "reaper: list_issues_with_label(em_revisao) failed", exc,
+            )
+            return
+        for issue in sort_by_priority(reviewing_issues):
+            if own_label not in issue.labels:
+                continue
+            applied_at = await monitor.forge.label_applied_at(
+                "issue", issue.number, WORKFLOW_REVIEWING,
+            )
+            if applied_at is None:
+                continue
+            age = now_ts - applied_at
+            if age < threshold:
+                continue
+            await _reap_one(
+                monitor, kind="issue", number=issue.number, labels=issue.labels,
+                from_label=WORKFLOW_REVIEWING, to_label=WORKFLOW_NEW,
+                max_attempts=max_attempts, age_seconds=age,
+                description=f"issue #{issue.number} em_revisao stuck há {age // 60}min",
+                url=issue.url,
+            )
 
     # Issues com ~workflow:em_refinamento / ~workflow:em_arquitetura travadas por
     # um refino fire-and-forget (issue #373). AMBÍGUOS: só reapa quando há ledger
@@ -3698,6 +3711,74 @@ async def reap_orphan_claims(monitor: "PipelineMonitor") -> None:
                 # Lock liberado → o dispatch em voo morreu; limpa o ledger pra
                 # não consultar resume-info de uma task abandonada.
                 ledger.clear(DispatchLedger.key_for_issue(issue.number))
+
+    # ----------------------------------------------------------------------- #
+    # Ramo sem-ledger: em_arquitetura / em_refinamento SEM task_id no ledger  #
+    # (AC1 + AC2 — issue #427)                                                #
+    # ----------------------------------------------------------------------- #
+    # Cobre dois sub-casos:
+    #   A) ledger is None  — modo sem worker (sem DispatchLedger disponível).
+    #   B) ledger is not None mas a entry está ausente ou sem task_id —
+    #      dispatch morreu antes de gravar no ledger (TOCTOU, restart, etc.).
+    #
+    # Um item sadio em "descanso entre passes" é re-selecionado em ~1-2
+    # poll_interval (60s) e a re-seleção grava ledger entry com task_id
+    # (stages.py:1270-1278), promovendo-o ao ramo com-ledger. Permanecer
+    # arch_hard_threshold (default 2h) SEM task_id ⇒ zumbi real.
+    #
+    # AC8 (#427): pula ramo inteiro quando arch_hard_threshold <= 0.
+    if arch_hard_threshold > 0:
+        for refine_state in (WORKFLOW_REFINING, WORKFLOW_ARCHITECTURE):
+            try:
+                refine_issues_no_ledger = await monitor.forge.list_issues_with_label(
+                    refine_state,
+                )
+            except GhCommandError as exc:
+                await _record_forge_error(
+                    monitor,
+                    f"reaper(no-ledger): list_issues_with_label({refine_state}) failed",
+                    exc,
+                )
+                continue
+            for issue in sort_by_priority(refine_issues_no_ledger):
+                if own_label not in issue.labels:
+                    continue
+                # Pula se o ramo com-ledger já tratou esta issue neste tick
+                # (ledger entry com task_id ⇒ o ramo com-ledger acima é o dono).
+                if ledger is not None:
+                    entry = ledger.get(DispatchLedger.key_for_issue(issue.number))
+                    if entry and entry.get("task_id"):
+                        continue  # item sadio com dispatch em voo — não é zumbi
+                applied_at = await monitor.forge.label_applied_at(
+                    "issue", issue.number, refine_state,
+                )
+                if applied_at is None:
+                    continue
+                age = now_ts - applied_at
+                if age < arch_hard_threshold:
+                    continue
+                # AC2: heurística de roteamento. Se a issue já passou por ao
+                # menos um pass de refino (current_refine_attempt > 0), volta
+                # para ~workflow:revisada (o contexto de refino está gravado nos
+                # labels ~refine:N — o próximo tick retoma do ponto). Caso
+                # contrário volta para ~workflow:nova (primeira tentativa).
+                if (
+                    refine_state == WORKFLOW_ARCHITECTURE
+                    and current_refine_attempt_from_labels(issue.labels) > 0
+                ):
+                    to_label = WORKFLOW_REVIEWED
+                else:
+                    to_label = WORKFLOW_NEW
+                await _reap_one(
+                    monitor, kind="issue", number=issue.number, labels=issue.labels,
+                    from_label=refine_state, to_label=to_label,
+                    max_attempts=max_attempts, age_seconds=age,
+                    description=(
+                        f"issue #{issue.number} {refine_state} zumbi "
+                        f"(sem task_id há {age // 60}min, hard-TTL={arch_hard_threshold // 60}min)"
+                    ),
+                    url=issue.url,
+                )
 
 
 async def _reap_one(

--- a/deile/tests/orchestration/pipeline/test_reaper.py
+++ b/deile/tests/orchestration/pipeline/test_reaper.py
@@ -88,6 +88,7 @@ def _make_monitor_for_reaper(
     *,
     reaper_stale_seconds=2700,
     reaper_max_attempts=3,
+    reaper_arch_hard_seconds=7200,
 ):
     cfg = PipelineConfig(
         repo="owner/repo",
@@ -96,6 +97,7 @@ def _make_monitor_for_reaper(
         use_pid_lock=False,
         reaper_stale_seconds=reaper_stale_seconds,
         reaper_max_attempts=reaper_max_attempts,
+        reaper_arch_hard_seconds=reaper_arch_hard_seconds,
     )
     github = MagicMock()
     github.list_open_prs = AsyncMock(return_value=[])
@@ -357,21 +359,21 @@ async def test_reaper_skips_fresh_em_revisao():
 
 @pytest.mark.asyncio
 async def test_reaper_does_not_touch_em_arquitetura():
-    """REGRESSÃO-GUARD: issue em ~workflow:em_arquitetura (refine state de
-    descanso) com idade > threshold NÃO é tocada pelo reaper.
+    """REGRESSÃO-GUARD (reinterpretado — issue #427): issue em
+    ~workflow:em_arquitetura em descanso (sem dispatch em voo e dentro do
+    hard-TTL de 2h) NÃO é tocada pelo reaper.
 
-    Em_arquitetura é um estado de descanso entre passes de refine — a issue
-    aguarda o próximo tick de refine_one_issue — e NÃO é um lock transitório.
-    Reapeá-la seria regressão: a issue perderia o contexto de refinamento.
+    O ramo sem-ledger (#427) só dispara após arch_hard_seconds (2h default).
+    list_issues_with_label retorna [] para todos os estados, logo nenhuma
+    issue é processada, o que é equivalente a nenhuma issue de descanso real
+    atingindo o TTL curto (o TTL do descanso é 2h >> reaper_stale_seconds=60).
     """
     from deile.orchestration.pipeline.labels import WORKFLOW_ARCHITECTURE
     monitor, github = _make_monitor_for_reaper(reaper_stale_seconds=60)
     own = monitor.identity.ownership_label()
     _make_issue(903, labels=[WORKFLOW_ARCHITECTURE, own, "refinar"])
-    # list_issues_with_label retorna a issue para WORKFLOW_REVIEWING somente
-    # se erroneamente invocado para esse estado — não deveria.
-    # Para WORKFLOW_IMPLEMENTING retorna [] (nenhuma stuck implement).
-    # Para WORKFLOW_REVIEWING retorna [] (em_arquitetura não está nesse bucket).
+    # Retorna [] para todos os estados — simula que não há issues zumbi
+    # na fila (o reaper não toca em issues inexistentes na lista).
     github.list_issues_with_label = AsyncMock(return_value=[])
     github.label_applied_at = AsyncMock(return_value=int(time.time()) - 9999)
 
@@ -383,8 +385,9 @@ async def test_reaper_does_not_touch_em_arquitetura():
 
 @pytest.mark.asyncio
 async def test_reaper_does_not_touch_em_refinamento():
-    """REGRESSÃO-GUARD: issue em ~workflow:em_refinamento (refine state de
-    descanso para intents) com idade > threshold NÃO é tocada pelo reaper."""
+    """REGRESSÃO-GUARD (reinterpretado — issue #427): issue em
+    ~workflow:em_refinamento em descanso com list_issues_with_label retornando
+    [] não é tocada pelo reaper (nenhuma issue na lista = nada a reapear)."""
     from deile.orchestration.pipeline.labels import WORKFLOW_REFINING
     monitor, github = _make_monitor_for_reaper(reaper_stale_seconds=60)
     own = monitor.identity.ownership_label()
@@ -531,3 +534,243 @@ async def test_reaper_block_disabled_notifier_is_noop():
     added = list(github.add_labels.await_args_list[0].args[2])
     assert "~workflow:bloqueada" in added
     github.comment_on_pr.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Issue #427 — ramo sem-ledger: em_arquitetura / em_refinamento zumbi
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reaper_arch_no_refine_labels_routes_to_nova():
+    """AC1 + AC2: issue em ~workflow:em_arquitetura sem ledger entry (ledger
+    ausente) e sem labels ~refine:N, após arch_hard_seconds, volta para
+    ~workflow:nova."""
+    from deile.orchestration.pipeline.labels import (WORKFLOW_ARCHITECTURE,
+                                                     WORKFLOW_NEW)
+    # TTL curto para o teste; arch_hard = 100s.
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=2700,
+        reaper_arch_hard_seconds=100,
+    )
+    own = monitor.identity.ownership_label()
+    issue = _make_issue(2001, labels=[WORKFLOW_ARCHITECTURE, own])
+    # Nenhum ledger no implementer.
+    monitor.implementer._ledger = None
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_ARCHITECTURE else [],
+    )
+    # Aplicada há 200s > arch_hard_seconds=100.
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    await reap_orphan_claims(monitor)
+
+    add_calls = github.add_labels.await_args_list
+    assert len(add_calls) >= 1
+    added = list(add_calls[0].args[2])
+    assert WORKFLOW_NEW in added
+    assert "~attempt:1" in added
+
+
+@pytest.mark.asyncio
+async def test_reaper_arch_with_refine_labels_routes_to_revisada():
+    """AC2: issue em ~workflow:em_arquitetura com ~refine:2 (já passou por ao
+    menos um pass de refino), após arch_hard_seconds, volta para
+    ~workflow:revisada."""
+    from deile.orchestration.pipeline.labels import (WORKFLOW_ARCHITECTURE,
+                                                     WORKFLOW_REVIEWED)
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=2700,
+        reaper_arch_hard_seconds=100,
+    )
+    own = monitor.identity.ownership_label()
+    issue = _make_issue(2002, labels=[WORKFLOW_ARCHITECTURE, own, "~refine:2"])
+    monitor.implementer._ledger = None
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_ARCHITECTURE else [],
+    )
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    await reap_orphan_claims(monitor)
+
+    add_calls = github.add_labels.await_args_list
+    assert len(add_calls) >= 1
+    added = list(add_calls[0].args[2])
+    assert WORKFLOW_REVIEWED in added
+    assert "~attempt:1" in added
+
+
+@pytest.mark.asyncio
+async def test_reaper_refining_no_ledger_routes_to_nova():
+    """AC1 + AC2: issue em ~workflow:em_refinamento sem ledger entry, após
+    arch_hard_seconds, sempre volta para ~workflow:nova (roteamento fixo para
+    intents — heurística de refino não se aplica ao estado em_refinamento)."""
+    from deile.orchestration.pipeline.labels import (WORKFLOW_NEW,
+                                                     WORKFLOW_REFINING)
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=2700,
+        reaper_arch_hard_seconds=100,
+    )
+    own = monitor.identity.ownership_label()
+    # Mesmo com ~refine:3, em_refinamento sempre vai para nova.
+    issue = _make_issue(2003, labels=[WORKFLOW_REFINING, own, "~refine:3"])
+    monitor.implementer._ledger = None
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_REFINING else [],
+    )
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    await reap_orphan_claims(monitor)
+
+    add_calls = github.add_labels.await_args_list
+    assert len(add_calls) >= 1
+    added = list(add_calls[0].args[2])
+    assert WORKFLOW_NEW in added
+
+
+@pytest.mark.asyncio
+async def test_reaper_arquitetura_no_ledger_fires_when_ledger_is_none():
+    """AC1: ramo sem-ledger FORA do guard `if ledger is not None` — cobre o
+    caso em que ledger=None (modo sem DispatchLedger disponível)."""
+    from deile.orchestration.pipeline.labels import (WORKFLOW_ARCHITECTURE,
+                                                     WORKFLOW_NEW)
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=2700,
+        reaper_arch_hard_seconds=100,
+    )
+    own = monitor.identity.ownership_label()
+    issue = _make_issue(2004, labels=[WORKFLOW_ARCHITECTURE, own])
+    # Garante ledger=None no implementer (explicitamente).
+    if hasattr(monitor.implementer, "_ledger"):
+        monitor.implementer._ledger = None
+    else:
+        monitor.implementer._ledger = None
+
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_ARCHITECTURE else [],
+    )
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    await reap_orphan_claims(monitor)
+
+    # Ramo sem-ledger DEVE ter disparado.
+    add_calls = github.add_labels.await_args_list
+    assert len(add_calls) >= 1
+    added = list(add_calls[0].args[2])
+    assert WORKFLOW_NEW in added
+
+
+@pytest.mark.asyncio
+async def test_reaper_arch_within_hard_ttl_not_reaped():
+    """AC5: issue em ~workflow:em_arquitetura em descanso (sem task_id no
+    ledger) com idade < arch_hard_seconds NÃO é tocada — invariante de
+    proteção do descanso entre passes."""
+    from deile.orchestration.pipeline.labels import WORKFLOW_ARCHITECTURE
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=2700,
+        reaper_arch_hard_seconds=7200,  # 2h
+    )
+    own = monitor.identity.ownership_label()
+    issue = _make_issue(2005, labels=[WORKFLOW_ARCHITECTURE, own])
+    monitor.implementer._ledger = None
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_ARCHITECTURE else [],
+    )
+    # Aplicada há 60s — muito abaixo dos 7200s de hard-TTL.
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 60)
+
+    await reap_orphan_claims(monitor)
+
+    github.remove_labels.assert_not_awaited()
+    github.add_labels.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reaper_arch_with_task_id_in_ledger_not_touched_by_no_ledger_branch():
+    """AC1: issue em ~workflow:em_arquitetura COM task_id no ledger (dispatch
+    em voo sadio) NÃO é tratada pelo ramo sem-ledger — é do ramo com-ledger."""
+    from deile.orchestration.pipeline.labels import WORKFLOW_ARCHITECTURE
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=2700,
+        reaper_arch_hard_seconds=100,  # TTL curto — dispararia se fosse zumbi
+    )
+    own = monitor.identity.ownership_label()
+    issue = _make_issue(2006, labels=[WORKFLOW_ARCHITECTURE, own])
+
+    # Ledger com task_id — indica dispatch em voo sadio.
+    from unittest.mock import MagicMock
+    mock_ledger = MagicMock()
+    mock_ledger.get.return_value = {"task_id": "task-abc-123"}
+    mock_ledger.clear = MagicMock()
+    monitor.implementer._ledger = mock_ledger
+
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_ARCHITECTURE else [],
+    )
+    # Aplicada há 200s > arch_hard_seconds=100 — seria reaped se fosse zumbi.
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    await reap_orphan_claims(monitor)
+
+    # O ramo sem-ledger NÃO deve ter disparado (task_id presente no ledger).
+    # O ramo com-ledger SIM tentaria reapear (threshold=2700 > 200 → não ativa).
+    # Portanto nada é reapado neste tick.
+    github.remove_labels.assert_not_awaited()
+    github.add_labels.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reaper_arch_branch_runs_when_pr_ttl_zero():
+    """AC8: quando reaper_stale_seconds=0 (PR-TTL desligado), o ramo
+    sem-ledger de em_arquitetura ainda deve disparar se arch_hard_seconds > 0.
+    Garante que desligar o PR-TTL não silencia o ramo de arquitetura."""
+    from deile.orchestration.pipeline.labels import (WORKFLOW_ARCHITECTURE,
+                                                     WORKFLOW_NEW)
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=0,     # PR-TTL desligado
+        reaper_arch_hard_seconds=100,
+    )
+    own = monitor.identity.ownership_label()
+    issue = _make_issue(2007, labels=[WORKFLOW_ARCHITECTURE, own])
+    monitor.implementer._ledger = None
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_ARCHITECTURE else [],
+    )
+    # list_open_prs retorna lista vazia (PR-TTL=0 não deve nem ser chamado,
+    # mas garantimos que não há PRs para reapear de qualquer modo).
+    github.list_open_prs = AsyncMock(return_value=[])
+    # Aplicada há 200s > arch_hard_seconds=100.
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 200)
+
+    await reap_orphan_claims(monitor)
+
+    # Ramo sem-ledger de arquitetura DEVE ter disparado mesmo com PR-TTL=0.
+    add_calls = github.add_labels.await_args_list
+    assert len(add_calls) >= 1
+    added = list(add_calls[0].args[2])
+    assert WORKFLOW_NEW in added
+
+
+@pytest.mark.asyncio
+async def test_reaper_arch_hard_zero_disables_no_ledger_branch():
+    """AC8 + AC3: quando reaper_arch_hard_seconds=0, o ramo sem-ledger é
+    desligado — issues em em_arquitetura zumbi NÃO são reaped."""
+    from deile.orchestration.pipeline.labels import WORKFLOW_ARCHITECTURE
+    monitor, github = _make_monitor_for_reaper(
+        reaper_stale_seconds=2700,
+        reaper_arch_hard_seconds=0,  # ramo sem-ledger desligado
+    )
+    own = monitor.identity.ownership_label()
+    issue = _make_issue(2008, labels=[WORKFLOW_ARCHITECTURE, own])
+    monitor.implementer._ledger = None
+    github.list_issues_with_label = AsyncMock(
+        side_effect=lambda label, **_: [issue] if label == WORKFLOW_ARCHITECTURE else [],
+    )
+    github.label_applied_at = AsyncMock(return_value=int(time.time()) - 99999)
+
+    await reap_orphan_claims(monitor)
+
+    # Com arch_hard_seconds=0 o ramo está desligado — nada reaped.
+    # (O ramo com-ledger também não dispara pois ledger=None e threshold > 200s.)
+    github.remove_labels.assert_not_awaited()
+    github.add_labels.assert_not_awaited()


### PR DESCRIPTION
## Summary

Extends `reap_orphan_claims` in `deile/orchestration/pipeline/stages.py` to handle `em_arquitetura` and `em_refinamento` issues that are **stuck without a DispatchLedger entry** — the zombie class exposed by #414, #419, and #426.

### What changed

- **`MonitorConfig`** (`monitor.py`): new field `reaper_arch_hard_seconds` (default 7200 = 2h) — hard-ceiling TTL for the no-ledger zombie path.
- **`reap_orphan_claims`** (`stages.py`): new branch **outside** the `if ledger is not None:` guard that reapers `WORKFLOW_ARCHITECTURE`/`WORKFLOW_REFINING` when (a) own label present, (b) age ≥ `reaper_arch_hard_seconds`, (c) ledger entry absent or missing `task_id` (including `ledger is None`). Routes: `em_arquitetura` + refine labels → `WORKFLOW_REVISED`; `em_arquitetura` no-refine / `em_refinamento` → `WORKFLOW_NEW`. Existing with-ledger branch untouched.
- **`test_reaper.py`**: updated regression tests (`test_reaper_does_not_touch_em_arquitetura`, `test_reaper_does_not_touch_em_refinamento`) + 6 new test cases covering the no-ledger paths.

### Why it's safe

A healthy issue in the "rest between passes" state gets re-selected by the refining stage in the next tick (~60s) and receives a ledger entry with `task_id` within 1-2 ticks — well under the 2h hard ceiling. Only genuine zombies (re-selection broken) survive past 2h without a ledger entry.

Closes #427.