### PR TITLE
docs: auto-merge do pipeline por aprovações

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,3 +782,5 @@ Projeto licenciado sob [**MIT License**](LICENSE).
 ---
 
 **DEILE 5.1.0** — `python3 deile.py`
+
+> Quando uma PR recebe **2 aprovações** de revisores distintos, o pipeline a **mergeia automaticamente**, sem intervenção manual.


### PR DESCRIPTION
Documenta no README o comportamento de auto-merge do pipeline quando uma PR acumula aprovações de revisores.