### PR TITLE
feat(homolog): homolog opencode round 2 — validar fix de double-dispatch

### DIFF
--- a/docs/homolog/opencode-roundtrip.md
+++ b/docs/homolog/opencode-roundtrip.md
@@ -1,0 +1,5 @@
+# Homologação opencode-worker — round 2 (anti-double-dispatch)
+
+Gerado pelo opencode-worker via pipeline. Valida que o fix de liveness
+(resume-info), reconcile-antes-de-resume e guard de PR garantem um único
+dispatch por issue (sem execução redundância).


### PR DESCRIPTION
Homologação E2E (PR #614, round 2). Valida que o fix de double-dispatch (commit e1979449) garante um único dispatch por issue.

Closes #617.