### PR TITLE
docs: frota multi-CLI (implementada)

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,3 +782,7 @@ Projeto licenciado sob [**MIT License**](LICENSE).
 ---
 
 **DEILE 5.1.0** — `python3 deile.py`
+
+## Frota Multi-CLI (implementada)
+
+A frota multi-CLI **já está implementada e em produção na `main`**: cinco workers CLI (aider, goose, opencode, codex, qwen) executam as cinco etapas do pipeline. Resumo do que entregamos: o subpacote `infra/k8s/cli_adapters/`, o servidor genérico `infra/k8s/cli_worker_server.py`, o roteamento per-stage e a auth dual-mode do codex — tudo ativo na branch principal.


### PR DESCRIPTION
Adiciona ao README uma seção afirmando que a frota multi-CLI **já está implementada e em produção na main**, com resumo. Teste de homologação do pr_review: a afirmação deve ser confrontada com o código real da main.