### PR TITLE
fix(pipeline): gate implement Definition-of-Done on AC evidence + spike Refs

### DIFF
--- a/deile/orchestration/forge/cli_renderer.py
+++ b/deile/orchestration/forge/cli_renderer.py
@@ -42,6 +42,7 @@ def render_brief_cmds(
     branch: str,
     main: str,
     issue_template: str = "feature_request.md",
+    close_keyword: str = "Closes",
 ) -> Mapping[str, str]:
     """Return ``{placeholder: command}`` for *config*.
 
@@ -53,6 +54,11 @@ def render_brief_cmds(
     ``issue_template`` only affects the ``fetch_template_cmd`` placeholder
     (used by the critique/refine briefs). The default matches the most
     common path; the renderer never hardcodes a fixed template name.
+
+    ``close_keyword`` is the issue-closing verb baked into ``create_pr_cmd``'s
+    body (``Closes #N``). Spikes — whose deliverable is measured evidence, not
+    production code — pass ``"Refs"`` so the PR references the issue without
+    auto-closing it on merge (a half-proven spike must never close its issue).
     """
     if config.kind is ForgeKind.GITHUB:
         return _github_cmds(
@@ -62,6 +68,7 @@ def render_brief_cmds(
             branch=branch,
             main=main,
             issue_template=issue_template,
+            close_keyword=close_keyword,
         )
     return _gitlab_cmds(
         project_path=config.project_path,
@@ -71,6 +78,7 @@ def render_brief_cmds(
         branch=branch,
         main=main,
         issue_template=issue_template,
+        close_keyword=close_keyword,
     )
 
 
@@ -82,6 +90,7 @@ def _github_cmds(
     branch: str,
     main: str,
     issue_template: str,
+    close_keyword: str = "Closes",
 ) -> Mapping[str, str]:
     """Concrete ``gh`` snippets — identical to the legacy literal commands
     that lived inline in the brief templates. Preserves byte-for-byte
@@ -93,8 +102,9 @@ def _github_cmds(
         "view_issue_cmd": f"gh issue view {number} --repo {project_path} --comments",
         "create_pr_cmd": (
             f'gh pr create --repo {project_path} --base {main} --head {branch} '
-            f'--title "<título coerente>" --body "<resumo>. Closes #{number}."'
+            f'--title "<título coerente>" --body "<resumo>. {close_keyword} #{number}."'
         ),
+        "mark_draft_cmd": f"gh pr ready {number} --repo {project_path} --undo",
         "check_pr_cmd": f"gh pr view {branch} --repo {project_path} --json url -q .url",
         "checkout_pr_cmd": f"gh pr checkout {number}",
         "merge_cmd": (
@@ -154,6 +164,7 @@ def _gitlab_cmds(
     branch: str,
     main: str,
     issue_template: str,
+    close_keyword: str = "Closes",
 ) -> Mapping[str, str]:
     """Concrete ``glab`` + GitLab REST snippets.
 
@@ -169,8 +180,9 @@ def _gitlab_cmds(
         "create_pr_cmd": (
             f'glab mr create -R {project_path} --target-branch {main} '
             f'--source-branch {branch} -t "<título coerente>" '
-            f'-d "<resumo>. Closes #{number}."'
+            f'-d "<resumo>. {close_keyword} #{number}."'
         ),
+        "mark_draft_cmd": f"glab mr update {number} -R {project_path} --draft",
         "check_pr_cmd": (
             f"glab mr view {branch} -R {project_path} -F json | jq -r .web_url"
         ),

--- a/deile/orchestration/forge/cli_renderer.py
+++ b/deile/orchestration/forge/cli_renderer.py
@@ -90,7 +90,7 @@ def _github_cmds(
     branch: str,
     main: str,
     issue_template: str,
-    close_keyword: str = "Closes",
+    close_keyword: str,
 ) -> Mapping[str, str]:
     """Concrete ``gh`` snippets — identical to the legacy literal commands
     that lived inline in the brief templates. Preserves byte-for-byte
@@ -104,7 +104,12 @@ def _github_cmds(
             f'gh pr create --repo {project_path} --base {main} --head {branch} '
             f'--title "<título coerente>" --body "<resumo>. {close_keyword} #{number}."'
         ),
-        "mark_draft_cmd": f"gh pr ready {number} --repo {project_path} --undo",
+        # Keyed by ``branch`` (not ``number``): in the implement flow the PR is
+        # created fresh, so its number is unknown when the DoD block tells the
+        # worker to mark it draft — but the head branch is always known. ``gh pr
+        # ready`` accepts ``[<number> | <url> | <branch>]``, matching the branch
+        # lookup already used by ``check_pr_cmd``.
+        "mark_draft_cmd": f"gh pr ready {branch} --repo {project_path} --undo",
         "check_pr_cmd": f"gh pr view {branch} --repo {project_path} --json url -q .url",
         "checkout_pr_cmd": f"gh pr checkout {number}",
         "merge_cmd": (
@@ -164,7 +169,7 @@ def _gitlab_cmds(
     branch: str,
     main: str,
     issue_template: str,
-    close_keyword: str = "Closes",
+    close_keyword: str,
 ) -> Mapping[str, str]:
     """Concrete ``glab`` + GitLab REST snippets.
 
@@ -182,7 +187,11 @@ def _gitlab_cmds(
             f'--source-branch {branch} -t "<título coerente>" '
             f'-d "<resumo>. {close_keyword} #{number}."'
         ),
-        "mark_draft_cmd": f"glab mr update {number} -R {project_path} --draft",
+        # Keyed by ``branch`` like ``check_pr_cmd`` above: the MR iid is unknown
+        # when the implement DoD block marks the just-created MR draft, so the
+        # REST path (which needs the iid) does not fit here. ``glab mr update``
+        # accepts a branch selector and exposes ``--draft`` natively.
+        "mark_draft_cmd": f"glab mr update {branch} -R {project_path} --draft",
         "check_pr_cmd": (
             f"glab mr view {branch} -R {project_path} -F json | jq -r .web_url"
         ),

--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -126,9 +126,17 @@ def _is_spike(title: str, body: str) -> bool:
     A spike's Definition-of-Done is measured ACs (numbers/verdict), so its PR must
     reference (``Refs``) — never auto-close (``Closes``) — the issue, and should
     stay draft until every AC is green. Detected by the conventional ``[SPIKE]``
-    title tag or a spike-style exit-condition section in the body. Conservative on
-    purpose: a missed spike (defaults to ``Closes``) is the dangerous direction, so
-    we only require an explicit, unambiguous signal.
+    title tag or a spike-style exit-condition section in the body (the headings the
+    architect/analyst personas emit for spike issues, e.g. issue #529's
+    "## Condição de Saída"). Conservative on purpose: a missed spike (defaults to
+    ``Closes``) is the dangerous direction, so we only require an explicit,
+    unambiguous signal.
+
+    Detection reads the FULL untruncated body (so a marker past
+    ``ISSUE_BODY_MAX_CHARS`` still classifies correctly, even if it won't appear in
+    the rendered brief) and is accent-sensitive by design — the canonical headings
+    carry their accents, and an accent-stripped variant safely falls back to
+    ``Closes`` rather than risking a false positive on incidental prose.
     """
     t = (title or "").lower()
     b = (body or "").lower()

--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -148,6 +148,16 @@ def _is_spike(title: str, body: str) -> bool:
     )
 
 
+def _close_keyword(title: str, body: str) -> str:
+    """Issue-closing verb for a PR/MR body: ``Refs`` for spikes (reference the
+    issue without auto-closing a half-proven one), ``Closes`` otherwise.
+
+    Single source of the spike→``Refs`` policy, shared by both implement briefs
+    and by the legacy local prompt (:func:`claude_dispatcher.render_implement_prompt`).
+    """
+    return "Refs" if _is_spike(title, body) else "Closes"
+
+
 def _build_brief_params(
     *,
     repo: str,
@@ -549,7 +559,7 @@ def _render_worker_implement_brief(
 ) -> str:
     params = _build_brief_params(
         repo=repo, main=main, branch=branch, number=number, forge=forge,
-        close_keyword="Refs" if _is_spike(title, body) else "Closes",
+        close_keyword=_close_keyword(title, body),
         extras={
             "title": title,
             "body": (body or "").strip()[:ISSUE_BODY_MAX_CHARS]
@@ -633,7 +643,7 @@ def _render_worker_implement_resume_brief(
 ) -> str:
     params = _build_brief_params(
         repo=repo, main=main, branch=branch, number=number, forge=forge,
-        close_keyword="Refs" if _is_spike(title, body) else "Closes",
+        close_keyword=_close_keyword(title, body),
         extras={
             "title": title,
             "body": (body or "").strip()[:ISSUE_BODY_MAX_CHARS]

--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -95,6 +95,51 @@ def _default_forge_config(repo: str) -> ForgeConfig:
     )
 
 
+# Definition-of-Done evidence gate, injected as ``{dod_block}`` into the
+# implement / implement-resume briefs. Closes the structural hole that let a
+# worker open an issue-closing PR whose hard ACs were never executed (skipped
+# integration tests count as "green"): "a PR exists + impacted tests pass" is
+# NOT done when the issue declares empirical acceptance criteria. Pre-formatted
+# in :func:`_build_brief_params` (embeds the per-forge draft/comment commands).
+_DOD_EVIDENCE_BLOCK = (
+    "DEFINIÇÃO DE PRONTO — confronte ENTREGA vs os Critérios de Aceite (ACs) da issue. "
+    "\"Compila + PR existe\" NÃO é pronto:\n"
+    "   a) AC com número/condição testável (HTTP 200, custo %, p95, trigger %) só está PRONTO "
+    "com o AC EXECUTADO e o NÚMERO real anexado ao corpo da PR/relatório. Scaffolding/harness "
+    "escrito ≠ AC cumprido.\n"
+    "   b) Teste `@pytest.mark.integration` que PULA (skip por falta de credencial/env) NÃO "
+    "satisfaz o AC — rode-o com a credencial disponível no pod (ex.: `ANTHROPIC_AUTH_TOKEN` / "
+    "`~/.claude/credentials.json`) ou marque o AC como NÃO-VERIFICADO no corpo da PR.\n"
+    "   c) AC duro que você NÃO conseguiu provar (bloqueado): NÃO feche a issue. Abra a PR como "
+    "DRAFT (`{mark_draft_cmd}` após criar), use `Refs #{number}` (não `Closes`) no --body, "
+    "registre a causa do bloqueio e escale ao autor (`{comment_issue_cmd}`). Nunca uma PR "
+    "`Closes` com ACs vazios.\n"
+    "   d) SPIKE (entregável = evidência, não código de produção): o `create_pr_cmd` abaixo já "
+    "usa `Refs` (não fecha a issue). Abra DRAFT e só tire do draft — trocando para `Closes` — "
+    "quando TODOS os ACs estiverem verdes com números anexados."
+)
+
+
+def _is_spike(title: str, body: str) -> bool:
+    """True when the issue's deliverable is empirical evidence, not production code.
+
+    A spike's Definition-of-Done is measured ACs (numbers/verdict), so its PR must
+    reference (``Refs``) — never auto-close (``Closes``) — the issue, and should
+    stay draft until every AC is green. Detected by the conventional ``[SPIKE]``
+    title tag or a spike-style exit-condition section in the body. Conservative on
+    purpose: a missed spike (defaults to ``Closes``) is the dangerous direction, so
+    we only require an explicit, unambiguous signal.
+    """
+    t = (title or "").lower()
+    b = (body or "").lower()
+    if "[spike]" in t:
+        return True
+    return any(
+        marker in b
+        for marker in ("condição de saída", "critérios de aprovação do spike")
+    )
+
+
 def _build_brief_params(
     *,
     repo: str,
@@ -103,6 +148,7 @@ def _build_brief_params(
     number: int,
     forge: Optional[ForgeConfig],
     issue_template: str = "feature_request.md",
+    close_keyword: str = "Closes",
     extras: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Assemble the full ``{key: value}`` map for ``.format()`` on a template.
@@ -112,10 +158,17 @@ def _build_brief_params(
     per-forge CLI snippets from :func:`render_brief_cmds`. Extras override
     everything else so callers can inject brief-specific fields
     (``title``/``body``/``progress_block`` …) without surprises.
+
+    ``close_keyword`` flows down to :func:`render_brief_cmds` so spike briefs
+    render ``create_pr_cmd`` with ``Refs`` instead of ``Closes`` (a spike PR
+    must reference, never auto-close, its issue). The ``dod_block`` placeholder
+    (Definition-of-Done evidence gate) is pre-formatted here because it embeds
+    the per-forge ``mark_draft_cmd``/``comment_issue_cmd`` and the issue number.
     """
     cfg = forge or _default_forge_config(repo)
     cmds = render_brief_cmds(
-        cfg, number=number, branch=branch, main=main, issue_template=issue_template,
+        cfg, number=number, branch=branch, main=main,
+        issue_template=issue_template, close_keyword=close_keyword,
     )
     params: dict[str, Any] = dict(_BRIEF_CONSTANTS)
     params.update({
@@ -125,6 +178,11 @@ def _build_brief_params(
         "number": number,
     })
     params.update(cmds)
+    params["dod_block"] = _DOD_EVIDENCE_BLOCK.format(
+        number=number,
+        mark_draft_cmd=cmds["mark_draft_cmd"],
+        comment_issue_cmd=cmds["comment_issue_cmd"],
+    )
     if extras:
         params.update(extras)
     return params
@@ -147,10 +205,11 @@ Implemente a issue #{number} de {repo} e abra uma {pr_noun}. Execute de verdade 
 2. Crie branch `{branch}` a partir de `{main}`.
 3. Leia comentários da issue (`{view_issue_cmd}`) — decisões do stakeholder FAZEM PARTE do escopo. Implemente o pedido + testes. CHECKPOINT INCREMENTAL: grave `.deile-progress.md` (um nível acima de ./repo, NÃO commite, NÃO em ./repo) a cada milestone — o timeout mata o processo sem aviso (rc=124) e só o journal sobrevive pro próximo tick.
 4. {impact_test_strategy}
-5. Commit atômico + `git push -u origin {branch}`.
-6. Abra a {pr_noun} (OBRIGATÓRIO): `{create_pr_cmd}`.
-7. Confirme: `{check_pr_cmd}` — se não retornar URL, volte ao passo 6.
-8. NÃO force-push. NÃO altere nada fora de ./repo. ÚLTIMA LINHA = URL da {pr_noun} (ex: {pr_url_pattern}).
+5. {dod_block}
+6. Commit atômico + `git push -u origin {branch}`.
+7. Abra a {pr_noun} (OBRIGATÓRIO): `{create_pr_cmd}`. No --body, confronte ENTREGA vs cada AC (com números) — não um resumo genérico.
+8. Confirme: `{check_pr_cmd}` — se não retornar URL, volte ao passo 7.
+9. NÃO force-push. NÃO altere nada fora de ./repo. ÚLTIMA LINHA = URL da {pr_noun} (ex: {pr_url_pattern}).
 
 === Issue #{number}: {title} ===
 {body}
@@ -232,10 +291,11 @@ RETOMADA da issue #{number} de {repo}. Há trabalho parcial em ./repo — NÃO r
    `git diff {main}...HEAD` + `git diff HEAD` + `git status --porcelain` (leia cada arquivo listado).
 3. Continue de onde parou. Edite o que falta + testes.
 4. {impact_test_strategy}
-5. Commit + `git push -u origin {branch}`.
-6. Abra a {pr_noun} (OBRIGATÓRIO): `{create_pr_cmd}` (ou confirme existente: `{check_pr_cmd}`).
-7. CHECKPOINT INCREMENTAL: atualize `.deile-progress.md` no diretório de trabalho (NÃO commite, NÃO em ./repo) **a cada milestone E antes de parar** — o timeout mata o processo sem aviso (rc=124), só o journal sobrevive pro próximo tick: feito, falta, decisões, bloqueios.
-8. Impedimento real → linha `{blocked_contract}`. Última linha = URL da {pr_noun} (ex: {pr_url_pattern}) OU `{blocked_contract}`.
+5. {dod_block}
+6. Commit + `git push -u origin {branch}`.
+7. Abra a {pr_noun} (OBRIGATÓRIO): `{create_pr_cmd}` (ou confirme existente: `{check_pr_cmd}`). No --body, confronte ENTREGA vs cada AC (com números).
+8. CHECKPOINT INCREMENTAL: atualize `.deile-progress.md` no diretório de trabalho (NÃO commite, NÃO em ./repo) **a cada milestone E antes de parar** — o timeout mata o processo sem aviso (rc=124), só o journal sobrevive pro próximo tick: feito, falta, decisões, bloqueios.
+9. Impedimento real → linha `{blocked_contract}`. Última linha = URL da {pr_noun} (ex: {pr_url_pattern}) OU `{blocked_contract}`.
 
 === Issue #{number}: {title} ===
 {body}
@@ -481,6 +541,7 @@ def _render_worker_implement_brief(
 ) -> str:
     params = _build_brief_params(
         repo=repo, main=main, branch=branch, number=number, forge=forge,
+        close_keyword="Refs" if _is_spike(title, body) else "Closes",
         extras={
             "title": title,
             "body": (body or "").strip()[:ISSUE_BODY_MAX_CHARS]
@@ -564,6 +625,7 @@ def _render_worker_implement_resume_brief(
 ) -> str:
     params = _build_brief_params(
         repo=repo, main=main, branch=branch, number=number, forge=forge,
+        close_keyword="Refs" if _is_spike(title, body) else "Closes",
         extras={
             "title": title,
             "body": (body or "").strip()[:ISSUE_BODY_MAX_CHARS]

--- a/deile/orchestration/pipeline/briefs.py
+++ b/deile/orchestration/pipeline/briefs.py
@@ -25,6 +25,7 @@ the legacy byte-exact GH output.
 
 from __future__ import annotations
 
+import re
 import shutil
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -108,8 +109,8 @@ _DOD_EVIDENCE_BLOCK = (
     "com o AC EXECUTADO e o NÚMERO real anexado ao corpo da PR/relatório. Scaffolding/harness "
     "escrito ≠ AC cumprido.\n"
     "   b) Teste `@pytest.mark.integration` que PULA (skip por falta de credencial/env) NÃO "
-    "satisfaz o AC — rode-o com a credencial disponível no pod (ex.: `ANTHROPIC_AUTH_TOKEN` / "
-    "`~/.claude/credentials.json`) ou marque o AC como NÃO-VERIFICADO no corpo da PR.\n"
+    "satisfaz o AC — rode-o com a credencial de LLM disponível no pod (a do worker que te "
+    "despachou) ou marque o AC como NÃO-VERIFICADO no corpo da PR.\n"
     "   c) AC duro que você NÃO conseguiu provar (bloqueado): NÃO feche a issue. Abra a PR como "
     "DRAFT (`{mark_draft_cmd}` após criar), use `Refs #{number}` (não `Closes`) no --body, "
     "registre a causa do bloqueio e escale ao autor (`{comment_issue_cmd}`). Nunca uma PR "
@@ -120,17 +121,21 @@ _DOD_EVIDENCE_BLOCK = (
 )
 
 
+_SPIKE_TAG_RE = re.compile(r"\[\s*spike\s*\]")
+
+
 def _is_spike(title: str, body: str) -> bool:
     """True when the issue's deliverable is empirical evidence, not production code.
 
     A spike's Definition-of-Done is measured ACs (numbers/verdict), so its PR must
     reference (``Refs``) — never auto-close (``Closes``) — the issue, and should
     stay draft until every AC is green. Detected by the conventional ``[SPIKE]``
-    title tag or a spike-style exit-condition section in the body (the headings the
-    architect/analyst personas emit for spike issues, e.g. issue #529's
-    "## Condição de Saída"). Conservative on purpose: a missed spike (defaults to
-    ``Closes``) is the dangerous direction, so we only require an explicit,
-    unambiguous signal.
+    title tag (whitespace-tolerant: ``[ spike ]`` also matches) or a spike-style
+    exit-condition section in the body (the headings the architect/analyst personas
+    emit for spike issues, e.g. issue #529's "## Condição de Saída"). Deliberately
+    conservative — it fires only on an explicit, unambiguous signal: a false-positive
+    ``Refs`` on a real feature would leave that issue open forever, so on any doubt we
+    keep the default ``Closes``.
 
     Detection reads the FULL untruncated body (so a marker past
     ``ISSUE_BODY_MAX_CHARS`` still classifies correctly, even if it won't appear in
@@ -140,7 +145,7 @@ def _is_spike(title: str, body: str) -> bool:
     """
     t = (title or "").lower()
     b = (body or "").lower()
-    if "[spike]" in t:
+    if _SPIKE_TAG_RE.search(t):
         return True
     return any(
         marker in b

--- a/deile/orchestration/pipeline/claude_dispatcher.py
+++ b/deile/orchestration/pipeline/claude_dispatcher.py
@@ -244,8 +244,8 @@ def render_implement_prompt(
     # lives in :mod:`deile.orchestration.pipeline.briefs` for the in-cluster
     # worker path — but it shares the same close-keyword safety so a spike run
     # locally never auto-closes a half-proven issue.
-    from deile.orchestration.pipeline.briefs import _is_spike
-    close_keyword = "Refs" if _is_spike(title, issue_body) else "Closes"
+    from deile.orchestration.pipeline.briefs import _close_keyword
+    close_keyword = _close_keyword(title, issue_body)
     return IMPLEMENT_PROMPT_TEMPLATE.format(
         repo=repo,
         number=number,

--- a/deile/orchestration/pipeline/claude_dispatcher.py
+++ b/deile/orchestration/pipeline/claude_dispatcher.py
@@ -166,7 +166,7 @@ IMPLEMENT_PROMPT_TEMPLATE = textwrap.dedent(
     - Faça commits pequenos e atômicos.
     - Adicione testes ANTES de finalizar; rode `pytest` e ajuste até 100% pass.
     - Push do branch e abra {pr_noun} via `{create_cmd}`. Use o título e corpo
-      coerentes com a issue. Adicione `Closes #{number}` no corpo.
+      coerentes com a issue. Adicione `{close_keyword} #{number}` no corpo.
     - Quando terminar, responda EXATAMENTE com a URL da {pr_noun} aberta numa única
       linha (ex: {pr_url_pattern}). Sem prosa adicional.
 
@@ -237,6 +237,15 @@ def render_implement_prompt(
     # snippet, which would over-specify and confuse the agent.
     from deile.orchestration.forge.base import ForgeKind
     create_cmd = "gh pr create" if cfg.kind is ForgeKind.GITHUB else "glab mr create"
+    # Spikes deliver measured evidence, not production code — their PR must
+    # ``Refs`` (never ``Closes``) the issue, mirroring the pipeline implement
+    # brief. This legacy local path (``ClaudeImplementer`` / ``claude -p`` on the
+    # host) does not carry the full Definition-of-Done evidence block — that
+    # lives in :mod:`deile.orchestration.pipeline.briefs` for the in-cluster
+    # worker path — but it shares the same close-keyword safety so a spike run
+    # locally never auto-closes a half-proven issue.
+    from deile.orchestration.pipeline.briefs import _is_spike
+    close_keyword = "Refs" if _is_spike(title, issue_body) else "Closes"
     return IMPLEMENT_PROMPT_TEMPLATE.format(
         repo=repo,
         number=number,
@@ -244,6 +253,7 @@ def render_implement_prompt(
         issue_body=issue_body.strip()[:ISSUE_BODY_MAX_CHARS],
         pr_noun=pr_noun,
         create_cmd=create_cmd,
+        close_keyword=close_keyword,
         pr_url_pattern=cmds["pr_url_pattern"],
     )
 

--- a/deile/tests/orchestration/forge/test_cli_renderer.py
+++ b/deile/tests/orchestration/forge/test_cli_renderer.py
@@ -19,6 +19,37 @@ def test_github_starts_with_gh(github_config):
     assert cmds["forge_name"] == "GitHub"
 
 
+def test_create_pr_cmd_defaults_to_closes(github_config):
+    """Default close_keyword keeps the legacy ``Closes #N`` (byte-for-byte)."""
+    cmds = render_brief_cmds(github_config, number=42, branch="auto/issue-42", main="main")
+    assert "Closes #42" in cmds["create_pr_cmd"]
+
+
+def test_create_pr_cmd_refs_when_spike_keyword(github_config):
+    """A spike passes ``close_keyword="Refs"`` so the PR never auto-closes the issue."""
+    cmds = render_brief_cmds(
+        github_config, number=42, branch="auto/issue-42", main="main",
+        close_keyword="Refs",
+    )
+    assert "Refs #42" in cmds["create_pr_cmd"]
+    assert "Closes #42" not in cmds["create_pr_cmd"]
+
+
+def test_github_mark_draft_cmd(github_config):
+    cmds = render_brief_cmds(github_config, number=42, branch="auto/issue-42", main="main")
+    assert cmds["mark_draft_cmd"] == "gh pr ready 42 --repo owner/repo --undo"
+
+
+def test_gitlab_close_keyword_and_draft(gitlab_config):
+    cmds = render_brief_cmds(
+        gitlab_config, number=7, branch="auto/issue-7", main="main", close_keyword="Refs",
+    )
+    assert "Refs #7" in cmds["create_pr_cmd"]
+    assert "Closes #7" not in cmds["create_pr_cmd"]
+    assert cmds["mark_draft_cmd"].startswith("glab mr update 7")
+    assert "--draft" in cmds["mark_draft_cmd"]
+
+
 def test_gitlab_starts_with_glab(gitlab_config):
     cmds = render_brief_cmds(gitlab_config, number=7, branch="auto/issue-7", main="main")
     assert cmds["clone_cmd"].startswith("glab ")

--- a/deile/tests/orchestration/forge/test_cli_renderer.py
+++ b/deile/tests/orchestration/forge/test_cli_renderer.py
@@ -36,8 +36,10 @@ def test_create_pr_cmd_refs_when_spike_keyword(github_config):
 
 
 def test_github_mark_draft_cmd(github_config):
+    # Keyed by branch (not issue/PR number): the implement flow creates the PR
+    # fresh, so only the head branch is known when marking it draft.
     cmds = render_brief_cmds(github_config, number=42, branch="auto/issue-42", main="main")
-    assert cmds["mark_draft_cmd"] == "gh pr ready 42 --repo owner/repo --undo"
+    assert cmds["mark_draft_cmd"] == "gh pr ready auto/issue-42 --repo owner/repo --undo"
 
 
 def test_gitlab_close_keyword_and_draft(gitlab_config):
@@ -46,7 +48,8 @@ def test_gitlab_close_keyword_and_draft(gitlab_config):
     )
     assert "Refs #7" in cmds["create_pr_cmd"]
     assert "Closes #7" not in cmds["create_pr_cmd"]
-    assert cmds["mark_draft_cmd"].startswith("glab mr update 7")
+    # Branch-keyed (the MR iid is unknown when the implement DoD block toggles draft).
+    assert cmds["mark_draft_cmd"].startswith("glab mr update auto/issue-7")
     assert "--draft" in cmds["mark_draft_cmd"]
 
 

--- a/deile/tests/orchestration/pipeline/test_briefs.py
+++ b/deile/tests/orchestration/pipeline/test_briefs.py
@@ -118,6 +118,30 @@ class TestImplementBriefDefinitionOfDone:
         assert not _is_spike("[FEATURE] foo", "implementa um botão")
         assert not _is_spike("Add spike-resistant retry", "feature normal")  # 'spike' solto no título não conta
 
+    def test_gitlab_forge_dod_and_spike_refs(self):
+        """Cobertura GitLab do gate: o brief renderiza comandos `glab` e o
+        spike usa `Refs` no `glab mr create` + o draft cmd no dod_block."""
+        from deile.orchestration.forge.base import ForgeConfig, ForgeKind
+
+        gl = ForgeConfig(
+            kind=ForgeKind.GITLAB, host="gitlab.com",
+            project_path="group/project", cli_path="/usr/bin/glab",
+        )
+        # Issue normal (GitLab) → `Closes` + comando glab.
+        normal = _render_worker_implement_brief(
+            "group/project", "main", "auto/issue-3", 3, "Add botão", "faça", forge=gl,
+        )
+        assert "DEFINIÇÃO DE PRONTO" in normal
+        assert "glab mr create" in normal
+        assert '. Closes #3."' in normal
+        # Spike (GitLab) → `Refs`, nunca `Closes`, e o draft cmd glab no dod_block.
+        spike = _render_worker_implement_brief(
+            "group/project", "main", "auto/issue-8", 8, "[SPIKE] Provar Z", "spike", forge=gl,
+        )
+        assert '. Refs #8."' in spike
+        assert '. Closes #8."' not in spike
+        assert "glab mr update auto/issue-8" in spike  # mark_draft_cmd embutido no dod_block
+
 
 class TestUnifiedPrBrief:
     """Após o refactor "PR é o quadro", os 3 briefs antigos

--- a/deile/tests/orchestration/pipeline/test_briefs.py
+++ b/deile/tests/orchestration/pipeline/test_briefs.py
@@ -110,13 +110,30 @@ class TestImplementBriefDefinitionOfDone:
         assert '. Refs #5."' in out
         assert '. Closes #5."' not in out
 
+    def test_spike_resume_brief_create_pr_uses_refs(self):
+        # O mesmo invariante de spike vale no brief de resume (briefs.py).
+        out = _render_worker_implement_resume_brief(
+            "o/r", "main", "b", 13, "[SPIKE] Provar Z", "retoma o spike"
+        )
+        assert '. Refs #13."' in out
+        assert '. Closes #13."' not in out
+
+    def test_normal_resume_brief_create_pr_uses_closes(self):
+        out = _render_worker_implement_resume_brief(
+            "o/r", "main", "b", 14, "Add widget", "retoma"
+        )
+        assert '. Closes #14."' in out
+        assert '. Refs #14."' not in out
+
     def test_is_spike_detection(self):
         assert _is_spike("[SPIKE] foo", "")
         assert _is_spike("[spike] foo", "")  # case-insensitive
+        assert _is_spike("[ spike ] foo", "")  # whitespace-tolerant
         assert _is_spike("foo", "## Condição de Saída\n...")
         assert _is_spike("foo", "Critérios de Aprovação do Spike: ...")
         assert not _is_spike("[FEATURE] foo", "implementa um botão")
         assert not _is_spike("Add spike-resistant retry", "feature normal")  # 'spike' solto no título não conta
+        assert not _is_spike(None, None)  # None-safe
 
     def test_gitlab_forge_dod_and_spike_refs(self):
         """Cobertura GitLab do gate: o brief renderiza comandos `glab` e o

--- a/deile/tests/orchestration/pipeline/test_briefs.py
+++ b/deile/tests/orchestration/pipeline/test_briefs.py
@@ -8,7 +8,7 @@ module against future drift after the SRP extraction out of implementer.py.
 from __future__ import annotations
 
 from deile.orchestration.pipeline.briefs import (
-    _classify_mention_action, _render_claude_mention_prompt,
+    _classify_mention_action, _is_spike, _render_claude_mention_prompt,
     _render_trigger_details, _render_worker_implement_brief,
     _render_worker_implement_resume_brief, _render_worker_mention_brief,
     _render_worker_pr_address_brief, _render_worker_pr_unified_brief,
@@ -69,6 +69,54 @@ class TestWorkerImplementBrief:
         out = _render_worker_implement_brief("o/r", "main", "b", 1, "T", body)
         assert "x" * ISSUE_BODY_MAX_CHARS in out
         assert "x" * (ISSUE_BODY_MAX_CHARS + 1) not in out
+
+
+class TestImplementBriefDefinitionOfDone:
+    """Brief de implement carrega o gate de Definição-de-Pronto (causa-raiz da
+    PR#605: spike fechou-pela-metade porque "PR existe + testes impactados verdes"
+    contava como pronto, e ``Closes`` era automático).
+    """
+
+    def test_dod_block_present(self):
+        out = _render_worker_implement_brief("o/r", "main", "b", 1, "T", "body")
+        assert "DEFINIÇÃO DE PRONTO" in out
+        assert "NÃO-VERIFICADO" in out
+        # skip de teste de integração não satisfaz AC
+        assert "PULA" in out
+        assert "@pytest.mark.integration" in out
+
+    def test_resume_brief_also_has_dod_block(self):
+        out = _render_worker_implement_resume_brief("o/r", "main", "b", 1, "T", "body")
+        assert "DEFINIÇÃO DE PRONTO" in out
+
+    def test_normal_issue_create_pr_uses_closes(self):
+        # Asserta no comando de criar PR (o DoD menciona "Refs" como fallback no texto).
+        out = _render_worker_implement_brief("o/r", "main", "b", 1, "Add widget", "do it")
+        assert '. Closes #1."' in out
+        assert '. Refs #1."' not in out
+
+    def test_spike_title_create_pr_uses_refs(self):
+        out = _render_worker_implement_brief(
+            "o/r", "main", "b", 99, "[SPIKE] Provar X", "faça o spike"
+        )
+        assert '. Refs #99."' in out
+        assert '. Closes #99."' not in out
+
+    def test_spike_exit_condition_body_create_pr_uses_refs(self):
+        out = _render_worker_implement_brief(
+            "o/r", "main", "b", 5, "Investigar Y",
+            "blah\n## Condição de Saída\nACs verdes com números",
+        )
+        assert '. Refs #5."' in out
+        assert '. Closes #5."' not in out
+
+    def test_is_spike_detection(self):
+        assert _is_spike("[SPIKE] foo", "")
+        assert _is_spike("[spike] foo", "")  # case-insensitive
+        assert _is_spike("foo", "## Condição de Saída\n...")
+        assert _is_spike("foo", "Critérios de Aprovação do Spike: ...")
+        assert not _is_spike("[FEATURE] foo", "implementa um botão")
+        assert not _is_spike("Add spike-resistant retry", "feature normal")  # 'spike' solto no título não conta
 
 
 class TestUnifiedPrBrief:

--- a/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
+++ b/deile/tests/orchestration/pipeline/test_claude_dispatcher.py
@@ -81,6 +81,18 @@ class TestPrompts:
         # The '@' marker isolates the body: the template contains none.
         assert prompt.count("@") == 5000
 
+    def test_implement_prompt_normal_issue_uses_closes(self):
+        prompt = render_implement_prompt("foo/bar", 42, "Add widget", "do it")
+        assert "Closes #42" in prompt
+        assert "Refs #42" not in prompt
+
+    def test_implement_prompt_spike_uses_refs(self):
+        # Legacy local path mirrors the pipeline brief: a spike references,
+        # never auto-closes, its issue.
+        prompt = render_implement_prompt("foo/bar", 7, "[SPIKE] Provar X", "spike body")
+        assert "Refs #7" in prompt
+        assert "Closes #7" not in prompt
+
     def test_review_prompt_includes_repo_and_number(self):
         prompt = render_review_prompt("foo/bar", 17, "PR title")
         assert "foo/bar" in prompt


### PR DESCRIPTION
## Causa-raiz (PR#605 / spike #529 fechando issue pela metade)

Um worker abriu uma PR que **fecha a issue** (`Closes #529`) sem ter executado nenhum AC duro: 1675 linhas de harness em `infra/k8s/spikes/`, `SPIKE_529_REPORT.md` com checklists **vazios**, e testes `@pytest.mark.integration` que **pulam sem `ANTHROPIC_AUTH_TOKEN`** (skip conta como verde). A issue #529 é impecável — o furo é a montante:

1. **`[SPIKE]` tratado como `feature` genérica** — sem caminho ciente de spike.
2. **Definição de Pronto do implement = "existe PR"** (`briefs.py` `_WORKER_IMPLEMENT_BRIEF`): nunca lia os ACs / "Condição de Saída".
3. **Skip = verde** — o gate "testes passam" é satisfeito sem rodar o experimento.
4. **`Closes #N` automático** (`cli_renderer.py:96`/`:172`) — toda PR de implement fia o fechamento da issue, mediu-se ou não.

## Correções (A/B/C)

- **A — Definição de Pronto (evidência):** novo `_DOD_EVIDENCE_BLOCK` injetado como `{dod_block}` nos briefs de implement e implement-resume. Confronta entrega vs ACs; AC empírico (HTTP 200, custo %, p95, trigger %) só está pronto com número real anexado; AC bloqueado → PR em **draft** + `Refs` + escala ao autor.
- **B — Skip ≠ cumprido:** o bloco instrui rodar `@integration` com a credencial do pod (`ANTHROPIC_AUTH_TOKEN`/`~/.claude/credentials.json`) ou marcar o AC como **NÃO-VERIFICADO** — skip não satisfaz AC.
- **C — `Closes` condicional:** `render_brief_cmds(..., close_keyword="Closes")`; spikes (`[SPIKE]` no título ou "Condição de Saída"/"Critérios de Aprovação do Spike" no corpo, via `_is_spike`) rendem `create_pr_cmd` com **`Refs`** — referencia, nunca fecha. Novo `mark_draft_cmd` por forge (GH `gh pr ready --undo`, GL `glab mr update --draft`).

## Testes
- `TestImplementBriefDefinitionOfDone` (DoD presente nos 2 briefs; normal→`Closes`, spike-título e spike-condição-de-saída→`Refs`; `_is_spike` conservador).
- `test_cli_renderer`: default `Closes`, `close_keyword="Refs"`, `mark_draft_cmd` GH+GL.
- Suíte completa: **7684 passed**, 1 falha **pré-existente** (`test_pod_presence::test_cleanup_stale_workspaces_removes_dead_pod_workspace`, confirmada no baseline `main` — sem relação com este diff).

## Escopo / não-objetivos
- Não altera o claude-worker nem o caminho SDK. Só endurece os briefs + renderer.
- Não deployar até revisão. PR#605 (#529) segue **segura em draft** até os ACs serem provados.

Refs #529
