### PR TITLE
[FEATURE] homolog opencode-worker: criar docs/homolog/opencode.md

### DIFF
--- a/docs/homolog/opencode.md
+++ b/docs/homolog/opencode.md
@@ -1,0 +1,3 @@
+# Homologação opencode-worker — OK
+
+Gerado pelo opencode-worker via pipeline (homologação E2E do PR #614).


### PR DESCRIPTION
Criação do arquivo `docs/homolog/opencode.md` com conteúdo de homologação E2E do opencode-worker.

Closes #615.