### PR TITLE
fix(pipeline): align 3 stale tests with reaper extension (#427)

### DIFF
--- a/deile/tests/orchestration/pipeline/test_classify.py
+++ b/deile/tests/orchestration/pipeline/test_classify.py
@@ -45,8 +45,12 @@ def _make_monitor(*, unclassified: list | None = None) -> tuple[PipelineMonitor,
         # cada tick chama ``list_open_prs + list_issues_with_label`` no
         # forge mock, poluindo call_order rastreado por testes legacy
         # (test_tick_calls_classify_before_review). Tests do reaper
-        # ligam explicitamente.
+        # ligam explicitamente. O reaper só fica inativo quando AMBOS os
+        # TTLs são 0 (guard em tick(): stale > 0 OR arch_hard > 0 — issue
+        # #427); o ramo sem-ledger de arch_hard varre em_refinamento/
+        # em_arquitetura via list_issues_with_label e também poluiria a ordem.
         reaper_stale_seconds=0,
+        reaper_arch_hard_seconds=0,
     )
     github = MagicMock()
     github.ensure_pipeline_labels = AsyncMock()

--- a/deile/tests/orchestration/pipeline/test_gap_regressions.py
+++ b/deile/tests/orchestration/pipeline/test_gap_regressions.py
@@ -70,8 +70,13 @@ def _make_monitor(
         use_pid_lock=False,
         # Reaper desligado em test default — adiciona round-trips ao
         # forge mock que poluem call_order/error counters legacy.
-        # Tests do reaper ligam explicitamente.
+        # Tests do reaper ligam explicitamente. O reaper só fica inativo
+        # quando AMBOS os TTLs são 0 (guard em tick(): stale > 0 OR
+        # arch_hard > 0 — issue #427); o ramo sem-ledger de arch_hard varre
+        # em_refinamento/em_arquitetura via list_issues_with_label e
+        # incrementaria gh_errors extras quando o forge mock falha.
         reaper_stale_seconds=0,
+        reaper_arch_hard_seconds=0,
     )
     github = MagicMock()
     github.ensure_pipeline_labels = AsyncMock()

--- a/deile/tests/orchestration/pipeline/test_reconcile_fire_and_forget.py
+++ b/deile/tests/orchestration/pipeline/test_reconcile_fire_and_forget.py
@@ -510,20 +510,28 @@ class TestReaperRefineExtended:
         assert ledger.get(DispatchLedger.key_for_issue(50)) is None
 
     async def test_does_not_reap_refine_resting_without_ledger(self):
+        """Reinterpretado pela issue #427 (commit d19ff4db): SEM ledger entry
+        deixou de significar "imune ao reaper" — o ramo sem-ledger reapa
+        ``em_arquitetura``/``em_refinamento`` zumbi após ``reaper_arch_hard_seconds``
+        (2h default). O invariante que continua valendo é o DESCANSO entre passes:
+        uma issue sem dispatch em voo, ainda dentro do hard-TTL, NÃO é tocada.
+        """
         import time
 
         from deile.orchestration.pipeline.stages import reap_orphan_claims
         client = _Client()
         own = "~by:default"
-        # Issue em em_arquitetura há muito tempo, SEM ledger entry (descanso).
+        # Issue em em_arquitetura em descanso (sem ledger entry, dentro do hard-TTL).
         issue = _issue(51, "feature", WORKFLOW_ARCHITECTURE, own)
         monitor, github, _ = _make(
             client, label_map={WORKFLOW_ARCHITECTURE: [issue]},
         )
         monitor.config.reaper_stale_seconds = 60
-        github.label_applied_at = AsyncMock(return_value=int(time.time()) - 9999)
+        monitor.config.reaper_arch_hard_seconds = 7200
+        # Aplicada há 60s — muito abaixo do hard-TTL de 7200s (descanso real).
+        github.label_applied_at = AsyncMock(return_value=int(time.time()) - 60)
         await reap_orphan_claims(monitor)
-        # NÃO reapou (sem ledger entry = descanso entre passes).
+        # NÃO reapou (descanso entre passes dentro do hard-TTL).
         added = [
             lb for c in github.add_labels.await_args_list
             if c.args[1] == 51 for lb in c.args[2]


### PR DESCRIPTION
## O que estava errado

Os 3 testes apontados pela issue falhavam em `origin/main`, mas **não eram regressão da #614 nem poluição de ordenação** — falham byte-a-byte iguais aos asserts da issue mesmo em isolamento (`-p no:randomly`). A causa real é que estavam **defasados (stale)** em relação à extensão **deliberada** do reaper introduzida pelo commit `d19ff4db` (issue #427):

- O reaper passou a reapar issues em `em_arquitetura`/`em_refinamento` **sem ledger entry** quando ultrapassam o hard-TTL `reaper_arch_hard_seconds` (2h por default) — distinguindo "descanso entre passes" (dentro do TTL) de "zumbi real" (além do TTL).
- O guard de ativação do reaper no `tick()` virou `reaper_stale_seconds > 0 OR reaper_arch_hard_seconds > 0`. Logo, zerar apenas `reaper_stale_seconds` **não desliga mais o reaper**.

Esse comportamento tem cobertura própria e abrangente em `test_reaper.py` (6 casos novos no mesmo commit), confirmando que a mudança de produto foi intencional. Nenhum código de produto foi alterado nesta PR.

## O que foi feito (teste a teste)

| Teste | Decisão | Por quê |
|---|---|---|
| `test_reconcile_fire_and_forget.py::...test_does_not_reap_refine_resting_without_ledger` | **Atualizar teste** | O asserto antigo presumia "sem ledger = imune ao reaper". Pós-#427 o invariante correto é o **descanso dentro do hard-TTL**. Ajustei a idade do label de 9999s para 60s (bem abaixo dos 7200s) e fixei `reaper_arch_hard_seconds=7200`. O teste continua verificando `WORKFLOW_NEW not in added` — agora sob condições em que isso é genuinamente verdadeiro (descanso real). A reapagem do zumbi já tem cobertura no irmão `test_reaps_refine_only_with_ledger_entry` e em `test_reaper.py`. |
| `test_classify.py::...test_tick_calls_classify_before_review` | **Atualizar fixture** | A fixture `_make_monitor` desligava o reaper zerando só `reaper_stale_seconds`. Com o guard do #427 o reaper seguia ativo pelo TTL de arquitetura, varrendo `em_refinamento`/`em_arquitetura` via `list_issues_with_label` **antes** do classify e poluindo o `call_order`. A fixture agora também zera `reaper_arch_hard_seconds`, restaurando a intenção já documentada no comentário ("reaper desligado por default"). O asserto `classify < review` permanece intacto. |
| `test_gap_regressions.py::...test_gh_error_in_review_increments_gh_errors` | **Atualizar fixture** | Mesma raiz: o reaper ativo pelo TTL de arquitetura chamava `list_issues_with_label` para 2 labels extras, cada uma incrementando `gh_errors` (daí `5` em vez de `1`). A fixture agora zera `reaper_arch_hard_seconds`. O asserto `gh_errors == 1` permanece intacto. |

Nenhuma asserção foi enfraquecida (sem `assert True`); todas seguem verificando o comportamento correto e atual.

## Evidência

- 3 testes alvo verdes em isolamento (`-p no:randomly`).
- Diretório de pipeline completo verde: **`1410 passed, 2 skipped`**.
- **Determinismo multi-seed** (`deile/tests/orchestration/pipeline/`), idêntico nas seeds 0/1/2/42:
  ```
  === seed 0 ===  1410 passed, 2 skipped in 40.90s
  === seed 1 ===  1410 passed, 2 skipped in 41.10s
  === seed 2 ===  1410 passed, 2 skipped in 41.05s
  === seed 42 === 1410 passed, 2 skipped in 40.64s
  ```
- Suíte completa com gate de cobertura (`python3 -m pytest deile/tests/ -q`): **`1 failed, 8213 passed, 31 skipped`**. A única falha (`test_pod_presence.py::test_cleanup_stale_workspaces_removes_dead_pod_workspace`) é **pré-existente em `origin/main`** — provei rodando-a num worktree limpo destacado em `origin/main` (falha idêntica, `assert 0 == 1`), está em `infrastructure/` e é totalmente independente do pipeline e do escopo da #640.
- `ruff check` limpo nos 3 arquivos tocados.

Closes #640