### PR TITLE
feat(worker): hardening V1 do deile-worker — graceful shutdown, métricas, retry, circuit breaker, idempotência, rate limit, schema (#620)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -88,6 +88,8 @@ infra/
 !infra/k8s/wrapper.py
 !infra/k8s/claude_worker_server.py
 !infra/k8s/worker_server.py
+!infra/k8s/worker_metrics.py
+!infra/k8s/worker_rate_limit.py
 !infra/k8s/_worker_resume.py
 !infra/k8s/pipeline_status_server.py
 !infra/k8s/dispatch_logger.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -231,6 +231,15 @@ RUN chmod 0555 /app/claude_worker_server.py
 COPY --chown=deile:deile infra/k8s/worker_server.py /app/worker_server.py
 RUN chmod 0555 /app/worker_server.py
 
+# Worker hardening helpers (issue #620). Imported by worker_server.py via bare
+# name (``import worker_metrics``, ``from worker_rate_limit import ...``), so
+# both MUST sit in /app next to worker_server.py — otherwise the deile-worker
+# pod crashes on import at startup (ModuleNotFoundError). Each needs a matching
+# `!infra/k8s/worker_*.py` exception in .dockerignore.
+COPY --chown=deile:deile infra/k8s/worker_metrics.py /app/worker_metrics.py
+COPY --chown=deile:deile infra/k8s/worker_rate_limit.py /app/worker_rate_limit.py
+RUN chmod 0555 /app/worker_metrics.py /app/worker_rate_limit.py
+
 # Pure-logic helper imported by worker_server.py (``import _worker_resume``):
 # resume fingerprint / journal / end-detection (issue #254). It MUST sit in
 # /app next to worker_server.py or the worker crashes on import at startup.

--- a/deile/core/schemas/__init__.py
+++ b/deile/core/schemas/__init__.py
@@ -1,0 +1,17 @@
+"""JSON Schema documents for the worker dispatch contract (issue #620).
+
+The result schema is versioned (``schema_version``) so future format changes
+can be migrated retroactively. :data:`RESULT_SCHEMA_VERSION` is the single
+source of truth for the current version — both the writer
+(``worker_server._run_task``) and any reader import it from here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Current version of the dispatch result document (issue #620 AC9).
+RESULT_SCHEMA_VERSION: int = 1
+
+#: Absolute path to the JSON Schema describing the result document.
+RESULT_SCHEMA_PATH: Path = Path(__file__).resolve().parent / "result_v1.json"

--- a/deile/core/schemas/result_v1.json
+++ b/deile/core/schemas/result_v1.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deile.dev/schemas/result_v1.json",
+  "title": "deile-worker dispatch result (v1)",
+  "description": "JSON written by worker_server._run_task to WORK_ROOT/.results/<task_id>.json and returned by POST /v1/dispatch and GET /v1/result/{task_id}. schema_version pins the contract so future readers can migrate retroactively (issue #620 AC9).",
+  "type": "object",
+  "required": ["schema_version", "task_id", "ok", "elapsed_s"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Contract version of this result document. A reader that finds a missing or different version serves the payload with a warning (forward compat)."
+    },
+    "task_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{12}$",
+      "description": "12-char hex id minted by the worker (uuid4().hex[:12])."
+    },
+    "ok": {
+      "type": ["boolean", "null"],
+      "description": "Terminal outcome: true=success, false=failure, null=still running (in-memory transient state only)."
+    },
+    "elapsed_s": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Wall-clock seconds the dispatch ran."
+    },
+    "brief": {
+      "type": "string",
+      "description": "The user brief that was dispatched."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Final agent output (success) or error description (failure)."
+    },
+    "files": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Workspace files present at the end of the dispatch (capped)."
+    },
+    "channel_id": {
+      "type": "string",
+      "description": "Discord channel id or synthetic pipeline/CLI id."
+    },
+    "workdir": {
+      "type": "string",
+      "description": "Absolute path of the per-channel workspace used."
+    },
+    "status_message_id": {
+      "type": ["string", "null"],
+      "description": "Discord message id of the live status message, or null."
+    },
+    "finished_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp when the result was persisted."
+    },
+    "error": {
+      "type": "string",
+      "description": "Terminal error string, present only on failure paths."
+    },
+    "resume": {
+      "type": "object",
+      "description": "Structured resume result (issue #254), present only on pipeline dispatches.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/deile/infrastructure/circuit_breaker.py
+++ b/deile/infrastructure/circuit_breaker.py
@@ -1,0 +1,117 @@
+"""Circuit breaker in-memory (3-state) para o cliente do deile-worker.
+
+Protege o caller de martelar um worker degradado: depois de
+``failure_threshold`` falhas consecutivas o circuito ABRE e rejeita os
+dispatches seguintes sem tocar a rede (``CIRCUIT_OPEN``). Após
+``reset_timeout_s`` segundos passa para HALF-OPEN e deixa UM probe passar;
+sucesso fecha o circuito, falha o reabre (issue #620 AC5).
+
+Estados (transições):
+
+    closed  --(N falhas consecutivas)-->  open
+    open    --(passados reset_timeout_s)-->  half-open  (apenas no probe)
+    half-open --(probe OK)-->  closed
+    half-open --(probe falha)-->  open
+
+Limitação V1 (documentada na issue): o estado vive em memória — reinicia
+como ``closed`` após restart do processo. Aceitável como proteção de
+curto prazo; CB persistente (cross-restart) fica para #621.
+
+A instância é compartilhada por todos os dispatches do processo, então o
+estado é protegido por um :class:`asyncio.Lock`. ``time_source`` é
+injetável para testar a janela de reset com fake clock sem ``sleep`` real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from enum import IntEnum
+from typing import Callable
+
+
+class CircuitState(IntEnum):
+    """Estados do breaker. Os valores inteiros são os expostos na métrica
+    Prometheus ``deile_worker_circuit_breaker_state`` (0/1/2)."""
+
+    CLOSED = 0
+    OPEN = 1
+    HALF_OPEN = 2
+
+
+class CircuitBreaker:
+    """Breaker 3-state thread-safe (event-loop-safe via ``asyncio.Lock``).
+
+    Args:
+        failure_threshold: falhas consecutivas que abrem o circuito (default 5).
+        reset_timeout_s: segundos em OPEN antes de permitir o probe HALF-OPEN.
+        time_source: fonte monotônica injetável (default ``time.monotonic``).
+    """
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int = 5,
+        reset_timeout_s: float = 30.0,
+        time_source: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if failure_threshold < 1:
+            raise ValueError("failure_threshold must be >= 1")
+        self._failure_threshold = failure_threshold
+        self._reset_timeout_s = reset_timeout_s
+        self._now = time_source
+        self._state = CircuitState.CLOSED
+        self._consecutive_failures = 0
+        self._opened_at = 0.0
+        self._lock = asyncio.Lock()
+
+    @property
+    def state(self) -> CircuitState:
+        """Estado corrente — leitura sem lock (eventualmente consistente),
+        usada apenas para a métrica gauge."""
+        return self._state
+
+    def reset(self) -> None:
+        """Volta ao estado inicial CLOSED. Síncrono — só para uso em
+        testes/bootstrap, fora de um dispatch ativo."""
+        self._state = CircuitState.CLOSED
+        self._consecutive_failures = 0
+        self._opened_at = 0.0
+
+    async def allow(self) -> bool:
+        """Decide se o próximo dispatch pode prosseguir.
+
+        Retorna ``True`` quando CLOSED, quando o probe HALF-OPEN é liberado
+        (a janela de reset expirou) ou quando já estamos HALF-OPEN aguardando
+        o resultado do probe. Retorna ``False`` enquanto OPEN dentro da
+        janela — o caller deve falhar com ``CIRCUIT_OPEN`` sem I/O.
+        """
+        async with self._lock:
+            if self._state is CircuitState.OPEN:
+                if (self._now() - self._opened_at) >= self._reset_timeout_s:
+                    self._state = CircuitState.HALF_OPEN
+                    return True
+                return False
+            return True
+
+    async def record_success(self) -> None:
+        """Sucesso: zera o contador e fecha o circuito (inclui o probe)."""
+        async with self._lock:
+            self._consecutive_failures = 0
+            self._state = CircuitState.CLOSED
+
+    async def record_failure(self) -> None:
+        """Falha: incrementa o contador; abre ao atingir o threshold.
+
+        Uma falha em HALF-OPEN (probe) reabre imediatamente, independente do
+        contador — o worker continua degradado.
+        """
+        async with self._lock:
+            if self._state is CircuitState.HALF_OPEN:
+                self._state = CircuitState.OPEN
+                self._opened_at = self._now()
+                return
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= self._failure_threshold:
+                self._state = CircuitState.OPEN
+                self._opened_at = self._now()

--- a/deile/infrastructure/deile_worker_client.py
+++ b/deile/infrastructure/deile_worker_client.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 import logging
 import os
+import random
 import re
 import uuid
 from typing import Any, Dict, List, Literal, Optional
@@ -28,6 +29,7 @@ from pydantic import (BaseModel, Field, ValidationError, ValidationInfo,
                       field_validator)
 
 from deile.core.exceptions import DEILEError
+from deile.infrastructure.circuit_breaker import CircuitBreaker
 from deile.orchestration.pipeline.dispatch_resolver import PIPELINE_STAGES
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,47 @@ _NOWAIT_TIMEOUT_S: float = 30.0
 # ``asyncio.wait_for`` no nível do tick (``WorkerImplementer._dispatch``).
 _CONNECT_TIMEOUT_S: float = 30.0
 _POOL_TIMEOUT_S: float = 30.0
+
+# Retry com exponential backoff (issue #620 AC4). Só re-tentamos falhas
+# TRANSIENTES (timeout/inalcançável/5xx) — 4xx (incl. 409/429) refletem o
+# pedido em si e nunca são re-tentados. ``_RETRY_MAX_ATTEMPTS`` é o teto
+# absoluto; ``DispatchPayload.max_retries`` (quando presente) o reduz ainda
+# mais. Backoff entre as tentativas k=0,1,...: ``base * factor^k ± jitter``.
+_RETRY_MAX_ATTEMPTS: int = 3
+_RETRY_BASE_S: float = 1.0
+_RETRY_FACTOR: float = 2.0
+_RETRY_JITTER_S: float = 0.3
+#: error_codes que indicam falha transitória e portanto re-tentável.
+_RETRYABLE_ERROR_CODES: frozenset = frozenset(
+    {"WORKER_TIMEOUT", "WORKER_UNREACHABLE", "WORKER_SERVER_ERROR"}
+)
+
+# Circuit breaker compartilhado pelo processo (issue #620 AC5): threshold de
+# 5 falhas consecutivas abre o circuito; reset de 30s leva ao probe half-open.
+# Instância única por processo — o estado de saúde do worker é global, não
+# por-dispatch. Exposto via ``circuit_breaker_state()`` para a métrica gauge.
+_CIRCUIT_FAILURE_THRESHOLD: int = 5
+_CIRCUIT_RESET_TIMEOUT_S: float = 30.0
+_CIRCUIT_BREAKER = CircuitBreaker(
+    failure_threshold=_CIRCUIT_FAILURE_THRESHOLD,
+    reset_timeout_s=_CIRCUIT_RESET_TIMEOUT_S,
+)
+
+
+def circuit_breaker_state() -> int:
+    """Estado corrente do circuit breaker como inteiro (0=closed, 1=open,
+    2=half-open) — espelha o gauge ``deile_worker_circuit_breaker_state``."""
+    return int(_CIRCUIT_BREAKER.state)
+
+
+def reset_circuit_breaker() -> None:
+    """Reseta o circuit breaker do processo para CLOSED.
+
+    Destinado a testes (o breaker é um singleton de processo, então estado
+    de um teste vazaria para o seguinte) e a bootstrap. Nunca chamado no
+    caminho de dispatch.
+    """
+    _CIRCUIT_BREAKER.reset()
 
 _DISPATCH_PATH = "/v1/dispatch"
 _PROGRESS_PATH = "/v1/progress/{task_id}"
@@ -103,7 +146,25 @@ class WorkerDispatchError(DEILEError):
 
     Carrega o ``error_code`` que a tool repassa no ``ToolResult``,
     preservando os códigos de erro originais do ``dispatch_deile_task``.
+
+    ``http_status`` (quando a falha veio de uma resposta HTTP) carrega o
+    status code para a lógica de retry classificar 5xx (transitório,
+    re-tentável) vs 4xx (definitivo, sem retry) — issue #620 AC4.
     """
+
+    def __init__(self, *args, http_status: Optional[int] = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.http_status = http_status
+
+    def is_retryable(self) -> bool:
+        """True se a falha é transitória: timeout, inalcançável ou HTTP 5xx.
+
+        4xx (incl. 409 duplicate, 429 rate-limit) NUNCA é re-tentável — o
+        erro está no pedido/estado, não no transporte (issue #620 AC4).
+        """
+        if self.http_status is not None:
+            return self.http_status >= 500
+        return self.error_code in _RETRYABLE_ERROR_CODES
 
 
 class DispatchPayload(BaseModel):
@@ -566,10 +627,20 @@ class DeileWorkerClient:
     ) -> Dict[str, Any]:
         """POST a dispatch payload to the worker and return its parsed JSON body.
 
+        Wraps :meth:`_dispatch_once` with the process-wide circuit breaker
+        (issue #620 AC5) and exponential-backoff retry (AC4):
+
+        - **Circuit breaker**: when 5 consecutive dispatches fail the circuit
+          opens and the next dispatch fails fast with ``CIRCUIT_OPEN`` (no
+          I/O); after 30s a single half-open probe is allowed.
+        - **Retry**: only transient failures (``WORKER_TIMEOUT`` /
+          ``WORKER_UNREACHABLE`` / HTTP >= 500) are retried, up to
+          :data:`_RETRY_MAX_ATTEMPTS` total attempts, capped further by the
+          payload's ``max_retries`` ceiling. 4xx (incl. 409/429) is never
+          retried — the request itself is the problem.
+
         Raises :class:`WorkerDispatchError` — carrying an ``error_code`` — for
-        every failure mode: missing/malformed credentials, missing ``httpx``,
-        transport timeout/unreachable, non-JSON body, or an HTTP >= 400
-        response.
+        every failure mode.
 
         Args:
             payload: dispatch body (validated against :class:`DispatchPayload`).
@@ -598,6 +669,76 @@ class DeileWorkerClient:
         validated = validate_dispatch_payload(payload)
         body = validated.model_dump(exclude_none=True)
 
+        # Circuit breaker gate (AC5): when OPEN inside the reset window we
+        # fail fast without touching the network. ``allow`` flips OPEN →
+        # HALF-OPEN once the window elapses, letting a single probe through.
+        if not await _CIRCUIT_BREAKER.allow():
+            raise WorkerDispatchError(
+                "circuit breaker open — worker degraded, dispatch rejected",
+                error_code="CIRCUIT_OPEN",
+            )
+
+        # Retry ceiling (AC4): the absolute max is ``_RETRY_MAX_ATTEMPTS``,
+        # narrowed by the per-stage ``max_retries`` (0 = no retry). The first
+        # call always runs, so ``max_attempts`` is the total attempt count.
+        max_attempts = _RETRY_MAX_ATTEMPTS
+        if validated.max_retries is not None:
+            max_attempts = min(max_attempts, validated.max_retries + 1)
+
+        last_exc: Optional[WorkerDispatchError] = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                data = await self._dispatch_once(
+                    body, wait=wait, endpoint_url=endpoint_url,
+                )
+            except WorkerDispatchError as exc:
+                last_exc = exc
+                if not exc.is_retryable() or attempt >= max_attempts:
+                    await _CIRCUIT_BREAKER.record_failure()
+                    raise
+                delay = self._backoff_delay(attempt - 1)
+                logger.warning(
+                    "worker dispatch attempt %d/%d failed (%s); retrying in %.2fs",
+                    attempt, max_attempts, exc.error_code, delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            else:
+                await _CIRCUIT_BREAKER.record_success()
+                return data
+
+        # Unreachable in practice (the loop returns or raises), but keeps the
+        # type checker happy and is defensive if max_attempts were ever 0.
+        await _CIRCUIT_BREAKER.record_failure()
+        raise last_exc or WorkerDispatchError(
+            "dispatch exhausted with no attempt", error_code="WORKER_ERROR",
+        )
+
+    @staticmethod
+    def _backoff_delay(retry_index: int) -> float:
+        """Backoff exponencial com jitter para a tentativa ``retry_index`` (0-based).
+
+        ``base * factor^retry_index`` mais jitter uniforme ``±jitter``;
+        nunca negativo (issue #620 AC4).
+        """
+        delay = _RETRY_BASE_S * (_RETRY_FACTOR ** retry_index)
+        delay += random.uniform(-_RETRY_JITTER_S, _RETRY_JITTER_S)
+        return max(0.0, delay)
+
+    async def _dispatch_once(
+        self,
+        body: Dict[str, Any],
+        *,
+        wait: bool,
+        endpoint_url: Optional[str],
+    ) -> Dict[str, Any]:
+        """Single POST attempt against the worker (no retry, no breaker).
+
+        ``body`` is already a validated/serialized dispatch payload. Raises
+        :class:`WorkerDispatchError` carrying the wire ``error_code`` and,
+        for HTTP responses, ``http_status`` so the retry layer can classify
+        transient (5xx) vs definitive (4xx) failures.
+        """
         # Issue #309 fase 2: ``endpoint_url`` (per-stage routing) sobrescreve
         # o resolver legacy quando truthy. Empty-string e ``None`` caem no
         # fallback de env var — paridade com ``_resolve_endpoint`` no
@@ -653,6 +794,7 @@ class DeileWorkerClient:
                 f"worker returned non-JSON (status={resp.status_code}, "
                 f"request_id={request_id})",
                 error_code="WORKER_BAD_RESPONSE",
+                http_status=resp.status_code,
             ) from exc
 
         if resp.status_code >= 400:
@@ -669,7 +811,9 @@ class DeileWorkerClient:
                 or f"HTTP {resp.status_code}"
             )
             raise WorkerDispatchError(
-                f"{msg} (request_id={request_id})", error_code=code
+                f"{msg} (request_id={request_id})",
+                error_code=code,
+                http_status=resp.status_code,
             )
 
         logger.info(

--- a/deile/tests/infra/test_worker_graceful_shutdown.py
+++ b/deile/tests/infra/test_worker_graceful_shutdown.py
@@ -1,0 +1,174 @@
+"""AC1 (issue #620) — graceful shutdown do deile-worker no SIGTERM.
+
+FIAÇÃO: ``_graceful_shutdown`` marca ``_SHUTTING_DOWN``, drena
+``_BG_DISPATCH_TASKS`` com timeout de 30s e escreve estado terminal nas tasks
+não concluídas; um dispatch HTTP chegando durante o shutdown é rejeitado com
+503. O watchdog de hard-deadline chama ``os._exit(0)`` (mockado) se o drain
+estourar 35s.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+aiohttp_test_utils = pytest.importorskip("aiohttp.test_utils")
+
+import worker_server  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_TOKEN = "test-token-0123456789abcdef"
+
+
+@pytest.fixture
+def _clean_state():
+    worker_server._TASKS.clear()
+    worker_server._BG_DISPATCH_TASKS.clear()
+    worker_server._SHUTTING_DOWN = False
+    yield
+    worker_server._TASKS.clear()
+    worker_server._BG_DISPATCH_TASKS.clear()
+    worker_server._SHUTTING_DOWN = False
+
+
+# ----- drain de tasks em voo + estado terminal -----------------------------
+
+
+async def test_graceful_shutdown_drains_and_marks_terminal(_clean_state):
+    done = asyncio.Event()
+
+    async def _bg():
+        worker_server._TASKS["aaaaaaaaaaaa"] = {
+            "task_id": "aaaaaaaaaaaa", "ok": None,
+        }
+        await asyncio.sleep(0.02)
+        worker_server._TASKS["aaaaaaaaaaaa"] = {
+            "task_id": "aaaaaaaaaaaa", "ok": True,
+        }
+        done.set()
+
+    t = asyncio.create_task(_bg())
+    worker_server._BG_DISPATCH_TASKS.add(t)
+    await asyncio.sleep(0)  # deixa a task começar e registrar ok=None
+
+    start = time.monotonic()
+    await worker_server._graceful_shutdown(app=None)
+    elapsed = time.monotonic() - start
+
+    # Drena dentro do orçamento e MUITO antes do teto de 35s.
+    assert elapsed < 35.0
+    assert worker_server._SHUTTING_DOWN is True
+    # A task drenou naturalmente (terminou antes do timeout).
+    assert done.is_set()
+    assert worker_server._TASKS["aaaaaaaaaaaa"]["ok"] is True
+
+
+async def test_drain_timeout_marks_remaining_terminal(_clean_state, monkeypatch):
+    # Drain timeout curtíssimo para forçar o caminho de "marcar terminal".
+    monkeypatch.setattr(worker_server, "_SHUTDOWN_DRAIN_TIMEOUT_S", 0.05)
+
+    release = asyncio.Event()
+
+    async def _bg():
+        worker_server._TASKS["bbbbbbbbbbbb"] = {
+            "task_id": "bbbbbbbbbbbb", "ok": None,
+        }
+        await release.wait()  # nunca liberado dentro do drain
+
+    t = asyncio.create_task(_bg())
+    worker_server._BG_DISPATCH_TASKS.add(t)
+    await asyncio.sleep(0)
+
+    await worker_server._graceful_shutdown(app=None)
+
+    # A task não terminou; o shutdown a marcou terminal explicitamente (AC1).
+    state = worker_server._TASKS["bbbbbbbbbbbb"]
+    assert state["ok"] is False
+    assert state["error"] == "worker shutting down"
+
+    # Limpa a task pendente.
+    release.set()
+    t.cancel()
+    try:
+        await t
+    except asyncio.CancelledError:
+        pass
+
+
+def test_mark_inflight_tasks_terminal(_clean_state):
+    worker_server._TASKS["t1"] = {"task_id": "t1", "ok": None}
+    worker_server._TASKS["t2"] = {"task_id": "t2", "ok": True}  # já terminal
+    worker_server._TASKS["t3"] = {"task_id": "t3", "ok": None}
+
+    marked = worker_server._mark_inflight_tasks_terminal()
+    assert marked == 2
+    assert worker_server._TASKS["t1"]["ok"] is False
+    assert worker_server._TASKS["t1"]["error"] == "worker shutting down"
+    assert worker_server._TASKS["t2"]["ok"] is True  # intacto
+
+
+# ----- 503 para novos dispatches durante o shutdown ------------------------
+
+
+@pytest.fixture
+async def client(_clean_state):
+    app = worker_server.build_app(_TOKEN)
+    async with aiohttp_test_utils.TestClient(
+        aiohttp_test_utils.TestServer(app)
+    ) as cli:
+        yield cli
+
+
+async def test_dispatch_rejected_503_while_shutting_down(client, monkeypatch):
+    monkeypatch.setattr(worker_server, "_SHUTTING_DOWN", True)
+    resp = await client.post(
+        "/v1/dispatch",
+        json={"brief": "late", "channel_id": "111"},
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+    )
+    assert resp.status == 503
+    data = await resp.json()
+    assert data["error"]["code"] == "SHUTTING_DOWN"
+    assert resp.headers.get("Retry-After")
+
+
+# ----- watchdog hard-deadline (os._exit mockado) ---------------------------
+
+
+def test_watchdog_calls_os_exit_after_deadline(monkeypatch):
+    """Ao receber SIGTERM, o watchdog arma um timer que chama os._exit(0)
+    após o hard-deadline. Mockamos ``os._exit`` para não matar o runner e
+    encurtamos o deadline para validar o disparo."""
+    import signal
+
+    exits: list = []
+    monkeypatch.setattr(worker_server.os, "_exit", lambda code: exits.append(code))
+    monkeypatch.setattr(worker_server, "_SHUTDOWN_HARD_DEADLINE_S", 0.05)
+    worker_server._SHUTTING_DOWN = False
+
+    captured = {}
+
+    def _fake_signal(signum, handler):
+        captured["handler"] = handler
+
+    monkeypatch.setattr(signal, "signal", _fake_signal)
+    worker_server._install_shutdown_watchdog()
+    assert "handler" in captured
+
+    # Dispara o handler como se o SIGTERM tivesse chegado.
+    captured["handler"](signal.SIGTERM, None)
+    assert worker_server._SHUTTING_DOWN is True
+
+    # O timer dispara os._exit(0) após ~50ms.
+    time.sleep(0.2)
+    assert exits == [0]
+    worker_server._SHUTTING_DOWN = False

--- a/deile/tests/infra/test_worker_idempotency.py
+++ b/deile/tests/infra/test_worker_idempotency.py
@@ -1,0 +1,163 @@
+"""AC6 (issue #620) — idempotência de dispatch via ``X-Idempotency-Key``.
+
+FIAÇÃO (HTTP real → handler → estado): 2 POSTs com a mesma key dentro do TTL
+devem servir o resultado original (200 + ``already_dispatched``); uma key de
+task ainda em execução → 409 ``duplicate_in_flight``; uma key expirada (>300s)
+→ nova task.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+aiohttp_test_utils = pytest.importorskip("aiohttp.test_utils")
+
+import worker_server  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_TOKEN = "test-token-0123456789abcdef"
+
+
+@pytest.fixture
+def _clean_state():
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+    yield
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+
+
+@pytest.fixture
+async def client(_clean_state):
+    app = worker_server.build_app(_TOKEN)
+    async with aiohttp_test_utils.TestClient(
+        aiohttp_test_utils.TestServer(app)
+    ) as cli:
+        yield cli
+
+
+def _fake_run_task(ok=True):
+    async def _fake(task_id, brief, channel_id, *a, **kw):
+        result = {
+            "schema_version": worker_server.RESULT_SCHEMA_VERSION,
+            "task_id": task_id, "ok": ok, "elapsed_s": 0.01,
+            "brief": brief, "summary": "done", "files": [],
+            "channel_id": channel_id,
+        }
+        worker_server._TASKS[task_id] = result
+        return result
+    return _fake
+
+
+async def _post(client, body, *, key=None):
+    h = {"Authorization": f"Bearer {_TOKEN}"}
+    if key is not None:
+        h["X-Idempotency-Key"] = key
+    return await client.post("/v1/dispatch", json=body, headers=h)
+
+
+async def test_same_key_returns_already_dispatched(client, monkeypatch):
+    monkeypatch.setattr(worker_server, "_run_task", _fake_run_task(True))
+    body = {"brief": "do it", "channel_id": "111"}
+
+    r1 = await _post(client, body, key="abc-key-1")
+    assert r1.status == 200
+    d1 = await r1.json()
+    first_task_id = d1["task_id"]
+
+    r2 = await _post(client, body, key="abc-key-1")
+    assert r2.status == 200
+    d2 = await r2.json()
+    assert d2["status"] == "already_dispatched"
+    # Mesma task original — não criou outra.
+    assert d2["task_id"] == first_task_id
+
+
+async def test_in_flight_key_returns_409(client, monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _blocking_run_task(task_id, brief, channel_id, *a, **kw):
+        # ``ok`` permanece None enquanto bloqueado → estado "em execução".
+        worker_server._TASKS[task_id] = {
+            "task_id": task_id, "ok": None, "brief": brief,
+        }
+        started.set()
+        await release.wait()
+        result = {"schema_version": worker_server.RESULT_SCHEMA_VERSION,
+                  "task_id": task_id, "ok": True, "elapsed_s": 0.01,
+                  "brief": brief, "summary": "done", "files": []}
+        worker_server._TASKS[task_id] = result
+        return result
+
+    monkeypatch.setattr(worker_server, "_run_task", _blocking_run_task)
+
+    # Fire-and-forget para a 1ª task ficar em execução de verdade.
+    r1 = await _post(client, {"brief": "x", "channel_id": "222",
+                              "wait_for_result": False}, key="same-key")
+    assert r1.status == 202
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+
+    # 2ª com a mesma key, enquanto a 1ª está em voo → 409.
+    r2 = await _post(client, {"brief": "x", "channel_id": "222",
+                              "wait_for_result": False}, key="same-key")
+    assert r2.status == 409
+    d2 = await r2.json()
+    assert d2["error"]["code"] == "duplicate_in_flight"
+
+    # Libera a 1ª para terminar limpo.
+    release.set()
+    await asyncio.sleep(0.05)
+
+
+async def test_expired_key_creates_new_task(client, monkeypatch):
+    monkeypatch.setattr(worker_server, "_run_task", _fake_run_task(True))
+    # TTL curtíssimo para forçar expiração determinística.
+    monkeypatch.setattr(worker_server, "_IDEMPOTENCY_TTL_S", 0.0)
+    body = {"brief": "do it", "channel_id": "333"}
+
+    r1 = await _post(client, body, key="ttl-key")
+    first_id = (await r1.json())["task_id"]
+
+    # Com TTL=0, a entrada já está expirada no próximo lookup → nova task.
+    r2 = await _post(client, body, key="ttl-key")
+    assert r2.status == 200
+    d2 = await r2.json()
+    assert d2.get("status") != "already_dispatched"
+    assert d2["task_id"] != first_id
+
+
+async def test_no_key_always_new_task(client, monkeypatch):
+    monkeypatch.setattr(worker_server, "_run_task", _fake_run_task(True))
+    body = {"brief": "do it", "channel_id": "444"}
+    r1 = await _post(client, body)
+    r2 = await _post(client, body)
+    id1 = (await r1.json())["task_id"]
+    id2 = (await r2.json())["task_id"]
+    assert id1 != id2  # sem key, cada POST é uma task nova (compat legado)
+
+
+async def test_malformed_key_ignored_as_absent(client, monkeypatch):
+    monkeypatch.setattr(worker_server, "_run_task", _fake_run_task(True))
+    body = {"brief": "do it", "channel_id": "555"}
+    # Key com caractere ilegal (espaço) → tratada como ausente → task nova.
+    r1 = await _post(client, body, key="bad key!")
+    r2 = await _post(client, body, key="bad key!")
+    id1 = (await r1.json())["task_id"]
+    id2 = (await r2.json())["task_id"]
+    assert id1 != id2

--- a/deile/tests/infra/test_worker_latency_phases.py
+++ b/deile/tests/infra/test_worker_latency_phases.py
@@ -1,0 +1,103 @@
+"""AC8 (issue #620) — latência por fase no ``_run_task`` do deile-worker.
+
+Executa ``_run_task`` com um agente mockado (sem LLM real) e valida que o log
+estruturado emitido ao final carrega o campo ``phases`` com os 5 marcos
+nomeados (``agent_start``, ``model_first_token``, ``agent_end``, ``io_ops``,
+``total``), com deltas em milissegundos.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+pytest.importorskip("aiohttp")
+
+import worker_server  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_EXPECTED_PHASES = {
+    "agent_start", "model_first_token", "agent_end", "io_ops", "total",
+}
+
+
+@pytest.fixture
+def _clean_tasks():
+    worker_server._TASKS.clear()
+    yield
+    worker_server._TASKS.clear()
+
+
+def _mock_agent_with_delay():
+    """Agente não-streaming que adiciona um pequeno delay real para que os
+    deltas de fase sejam positivos de forma determinística."""
+    class _Resp:
+        content = "feito"
+
+    async def _slow_process_input(prompt, **kwargs):
+        await asyncio.sleep(0.005)
+        return _Resp()
+
+    agent = MagicMock()
+    agent.get_or_create_session = AsyncMock(return_value=MagicMock(context_data={}))
+    agent.process_input = AsyncMock(side_effect=_slow_process_input)
+    agent.process_input_stream = None  # força o caminho não-streaming
+    return agent
+
+
+def _capture_phases(records) -> dict:
+    for rec in records:
+        phases = getattr(rec, "phases", None)
+        if isinstance(phases, dict):
+            return phases
+    return {}
+
+
+async def test_run_task_logs_five_named_phases(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(worker_server, "WORK_ROOT", tmp_path)
+    monkeypatch.setattr(worker_server, "_get_agent",
+                        AsyncMock(return_value=_mock_agent_with_delay()))
+    monkeypatch.setattr(worker_server, "_post_status_message",
+                        AsyncMock(return_value=None))
+    monkeypatch.setattr(worker_server, "_edit_status_message",
+                        AsyncMock(return_value=True))
+    monkeypatch.setattr(worker_server, "_react", AsyncMock(return_value=True))
+
+    with caplog.at_level(logging.INFO, logger="deile.worker_server"):
+        await worker_server._run_task(
+            "aaaaaaaaaaaa", "faça algo", "12345", None, "developer",
+        )
+
+    phases = _capture_phases(caplog.records)
+    assert phases, "log com campo 'phases' não foi emitido"
+    # AC8: exatamente os 5 marcos nomeados.
+    assert set(phases) == _EXPECTED_PHASES
+    # Cada delta é numérico (ms) e não-negativo.
+    for name, delta in phases.items():
+        assert isinstance(delta, (int, float)), f"{name} não é numérico"
+        assert delta >= 0.0, f"{name} delta negativo: {delta}"
+    # ``total`` cobre o wall-clock inteiro; com o delay de 5ms é > 0.
+    assert phases["total"] > 0.0
+    # ``model_first_token`` foi marcado (delay real do agente) → > 0.
+    assert phases["agent_start"] >= 0.0
+
+
+def test_phase_helper_handles_missing_marks():
+    """``_log_phase_latencies`` é robusto a marcos ausentes (timeout antes do
+    1º token): cai no marco anterior, sem deltas negativos, sem levantar."""
+    import time
+
+    start = time.monotonic()
+    marks = {"start": start, "agent_start": start + 0.01, "total": start + 0.02}
+    # Não deve levantar mesmo com model_first_token/agent_end/io_ops ausentes.
+    worker_server._log_phase_latencies("bbbbbbbbbbbb", marks)

--- a/deile/tests/infra/test_worker_metrics.py
+++ b/deile/tests/infra/test_worker_metrics.py
@@ -1,0 +1,173 @@
+"""AC2 (issue #620) — endpoint ``GET /v1/metrics`` do deile-worker.
+
+FIAÇÃO: POST /v1/dispatch (com ``_run_task`` mockado para não chamar LLM) →
+GET /v1/metrics → parse do Prometheus text format → valida as métricas
+nomeadas + o histograma skeleton (``_count=0``).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+aiohttp_test_utils = pytest.importorskip("aiohttp.test_utils")
+
+import worker_server  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_TOKEN = "test-token-0123456789abcdef"
+
+
+@pytest.fixture
+def _clean_state():
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+    yield
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+
+
+@pytest.fixture
+async def client(_clean_state):
+    app = worker_server.build_app(_TOKEN)
+    async with aiohttp_test_utils.TestClient(
+        aiohttp_test_utils.TestServer(app)
+    ) as cli:
+        yield cli
+
+
+def _fake_run_task_factory(ok: bool = True):
+    async def _fake(task_id, brief, channel_id, *a, **kw):
+        result = {
+            "schema_version": worker_server.RESULT_SCHEMA_VERSION,
+            "task_id": task_id, "ok": ok, "elapsed_s": 0.01,
+            "brief": brief, "summary": "done", "files": [],
+            "channel_id": channel_id,
+        }
+        worker_server._TASKS[task_id] = result
+        return result
+    return _fake
+
+
+def _parse_prom(text: str) -> dict:
+    """Parse mínimo do text format: ``metric{labels} value`` → {name: value}.
+
+    Linhas ``# HELP``/``# TYPE`` são ignoradas. Para métricas com labels o
+    nome é a parte antes de ``{``.
+    """
+    out: dict = {}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name_part, _, value = line.rpartition(" ")
+        name = name_part.split("{", 1)[0]
+        out.setdefault(name, []).append((name_part, value))
+    return out
+
+
+async def _post(client, body, headers=None):
+    h = {"Authorization": f"Bearer {_TOKEN}"}
+    if headers:
+        h.update(headers)
+    return await client.post("/v1/dispatch", json=body, headers=h)
+
+
+async def _get_metrics(client):
+    resp = await client.get(
+        "/v1/metrics", headers={"Authorization": f"Bearer {_TOKEN}"}
+    )
+    return resp
+
+
+async def test_metrics_requires_auth(client):
+    resp = await client.get("/v1/metrics")
+    assert resp.status == 401
+
+
+async def test_metrics_content_type_and_named_metrics(client, monkeypatch):
+    monkeypatch.setattr(worker_server, "_run_task", _fake_run_task_factory(True))
+    r = await _post(client, {"brief": "do it", "channel_id": "111",
+                             "stage": "implement", "persona": "developer"})
+    assert r.status == 200
+
+    resp = await _get_metrics(client)
+    assert resp.status == 200
+    assert resp.headers["Content-Type"] == "text/plain; version=0.0.4; charset=utf-8"
+
+    text = await resp.text()
+    # AC2: pelo menos as 5 métricas nomeadas presentes.
+    for name in (
+        "deile_worker_dispatches_total",
+        "deile_worker_errors_total",
+        "deile_worker_in_flight",
+        "deile_worker_tasks_memory",
+        "deile_worker_dispatch_duration_seconds",
+    ):
+        assert name in text, f"métrica {name} ausente no /v1/metrics"
+
+
+async def test_dispatch_counter_increments_with_labels(client, monkeypatch):
+    monkeypatch.setattr(worker_server, "_run_task", _fake_run_task_factory(True))
+    await _post(client, {"brief": "a", "channel_id": "222",
+                         "stage": "implement", "persona": "developer"})
+
+    text = await (await _get_metrics(client)).text()
+    parsed = _parse_prom(text)
+    series = parsed["deile_worker_dispatches_total"]
+    # Há uma série com labels stage/persona/ok="true".
+    matched = [s for s in series
+               if 'stage="implement"' in s[0] and 'ok="true"' in s[0]]
+    assert matched, f"série com labels esperados ausente: {series}"
+    assert matched[0][1] == "1"
+
+
+async def test_histogram_skeleton_count_zero(client):
+    """Histograma skeleton: presente, com buckets e ``_count=0`` / ``_sum=0``."""
+    text = await (await _get_metrics(client)).text()
+    assert "deile_worker_dispatch_duration_seconds_count 0" in text
+    assert "deile_worker_dispatch_duration_seconds_sum 0" in text
+    # Buckets definidos (le="1" ... le="+Inf").
+    assert 'deile_worker_dispatch_duration_seconds_bucket{le="1"} 0' in text
+    assert 'deile_worker_dispatch_duration_seconds_bucket{le="+Inf"} 0' in text
+
+
+async def test_in_flight_gauge_zero_when_idle(client):
+    text = await (await _get_metrics(client)).text()
+    parsed = _parse_prom(text)
+    assert parsed["deile_worker_in_flight"][0][1] == "0"
+
+
+# ----- packaging guard (issue #620) ---------------------------------------
+#
+# worker_server.py importa ``worker_metrics`` e ``worker_rate_limit`` por nome
+# nu — ambos PRECISAM ser baked em /app (COPY no Dockerfile + exceção no
+# .dockerignore), senão o deile-worker pod crasha na importação no startup.
+# Mesma disciplina de test_monitor_packaging.py (incidente do cost-ledger).
+
+@pytest.mark.parametrize("mod", ("worker_metrics.py", "worker_rate_limit.py"))
+def test_dockerfile_copies_worker_hardening_module(mod):
+    dockerfile = (_REPO / "Dockerfile").read_text(encoding="utf-8")
+    assert f"COPY --chown=deile:deile infra/k8s/{mod} /app/{mod}" in dockerfile, (
+        f"{mod} deve ser COPY'd para /app no Dockerfile ou o pod crasha no import"
+    )
+
+
+@pytest.mark.parametrize("mod", ("worker_metrics.py", "worker_rate_limit.py"))
+def test_dockerignore_excepts_worker_hardening_module(mod):
+    dockerignore = (_REPO / ".dockerignore").read_text(encoding="utf-8")
+    assert f"!infra/k8s/{mod}" in dockerignore, (
+        f"{mod} precisa de exceção `!infra/k8s/{mod}` no .dockerignore ou o COPY falha"
+    )

--- a/deile/tests/infra/test_worker_rate_limit.py
+++ b/deile/tests/infra/test_worker_rate_limit.py
@@ -1,0 +1,172 @@
+"""AC7 (issue #620) — rate limit por canal (token bucket capacity=10, rate=1/s).
+
+FIAÇÃO (HTTP real → handler → 429): um burst de 15 dispatches do MESMO canal
+em <1s produz >=5 rejeições 429 com header ``Retry-After``; um canal diferente
+não é afetado (0 rejeições). Cobre também a unidade do
+:class:`TokenBucketRateLimiter` (refil, isolamento, reset de balde ocioso).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+aiohttp_test_utils = pytest.importorskip("aiohttp.test_utils")
+
+import worker_server  # noqa: E402
+from worker_rate_limit import TokenBucketRateLimiter  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_TOKEN = "test-token-0123456789abcdef"
+
+
+# ----- unidade do token bucket --------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, s):
+        self.t += s
+
+
+def test_burst_consumes_capacity_then_rejects():
+    clock = _FakeClock()
+    rl = TokenBucketRateLimiter(capacity=10, rate=1, time_source=clock)
+    allowed = sum(1 for _ in range(10) if rl.acquire("c1")[0])
+    assert allowed == 10  # capacidade cheia consumida
+    ok, retry_after = rl.acquire("c1")
+    assert ok is False
+    assert retry_after >= 1  # Retry-After em segundos
+
+
+def test_refill_over_time():
+    clock = _FakeClock()
+    rl = TokenBucketRateLimiter(capacity=10, rate=1, time_source=clock)
+    for _ in range(10):
+        rl.acquire("c1")
+    assert rl.acquire("c1")[0] is False
+    clock.advance(2.0)  # 2 tokens recarregados
+    assert rl.acquire("c1")[0] is True
+    assert rl.acquire("c1")[0] is True
+    assert rl.acquire("c1")[0] is False
+
+
+def test_channels_are_isolated():
+    clock = _FakeClock()
+    rl = TokenBucketRateLimiter(capacity=10, rate=1, time_source=clock)
+    for _ in range(10):
+        rl.acquire("c1")
+    assert rl.acquire("c1")[0] is False  # c1 esgotado
+    assert rl.acquire("c2")[0] is True   # c2 intacto
+
+
+def test_idle_bucket_resets_to_full():
+    clock = _FakeClock()
+    rl = TokenBucketRateLimiter(
+        capacity=10, rate=1, idle_reset_s=300.0, time_source=clock,
+    )
+    for _ in range(10):
+        rl.acquire("c1")
+    assert rl.acquire("c1")[0] is False
+    clock.advance(301.0)  # ocioso > 300s → reset para cheio
+    # Próximo acesso reseta para capacity; 10 dispatches passam de novo.
+    allowed = sum(1 for _ in range(10) if rl.acquire("c1")[0])
+    assert allowed == 10
+
+
+def test_invalid_params_rejected():
+    with pytest.raises(ValueError):
+        TokenBucketRateLimiter(capacity=0)
+    with pytest.raises(ValueError):
+        TokenBucketRateLimiter(rate=0)
+
+
+# ----- FIAÇÃO HTTP ---------------------------------------------------------
+
+
+@pytest.fixture
+def _clean_state():
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+    yield
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+
+
+@pytest.fixture
+async def client(_clean_state, monkeypatch):
+    # Rate limiter fresco por teste (o módulo usa um singleton).
+    fresh = TokenBucketRateLimiter(capacity=10, rate=1, idle_reset_s=300.0)
+    monkeypatch.setattr(worker_server, "_RATE_LIMITER", fresh)
+
+    async def _fake(task_id, brief, channel_id, *a, **kw):
+        result = {"schema_version": worker_server.RESULT_SCHEMA_VERSION,
+                  "task_id": task_id, "ok": True, "elapsed_s": 0.01,
+                  "brief": brief, "summary": "ok", "files": []}
+        worker_server._TASKS[task_id] = result
+        return result
+
+    monkeypatch.setattr(worker_server, "_run_task", _fake)
+
+    app = worker_server.build_app(_TOKEN)
+    async with aiohttp_test_utils.TestClient(
+        aiohttp_test_utils.TestServer(app)
+    ) as cli:
+        yield cli
+
+
+async def _post(client, channel_id):
+    return await client.post(
+        "/v1/dispatch",
+        json={"brief": "do it", "channel_id": channel_id,
+              "wait_for_result": False},
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+    )
+
+
+async def test_burst_same_channel_yields_429s_with_retry_after(client):
+    statuses = []
+    retry_afters = []
+    for _ in range(15):
+        r = await _post(client, "chan-A")
+        statuses.append(r.status)
+        if r.status == 429:
+            retry_afters.append(r.headers.get("Retry-After"))
+
+    rejected = sum(1 for s in statuses if s == 429)
+    accepted = sum(1 for s in statuses if s == 202)
+    assert accepted == 10  # capacity
+    assert rejected >= 5    # AC7: >= 5 rejeições
+    # Todas as 429 trazem Retry-After.
+    assert all(ra is not None for ra in retry_afters)
+
+
+async def test_other_channel_not_affected(client):
+    # Esgota o canal A.
+    for _ in range(15):
+        await _post(client, "chan-A")
+    # Canal B não sofre nenhuma rejeição no seu próprio burst de 10.
+    b_rejected = 0
+    for _ in range(10):
+        r = await _post(client, "chan-B")
+        if r.status == 429:
+            b_rejected += 1
+    assert b_rejected == 0

--- a/deile/tests/infra/test_worker_schema_skeleton.py
+++ b/deile/tests/infra/test_worker_schema_skeleton.py
@@ -1,0 +1,144 @@
+"""AC9 (issue #620) — schema_version skeleton no resultado do deile-worker.
+
+Valida três coisas:
+  1. ``_run_task`` grava ``"schema_version": 1`` no JSON de resultado.
+  2. O arquivo ``deile/core/schemas/result_v1.json`` existe e é um JSON Schema
+     draft-2020-12 bem-formado.
+  3. ``result_handler`` aceita um resultado SEM ``schema_version`` (compat
+     forward) — serve com warning, não rejeita.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+aiohttp_test_utils = pytest.importorskip("aiohttp.test_utils")
+
+import worker_server  # noqa: E402
+
+import deile.core.schemas as schemas  # noqa: E402
+
+RESULT_SCHEMA_PATH = schemas.RESULT_SCHEMA_PATH
+RESULT_SCHEMA_VERSION = schemas.RESULT_SCHEMA_VERSION
+
+pytestmark = pytest.mark.unit
+
+_TOKEN = "test-token-0123456789abcdef"
+
+
+@pytest.fixture
+def _clean_tasks():
+    worker_server._TASKS.clear()
+    yield
+    worker_server._TASKS.clear()
+
+
+# ----- 1. result carrega schema_version ------------------------------------
+
+
+async def test_run_task_result_has_schema_version(tmp_path, monkeypatch):
+    monkeypatch.setattr(worker_server, "WORK_ROOT", tmp_path)
+
+    class _Resp:
+        content = "feito"
+
+    agent = MagicMock()
+    agent.get_or_create_session = AsyncMock(return_value=MagicMock(context_data={}))
+    agent.process_input = AsyncMock(return_value=_Resp())
+    agent.process_input_stream = None
+    monkeypatch.setattr(worker_server, "_get_agent", AsyncMock(return_value=agent))
+    monkeypatch.setattr(worker_server, "_post_status_message", AsyncMock(return_value=None))
+    monkeypatch.setattr(worker_server, "_edit_status_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(worker_server, "_react", AsyncMock(return_value=True))
+
+    result = await worker_server._run_task(
+        "cccccccccccc", "faça algo", "12345", None, "developer",
+    )
+    assert result["schema_version"] == RESULT_SCHEMA_VERSION == 1
+
+    # E o JSON persistido no PVC também o contém.
+    persisted = tmp_path / ".results" / (result["task_id"] + ".json")
+    assert persisted.is_file()
+    on_disk = json.loads(persisted.read_text(encoding="utf-8"))
+    assert on_disk["schema_version"] == 1
+
+
+# ----- 2. arquivo de schema existe e é válido ------------------------------
+
+
+def test_schema_file_exists_and_is_valid_draft202012():
+    assert RESULT_SCHEMA_PATH.is_file(), f"{RESULT_SCHEMA_PATH} não existe"
+    doc = json.loads(RESULT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    # Declara draft-2020-12.
+    assert doc["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert "schema_version" in doc["properties"]
+    assert doc["properties"]["schema_version"]["const"] == 1
+
+    # Se o validador estiver disponível, prova que o schema é bem-formado.
+    jsonschema = pytest.importorskip(
+        "jsonschema",
+        reason="jsonschema não é dependência do projeto; validação completa "
+               "roda apenas quando presente (a estrutura já é checada acima)",
+    )
+    jsonschema.Draft202012Validator.check_schema(doc)
+    # E que um documento de resultado real valida contra ele.
+    sample = {
+        "schema_version": 1, "task_id": "abcdef012345", "ok": True,
+        "elapsed_s": 1.5, "files": ["a.py"], "summary": "ok",
+    }
+    jsonschema.Draft202012Validator(doc).validate(sample)
+
+
+# ----- 3. result_handler tolera ausência de schema_version -----------------
+
+
+@pytest.fixture
+async def client(_clean_tasks):
+    app = worker_server.build_app(_TOKEN)
+    async with aiohttp_test_utils.TestClient(
+        aiohttp_test_utils.TestServer(app)
+    ) as cli:
+        yield cli
+
+
+async def test_result_handler_accepts_missing_schema_version(client, caplog):
+    """Resultado legado SEM schema_version → servido com warning (não 4xx)."""
+    task_id = "ddeeff001122"
+    worker_server._TASKS[task_id] = {
+        "task_id": task_id, "ok": True, "elapsed_s": 1.0, "summary": "x",
+        # sem "schema_version"
+    }
+    with caplog.at_level(logging.WARNING, logger="deile.worker_server"):
+        resp = await client.get(
+            f"/v1/result/{task_id}",
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+        )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["task_id"] == task_id
+    assert any("schema_version" in r.getMessage() for r in caplog.records)
+
+
+async def test_result_handler_no_warning_for_current_version(client, caplog):
+    task_id = "112233445566"
+    worker_server._TASKS[task_id] = {
+        "task_id": task_id, "ok": True, "elapsed_s": 1.0,
+        "schema_version": 1,
+    }
+    with caplog.at_level(logging.WARNING, logger="deile.worker_server"):
+        resp = await client.get(
+            f"/v1/result/{task_id}",
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+        )
+    assert resp.status == 200
+    assert not any("schema_version" in r.getMessage() for r in caplog.records)

--- a/deile/tests/infra/test_worker_tasks_lock.py
+++ b/deile/tests/infra/test_worker_tasks_lock.py
@@ -1,0 +1,124 @@
+"""AC3 (issue #620) — lock de higiene na seção evict+insert de ``_TASKS``.
+
+FIAÇÃO (HTTP real → handler → estado): um burst de 100 dispatches concorrentes
+com ``_TASKS_MAX=10`` mantém ``len(_TASKS) <= 10 + N_em_voo`` ao final. O lock
+``_TASKS_LOCK`` torna a invariante de tamanho à prova de regressão se um
+``await`` for introduzido entre o evict e o insert no futuro.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+aiohttp_test_utils = pytest.importorskip("aiohttp.test_utils")
+
+import worker_server  # noqa: E402
+from worker_rate_limit import TokenBucketRateLimiter  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_TOKEN = "test-token-0123456789abcdef"
+
+
+@pytest.fixture
+def _clean_state():
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+    yield
+    worker_server._TASKS.clear()
+    worker_server._IDEMPOTENCY_KEYS.clear()
+    worker_server._IN_FLIGHT = 0
+    worker_server._SHUTTING_DOWN = False
+    worker_server._METRICS.reset()
+
+
+@pytest.fixture
+async def client(_clean_state, monkeypatch):
+    # Rate limiter generoso para não interferir no teste de lock.
+    monkeypatch.setattr(
+        worker_server, "_RATE_LIMITER",
+        TokenBucketRateLimiter(capacity=10_000, rate=10_000),
+    )
+
+    app = worker_server.build_app(_TOKEN)
+    async with aiohttp_test_utils.TestClient(
+        aiohttp_test_utils.TestServer(app)
+    ) as cli:
+        yield cli
+
+
+async def test_burst_keeps_tasks_within_bound(client, monkeypatch):
+    """100 dispatches concorrentes (fire-and-forget), todos em voo durante o
+    burst: o evict NUNCA descarta trabalho ativo, logo ``len(_TASKS)`` fica
+    dentro de ``10 + N_em_voo`` — invariante AC3 que o lock protege."""
+    monkeypatch.setattr(worker_server, "_TASKS_MAX", 10)
+
+    release = asyncio.Event()
+
+    async def _blocking(task_id, brief, channel_id, *a, **kw):
+        # ``ok`` permanece None enquanto bloqueado → todas as 100 tasks ficam
+        # em voo simultaneamente durante a medição.
+        worker_server._TASKS[task_id] = {
+            "task_id": task_id, "ok": None, "brief": brief,
+        }
+        await release.wait()
+        result = {"schema_version": worker_server.RESULT_SCHEMA_VERSION,
+                  "task_id": task_id, "ok": True, "elapsed_s": 0.0,
+                  "finished_at": "2026-01-01T00:00:00+00:00",
+                  "brief": brief, "summary": "ok", "files": []}
+        worker_server._TASKS[task_id] = result
+        return result
+
+    monkeypatch.setattr(worker_server, "_run_task", _blocking)
+
+    async def _one(i):
+        return await client.post(
+            "/v1/dispatch",
+            json={"brief": f"task {i}", "channel_id": f"chan-{i}",
+                  "wait_for_result": False},
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+        )
+
+    # Admite as 100 (cada uma 202; a task fica em voo, bloqueada em ``release``).
+    resps = await asyncio.gather(*[_one(i) for i in range(100)])
+    assert all(r.status == 202 for r in resps)
+    # Deixa o background task de cada dispatch chegar ao ponto de bloqueio.
+    await asyncio.sleep(0.05)
+
+    in_flight = sum(
+        1 for s in worker_server._TASKS.values()
+        if isinstance(s, dict) and s.get("ok") is None
+    )
+    # AC3: o evict preserva todo o trabalho em voo → bound 10 + N_em_voo.
+    assert len(worker_server._TASKS) <= 10 + in_flight
+    # Sanidade: o estado tem as 100 tasks em voo (eviction não as tocou).
+    assert in_flight == 100
+
+    # Libera para todas terminarem limpas (evita warnings de task pendente).
+    release.set()
+    await asyncio.sleep(0.05)
+
+
+async def test_evict_runs_under_lock_in_source():
+    """A seção evict+insert deve estar sob ``_TASKS_LOCK`` (AC3)."""
+    import inspect
+
+    src = inspect.getsource(worker_server.dispatch_handler)
+    assert "async with _TASKS_LOCK:" in src
+    # O evict e o insert do task_id vivem dentro do bloco do lock.
+    lock_idx = src.index("async with _TASKS_LOCK:")
+    evict_idx = src.index("_evict_old_tasks_if_needed()")
+    assert evict_idx > lock_idx, (
+        "_evict_old_tasks_if_needed deve ser chamado DENTRO do _TASKS_LOCK"
+    )

--- a/deile/tests/infrastructure/test_deile_worker_client.py
+++ b/deile/tests/infrastructure/test_deile_worker_client.py
@@ -17,7 +17,30 @@ from deile.infrastructure import deile_worker_client as wc
 from deile.infrastructure.deile_worker_client import (
     DEFAULT_TIMEOUT_S, DeileWorkerClient, DispatchPayload, WorkerDispatchError,
     _read_token, _resolve_endpoint, _validate_token_charset,
-    validate_dispatch_payload)
+    reset_circuit_breaker, validate_dispatch_payload)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_resilience(monkeypatch):
+    """Isola a resiliência entre testes (issue #620 AC4/AC5).
+
+    O circuit breaker é singleton de processo, então estado de um teste
+    vazaria para o seguinte; resetamos antes de cada teste. O ``asyncio.sleep``
+    do backoff é neutralizado para que os testes de caminho-de-falha não
+    durmam de verdade (a contagem de tentativas é o que importa, não o
+    tempo de parede; o cálculo real do backoff tem teste dedicado). Note
+    que patchamos o sleep — não o ``_backoff_delay`` — para que o teste do
+    backoff exercite a fórmula real.
+    """
+    reset_circuit_breaker()
+
+    async def _no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(wc.asyncio, "sleep", _no_sleep)
+    yield
+    reset_circuit_breaker()
+
 
 # ----- endpoint resolution -----
 
@@ -459,3 +482,124 @@ async def test_get_progress_non_dict_body(monkeypatch):
             monkeypatch, handler, fn="get_progress", path="/v1/progress"
         )
     assert ei.value.error_code == "WORKER_BAD_RESPONSE"
+
+
+# ----- AC4: retry com exponential backoff (issue #620) --------------------
+#
+# A FIAÇÃO real (cliente → MockTransport) é exercitada contando os hits do
+# handler: a função de dispatch tem de re-tentar APENAS falhas transientes
+# (timeout/unreachable/5xx) e NUNCA 4xx (incl. 409/429). O backoff já é
+# zerado pelo fixture autouse ``_isolate_resilience`` (sem sleeps reais);
+# o timing fica no teste dedicado de fake clock.
+
+
+async def test_retry_worker_timeout_three_attempts(monkeypatch):
+    """WORKER_TIMEOUT é transiente → 3 tentativas antes de desistir (AC4)."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        raise httpx.TimeoutException("simulated")
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "WORKER_TIMEOUT"
+    assert calls["n"] == 3
+
+
+async def test_retry_unreachable_three_attempts(monkeypatch):
+    """WORKER_UNREACHABLE também é transiente → 3 tentativas (AC4)."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        raise httpx.ConnectError("nope")
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "WORKER_UNREACHABLE"
+    assert calls["n"] == 3
+
+
+async def test_retry_http_500_three_attempts(monkeypatch):
+    """HTTP 500 (>= 500) é transiente → 3 tentativas (AC4)."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(500, json={"error": {"code": "BOOM", "message": "x"}})
+
+    with pytest.raises(WorkerDispatchError):
+        await _run_with_transport(monkeypatch, handler)
+    assert calls["n"] == 3
+
+
+async def test_no_retry_http_409(monkeypatch):
+    """HTTP 409 (duplicate in-flight) é 4xx → 0 retry, falha na 1ª (AC4)."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(
+            409, json={"error": {"code": "duplicate_in_flight", "message": "x"}}
+        )
+
+    with pytest.raises(WorkerDispatchError) as ei:
+        await _run_with_transport(monkeypatch, handler)
+    assert ei.value.error_code == "duplicate_in_flight"
+    assert calls["n"] == 1
+
+
+async def test_no_retry_http_429(monkeypatch):
+    """HTTP 429 (rate-limited) é 4xx → 0 retry (AC4)."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(
+            429, json={"error": {"code": "rate_limited", "message": "slow down"}}
+        )
+
+    with pytest.raises(WorkerDispatchError):
+        await _run_with_transport(monkeypatch, handler)
+    assert calls["n"] == 1
+
+
+async def test_retry_succeeds_on_second_attempt(monkeypatch):
+    """Falha transiente seguida de sucesso → retorna o sucesso (AC4)."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.TimeoutException("first fails")
+        return httpx.Response(200, json={"ok": True, "task_id": "T-2"})
+
+    data = await _run_with_transport(monkeypatch, handler)
+    assert data["task_id"] == "T-2"
+    assert calls["n"] == 2
+
+
+async def test_max_retries_payload_caps_attempts(monkeypatch):
+    """``max_retries=0`` no payload força 1 tentativa só, mesmo em 5xx (AC4)."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(503, json={})
+
+    cli = _install_mock_transport(monkeypatch, handler)
+    payload = {**_good_payload(), "max_retries": 0}
+    with pytest.raises(WorkerDispatchError):
+        await cli.dispatch(payload, wait=False)
+    assert calls["n"] == 1
+
+
+def test_backoff_delay_grows_exponentially_with_jitter():
+    """Backoff base=1s, factor=2, jitter=±0.3s para retry_index 0/1/2 (AC4)."""
+    # retry_index 0 → ~1s (±0.3), 1 → ~2s (±0.3), 2 → ~4s (±0.3).
+    for retry_index, center in ((0, 1.0), (1, 2.0), (2, 4.0)):
+        for _ in range(50):
+            d = DeileWorkerClient._backoff_delay(retry_index)
+            assert center - 0.3 <= d <= center + 0.3
+            assert d >= 0.0

--- a/deile/tests/infrastructure/test_worker_circuit_breaker.py
+++ b/deile/tests/infrastructure/test_worker_circuit_breaker.py
@@ -1,0 +1,186 @@
+"""AC5 (issue #620) — circuit breaker 3-state do cliente do deile-worker.
+
+Exercita :class:`deile.infrastructure.circuit_breaker.CircuitBreaker` com uma
+fonte de tempo injetada (fake clock) para validar as transições sem ``sleep``
+real:
+
+    closed --(5 falhas)--> open
+    open --(< reset)--> rejeita (allow=False)
+    open --(>= reset)--> half-open (allow libera 1 probe)
+    half-open --(probe OK)--> closed
+    half-open --(probe falha)--> open
+
+Inclui um teste de FIAÇÃO no cliente (``DeileWorkerClient.dispatch``): após
+abrir o breaker, o próximo dispatch falha com ``CIRCUIT_OPEN`` SEM tocar a
+rede (o MockTransport não é chamado).
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from deile.infrastructure import deile_worker_client as wc
+from deile.infrastructure.circuit_breaker import CircuitBreaker, CircuitState
+from deile.infrastructure.deile_worker_client import (DeileWorkerClient,
+                                                      WorkerDispatchError,
+                                                      reset_circuit_breaker)
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeClock:
+    """Relógio monotônico controlável para a janela de reset."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _breaker(clock: _FakeClock) -> CircuitBreaker:
+    return CircuitBreaker(
+        failure_threshold=5, reset_timeout_s=30.0, time_source=clock,
+    )
+
+
+async def test_starts_closed_and_allows():
+    cb = _breaker(_FakeClock())
+    assert cb.state is CircuitState.CLOSED
+    assert await cb.allow() is True
+
+
+async def test_five_consecutive_failures_open_the_circuit():
+    cb = _breaker(_FakeClock())
+    for _ in range(4):
+        await cb.record_failure()
+        assert cb.state is CircuitState.CLOSED  # ainda fechado em 4 falhas
+    await cb.record_failure()  # 5ª falha
+    assert cb.state is CircuitState.OPEN
+    # Em OPEN dentro da janela, allow rejeita (caller falha sem I/O).
+    assert await cb.allow() is False
+
+
+async def test_success_resets_failure_count():
+    cb = _breaker(_FakeClock())
+    for _ in range(4):
+        await cb.record_failure()
+    await cb.record_success()  # zera o contador
+    assert cb.state is CircuitState.CLOSED
+    for _ in range(4):
+        await cb.record_failure()
+    # Só 4 falhas após o reset → ainda fechado.
+    assert cb.state is CircuitState.CLOSED
+
+
+async def test_half_open_after_reset_timeout():
+    clock = _FakeClock()
+    cb = _breaker(clock)
+    for _ in range(5):
+        await cb.record_failure()
+    assert cb.state is CircuitState.OPEN
+    # Antes da janela: continua rejeitando.
+    clock.advance(29.0)
+    assert await cb.allow() is False
+    assert cb.state is CircuitState.OPEN
+    # Passados 30s: o próximo allow libera o probe e move para half-open.
+    clock.advance(1.0)
+    assert await cb.allow() is True
+    assert cb.state is CircuitState.HALF_OPEN
+
+
+async def test_half_open_probe_success_closes():
+    clock = _FakeClock()
+    cb = _breaker(clock)
+    for _ in range(5):
+        await cb.record_failure()
+    clock.advance(30.0)
+    assert await cb.allow() is True  # → half-open
+    await cb.record_success()  # probe OK
+    assert cb.state is CircuitState.CLOSED
+    assert await cb.allow() is True
+
+
+async def test_half_open_probe_failure_reopens():
+    clock = _FakeClock()
+    cb = _breaker(clock)
+    for _ in range(5):
+        await cb.record_failure()
+    clock.advance(30.0)
+    assert await cb.allow() is True  # → half-open
+    await cb.record_failure()  # probe falha
+    assert cb.state is CircuitState.OPEN
+    # E reabre a janela: imediatamente após, allow rejeita de novo.
+    assert await cb.allow() is False
+    # Após nova janela de 30s, libera novo probe.
+    clock.advance(30.0)
+    assert await cb.allow() is True
+    assert cb.state is CircuitState.HALF_OPEN
+
+
+def test_state_int_values_match_gauge():
+    """Os valores inteiros são o contrato da métrica gauge (0/1/2)."""
+    assert int(CircuitState.CLOSED) == 0
+    assert int(CircuitState.OPEN) == 1
+    assert int(CircuitState.HALF_OPEN) == 2
+
+
+def test_threshold_must_be_positive():
+    with pytest.raises(ValueError):
+        CircuitBreaker(failure_threshold=0)
+
+
+# ----- FIAÇÃO no cliente: breaker aberto rejeita sem I/O -------------------
+
+
+def _install_mock_transport(monkeypatch, handler) -> DeileWorkerClient:
+    monkeypatch.setattr(wc, "_read_token", lambda: "a-valid-token-123")
+    monkeypatch.setattr(wc, "_resolve_endpoint", lambda: "http://mock.invalid")
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+    return DeileWorkerClient()
+
+
+async def test_dispatch_rejects_with_circuit_open_without_io(monkeypatch):
+    """Após 5 falhas, o dispatch seguinte falha com ``CIRCUIT_OPEN`` e o
+    transporte NÃO é chamado (prova de que não há I/O em OPEN)."""
+    reset_circuit_breaker()
+
+    async def _no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(wc.asyncio, "sleep", _no_sleep)
+
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        raise httpx.ConnectError("down")
+
+    cli = _install_mock_transport(monkeypatch, handler)
+    payload = {"brief": "hi", "channel_id": "c"}
+
+    # 5 dispatches que falham: cada um esgota o retry (3 tentativas) e conta
+    # uma falha consecutiva no breaker. 1 dispatch falho → 1 record_failure.
+    # Precisamos de 5 record_failure para abrir → 5 dispatches.
+    for _ in range(5):
+        with pytest.raises(WorkerDispatchError):
+            await cli.dispatch(payload, wait=False)
+
+    calls_after_open = calls["n"]
+    # Próximo dispatch: breaker aberto → CIRCUIT_OPEN sem novo hit no handler.
+    with pytest.raises(WorkerDispatchError) as ei:
+        await cli.dispatch(payload, wait=False)
+    assert ei.value.error_code == "CIRCUIT_OPEN"
+    assert calls["n"] == calls_after_open  # nenhuma chamada de rede nova
+
+    reset_circuit_breaker()

--- a/infra/k8s/manifests/45-deile-worker-deployment.yaml
+++ b/infra/k8s/manifests/45-deile-worker-deployment.yaml
@@ -36,6 +36,10 @@ spec:
         app: deile-worker
         role: deile
     spec:
+      # Graceful shutdown (issue #620 AC1): o worker dreena dispatches em voo
+      # por até 35s no SIGTERM. O default k8s (30s) é insuficiente, então
+      # damos 40s de folga antes de o k8s recorrer ao SIGKILL.
+      terminationGracePeriodSeconds: 40
       automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:

--- a/infra/k8s/worker_metrics.py
+++ b/infra/k8s/worker_metrics.py
@@ -1,0 +1,178 @@
+"""worker_metrics — registry Prometheus hand-rolled (zero deps) do deile-worker.
+
+Implementa o subconjunto do text exposition format 0.0.4 que o ``/v1/metrics``
+do worker precisa expor (issue #620 AC2), sem trazer o client_python como
+dependência: o worker já tem orçamento de imagem apertado e o conjunto de
+métricas é pequeno e estável.
+
+Tipos suportados:
+  * Counter — monotônico, com labels.
+  * Gauge — valor instantâneo (sem labels neste worker; resolvido via callbacks
+    no momento do scrape).
+  * Histogram **skeleton** (AC2/§Fora-de-escopo) — buckets registrados, mas
+    sem ``.observe()`` em V1: o output mostra ``_bucket``/``_count``/``_sum``
+    com 0. Coleta real difere para #621.
+
+Thread-safety: cada mutação de counter é protegida por um ``threading.Lock``;
+o worker roda single event loop, mas os incrementos podem ocorrer de dentro
+de tasks concorrentes e o lock mantém o estado consistente sem custo relevante.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, Dict, Iterable, List, Tuple
+
+#: Content-Type exigido pelo AC2 (Prometheus text exposition v0.0.4).
+CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+#: Buckets do histograma de duração de dispatch (segundos) — AC2 item 2.
+DISPATCH_DURATION_BUCKETS: Tuple[float, ...] = (
+    1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600,
+)
+
+_LabelKey = Tuple[Tuple[str, str], ...]
+
+
+def _format_labels(labels: _LabelKey) -> str:
+    if not labels:
+        return ""
+    inner = ",".join(f'{k}="{_escape(v)}"' for k, v in labels)
+    return "{" + inner + "}"
+
+
+def _escape(value: str) -> str:
+    """Escapa label values conforme o text format (\\, \" e newline)."""
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+    )
+
+
+class Counter:
+    """Counter Prometheus com labels, monotônico e thread-safe."""
+
+    def __init__(self, name: str, help_text: str, labelnames: Iterable[str] = ()):
+        self.name = name
+        self.help_text = help_text
+        self.labelnames = tuple(labelnames)
+        self._values: Dict[_LabelKey, float] = {}
+        self._lock = threading.Lock()
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def reset(self) -> None:
+        """Zera todas as séries. Só para testes (os counters são singletons
+        de processo, então estado vazaria entre testes)."""
+        with self._lock:
+            self._values.clear()
+
+    def _key(self, labels: Dict[str, str]) -> _LabelKey:
+        if set(labels) != set(self.labelnames):
+            raise ValueError(
+                f"counter {self.name} expects labels {self.labelnames}, "
+                f"got {tuple(labels)}"
+            )
+        return tuple(sorted((k, str(v)) for k, v in labels.items()))
+
+    def render(self) -> List[str]:
+        lines = [
+            f"# HELP {self.name} {self.help_text}",
+            f"# TYPE {self.name} counter",
+        ]
+        with self._lock:
+            items = list(self._values.items())
+        if not items:
+            # Sem séries ainda: emite a linha com valor 0 (e sem labels) para
+            # que o nome da métrica apareça no scrape mesmo antes do 1º evento.
+            lines.append(f"{self.name} 0")
+            return lines
+        for key, value in items:
+            lines.append(f"{self.name}{_format_labels(key)} {_render_number(value)}")
+        return lines
+
+
+class Gauge:
+    """Gauge resolvido por callback no momento do scrape (sem labels).
+
+    Usar callback evita estado duplicado: o valor canônico vive em ``_TASKS`` /
+    no circuit breaker do cliente; o gauge apenas o lê quando scrapeado.
+    """
+
+    def __init__(self, name: str, help_text: str, callback: Callable[[], float]):
+        self.name = name
+        self.help_text = help_text
+        self._callback = callback
+
+    def render(self) -> List[str]:
+        try:
+            value = float(self._callback())
+        except Exception:  # noqa: BLE001 — métrica nunca derruba o scrape
+            value = 0.0
+        return [
+            f"# HELP {self.name} {self.help_text}",
+            f"# TYPE {self.name} gauge",
+            f"{self.name} {_render_number(value)}",
+        ]
+
+
+class HistogramSkeleton:
+    """Histograma **skeleton** (AC2): buckets registrados, sem coleta.
+
+    Emite ``_bucket`` (cumulativo, todos 0), ``_count=0`` e ``_sum=0``. A
+    coleta real (``.observe()``) difere para #621 — manter como skeleton evita
+    falsear latência antes de a instrumentação por-fase (AC8) estar plugada na
+    métrica.
+    """
+
+    def __init__(self, name: str, help_text: str, buckets: Iterable[float]):
+        self.name = name
+        self.help_text = help_text
+        self.buckets = tuple(buckets)
+
+    def render(self) -> List[str]:
+        lines = [
+            f"# HELP {self.name} {self.help_text}",
+            f"# TYPE {self.name} histogram",
+        ]
+        for b in self.buckets:
+            lines.append(f'{self.name}_bucket{{le="{_render_number(b)}"}} 0')
+        lines.append(f'{self.name}_bucket{{le="+Inf"}} 0')
+        lines.append(f"{self.name}_count 0")
+        lines.append(f"{self.name}_sum 0")
+        return lines
+
+
+def _render_number(value: float) -> str:
+    """Renderiza inteiros sem ``.0`` e floats compactos (saída determinística)."""
+    if float(value).is_integer():
+        return str(int(value))
+    return repr(float(value))
+
+
+class MetricsRegistry:
+    """Coleção ordenada de métricas com render do text exposition format."""
+
+    def __init__(self) -> None:
+        self._metrics: List[object] = []
+
+    def register(self, metric: object) -> object:
+        self._metrics.append(metric)
+        return metric
+
+    def reset(self) -> None:
+        """Zera todos os counters registrados (gauges/histogramas são
+        stateless). Só para testes."""
+        for m in self._metrics:
+            reset = getattr(m, "reset", None)
+            if callable(reset):
+                reset()
+
+    def render(self) -> str:
+        blocks = ["\n".join(m.render()) for m in self._metrics]  # type: ignore[attr-defined]
+        return "\n".join(blocks) + "\n"

--- a/infra/k8s/worker_rate_limit.py
+++ b/infra/k8s/worker_rate_limit.py
@@ -1,0 +1,90 @@
+"""worker_rate_limit — token bucket por canal do deile-worker (issue #620 AC7).
+
+Controle de admissão por ``channel_id`` para evitar que um único canal
+monopolize o worker. Cada canal tem um balde de tokens com ``capacity`` tokens
+que recarrega a ``rate`` tokens/segundo. Um dispatch consome 1 token; sem
+token disponível → rejeição com ``Retry-After`` (segundos até o próximo token).
+
+Isolamento: cada canal tem seu próprio balde — um canal saturado não afeta os
+demais. Limpeza lazy: um balde sem uso há mais de ``idle_reset_s`` segundos é
+resetado para a capacidade cheia no próximo acesso (canais inativos não
+acumulam dívida nem ocupam dívida histórica).
+
+In-memory por processo (V1). Distributed rate limiting (Redis) → #621.
+``time_source`` é injetável para teste determinístico.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Tuple
+
+
+@dataclass
+class _Bucket:
+    tokens: float
+    last_refill: float
+
+
+class TokenBucketRateLimiter:
+    """Token bucket in-memory por ator (``channel_id``), thread-safe.
+
+    Args:
+        capacity: tokens máximos no balde (burst permitido). Default 10.
+        rate: tokens recarregados por segundo. Default 1/s.
+        idle_reset_s: balde ocioso por mais que isto é resetado para cheio
+            no próximo acesso. Default 300s.
+        time_source: fonte monotônica injetável (default ``time.monotonic``).
+    """
+
+    def __init__(
+        self,
+        *,
+        capacity: float = 10.0,
+        rate: float = 1.0,
+        idle_reset_s: float = 300.0,
+        time_source: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be >= 1")
+        if rate <= 0:
+            raise ValueError("rate must be > 0")
+        self._capacity = float(capacity)
+        self._rate = float(rate)
+        self._idle_reset_s = float(idle_reset_s)
+        self._now = time_source
+        self._buckets: Dict[str, _Bucket] = {}
+        self._lock = threading.Lock()
+
+    def acquire(self, actor: str) -> Tuple[bool, float]:
+        """Tenta consumir 1 token de *actor*.
+
+        Returns:
+            ``(allowed, retry_after_s)`` — ``allowed=True`` quando havia token
+            (consumido); ``retry_after_s`` é 0.0 quando permitido, ou os
+            segundos até o próximo token quando rejeitado.
+        """
+        now = self._now()
+        with self._lock:
+            bucket = self._buckets.get(actor)
+            if bucket is None or (now - bucket.last_refill) >= self._idle_reset_s:
+                # Novo canal, ou ocioso o suficiente para resetar para cheio.
+                bucket = _Bucket(tokens=self._capacity, last_refill=now)
+                self._buckets[actor] = bucket
+            else:
+                elapsed = now - bucket.last_refill
+                bucket.tokens = min(
+                    self._capacity, bucket.tokens + elapsed * self._rate,
+                )
+                bucket.last_refill = now
+
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return True, 0.0
+            # Sem token: tempo até o balde ter 1 token de novo.
+            deficit = 1.0 - bucket.tokens
+            retry_after = math.ceil(deficit / self._rate)
+            return False, float(retry_after)

--- a/infra/k8s/worker_server.py
+++ b/infra/k8s/worker_server.py
@@ -52,8 +52,19 @@ from typing import Any, Dict, Optional
 # logic is unit-testable without aiohttp.
 import _worker_resume as resume
 import dispatch_logger as dlog
+import worker_metrics as wm
 # aiohttp comes from the deilebot extra (already in the image).
 from aiohttp import web
+from worker_rate_limit import TokenBucketRateLimiter
+
+# Schema version is the single source of truth for the result contract
+# (issue #620 AC9). Lives in the ``deile`` package (importable in the worker
+# pod); fail-open to 1 if the package layout ever shifts so a missing import
+# never breaks a dispatch.
+try:
+    from deile.core.schemas import RESULT_SCHEMA_VERSION
+except Exception:  # noqa: BLE001 — defensive: never break dispatch on import
+    RESULT_SCHEMA_VERSION = 1
 
 logger = logging.getLogger("deile.worker_server")
 
@@ -118,6 +129,103 @@ _TASKS: Dict[str, Dict[str, Any]] = {}
 _TASKS_MAX: int = int(os.environ.get("DEILE_WORKER_MAX_INMEM_TASKS", "500"))
 _AGENT = None
 _AGENT_LOCK = asyncio.Lock()
+
+# G3 / AC3 (issue #620): protege a seção crítica evict + insert em ``_TASKS``.
+# É um lock de HIGIENE, não a correção de um bug vivo: o worker roda um único
+# event loop e não há ``await`` entre ``_evict_old_tasks_if_needed()`` e a
+# inserção do task_id em ``dispatch_handler`` — duas corrotinas nunca se
+# intercalam ali. O lock torna a invariante (``len(_TASKS) <= _TASKS_MAX + N``)
+# explícita e à prova de regressão caso um ``await`` seja introduzido entre as
+# duas operações no futuro. Mantido proporcional (sem locks por-leitura: o
+# ``result_handler``/``progress_handler`` leem sem lock — consistência
+# eventual é suficiente, conforme o desejado §3).
+_TASKS_LOCK = asyncio.Lock()
+
+# G6 / AC6 (issue #620): cache de idempotência ``X-Idempotency-Key`` →
+# ``(task_id, created_at_monotonic)``. Limpeza lazy no lookup (entradas com
+# idade > ``_IDEMPOTENCY_TTL_S`` são descartadas). Volume de dispatches por
+# worker é baixo (<100/min), então o bound implícito por TTL + ``_TASKS_MAX``
+# é suficiente em V1.
+_IDEMPOTENCY_KEYS: Dict[str, tuple] = {}
+_IDEMPOTENCY_TTL_S: float = 300.0
+_IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+# G7 / AC7 (issue #620): token bucket por canal — capacity=10, rate=1/s.
+_RATE_LIMITER = TokenBucketRateLimiter(capacity=10.0, rate=1.0, idle_reset_s=300.0)
+
+# Contador de dispatches em voo (gauge ``deile_worker_in_flight``). Incrementado
+# na admissão de cada dispatch (wait e fire-and-forget) e decrementado no
+# terminal — fonte do gauge no scrape de ``/v1/metrics``.
+_IN_FLIGHT: int = 0
+
+# AC1 (issue #620): sinaliza shutdown em curso. Quando True o ``dispatch_handler``
+# rejeita novos dispatches com 503 enquanto o drain de ``_BG_DISPATCH_TASKS``
+# acontece em ``_graceful_shutdown``.
+_SHUTTING_DOWN: bool = False
+
+# AC1: timeout de drain do graceful shutdown (≤30s); o teto total até
+# ``os._exit(0)`` é ≤35s (drain + margem de estado terminal).
+_SHUTDOWN_DRAIN_TIMEOUT_S: float = 30.0
+_SHUTDOWN_HARD_DEADLINE_S: float = 35.0
+
+
+# ---- Metrics registry (AC2) --------------------------------------------------
+
+def _circuit_breaker_state_value() -> float:
+    """Lê o estado do circuit breaker do cliente (0/1/2) para o gauge.
+
+    Importado lazy: o gauge é avaliado só no scrape, e o cliente vive no
+    pacote ``deile`` (disponível no worker pod). Fail-open → 0 (closed) se
+    o módulo não estiver importável neste contexto.
+    """
+    try:
+        from deile.infrastructure.deile_worker_client import \
+            circuit_breaker_state
+        return float(circuit_breaker_state())
+    except Exception:  # noqa: BLE001 — métrica nunca derruba o scrape
+        return 0.0
+
+
+_METRICS = wm.MetricsRegistry()
+_M_DISPATCHES = _METRICS.register(wm.Counter(
+    "deile_worker_dispatches_total",
+    "Total de dispatches admitidos, por stage/persona/ok.",
+    labelnames=("stage", "persona", "ok"),
+))
+_M_ERRORS = _METRICS.register(wm.Counter(
+    "deile_worker_errors_total",
+    "Total de erros de dispatch, por error_code.",
+    labelnames=("error_code",),
+))
+_M_IDEMPOTENCY_HITS = _METRICS.register(wm.Counter(
+    "deile_worker_idempotency_hits_total",
+    "Dispatches servidos do cache de idempotência (já despachados).",
+))
+_M_RATE_LIMIT_REJECTIONS = _METRICS.register(wm.Counter(
+    "deile_worker_rate_limit_rejections_total",
+    "Dispatches rejeitados por rate limit, por canal.",
+    labelnames=("channel",),
+))
+_METRICS.register(wm.Gauge(
+    "deile_worker_in_flight",
+    "Dispatches atualmente em execução.",
+    lambda: float(_IN_FLIGHT),
+))
+_METRICS.register(wm.Gauge(
+    "deile_worker_tasks_memory",
+    "Tasks no registro in-memory _TASKS.",
+    lambda: float(len(_TASKS)),
+))
+_METRICS.register(wm.Gauge(
+    "deile_worker_circuit_breaker_state",
+    "Estado do circuit breaker do cliente (0=closed, 1=open, 2=half-open).",
+    _circuit_breaker_state_value,
+))
+_METRICS.register(wm.HistogramSkeleton(
+    "deile_worker_dispatch_duration_seconds",
+    "Duração de dispatch (skeleton V1 — coleta real em #621).",
+    wm.DISPATCH_DURATION_BUCKETS,
+))
 
 # B2 (PR #295 review): strong refs para background tasks geradas em
 # ``dispatch_handler`` quando ``wait=False``. ``asyncio.create_task`` mantém
@@ -482,6 +590,40 @@ def _prune_results_dir(results_dir: Path, keep: int = 200) -> None:
             logger.debug("could not prune result file %s", stale, exc_info=True)
 
 
+#: Ordem canônica dos 5 marcos de latência por fase (AC8). Cada fase é o delta
+#: até o marco anterior na sequência; ``total`` é o wall-clock completo.
+_PHASE_MARK_ORDER = ("agent_start", "model_first_token", "agent_end", "io_ops")
+
+
+def _log_phase_latencies(task_id: str, marks: Dict[str, float]) -> None:
+    """Loga as latências por fase (ms) ao final de ``_run_task`` (AC8).
+
+    Calcula os deltas entre marcos monotônicos consecutivos e emite um log
+    estruturado com o campo ``phases`` (dict ``nome -> delta_ms``). Best-effort:
+    nunca derruba o dispatch. Marcos ausentes (ex.: timeout antes do 1º token)
+    caem no marco anterior, garantindo um delta não-negativo para cada fase.
+    """
+    try:
+        start = marks.get("start")
+        if start is None:
+            return
+        # Resolve cada marco; ausências caem no anterior (delta vira ~0).
+        prev = start
+        phases: Dict[str, float] = {}
+        for name in _PHASE_MARK_ORDER:
+            ts = marks.get(name, prev)
+            phases[name] = round(max(0.0, ts - prev) * 1000.0, 3)
+            prev = ts
+        total_ts = marks.get("total", prev)
+        phases["total"] = round(max(0.0, total_ts - start) * 1000.0, 3)
+        logger.info(
+            "task %s phase latencies", task_id,
+            extra={"task_id": task_id, "phases": phases},
+        )
+    except Exception:  # noqa: BLE001 — observability never breaks a dispatch
+        logger.debug("phase latency logging failed for %s", task_id, exc_info=True)
+
+
 async def _list_workspace_files(workdir: Path) -> list[str]:
     out: list[str] = []
     if not workdir.exists():
@@ -610,9 +752,12 @@ async def _run_task(
     disturbing the worker's process-wide default.
     """
     start = time.monotonic()
-    # Workdir POR canal (não por task): o payload de dispatch não traz
-    # user_id, então dispatches do mesmo channel_id reusam a mesma pasta
-    # persistente; canais diferentes ficam isolados entre si.
+    # AC8 (issue #620): latência por fase. Capturamos ``time.monotonic()`` em
+    # 5 marcos nomeados e logamos os deltas (ms) num campo estruturado
+    # ``phases`` ao final. ``model_first_token`` é fixado no 1º chunk do stream
+    # (ou no retorno do process_input não-streaming); os demais são marcos do
+    # ciclo de vida do dispatch. ``total`` é o wall-clock completo.
+    _marks: Dict[str, float] = {"start": start}
     workdir = WORK_ROOT / _channel_workdir(channel_id)
     workdir.mkdir(parents=True, exist_ok=True)
 
@@ -668,6 +813,7 @@ async def _run_task(
     # Structured resume result, populated only on the pipeline path.
     resume_result: Optional[Dict[str, Any]] = None
     try:
+        _marks["agent_start"] = time.monotonic()
         agent = await _get_agent()
         session_id = f"worker_{task_id}"
         try:
@@ -779,6 +925,8 @@ async def _run_task(
             async def _consume_stream():
                 nonlocal final_text
                 async for chunk in stream_method(prompt, **kwargs):
+                    # AC8: 1º chunk = momento do primeiro token do modelo.
+                    _marks.setdefault("model_first_token", time.monotonic())
                     # Chunk shape varies; we accept str / dict / object.
                     if isinstance(chunk, str):
                         response_text_chunks.append(chunk)
@@ -801,6 +949,9 @@ async def _run_task(
                 agent.process_input(prompt, **kwargs),
                 timeout=_eff_timeout,
             )
+            # AC8: caminho não-streaming — o "primeiro token" coincide com o
+            # retorno da resposta completa.
+            _marks.setdefault("model_first_token", time.monotonic())
             final_text = str(getattr(resp, "content", "") or "")
 
         ok = True
@@ -839,6 +990,8 @@ async def _run_task(
         except Exception:  # noqa: BLE001 — never break the dispatch
             logger.exception("resume bookkeeping failed for task %s", task_id)
 
+    # AC8: fim do trabalho do agente (após o tool-loop + bookkeeping de resume).
+    _marks["agent_end"] = time.monotonic()
     elapsed = time.monotonic() - start
     files = await _list_workspace_files(workdir)
     summary = final_text.strip() if ok else f"erro: {error_repr}"
@@ -851,7 +1004,10 @@ async def _run_task(
         await _react(channel_id, user_message_id, "✅" if ok else "❌")
 
     # Persist result.json into the workspace (audit + later inspection).
+    # AC9: ``schema_version`` pins the result contract (deile/core/schemas/
+    # result_v1.json) so future format changes are migratable retroactively.
     result = {
+        "schema_version": RESULT_SCHEMA_VERSION,
         "task_id": task_id,
         "ok": ok,
         "elapsed_s": elapsed,
@@ -881,6 +1037,11 @@ async def _run_task(
         _prune_results_dir(results_dir)
     except OSError:
         logger.exception("could not persist result for task %s", task_id)
+
+    # AC8: marca o fim das operações de I/O e o total; loga os deltas por fase.
+    _marks["io_ops"] = time.monotonic()
+    _marks["total"] = time.monotonic()
+    _log_phase_latencies(task_id, _marks)
 
     # Dispatch terminou: remove o marcador de doing-now (painel volta a idle).
     _clear_current_marker(task_id)
@@ -936,7 +1097,45 @@ def _parse_resume_ctx(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     }
 
 
+def _idempotency_lookup(key: str) -> Optional[str]:
+    """Resolve um ``X-Idempotency-Key`` para o ``task_id`` original, ou None.
+
+    Limpeza lazy (AC6): entradas com idade > ``_IDEMPOTENCY_TTL_S`` são
+    descartadas no lookup, então uma key expirada vira "nova task". Chamado
+    sob ``_TASKS_LOCK`` para ser atômico com o registro da nova task.
+    """
+    now = time.monotonic()
+    # Prune lazy de entradas expiradas (evita crescimento ilimitado do cache).
+    expired = [
+        k for k, (_tid, created) in _IDEMPOTENCY_KEYS.items()
+        if (now - created) > _IDEMPOTENCY_TTL_S
+    ]
+    for k in expired:
+        _IDEMPOTENCY_KEYS.pop(k, None)
+    entry = _IDEMPOTENCY_KEYS.get(key)
+    return entry[0] if entry else None
+
+
+def _record_dispatch_metric(stage: Optional[str], persona: Optional[str],
+                            ok: Optional[bool]) -> None:
+    """Incrementa ``deile_worker_dispatches_total`` com labels normalizados."""
+    _M_DISPATCHES.inc(
+        stage=stage or "none",
+        persona=persona or "none",
+        ok=("true" if ok else "false"),
+    )
+
+
 async def dispatch_handler(request: web.Request) -> web.Response:
+    # AC1: durante o graceful shutdown rejeitamos novos dispatches com 503
+    # (Retry-After curto) — o drain das tasks em voo segue em background.
+    if _SHUTTING_DOWN:
+        _M_ERRORS.inc(error_code="SHUTTING_DOWN")
+        return web.json_response(
+            {"error": {"code": "SHUTTING_DOWN", "message": "worker shutting down"}},
+            status=503,
+            headers={"Retry-After": "5"},
+        )
     try:
         body = await request.json()
     except json.JSONDecodeError:
@@ -1022,14 +1221,71 @@ async def dispatch_handler(request: web.Request) -> web.Response:
         except (TypeError, ValueError):
             pass
 
-    task_id = uuid.uuid4().hex[:_TASK_ID_LEN]
-    _evict_old_tasks_if_needed()
-    _TASKS[task_id] = {
-        "task_id": task_id,
-        "ok": None,
-        "started_at": datetime.now(timezone.utc).isoformat(),
-        "brief": brief,
-    }
+    # AC7: rate limit por canal (token bucket capacity=10, rate=1/s). Aplicado
+    # ANTES de criar a task — um canal saturado é rejeitado com 429 +
+    # Retry-After sem consumir recurso. Canais distintos têm baldes isolados.
+    allowed, retry_after = _RATE_LIMITER.acquire(channel_id)
+    if not allowed:
+        _M_RATE_LIMIT_REJECTIONS.inc(channel=channel_id)
+        _M_ERRORS.inc(error_code="RATE_LIMITED")
+        return web.json_response(
+            {"error": {"code": "RATE_LIMITED",
+                       "message": "channel rate limit exceeded"}},
+            status=429,
+            headers={"Retry-After": str(int(retry_after))},
+        )
+
+    # AC6: idempotência. Um ``X-Idempotency-Key`` válido permite ao cliente
+    # re-enviar (ex.: após timeout de rede) sem duplicar trabalho. Validamos o
+    # charset (defesa contra keys absurdas) — keys malformadas são ignoradas
+    # (tratadas como ausentes), preservando compat com callers legados.
+    #
+    # O lookup + a possível leitura de disco ficam FORA do ``_TASKS_LOCK``: a
+    # seção crítica do lock cobre só evict+insert (AC3). A janela TOCTOU entre
+    # este lookup e o insert é benigna — duas requisições simultâneas com a
+    # mesma key de uma task já terminal servem o MESMO resultado (idempotente).
+    idem_key = request.headers.get("X-Idempotency-Key", "").strip()
+    if idem_key and not _IDEMPOTENCY_KEY_RE.match(idem_key):
+        idem_key = ""
+    if idem_key:
+        existing_id = _idempotency_lookup(idem_key)
+        if existing_id is not None:
+            existing = _TASKS.get(existing_id)
+            if existing is not None and existing.get("ok") is None:
+                # Task original ainda em execução → 409 duplicate in-flight.
+                _M_ERRORS.inc(error_code="duplicate_in_flight")
+                return web.json_response(
+                    {"error": {"code": "duplicate_in_flight",
+                               "message": f"task {existing_id} still running"}},
+                    status=409,
+                )
+            # Task original terminal (em memória ou no PVC) → serve o
+            # resultado original com marcador ``already_dispatched``.
+            state = existing if existing is not None \
+                else _lookup_task_state(existing_id)[0]
+            if state is not None:
+                _M_IDEMPOTENCY_HITS.inc()
+                payload = {k: v for k, v in state.items()
+                           if not k.startswith("_")}
+                payload["status"] = "already_dispatched"
+                return web.json_response(payload)
+            # Original sumiu (evicção + PVC podado) → trata como nova task.
+
+    # AC3: seção crítica — evict + insert do task_id são atômicos sob
+    # ``_TASKS_LOCK`` (lock de higiene; ver nota no ``_TASKS_LOCK``). Mantém a
+    # invariante de tamanho à prova de regressão.
+    async with _TASKS_LOCK:
+        task_id = uuid.uuid4().hex[:_TASK_ID_LEN]
+        _evict_old_tasks_if_needed()
+        _TASKS[task_id] = {
+            "task_id": task_id,
+            "ok": None,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "brief": brief,
+        }
+        if idem_key:
+            _IDEMPOTENCY_KEYS[idem_key] = (task_id, time.monotonic())
+
     # Structured one-line dispatch log — single source of truth consumed by
     # ``infra.k8s._panel_data.WorkerProvider`` to populate the Pod Watch
     # "current task" header (issue #309 fase 2 follow-up, #435). NEVER include
@@ -1049,6 +1305,10 @@ async def dispatch_handler(request: web.Request) -> web.Response:
 
     wait_for_result = bool(body.get("wait_for_result", True))
     _outer_timeout = (dispatch_timeout_s + 30) if dispatch_timeout_s is not None else (TASK_TIMEOUT_S + 30)
+    # Gauge ``deile_worker_in_flight`` (AC2): conta dispatches em execução. O
+    # decremento é garantido no terminal de ambos os caminhos.
+    global _IN_FLIGHT
+    _IN_FLIGHT += 1
     if wait_for_result:
         try:
             result = await asyncio.wait_for(
@@ -1060,16 +1320,24 @@ async def dispatch_handler(request: web.Request) -> web.Response:
                 timeout=_outer_timeout,
             )
             _TASKS[task_id] = result
+            _record_dispatch_metric(stage, persona, bool(result.get("ok")))
+            if not result.get("ok"):
+                _M_ERRORS.inc(error_code="DISPATCH_FAILED")
             # Terminal marker for the panel — pairs with dispatch.received (#435).
             dlog.dispatch_completed(task=task_id, ok=bool(result.get("ok")))
             return web.json_response(result)
         except asyncio.TimeoutError:
             _TASKS[task_id] = {**_TASKS[task_id], "ok": False, "error": "outer timeout"}
+            _record_dispatch_metric(stage, persona, False)
+            _M_ERRORS.inc(error_code="OUTER_TIMEOUT")
             dlog.dispatch_failed(task=task_id, reason="outer_timeout", error_code="OUTER_TIMEOUT")
             return web.json_response(_TASKS[task_id], status=504)
+        finally:
+            _IN_FLIGHT -= 1
     else:
         # Fire-and-forget — caller polls /v1/result/{id}
         async def _bg():
+            global _IN_FLIGHT
             # Iter-2 review: handle CancelledError separately so that loop
             # shutdown still writes a terminal state to _TASKS (otherwise
             # ``ok`` stays ``None`` forever and pollers loop indefinitely).
@@ -1079,6 +1347,9 @@ async def dispatch_handler(request: web.Request) -> web.Response:
                                                   preferred_model=preferred_model,
                                                   reasoning_effort=reasoning_effort,
                                                   task_timeout_s=dispatch_timeout_s)
+                _record_dispatch_metric(stage, persona, bool(_TASKS[task_id].get("ok")))
+                if not _TASKS[task_id].get("ok"):
+                    _M_ERRORS.inc(error_code="DISPATCH_FAILED")
                 dlog.dispatch_completed(
                     task=task_id, ok=bool(_TASKS[task_id].get("ok")),
                 )
@@ -1088,6 +1359,8 @@ async def dispatch_handler(request: web.Request) -> web.Response:
                     "ok": False,
                     "error": "task cancelled",
                 }
+                _record_dispatch_metric(stage, persona, False)
+                _M_ERRORS.inc(error_code="TASK_CANCELLED")
                 dlog.dispatch_failed(task=task_id, reason="cancelled", error_code="TASK_CANCELLED")
                 raise
             except Exception as exc:
@@ -1095,7 +1368,11 @@ async def dispatch_handler(request: web.Request) -> web.Response:
                     "task_id": task_id, "ok": False,
                     "error": f"{type(exc).__name__}: {exc}",
                 }
+                _record_dispatch_metric(stage, persona, False)
+                _M_ERRORS.inc(error_code="RUNTIME_EXCEPTION")
                 dlog.dispatch_failed(task=task_id, reason=type(exc).__name__, error_code="RUNTIME_EXCEPTION")
+            finally:
+                _IN_FLIGHT -= 1
         # B2 (PR #295 review): guarda strong ref para a task em background.
         # asyncio mantém apenas weak refs internamente; sem o set + callback,
         # o GC pode coletar a task antes de ela completar.
@@ -1141,6 +1418,15 @@ async def result_handler(request: web.Request) -> web.Response:
     state, error = _lookup_task_state(task_id)
     if error is not None:
         return error
+    # AC9: leitura tolerante de schema_version (forward compat). Um resultado
+    # sem o campo ou com versão diferente é SERVIDO mesmo assim — só logamos
+    # um warning para que migrações futuras nunca quebrem leitores legados.
+    version = state.get("schema_version")
+    if version != RESULT_SCHEMA_VERSION:
+        logger.warning(
+            "task %s result schema_version=%r (expected %d) — serving anyway",
+            task_id, version, RESULT_SCHEMA_VERSION,
+        )
     # Strip internal-only keys (_mono_start) before returning to the client.
     payload = {k: v for k, v in state.items() if not k.startswith("_")}
     return web.json_response(payload)
@@ -1183,6 +1469,24 @@ async def progress_handler(request: web.Request) -> web.Response:
     })
 
 
+async def metrics_handler(request: web.Request) -> web.Response:
+    """``GET /v1/metrics`` — exposição Prometheus text format (AC2).
+
+    Gated pelo mesmo Bearer dos demais endpoints (só ``/v1/health`` é aberto).
+    Zero dependências externas: o texto é renderizado pelo registry
+    hand-rolled em ``worker_metrics``. O histograma de duração é skeleton em
+    V1 (buckets registrados, ``_count=0``) — coleta real difere para #621.
+    """
+    body = _METRICS.render()
+    # Não usamos os params ``content_type``/``charset`` do aiohttp porque eles
+    # não conseguem emitir o parâmetro ``version=0.0.4`` exigido pelo formato
+    # Prometheus; setamos o header completo diretamente (AC2).
+    return web.Response(
+        body=body.encode("utf-8"),
+        headers={"Content-Type": wm.CONTENT_TYPE},
+    )
+
+
 def build_app(auth_token: str) -> web.Application:
     app = web.Application(middlewares=[_bearer_auth_mw], client_max_size=64 * 1024)
     app["auth_token"] = auth_token
@@ -1191,6 +1495,8 @@ def build_app(auth_token: str) -> web.Application:
     app.router.add_get("/v1/result/{task_id}", result_handler)
     # Issue #257 — snapshot mid-flight para polling do CLI multipanel.
     app.router.add_get("/v1/progress/{task_id}", progress_handler)
+    # Issue #620 AC2 — métricas Prometheus.
+    app.router.add_get("/v1/metrics", metrics_handler)
     return app
 
 
@@ -1211,6 +1517,85 @@ async def _on_startup(app: web.Application) -> None:
         logger.info("agent warmup complete; cwd=%s", os.getcwd())
     except Exception:
         logger.exception("agent warmup failed; dispatches will retry")
+
+
+def _mark_inflight_tasks_terminal(reason: str = "worker shutting down") -> int:
+    """Escreve estado terminal nas tasks de ``_TASKS`` que não concluíram.
+
+    AC1: ao fim do drain, tasks ainda com ``ok is None`` (não drenadas a tempo)
+    recebem ``ok=False`` + ``error=<reason>`` para que pollers de
+    ``/v1/result`` não fiquem presos esperando um terminal que nunca virá.
+    Retorna quantas foram marcadas.
+    """
+    marked = 0
+    for tid, state in list(_TASKS.items()):
+        if isinstance(state, dict) and state.get("ok") is None:
+            _TASKS[tid] = {**state, "ok": False, "error": reason}
+            marked += 1
+    return marked
+
+
+async def _graceful_shutdown(app: web.Application) -> None:
+    """Drena dispatches em voo no SIGTERM (AC1).
+
+    Ciclo: (i) marca ``_SHUTTING_DOWN`` para que ``dispatch_handler`` rejeite
+    novos pedidos com 503; (ii) drena ``_BG_DISPATCH_TASKS`` com
+    ``asyncio.wait_for(..., timeout=_SHUTDOWN_DRAIN_TIMEOUT_S)`` (≤30s);
+    (iii) escreve estado terminal nas tasks não concluídas. Registrado como
+    ``on_shutdown`` do aiohttp — ``web.run_app`` o executa quando o sinal de
+    término chega, antes de fechar o servidor. O teto total até o ponto de
+    ``os._exit(0)`` no watchdog é ≤35s.
+    """
+    global _SHUTTING_DOWN
+    _SHUTTING_DOWN = True
+    logger.info("graceful shutdown: draining %d in-flight dispatch(es)",
+                len(_BG_DISPATCH_TASKS))
+    pending = [t for t in _BG_DISPATCH_TASKS if not t.done()]
+    if pending:
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=_SHUTDOWN_DRAIN_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "graceful shutdown: drain timed out after %.0fs; "
+                "marking remaining tasks terminal",
+                _SHUTDOWN_DRAIN_TIMEOUT_S,
+            )
+    marked = _mark_inflight_tasks_terminal()
+    logger.info("graceful shutdown: drain complete; %d task(s) marked terminal",
+                marked)
+
+
+def _install_shutdown_watchdog() -> None:
+    """Watchdog de hard-deadline: se o drain travar, força ``os._exit(0)``.
+
+    Mesmo com o drain do aiohttp, um cleanup pendurado poderia segurar o pod
+    além do ``terminationGracePeriodSeconds``. Ao receber SIGTERM agendamos um
+    timer que chama ``os._exit(0)`` após ``_SHUTDOWN_HARD_DEADLINE_S`` — o k8s
+    não precisa recorrer ao SIGKILL. Best-effort: se não houver loop corrente
+    (ex.: import em teste), no-op.
+    """
+    import signal
+    import threading
+
+    def _hard_exit() -> None:
+        logger.error("graceful shutdown: hard deadline reached; os._exit(0)")
+        os._exit(0)
+
+    def _on_sigterm(_signum, _frame) -> None:
+        global _SHUTTING_DOWN
+        _SHUTTING_DOWN = True
+        timer = threading.Timer(_SHUTDOWN_HARD_DEADLINE_S, _hard_exit)
+        timer.daemon = True
+        timer.start()
+
+    try:
+        signal.signal(signal.SIGTERM, _on_sigterm)
+    except (ValueError, OSError):
+        # Fora da main thread (ex.: alguns runners de teste) — sem watchdog.
+        logger.debug("could not install SIGTERM watchdog", exc_info=True)
 
 
 def main() -> int:
@@ -1236,6 +1621,10 @@ def main() -> int:
         return 78
     app = build_app(token)
     app.on_startup.append(_on_startup)
+    # AC1: drena dispatches em voo no SIGTERM antes de o servidor fechar, e
+    # arma o watchdog de hard-deadline que força os._exit(0) se o drain travar.
+    app.on_shutdown.append(_graceful_shutdown)
+    _install_shutdown_watchdog()
     logger.info("worker_server listening on %s:%d, work root=%s",
                 LISTEN_HOST, LISTEN_PORT, WORK_ROOT)
     web.run_app(app, host=LISTEN_HOST, port=LISTEN_PORT, print=lambda *_: None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,3 +113,6 @@ version = { attr = "deile.__version__.__version__" }
 [tool.setuptools.packages.find]
 include = ["deile*"]
 exclude = ["deilebot*", "tests*"]
+
+[tool.setuptools.package-data]
+"deile.core.schemas" = ["*.json"]


### PR DESCRIPTION
## Resumo

Hardening V1 do `deile-worker` (servidor `infra/k8s/worker_server.py` + cliente `deile/infrastructure/deile_worker_client.py`), implementando os 9 critérios de aceite da issue #620 com os valores numéricos exatos especificados. Sem novas dependências externas (Prometheus text format e circuit breaker/rate limiter são hand-rolled in-memory).

`Closes #620`

## Mapa AC → implementação → teste (prova de FIAÇÃO)

| AC | O que entregou | Onde | Teste que prova |
|----|----------------|------|-----------------|
| **AC1** Graceful shutdown | Handler SIGTERM dreena `_BG_DISPATCH_TASKS` (`wait_for` timeout=30s), marca estado terminal nas tasks não concluídas, rejeita novos com 503; watchdog força `os._exit(0)` em 35s; `terminationGracePeriodSeconds: 40` no manifest | `worker_server.py` (`_graceful_shutdown`, `_mark_inflight_tasks_terminal`, `_install_shutdown_watchdog`, `main`), `manifests/45-deile-worker-deployment.yaml` | `test_worker_graceful_shutdown.py` |
| **AC2** Métricas | `GET /v1/metrics` Prometheus text 0.0.4; counters `dispatches_total`/`errors_total`/`idempotency_hits_total`/`rate_limit_rejections_total`, gauges `in_flight`/`tasks_memory`/`circuit_breaker_state`, histograma skeleton `dispatch_duration_seconds` (`_count=0`) | `worker_metrics.py` (novo), `metrics_handler`/`build_app` | `test_worker_metrics.py` |
| **AC3** TOCTOU lock | `_TASKS_LOCK` (lock de higiene) na seção evict+insert; bound `len(_TASKS) ≤ 10 + N_em_voo` | `worker_server.py` (`dispatch_handler`) | `test_worker_tasks_lock.py` |
| **AC4** Retry | 3 tentativas, base=1s, fator=2, jitter ±0,3s; só 5xx/`WORKER_TIMEOUT`/`WORKER_UNREACHABLE`; 4xx (409/429) sem retry; `max_retries` como teto | `deile_worker_client.py` (`dispatch`/`_dispatch_once`/`_backoff_delay`) | `test_deile_worker_client.py` (estendido) |
| **AC5** Circuit breaker | 3-state in-memory, threshold=5, reset=30s, probe half-open; `CIRCUIT_OPEN` sem I/O em open | `circuit_breaker.py` (novo) + integração no `dispatch` | `test_worker_circuit_breaker.py` |
| **AC6** Idempotência | `X-Idempotency-Key` → cache (TTL 300s, limpeza lazy); 200 `already_dispatched` / 409 `duplicate_in_flight` / nova task sem key | `worker_server.py` (`dispatch_handler`, `_idempotency_lookup`) | `test_worker_idempotency.py` |
| **AC7** Rate limit | Token bucket por canal capacity=10, rate=1/s; 429 + `Retry-After`; isolamento entre canais; reset de balde ocioso >300s | `worker_rate_limit.py` (novo) + admissão no `dispatch_handler` | `test_worker_rate_limit.py` |
| **AC8** Latência por fase | 5 marcos `time.monotonic()` (`agent_start`, `model_first_token`, `agent_end`, `io_ops`, `total`) → log estruturado `phases` | `worker_server.py` (`_run_task`, `_log_phase_latencies`) | `test_worker_latency_phases.py` |
| **AC9** Schema skeleton | `schema_version: 1` no resultado; `deile/core/schemas/result_v1.json` (draft-2020-12, package-data); `result_handler` aceita sem versão com warning | `worker_server.py`, `deile/core/schemas/`, `pyproject.toml` | `test_worker_schema_skeleton.py` |

## Reuso de primitivas (`_worker_core`)

Avaliei o `RateLimiter` sliding-window e os helpers já presentes em `infra/k8s/_worker_core.py`. **Não foram reusados** porque a semântica diverge do AC7: o AC exige um **token bucket** (capacity + recarga por taxa + `Retry-After` calculado + reset de balde ocioso), enquanto o `_worker_core.RateLimiter` é sliding-window por contagem (sem `Retry-After`, sem refil por taxa). Reusá-lo não satisfaria o AC literalmente, e unificar `_worker_core` no deile-worker (que hoje não o usa) estava explicitamente fora de escopo. Optei por um `TokenBucketRateLimiter` dedicado e enxuto. As demais primitivas do core (lease/subprocess) não se aplicam ao deile-worker (in-process, não subprocess).

## Nota sobre o AC3 (lock de higiene, não bug vivo)

O `_TASKS_LOCK` torna a invariante de tamanho à prova de regressão, mas é **higiene**: o deile-worker roda um único event loop e não há `await` entre `_evict_old_tasks_if_needed()` e o insert do task_id, então duas corrotinas nunca se intercalam ali hoje. O lock cobre só evict+insert (seção crítica mínima); o lookup de idempotência e a eventual leitura de disco ficam **fora** do lock para não bloquear o event loop. Sem locks por-leitura (consistência eventual basta no `result`/`progress`).

## Packaging

`worker_metrics.py` e `worker_rate_limit.py` são importados por nome nu pelo `worker_server.py` → adicionados ao `COPY` do Dockerfile + exceção no `.dockerignore` (mesma disciplina dos demais módulos `infra/k8s`), com teste de regressão de packaging. O `result_v1.json` viaja no `COPY deile ./deile` e está declarado como `package-data`.

## Evidência de testes

- **9 arquivos de teste novos/estendidos**, todos verdes (111 testes worker + adjacentes; AC9 tem 1 `skip` quando `jsonschema` ausente — a validação estrutural roda mesmo assim).
- **Suíte completa com gate de cobertura**: `4 failed, 8260 passed, 32 skipped in 247.77s`. As **4 falhas são pré-existentes em `origin/main`** (verificado em worktree pristina do baseline) e **não** tocam o código desta PR: `test_pod_presence.py::test_cleanup_stale_workspaces_removes_dead_pod_workspace`, `test_classify.py::...test_tick_calls_classify_before_review`, `test_gap_regressions.py::...test_gh_error_in_review_increments_gh_errors`, `test_reconcile_fire_and_forget.py::...test_does_not_reap_refine_resting_without_ledger`. Zero novas falhas.
- **Multi-seed** (0/1/2/42) em `deile/tests/infra/` + `deile/tests/infrastructure/`: `2463 passed` por seed (só a falha pré-existente do `test_pod_presence`).
- `ruff` e `isort` limpos nos arquivos tocados.

## Fora de escopo (→ #621)

Coleta real do histograma (`.observe()`), schema migration tooling, rate limit distribuído (Redis), HPA, fallback chain de LLM, doc de SLO, circuit breaker persistente cross-restart.