### PR TITLE
feat(observability): fleet CLI cost via central push to UsageRepository

### DIFF
--- a/deile/orchestration/pipeline/fleet_cost_recorder.py
+++ b/deile/orchestration/pipeline/fleet_cost_recorder.py
@@ -1,0 +1,251 @@
+"""Persistência central do custo da frota CLI no ``UsageRepository`` (issue #638).
+
+Substitui o pull-via-``kubectl exec`` (parsear ``.progress`` + ledger por-PVC, que
+some quando o pod escala a zero / é ``force-delete``) por um **push central** no
+momento do dispatch: o worker reporta tokens-por-modelo no bloco ``usage`` da
+resposta do ``/v1/dispatch``; o **pipeline** (componente longevo) persiste 1
+registro por modelo no SQLite central (``~/.deile/db/usage.db``). A tela
+``[T]okens`` passa a ler desse store — independe de pod estar de pé.
+
+DECISÃO DE SCHEMA (sem migração, sem tabela paralela): o ``UsageRecord`` já
+existente carrega worker/stage/issue em colunas que tinham slots livres,
+espelhando o que o ``records_for_stage_model`` já faz (stage no ``session_id``):
+
+* ``provider_id`` ← worker-kind (``opencode``/``codex``/… — "quem serviu");
+* ``tier``        ← stage (``implement``/``pr_review``/…);
+* ``session_id``  ← ``channel_id`` do dispatch (``pipeline-issue-<N>`` /
+                    ``pipeline-pr-<N>``), que carrega o issue/PR;
+* ``model_id``    ← model-id real do dispatch (``cli_model``, anti ``unknown``).
+
+Um dispatch multi-modelo vira N registros (1 por modelo do ``tokens_by_model``).
+Preço: fonte ÚNICA ``jsonl_cost.fleet_cost_of_model`` — sem duplicar tabela.
+
+Best-effort cardinal: qualquer falha (parser/preço/SQLite indisponível) é logada
+e engolida — NUNCA derruba o dispatch.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _load_jsonl_cost():
+    """Importa ``jsonl_cost`` de ``infra/k8s/`` (fonte única de preço da frota).
+
+    Mesmo padrão robusto do ``dispatch_resolver._load_cli_adapter_registry``: no
+    cluster o módulo é COPiado plano para ``/app`` (já no path); em dev/local
+    insere-se ``infra/k8s`` no path. Indisponível → ``None`` (degrada: o custo
+    fica 0.0 mas os tokens ainda são persistidos).
+    """
+    try:
+        import jsonl_cost  # noqa: PLC0415
+        return jsonl_cost
+    except ImportError:
+        repo_root = Path(__file__).resolve().parents[3]
+        infra_k8s = repo_root / "infra" / "k8s"
+        if infra_k8s.is_dir() and str(infra_k8s) not in sys.path:
+            sys.path.insert(0, str(infra_k8s))
+        try:
+            import jsonl_cost  # noqa: PLC0415
+            return jsonl_cost
+        except Exception as exc:  # noqa: BLE001 — degrada sem derrubar o dispatch
+            logger.debug("jsonl_cost indisponível (%s) — custo da frota fica 0.0", exc)
+            return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("falha ao carregar jsonl_cost (%s) — custo da frota fica 0.0", exc)
+        return None
+
+
+def _coerce_tokens(tk: object) -> dict:
+    """Normaliza um bloco de tokens do wire para ``{in,out,cache_read,cache_write}``.
+
+    Tolera tanto o contrato novo (``cache_read``/``cache_write``) quanto o shape
+    interno do parser (``cr``/``cc``) por robustez de wire.
+    """
+    if not isinstance(tk, dict):
+        return {"in": 0, "out": 0, "cache_read": 0, "cache_write": 0}
+
+    def _i(*keys: str) -> int:
+        for k in keys:
+            v = tk.get(k)
+            if isinstance(v, (int, float)):
+                return int(v)
+        return 0
+
+    return {
+        "in": _i("in", "input"),
+        "out": _i("out", "output"),
+        "cache_read": _i("cache_read", "cr"),
+        "cache_write": _i("cache_write", "cc"),
+    }
+
+
+def record_fleet_usage(
+    response: object,
+    *,
+    worker_kind: str,
+    stage: Optional[str],
+    channel_id: str,
+    cli_model: Optional[str],
+    repo: Optional[object] = None,
+) -> int:
+    """Persiste o uso de um dispatch da frota no ``UsageRepository`` central.
+
+    Caminho ``wait`` (critique/refine/pr_review/follow_ups/mention): lê o bloco
+    ``usage`` da resposta do ``/v1/dispatch`` (``tokens_by_model`` + ``model`` +
+    ``worker``) e grava 1 :class:`UsageRecord` por modelo. Retorna o número de
+    registros gravados (0 quando não há uso — claude/deile contabilizam por
+    outras vias, ou worker antigo sem o bloco).
+
+    Args:
+        response: dict da resposta do ``/v1/dispatch``.
+        worker_kind: kind do worker (``opencode``/…); fallback do bloco ``usage``.
+        stage: etapa canônica do pipeline (vai para ``tier``).
+        channel_id: ``pipeline-issue-<N>`` / ``pipeline-pr-<N>`` (vai para ``session_id``).
+        cli_model: model-id do payload (anti ``unknown`` no fallback do model).
+        repo: ``UsageRepository`` opcional (injeção em teste); default = singleton.
+
+    Best-effort: qualquer exceção é logada e engolida; retorna 0.
+    """
+    if not isinstance(response, dict):
+        return 0
+    usage = response.get("usage") if isinstance(response.get("usage"), dict) else {}
+    return _persist_usage(
+        usage,
+        worker=str(usage.get("worker") or worker_kind or "").strip() or "cli",
+        stage=stage,
+        session_id=str(channel_id or "").strip() or "pipeline-fleet",
+        cli_model=cli_model,
+        success=bool(response.get("ok")),
+        repo=repo,
+        dedup=False,
+    )
+
+
+def record_fleet_usage_from_resume_info(
+    info: object,
+    *,
+    worker_kind: str,
+    stage: Optional[str],
+    channel_id: str,
+    task_id: str,
+    repo: Optional[object] = None,
+) -> int:
+    """Grava o custo central de um dispatch fire-and-forget já CONCLUÍDO (issue #638).
+
+    O ``implement`` paralelo despacha fire-and-forget (202) — a resposta do
+    dispatch é descartada, então o bloco ``usage`` é lido depois via resume-info
+    no reconcile. Como o reconcile roda a cada tick até o label mudar, a escrita
+    é DEDUPADA pelo ``session_id`` ``<channel_id>#<task_id>`` (único por task):
+    registros já presentes para esse session_id → no-op idempotente.
+
+    Best-effort: qualquer exceção é logada e engolida; retorna registros gravados.
+    """
+    if not isinstance(info, dict):
+        return 0
+    usage = info.get("usage") if isinstance(info.get("usage"), dict) else {}
+    tid = str(task_id or "").strip()
+    base = str(channel_id or "").strip() or "pipeline-fleet"
+    session_id = f"{base}#{tid}" if tid else base
+    return _persist_usage(
+        usage,
+        worker=str(worker_kind or "").strip() or "cli",
+        stage=stage,
+        session_id=session_id,
+        cli_model=info.get("cli_model"),
+        success=not bool(info.get("last_is_error")),
+        repo=repo,
+        dedup=True,
+    )
+
+
+def _persist_usage(
+    usage: dict,
+    *,
+    worker: str,
+    stage: Optional[str],
+    session_id: str,
+    cli_model: Optional[str],
+    success: bool,
+    repo: Optional[object],
+    dedup: bool,
+) -> int:
+    """Núcleo da persistência: 1 :class:`UsageRecord` por modelo do ``usage``.
+
+    Compartilhado pelos caminhos ``wait`` e fire-and-forget. Best-effort: toda
+    exceção é engolida (custo NUNCA derruba o dispatch/reconcile).
+    """
+    try:
+        if not isinstance(usage, dict):
+            return 0
+        tokens_by_model = usage.get("tokens_by_model")
+        if not isinstance(tokens_by_model, dict) or not tokens_by_model:
+            return 0
+
+        fallback_model = str(usage.get("model") or cli_model or "").strip()
+        tier = str(stage or "").strip() or "implement"
+
+        if repo is None:
+            from deile.storage.usage_repository import get_usage_repository
+            repo = get_usage_repository()
+        from deile.storage.usage_repository import UsageRecord
+
+        if dedup and repo.records_for_session(session_id):
+            # Já contabilizado em tick anterior — idempotente.
+            return 0
+
+        jsonl_cost = _load_jsonl_cost()
+        ts = time.time()
+        written = 0
+        for model_id, raw_tk in tokens_by_model.items():
+            tk = _coerce_tokens(raw_tk)
+            prompt, completion = tk["in"], tk["out"]
+            cached, cache_write = tk["cache_read"], tk["cache_write"]
+            total = prompt + completion + cached + cache_write
+            if total <= 0:
+                continue  # sem tokens reais → não polui o store
+            # Anti model=unknown: chave vazia OU literal "unknown" cai no
+            # fallback (model do bloco usage → cli_model do payload).
+            mid = str(model_id or "").strip()
+            model = (mid if mid and mid != "unknown" else fallback_model) or "unknown"
+            cost = 0.0
+            if jsonl_cost is not None:
+                # Fonte ÚNICA de preço; cache-write soma ao input (chave ``cc``),
+                # cache-read ao preço de read (chave ``cr``) no fleet_cost_of_model.
+                cost = float(jsonl_cost.fleet_cost_of_model(
+                    {"in": prompt, "out": completion, "cc": cache_write, "cr": cached},
+                    model,
+                ))
+            repo.record(UsageRecord(
+                provider_id=worker,
+                model_id=model,
+                tier=tier,
+                session_id=session_id,
+                prompt_tokens=prompt,
+                completion_tokens=completion,
+                cached_tokens=cached,
+                total_tokens=total,
+                cost_usd=cost,
+                success=success,
+                timestamp=ts,
+            ))
+            written += 1
+
+        if written:
+            logger.info(
+                "custo da frota persistido: worker=%s stage=%s session=%s registros=%d",
+                worker, tier, session_id, written,
+            )
+        return written
+    except Exception as exc:  # noqa: BLE001 — escrita de custo NUNCA derruba o tick
+        logger.warning(
+            "falha ao persistir custo da frota (worker=%s stage=%s session=%s): %s",
+            worker, stage, session_id, exc,
+        )
+        return 0

--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -1148,6 +1148,23 @@ class WorkerImplementer(PipelineImplementer):
             )
         outcome = _outcome_from_worker_response(data)
 
+        # Observabilidade de custo central (issue #638): persiste 1 registro por
+        # modelo no UsageRepository central a partir do bloco ``usage`` estruturado
+        # que o cli-worker reporta. Só para workers da frota CLI — deile/claude
+        # contabilizam por outras vias (deile grava no SQLite do próprio pod;
+        # claude via JSONL). A escrita é best-effort isolada (record_fleet_usage
+        # nunca propaga exceção): falha de SQLite/preço NÃO derruba o dispatch.
+        if is_cli_worker:
+            from deile.orchestration.pipeline.fleet_cost_recorder import \
+                record_fleet_usage  # noqa: PLC0415
+            record_fleet_usage(
+                data,
+                worker_kind=_worker_kind_from_url(url),
+                stage=stage,
+                channel_id=channel_id,
+                cli_model=cli_model,
+            )
+
         # OAuth auto-renew (Nível 3): se o worker reportou WORKER_AUTH_EXPIRED,
         # tente uma renovação automática + retry UMA vez antes de propagar o
         # erro pro stage handler (que bloqueia a issue). Em sucesso do refresh

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -21,8 +21,8 @@ import asyncio
 import logging
 import re
 import time
-from datetime import timedelta
 from dataclasses import replace
+from datetime import timedelta
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from deile.orchestration.forge import (CommentRef, GhCommandError, IssueRef,
@@ -1191,7 +1191,10 @@ async def reconcile_critique_issues(monitor: "PipelineMonitor") -> None:
         # stage="classify"): o reconcile precisa resolver o MESMO worker pelo
         # stage="classify", senão consultaria o endpoint errado (404 → fresh →
         # double-dispatch). Refine continua em stage="refine".
-        state, info = await _fetch_reconcile_state(monitor, task_id, "classify")
+        state, info = await _fetch_reconcile_state(
+            monitor, task_id, "classify",
+            channel_id=f"pipeline-issue-{issue.number}",
+        )
         if state == _RECON_RUNNING:
             continue
         if state == _RECON_GONE:
@@ -1417,7 +1420,10 @@ async def reconcile_refine_issues(monitor: "PipelineMonitor") -> None:
         if not task_id:
             ledger.clear(key)
             continue
-        state, info = await _fetch_reconcile_state(monitor, task_id, "refine")
+        state, info = await _fetch_reconcile_state(
+            monitor, task_id, "refine",
+            channel_id=f"pipeline-issue-{issue.number}",
+        )
         if state == _RECON_RUNNING:
             continue
         if state == _RECON_GONE:
@@ -1867,7 +1873,8 @@ _RECON_GONE = "gone"
 
 
 async def _fetch_reconcile_state(
-    monitor: "PipelineMonitor", task_id: str, stage: str
+    monitor: "PipelineMonitor", task_id: str, stage: str,
+    *, channel_id: str = "",
 ) -> Tuple[str, dict]:
     """Consulta ``/v1/dispatches/{task_id}/resume-info`` e normaliza o estado.
 
@@ -1882,6 +1889,11 @@ async def _fetch_reconcile_state(
       True — o worker ainda está processando.
     - ``_RECON_DONE``: concluiu; ``info`` traz ``last_result_full`` /
       ``last_result_summary`` / ``last_is_error`` pro parser de veredito.
+
+    Issue #638: quando o estado é DONE e o dispatch foi fire-and-forget num
+    worker da frota CLI, o bloco ``usage`` do resume-info é persistido no
+    UsageRepository central (dedupado por task_id) — a resposta do 202 foi
+    descartada, então este é o único ponto de read-back de custo. Best-effort.
     """
     implementer = monitor.implementer
     client = getattr(implementer, "_client", None)
@@ -1907,7 +1919,58 @@ async def _fetch_reconcile_state(
     still_running = info.get("last_completed_at") is None or info.get("claude_alive")
     if still_running:
         return _RECON_RUNNING, info
+    _record_fleet_usage_from_reconcile(url, info, stage, channel_id, task_id)
     return _RECON_DONE, info
+
+
+async def _capture_implement_fleet_cost(
+    monitor: "PipelineMonitor", issue_number: int,
+) -> None:
+    """Lê o resume-info do implement concluído e persiste o custo central (#638).
+
+    O implement é fire-and-forget; quando o PR aparece (ground-truth), lemos a
+    sessão uma vez para colher o uso. ``_fetch_reconcile_state`` (stage=implement)
+    já dispara a escrita central dedupada quando o estado é DONE. Best-effort.
+    """
+    try:
+        ledger = getattr(monitor.implementer, "_ledger", None)
+        if ledger is None:
+            return
+        from deile.orchestration.pipeline.dispatch_ledger import DispatchLedger
+        entry = ledger.get(DispatchLedger.key_for_issue(issue_number))
+        task_id = (entry or {}).get("task_id") or ""
+        if not task_id:
+            return
+        await _fetch_reconcile_state(
+            monitor, task_id, "implement",
+            channel_id=f"pipeline-issue-{issue_number}",
+        )
+    except Exception as exc:  # noqa: BLE001 — captura de custo nunca bloqueia o reconcile
+        logger.debug(
+            "captura de custo do implement #%d falhou (non-fatal): %s",
+            issue_number, exc,
+        )
+
+
+def _record_fleet_usage_from_reconcile(
+    url: Optional[str], info: dict, stage: str, channel_id: str, task_id: str,
+) -> None:
+    """Persiste custo central de um fire-and-forget concluído (issue #638).
+
+    No-op para workers núcleo (deile/claude): o resume-info deles não traz o
+    bloco ``usage`` (só o cli-worker o preenche), então o recorder retorna 0.
+    Best-effort isolado — o recorder nunca propaga exceção.
+    """
+    from deile.orchestration.pipeline.fleet_cost_recorder import \
+        record_fleet_usage_from_resume_info
+    from deile.orchestration.pipeline.implementer import _worker_kind_from_url
+    record_fleet_usage_from_resume_info(
+        info,
+        worker_kind=_worker_kind_from_url(url or ""),
+        stage=stage,
+        channel_id=channel_id,
+        task_id=task_id,
+    )
 
 
 async def _count_total_in_flight(monitor: "PipelineMonitor") -> int:
@@ -2055,6 +2118,11 @@ async def reconcile_implementing_issues(monitor: "PipelineMonitor") -> None:
             "reconcile #%d: PR detected via ground truth → transitioning to %s",
             issue.number, WORKFLOW_PR,
         )
+        # Issue #638: o implement é fire-and-forget (resposta do 202 descartada).
+        # Agora que o worker concluiu (PR existe), lê o resume-info uma vez para
+        # persistir o custo central do dispatch (dedupado por task_id no recorder).
+        # Best-effort: falha de leitura/escrita não bloqueia a transição.
+        await _capture_implement_fleet_cost(monitor, issue.number)
         try:
             await monitor.forge.transition_issue(
                 issue.number,
@@ -2872,7 +2940,10 @@ async def reconcile_review_prs(monitor: "PipelineMonitor") -> None:
         if not task_id:
             ledger.clear(key)
             continue
-        state, info = await _fetch_reconcile_state(monitor, task_id, "pr_review")
+        state, info = await _fetch_reconcile_state(
+            monitor, task_id, "pr_review",
+            channel_id=f"pipeline-pr-{pr.number}",
+        )
         if state == _RECON_RUNNING:
             continue
         if state == _RECON_GONE:

--- a/deile/tests/infra/test_cli_adapter_registry.py
+++ b/deile/tests/infra/test_cli_adapter_registry.py
@@ -40,6 +40,25 @@ def test_workresult_defaults():
     assert wr.result_text == ""
     assert wr.error_code is None
     assert wr.cost_usd is None
+    # Contrato de uso central (issue #638) — retrocompat: defaults vazios.
+    assert wr.tokens_by_model == {}
+    assert wr.model is None
+
+
+def test_workresult_usage_fields_are_settable():
+    """Os campos novos de uso (issue #638) são preenchíveis e independentes por
+    instância (default_factory evita dict compartilhado entre WorkResults)."""
+    b = base.WorkResult(
+        ok=True,
+        tokens_by_model={"deepseek": {"in": 10, "out": 5, "cache_read": 0,
+                                      "cache_write": 0}},
+        model="deepseek",
+    )
+    assert b.tokens_by_model == {
+        "deepseek": {"in": 10, "out": 5, "cache_read": 0, "cache_write": 0}}
+    assert b.model == "deepseek"
+    # default_factory (não default mutável): cada WorkResult novo tem dict próprio.
+    assert base.WorkResult(ok=True).tokens_by_model == {}
 
 
 def test_modelinfo_as_dict_fills_label_from_id():

--- a/deile/tests/infra/test_cli_worker_server.py
+++ b/deile/tests/infra/test_cli_worker_server.py
@@ -803,6 +803,96 @@ def test_run_cleanup_invokes_harvest(mock_adapter, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# Bloco de uso estruturado para o store central (issue #638)
+# --------------------------------------------------------------------------- #
+
+
+def test_build_usage_block_opencode_shape(mock_adapter, monkeypatch):
+    """``build_usage_block`` extrai tokens-por-modelo do shape nativo via o parser
+    ÚNICO (fleet_progress_parse) e normaliza p/ cache_read/cache_write (#638)."""
+    import json as _json
+    stdout = "\n".join([
+        _json.dumps({"type": "step_start", "modelID": "deepseek/deepseek-v4-pro"}),
+        _json.dumps({"type": "step_finish", "part": {
+            "cost": 0.012,
+            "tokens": {"input": 1500, "output": 300,
+                       "cache": {"read": 21415, "write": 100}}}}),
+    ])
+    tbm, model = cws.build_usage_block(
+        kind="opencode", stdout=stdout, task_id="t1",
+        cli_model="deepseek/deepseek-v4-pro",
+    )
+    assert model == "deepseek/deepseek-v4-pro"
+    assert tbm == {"deepseek/deepseek-v4-pro": {
+        "in": 1500, "out": 300, "cache_read": 21415, "cache_write": 100}}
+
+
+def test_build_usage_block_remaps_unknown_to_cli_model(mock_adapter):
+    """goose só emite total_tokens (sem modelo) → ``unknown`` é remapeado para o
+    ``cli_model`` do payload (anti model=unknown)."""
+    import json as _json
+    stdout = _json.dumps({"messages": [],
+                          "metadata": {"total_tokens": 8000, "status": "completed"}})
+    tbm, model = cws.build_usage_block(
+        kind="goose", stdout=stdout, task_id="t2",
+        cli_model="deepseek/deepseek-v4-flash",
+    )
+    assert "unknown" not in tbm
+    assert "deepseek/deepseek-v4-flash" in tbm
+    assert model == "deepseek/deepseek-v4-flash"
+
+
+def test_build_usage_block_noop_for_non_progress_kind(mock_adapter):
+    """Kinds sem parser de .progress (claude/deile/mock) → bloco vazio + cli_model."""
+    tbm, model = cws.build_usage_block(
+        kind="claude", stdout="irrelevante", task_id="t3", cli_model="claude:sonnet",
+    )
+    assert tbm == {} and model == "claude:sonnet"
+
+
+async def test_dispatch_usage_block_present(mock_resume_adapter, monkeypatch):
+    """A resposta do /v1/dispatch + resume-info carregam o bloco ``usage`` (#638)."""
+    import json as _json
+    _commit_pushed_git(monkeypatch)
+    monkeypatch.setenv("DEILE_CLI_WORKER_KIND", "opencode")
+    cli_adapters.reload_adapters()
+    app = cws.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        adapter = cws._resolve_adapter()
+
+        def _argv(**kw):
+            wd = kw["workdir"]
+            modeline = _json.dumps({"type": "step_start",
+                                    "modelID": "openrouter/deepseek/deepseek-v4-pro"})
+            event = _json.dumps({"type": "step_finish", "part": {
+                "tokens": {"input": 1200, "output": 250,
+                           "cache": {"read": 0, "write": 0}}}})
+            return ["sh", "-c",
+                    f"printf '%s\\n%s\\n' '{modeline}' '{event}'; touch {wd}/.ran"]
+
+        monkeypatch.setattr(adapter, "build_argv", _argv)
+        resp = await client.post(
+            "/v1/dispatch", headers=_AUTH_HEADERS,
+            json={"brief": "x", "branch": "auto/issue-1",
+                  "cli_model": "openrouter/deepseek/deepseek-v4-pro"},
+        )
+        body = await resp.json()
+        usage = body["usage"]
+        assert usage["worker"] == "opencode"
+        assert usage["model"] == "openrouter/deepseek/deepseek-v4-pro"
+        tbm = usage["tokens_by_model"]["openrouter/deepseek/deepseek-v4-pro"]
+        assert tbm["in"] == 1200 and tbm["out"] == 250
+
+        # resume-info também surface o bloco usage (para o read-back fire-and-forget).
+        ri = await client.get(
+            f"/v1/dispatches/{body['task_id']}/resume-info", headers=_AUTH_HEADERS,
+        )
+        ri_body = await ri.json()
+        assert ri_body["usage"]["model"] == "openrouter/deepseek/deepseek-v4-pro"
+        assert ri_body["cli_model"] == "openrouter/deepseek/deepseek-v4-pro"
+
+
+# --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
 

--- a/deile/tests/infra/test_fleet_tokens_audit.py
+++ b/deile/tests/infra/test_fleet_tokens_audit.py
@@ -547,6 +547,140 @@ def test_parser_ledger_env_override_path(fta, tmp_path):
 # --------------------------------------------------------------------------- #
 # 8. Mensagem correta de worker indisponível (replicas=0 × ausente)            #
 # --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
+# 9. Store central como fonte PRIMÁRIA (issue #638) — independe de pod            #
+# --------------------------------------------------------------------------- #
+def _seed_central_db(path, rows):
+    """Cria um usage.db central com ``rows`` (worker, model, stage, session, ...)."""
+    import sqlite3
+    con = sqlite3.connect(path)
+    con.execute("""CREATE TABLE usage_records (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, provider_id TEXT,
+        model_id TEXT, tier TEXT, session_id TEXT, prompt_tokens INTEGER,
+        completion_tokens INTEGER, cached_tokens INTEGER, total_tokens INTEGER,
+        cost_usd REAL, latency_ms INTEGER, success INTEGER, error_type TEXT)""")
+    for r in rows:
+        con.execute(
+            "INSERT INTO usage_records (timestamp, provider_id, model_id, tier, "
+            "session_id, prompt_tokens, completion_tokens, cached_tokens, "
+            "total_tokens, cost_usd) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            r)
+    con.commit()
+    con.close()
+
+
+def test_collect_central_store_reads_fleet_workers(fta, tmp_path):
+    """O store central agrupa por (worker, session) e exclui o núcleo (claude/deile)."""
+    db = tmp_path / "usage.db"
+    _seed_central_db(db, [
+        # (ts, provider/worker, model, tier/stage, session, in, out, cached, total, cost)
+        (1_700_000_000.0, "opencode", "deepseek/deepseek-v4-pro", "implement",
+         "pipeline-issue-242", 1500, 300, 21415, 23215, 0.012),
+        (1_700_000_001.0, "qwen", "qwen3-coder-plus", "pr_review",
+         "pipeline-pr-300", 5000, 1200, 800, 7000, 0.011),
+        # núcleo deile → NÃO entra no central (coletado via pods).
+        (1_700_000_002.0, "deile", "deepseek-chat", "implement", "sess-x",
+         100, 50, 0, 150, 0.001),
+    ])
+    sessions = fta.collect_central_store(db_path=str(db))
+    workers = {s["worker"] for s in sessions}
+    assert workers == {"opencode", "qwen"}  # deile (núcleo) excluído
+    oc = next(s for s in sessions if s["worker"] == "opencode")
+    assert oc["source"] == "<central-store>" and oc["central"] is True
+    assert oc["stage"] == "implement"
+    m = oc["models"]["deepseek/deepseek-v4-pro"]
+    assert m["in"] == 1500 and m["out"] == 300 and m["cr"] == 21415
+    assert abs(oc["native_cost"] - 0.012) < 1e-9
+
+
+def test_central_store_missing_db_is_empty(fta, tmp_path):
+    assert fta.collect_central_store(db_path=str(tmp_path / "nope.db")) == []
+
+
+def test_central_session_cost_is_native_for_any_worker(fta, tmp_path):
+    """Sessão do central usa o custo já gravado (jsonl_cost) como NATIVO (✓),
+    mesmo para um worker cujo coletor não reporta custo nativo (qwen/codex)."""
+    db = tmp_path / "usage.db"
+    _seed_central_db(db, [
+        (1_700_000_000.0, "qwen", "qwen3-coder-plus", "implement",
+         "pipeline-issue-1", 5000, 1000, 0, 6000, 0.42),
+    ])
+    sessions = fta.collect_central_store(db_path=str(db))
+    collectors = {k: fta.collector_for(k, {}) for k in fta.fleet_worker_kinds()}
+    enriched = fta.enrich(sessions, collectors)
+    s = enriched[0]
+    assert s["cost_basis"] == "nativo"
+    assert abs(s["cost_usd"] - 0.42) < 1e-9
+
+
+def test_collect_all_central_works_without_kubectl(fta, tmp_path, monkeypatch):
+    """AC #638: ``[T]okens`` mostra custo da frota com workers em replicas=0 e SEM
+    kubectl — ``source=central`` lê só o store local."""
+    db = tmp_path / "usage.db"
+    _seed_central_db(db, [
+        (1_700_000_000.0, "opencode", "deepseek/deepseek-v4-pro", "implement",
+         "pipeline-issue-242", 1500, 300, 0, 1800, 0.012),
+    ])
+    monkeypatch.setenv("DEILE_USAGE_DB_PATH", str(db))
+    collectors = {k: fta.collector_for(k, {}) for k in fta.fleet_worker_kinds()}
+
+    # kubectl="" (nunca usado em source=central): se algo tentar exec, quebra.
+    def _boom(*_a, **_kw):
+        raise AssertionError("source=central NÃO deve tocar pods/kubectl")
+
+    monkeypatch.setattr(fta, "_collect_pod_sessions", _boom)
+    sessions = fta.collect_all("", "deile", fta.fleet_worker_kinds(), collectors,
+                               source="central")
+    assert len(sessions) == 1
+    assert sessions[0]["worker"] == "opencode"
+    assert sessions[0]["cost_basis"] == "nativo"
+
+
+def test_collect_all_both_central_supersedes_pod_session(fta, tmp_path, monkeypatch):
+    """``both``: central prevalece por (worker, session); a sessão do mesmo
+    dispatch via pod (PVC) é suprimida (sem dupla contagem)."""
+    db = tmp_path / "usage.db"
+    _seed_central_db(db, [
+        (1_700_000_000.0, "opencode", "x/y", "implement", "pipeline-issue-9",
+         1000, 200, 0, 1200, 0.05),
+    ])
+    monkeypatch.setenv("DEILE_USAGE_DB_PATH", str(db))
+    collectors = {k: fta.collector_for(k, {}) for k in fta.fleet_worker_kinds()}
+
+    # Pods devolvem a MESMA sessão (mesmo task_id == session_id) + uma do núcleo.
+    def _fake_pods(_kubectl, _ns, _kinds, _since=0.0):
+        return [
+            {"worker": "opencode", "task_id": "pipeline-issue-9", "source": "pvc",
+             "models": {"x/y": {"in": 999, "out": 1, "cc": 0, "cr": 0}},
+             "native_cost": 0.99, "first_ts": None, "last_ts": None,
+             "mtime": None, "brief": None},
+            {"worker": "claude", "task_id": "csess", "source": "jsonl",
+             "models": {"claude-sonnet-4-6": {"in": 100, "out": 20, "cc": 0, "cr": 0}},
+             "native_cost": None, "first_ts": None, "last_ts": None,
+             "mtime": None, "brief": None},
+        ]
+
+    monkeypatch.setattr(fta, "_collect_pod_sessions", _fake_pods)
+    sessions = fta.collect_all("kc", "deile", fta.fleet_worker_kinds(), collectors,
+                               source="both")
+    by_worker = {(s["worker"], s["task_id"]): s for s in sessions}
+    # 1 opencode (central, NÃO o do PVC) + 1 claude (núcleo via pods).
+    oc = by_worker[("opencode", "pipeline-issue-9")]
+    assert oc["central"] is True
+    assert oc["models"]["x/y"]["in"] == 1000  # do central, não 999 do PVC
+    assert ("claude", "csess") in by_worker
+
+
+def test_central_store_respects_since_mtime(fta, tmp_path):
+    db = tmp_path / "usage.db"
+    _seed_central_db(db, [
+        (1_700_000_000.0, "opencode", "x/y", "implement", "old", 100, 10, 0, 110, 0.01),
+        (1_700_999_999.0, "opencode", "x/y", "implement", "new", 200, 20, 0, 220, 0.02),
+    ])
+    sessions = fta.collect_central_store(db_path=str(db), since_mtime=1_700_500_000.0)
+    assert {s["task_id"] for s in sessions} == {"new"}
+
+
 def test_unavailable_reason_distinguishes_scaled_zero_from_absent(fta, monkeypatch):
     calls = {}
 

--- a/deile/tests/orchestration/pipeline/test_fleet_cost_recorder.py
+++ b/deile/tests/orchestration/pipeline/test_fleet_cost_recorder.py
@@ -1,0 +1,243 @@
+"""Persistência central do custo da frota CLI no UsageRepository (issue #638).
+
+A frota CLI tinha custo só no PVC (``.progress`` + ledger por-worker), que some
+quando o pod escala a zero / é ``force-delete``. Agora o pipeline faz PUSH
+central: lê o bloco ``usage`` estruturado da resposta do ``/v1/dispatch`` e grava
+1 :class:`UsageRecord` por modelo no SQLite central.
+
+DECISÃO DE SCHEMA (sem migração): worker→``provider_id``, stage→``tier``,
+channel_id→``session_id``, modelo→``model_id``. Um dispatch multi-modelo vira N
+registros. Preço pela fonte única ``jsonl_cost.fleet_cost_of_model``.
+
+Cobertura:
+  1. Caminho ``wait`` grava N registros com o schema correto.
+  2. Multi-modelo → N linhas; sem tokens → 0 linhas.
+  3. ``model`` correto sem ``unknown`` (cai no ``cli_model``).
+  4. Custo via fonte única de preço (sem duplicar tabela).
+  5. Best-effort: response inválido / repo que explode → 0, sem propagar.
+  6. Caminho fire-and-forget (resume-info) com dedup por task_id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.orchestration.pipeline.fleet_cost_recorder import (
+    record_fleet_usage, record_fleet_usage_from_resume_info)
+from deile.storage.usage_repository import UsageRepository
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    return UsageRepository(db_path=tmp_path / "usage.db")
+
+
+def _all_records(repo: UsageRepository) -> list:
+    with repo._connect() as conn:  # noqa: SLF001 — leitura direta no teste
+        rows = conn.execute("SELECT * FROM usage_records ORDER BY id").fetchall()
+    return [dict(r) for r in rows]
+
+
+# --------------------------------------------------------------------------- #
+# 1-4. Caminho wait: schema, multi-modelo, model correto, preço único          #
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_wait_path_writes_one_record_with_correct_schema(repo):
+    response = {
+        "ok": True,
+        "usage": {
+            "worker": "opencode",
+            "model": "deepseek/deepseek-v4-pro",
+            "tokens_by_model": {
+                "deepseek/deepseek-v4-pro": {
+                    "in": 1500, "out": 300, "cache_read": 21415, "cache_write": 100,
+                },
+            },
+        },
+    }
+    n = record_fleet_usage(
+        response, worker_kind="opencode", stage="implement",
+        channel_id="pipeline-issue-242", cli_model="deepseek/deepseek-v4-pro",
+        repo=repo,
+    )
+    assert n == 1
+    recs = _all_records(repo)
+    assert len(recs) == 1
+    r = recs[0]
+    # DECISÃO DE SCHEMA: worker→provider_id, stage→tier, channel→session_id.
+    assert r["provider_id"] == "opencode"
+    assert r["tier"] == "implement"
+    assert r["session_id"] == "pipeline-issue-242"
+    assert r["model_id"] == "deepseek/deepseek-v4-pro"
+    assert r["prompt_tokens"] == 1500
+    assert r["completion_tokens"] == 300
+    assert r["cached_tokens"] == 21415
+    assert r["total_tokens"] == 1500 + 300 + 21415 + 100
+    assert r["success"] == 1
+    # Custo > 0 e via fonte única (deepseek-v4-pro = $0.435/MTok input).
+    assert r["cost_usd"] > 0
+
+
+@pytest.mark.unit
+def test_cost_uses_single_price_source(repo):
+    # 1M tokens de input em deepseek-v4-pro = $0.435 (FLEET_PRICING_BY_SUBSTRING).
+    response = {
+        "ok": True,
+        "usage": {
+            "worker": "qwen", "model": "deepseek-v4-pro",
+            "tokens_by_model": {"deepseek-v4-pro": {"in": 1_000_000, "out": 0}},
+        },
+    }
+    record_fleet_usage(
+        response, worker_kind="qwen", stage="pr_review",
+        channel_id="pipeline-pr-9", cli_model="deepseek-v4-pro", repo=repo,
+    )
+    r = _all_records(repo)[0]
+    assert abs(r["cost_usd"] - 0.435) < 1e-6
+
+
+@pytest.mark.unit
+def test_multi_model_dispatch_writes_n_records(repo):
+    response = {
+        "ok": True,
+        "usage": {
+            "worker": "codex", "model": "gpt-5.1-codex",
+            "tokens_by_model": {
+                "gpt-5.1-codex": {"in": 1000, "out": 200},
+                "gpt-5.1-codex-mini": {"in": 500, "out": 50},
+            },
+        },
+    }
+    n = record_fleet_usage(
+        response, worker_kind="codex", stage="implement",
+        channel_id="pipeline-issue-1", cli_model="gpt-5.1-codex", repo=repo,
+    )
+    assert n == 2
+    models = {r["model_id"] for r in _all_records(repo)}
+    assert models == {"gpt-5.1-codex", "gpt-5.1-codex-mini"}
+
+
+@pytest.mark.unit
+def test_model_unknown_falls_back_to_cli_model(repo):
+    # goose/aider emitem tokens sob "unknown"; o server já remapeia, mas se vier
+    # "unknown" no wire (worker antigo), o recorder cai no cli_model do payload.
+    response = {
+        "ok": True,
+        "usage": {
+            "worker": "goose", "model": "",
+            "tokens_by_model": {"unknown": {"in": 2000, "out": 6000}},
+        },
+    }
+    record_fleet_usage(
+        response, worker_kind="goose", stage="implement",
+        channel_id="pipeline-issue-7", cli_model="deepseek/deepseek-v4-flash",
+        repo=repo,
+    )
+    r = _all_records(repo)[0]
+    assert r["model_id"] == "deepseek/deepseek-v4-flash"  # sem "unknown"
+
+
+@pytest.mark.unit
+def test_zero_token_models_are_skipped(repo):
+    response = {
+        "ok": True,
+        "usage": {
+            "worker": "qwen", "model": "qwen3-coder-plus",
+            "tokens_by_model": {"qwen3-coder-plus": {"in": 0, "out": 0}},
+        },
+    }
+    assert record_fleet_usage(
+        response, worker_kind="qwen", stage="classify",
+        channel_id="pipeline-issue-3", cli_model="qwen3-coder-plus", repo=repo,
+    ) == 0
+    assert _all_records(repo) == []
+
+
+@pytest.mark.unit
+def test_worker_from_usage_block_prevails_over_kwarg(repo):
+    # O server é a autoridade do worker; o derivado da URL é só fallback.
+    response = {
+        "ok": True,
+        "usage": {
+            "worker": "opencode", "model": "x/y",
+            "tokens_by_model": {"x/y": {"in": 10, "out": 5}},
+        },
+    }
+    record_fleet_usage(
+        response, worker_kind="WRONG", stage="implement",
+        channel_id="c", cli_model=None, repo=repo,
+    )
+    assert _all_records(repo)[0]["provider_id"] == "opencode"
+
+
+# --------------------------------------------------------------------------- #
+# 5. Best-effort: nunca propaga, nunca derruba o dispatch                       #
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_no_usage_block_is_noop(repo):
+    assert record_fleet_usage(
+        {"ok": True}, worker_kind="opencode", stage="implement",
+        channel_id="c", cli_model=None, repo=repo,
+    ) == 0
+    assert record_fleet_usage(
+        "not a dict", worker_kind="opencode", stage="implement",
+        channel_id="c", cli_model=None, repo=repo,
+    ) == 0
+
+
+@pytest.mark.unit
+def test_repo_failure_is_swallowed(repo):
+    class _BoomRepo:
+        def record(self, *_a, **_k):
+            raise RuntimeError("disk full")
+
+    response = {
+        "ok": True,
+        "usage": {"worker": "opencode", "model": "x/y",
+                  "tokens_by_model": {"x/y": {"in": 1, "out": 1}}},
+    }
+    # NÃO deve propagar — retorna 0.
+    assert record_fleet_usage(
+        response, worker_kind="opencode", stage="implement",
+        channel_id="c", cli_model=None, repo=_BoomRepo(),
+    ) == 0
+
+
+# --------------------------------------------------------------------------- #
+# 6. Fire-and-forget (resume-info) com dedup por task_id                        #
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_resume_info_path_writes_and_dedups(repo):
+    info = {
+        "last_is_error": False,
+        "cli_model": "qwen3-coder-plus",
+        "usage": {
+            "model": "qwen3-coder-plus",
+            "tokens_by_model": {"qwen3-coder-plus": {"in": 4000, "out": 900}},
+        },
+    }
+    n1 = record_fleet_usage_from_resume_info(
+        info, worker_kind="qwen", stage="implement",
+        channel_id="pipeline-issue-50", task_id="abc123", repo=repo,
+    )
+    assert n1 == 1
+    r = _all_records(repo)[0]
+    # session_id dedupável = <channel>#<task_id>.
+    assert r["session_id"] == "pipeline-issue-50#abc123"
+    assert r["provider_id"] == "qwen" and r["tier"] == "implement"
+    # Segunda chamada (próximo tick) → no-op idempotente.
+    n2 = record_fleet_usage_from_resume_info(
+        info, worker_kind="qwen", stage="implement",
+        channel_id="pipeline-issue-50", task_id="abc123", repo=repo,
+    )
+    assert n2 == 0
+    assert len(_all_records(repo)) == 1
+
+
+@pytest.mark.unit
+def test_resume_info_without_usage_is_noop(repo):
+    # claude/deile resume-info não trazem bloco usage → 0.
+    assert record_fleet_usage_from_resume_info(
+        {"last_is_error": False}, worker_kind="claude", stage="implement",
+        channel_id="pipeline-issue-9", task_id="t", repo=repo,
+    ) == 0

--- a/deile/tests/orchestration/pipeline/test_fleet_cost_wiring.py
+++ b/deile/tests/orchestration/pipeline/test_fleet_cost_wiring.py
@@ -1,0 +1,265 @@
+"""Integração da fiação de custo central da frota CLI (issue #638).
+
+Prova ponta-a-ponta a FIAÇÃO (não só unit): um dispatch real simulado de um
+worker da frota CLI através do ``WorkerImplementer._dispatch`` grava registros no
+``UsageRepository`` central com tokens+custo+modelo+stage corretos. Espelha a
+harness de ``test_implementer_cli_model_routing.py`` (worker CLI sintético
+registrado em runtime + ``_FakeClient`` devolvendo a resposta do dispatch já com
+o bloco ``usage`` estruturado que o ``cli_worker_server`` reporta).
+
+Cobre os critérios de aceite #638:
+  * dispatch ``wait`` da frota → 1+ registro central com schema correto;
+  * dispatch fire-and-forget → custo capturado no reconcile (read-back dedupado);
+  * workers núcleo (deile) → NÃO gravam central por esta via (sem regressão).
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from deile.config.settings import reset_settings
+from deile.orchestration.pipeline.implementer import WorkerImplementer
+from deile.orchestration.pipeline.model_resolver import PIPELINE_STAGES
+from deile.storage.usage_repository import UsageRepository
+
+_REPO = Path(__file__).resolve().parents[4]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import cli_adapters  # noqa: E402
+
+_CLI_KIND = "zzz_costwire"
+_CLI_DISPATCHER = f"{_CLI_KIND}-worker"
+_CLI_PORT = 8795
+
+
+@pytest.fixture
+def cli_worker_adapter(monkeypatch):
+    """Registra um worker CLI sintético e o aponta no stage ``classify``."""
+    pkg_dir = Path(cli_adapters.__path__[0])
+    mod_path = pkg_dir / f"{_CLI_KIND}.py"
+    mod_path.write_text(
+        textwrap.dedent(
+            f'''\
+            from cli_adapters.base import BaseCliAdapter, WorkResult
+
+
+            class CostWireAdapter(BaseCliAdapter):
+                def build_argv(self, *, brief_path, model, reasoning, workdir, resume, task_id=""):
+                    return ["true"]
+
+                def parse_output(self, *, stdout, stderr, rc):
+                    return WorkResult(ok=True)
+
+
+            ADAPTER = CostWireAdapter(kind="{_CLI_KIND}", default_port={_CLI_PORT})
+            '''
+        ),
+        encoding="utf-8",
+    )
+    cli_adapters.reload_adapters()
+    # Endpoint na forma REAL ``http://<kind>-worker:<port>`` (não localhost): o
+    # _worker_kind_from_url deriva o kind do host no caminho fire-and-forget. O
+    # _FakeClient ignora a URL — isto só garante a derivação correta do worker.
+    monkeypatch.setenv(
+        f"DEILE_{_CLI_KIND.upper()}_WORKER_ENDPOINT",
+        f"http://{_CLI_DISPATCHER}:18795",
+    )
+    from deile.orchestration.pipeline.cli_worker_scaler import (
+        EnsureReplicaOutcome, ScaleResult)
+
+    async def _ready(_dispatcher):
+        return EnsureReplicaOutcome(ScaleResult.READY, "test: ready")
+
+    monkeypatch.setattr(
+        "deile.orchestration.pipeline.cli_worker_scaler.ensure_replica", _ready,
+    )
+    try:
+        yield
+    finally:
+        mod_path.unlink(missing_ok=True)
+        sys.modules.pop(f"cli_adapters.{_CLI_KIND}", None)
+        cli_adapters.reload_adapters()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_settings(monkeypatch):
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_MODEL_{stage.upper()}", raising=False)
+        monkeypatch.delenv(f"DEILE_PIPELINE_DISPATCH_{stage.upper()}", raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_DISPATCH_MODE", raising=False)
+    monkeypatch.delenv("DEILE_PREFERRED_MODEL", raising=False)
+    reset_settings()
+    yield
+    reset_settings()
+
+
+@pytest.fixture
+def central_repo(tmp_path, monkeypatch):
+    """UsageRepository central isolado + injeção no singleton lido pelo recorder."""
+    repo = UsageRepository(db_path=tmp_path / "usage.db")
+    import deile.storage.usage_repository as ur
+    monkeypatch.setattr(ur, "_usage_repository", repo)
+    return repo
+
+
+class _FakeClient:
+    """Devolve a resposta do dispatch já com o bloco ``usage`` estruturado.
+
+    ``get_resume_info`` alimenta o read-back fire-and-forget do reconcile.
+    """
+
+    def __init__(self, response, resume_info=None):
+        self._response = response
+        self._resume_info = resume_info
+        self.last_payload = None
+
+    async def dispatch(self, payload, *, wait, endpoint_url=None):
+        self.last_payload = payload
+        return self._response
+
+    async def get_resume_info(self, task_id, *, endpoint_url=None):
+        return self._resume_info
+
+
+def _all(repo: UsageRepository) -> list:
+    with repo._connect() as conn:  # noqa: SLF001 — leitura direta no teste
+        return [dict(r) for r in conn.execute(
+            "SELECT * FROM usage_records ORDER BY id")]
+
+
+# --------------------------------------------------------------------------- #
+# Caminho wait: dispatch da frota → registro central                           #
+# --------------------------------------------------------------------------- #
+class TestWaitPathWiring:
+    async def test_cli_dispatch_wait_records_central_usage(
+        self, cli_worker_adapter, central_repo, monkeypatch,
+    ):
+        """AC #638: um dispatch real (wait) da frota grava 1 registro central com
+        tokens+custo+modelo+stage corretos — fiação ponta-a-ponta."""
+        monkeypatch.setenv("DEILE_PIPELINE_DISPATCH_CLASSIFY", _CLI_DISPATCHER)
+        monkeypatch.setenv(
+            "DEILE_PIPELINE_MODEL_CLASSIFY", "openrouter/deepseek/deepseek-v4-pro"
+        )
+        reset_settings()
+        response = {
+            "ok": True,
+            "summary": "done",
+            "task_id": "deadbeef",
+            "usage": {
+                "worker": _CLI_KIND,
+                "model": "openrouter/deepseek/deepseek-v4-pro",
+                "tokens_by_model": {
+                    "openrouter/deepseek/deepseek-v4-pro": {
+                        "in": 1500, "out": 300, "cache_read": 21415, "cache_write": 0,
+                    },
+                },
+            },
+        }
+        impl = WorkerImplementer(client=_FakeClient(response))
+        # _dispatch é o ponto de fiação real (mesma chamada que critique/refine/
+        # mention fazem); nowait=False exercita o caminho wait que lê o bloco usage.
+        await impl._dispatch(
+            "brief", channel_id="pipeline-issue-242", stage="classify",
+            nowait=False,
+        )
+        recs = _all(central_repo)
+        assert len(recs) == 1, recs
+        r = recs[0]
+        assert r["provider_id"] == _CLI_KIND          # worker
+        assert r["tier"] == "classify"                # stage
+        assert r["session_id"] == "pipeline-issue-242"
+        assert r["model_id"] == "openrouter/deepseek/deepseek-v4-pro"
+        assert r["prompt_tokens"] == 1500
+        assert r["completion_tokens"] == 300
+        assert r["cached_tokens"] == 21415
+        assert r["cost_usd"] > 0
+
+    async def test_cli_dispatch_without_usage_block_writes_nothing(
+        self, cli_worker_adapter, central_repo, monkeypatch,
+    ):
+        """Worker antigo (sem bloco usage) → no-op central, sem quebrar dispatch."""
+        monkeypatch.setenv("DEILE_PIPELINE_DISPATCH_CLASSIFY", _CLI_DISPATCHER)
+        reset_settings()
+        impl = WorkerImplementer(client=_FakeClient({"ok": True, "summary": "x"}))
+        out = await impl._dispatch(
+            "brief", channel_id="pipeline-issue-1", stage="classify", nowait=False,
+        )
+        assert out.ok is True
+        assert _all(central_repo) == []
+
+    async def test_deile_worker_does_not_write_fleet_central(
+        self, central_repo,
+    ):
+        """Sem regressão: deile-worker (núcleo) NÃO grava central por esta via —
+        ele contabiliza no SQLite do próprio pod. O recorder só roda p/ CLI."""
+        reset_settings()
+        response = {
+            "ok": True, "summary": "ok", "task_id": "t1",
+            # Mesmo que viesse um bloco usage, o gate is_cli_worker barra.
+            "usage": {"worker": "deile", "model": "x:y",
+                      "tokens_by_model": {"x:y": {"in": 9, "out": 9}}},
+        }
+        impl = WorkerImplementer(client=_FakeClient(response))
+        await impl._dispatch(
+            "brief", channel_id="pipeline-issue-2", stage="classify", nowait=False,
+        )
+        assert _all(central_repo) == []
+
+
+# --------------------------------------------------------------------------- #
+# Caminho fire-and-forget: reconcile lê resume-info → registro central dedupado #
+# --------------------------------------------------------------------------- #
+class TestFireAndForgetWiring:
+    async def test_reconcile_records_central_usage_from_resume_info(
+        self, cli_worker_adapter, central_repo, monkeypatch,
+    ):
+        """AC #638: implement paralelo (fire-and-forget) tem o custo capturado no
+        reconcile (a resposta do 202 é descartada). DONE + bloco usage → grava."""
+        from deile.orchestration.pipeline import stages
+
+        monkeypatch.setenv("DEILE_PIPELINE_DISPATCH_IMPLEMENT", _CLI_DISPATCHER)
+        reset_settings()
+        resume_info = {
+            "task_id": "abc123",
+            "workdir_exists": True,
+            "claude_alive": False,
+            "last_completed_at": 1_700_000_000,
+            "last_is_error": False,
+            "cli_model": "openrouter/qwen3-coder-plus",
+            "usage": {
+                "model": "openrouter/qwen3-coder-plus",
+                "tokens_by_model": {
+                    "openrouter/qwen3-coder-plus": {"in": 4000, "out": 900,
+                                                    "cache_read": 0, "cache_write": 0},
+                },
+            },
+        }
+        impl = WorkerImplementer(client=_FakeClient({}, resume_info=resume_info))
+        monitor = SimpleNamespace(implementer=impl)
+
+        state, _info = await stages._fetch_reconcile_state(
+            monitor, "abc123", "implement",
+            channel_id="pipeline-issue-50",
+        )
+        assert state == stages._RECON_DONE
+        recs = _all(central_repo)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r["provider_id"] == _CLI_KIND
+        assert r["tier"] == "implement"
+        assert r["session_id"] == "pipeline-issue-50#abc123"  # dedup key
+        assert r["model_id"] == "openrouter/qwen3-coder-plus"
+        assert r["prompt_tokens"] == 4000 and r["completion_tokens"] == 900
+
+        # Reconcile roda a cada tick: 2ª leitura DONE → no-op idempotente.
+        await stages._fetch_reconcile_state(
+            monitor, "abc123", "implement", channel_id="pipeline-issue-50",
+        )
+        assert len(_all(central_repo)) == 1

--- a/infra/k8s/cli_adapters/base.py
+++ b/infra/k8s/cli_adapters/base.py
@@ -18,7 +18,7 @@ editado. Não importa nada de CLI concreto nem toca rede/filesystem.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional, Protocol, Tuple, runtime_checkable
+from typing import Dict, List, Literal, Optional, Protocol, Tuple, runtime_checkable
 
 #: Modo de autenticação: ``env`` = API key (não expira; automação);
 #: ``oauth_file`` = credencial OAuth em arquivo (claude/codex/antigravity;
@@ -37,12 +37,25 @@ class WorkResult:
     ``ok`` é a leitura do adapter; o servidor ainda aplica gate pós-execução
     (commit/push/testes) antes de declarar sucesso — exit-code não é confiável
     (§1.6). ``cost_usd`` só presente para claude/aider.
+
+    Observabilidade de custo central (issue #638) — campos estruturados de uso,
+    preenchidos pelo servidor a partir do parser único ``fleet_progress_parse``
+    (não pelo adapter, que tem múltiplos pontos de retorno). Viajam na resposta
+    do ``/v1/dispatch`` para o pipeline persistir 1 registro por modelo no
+    ``UsageRepository`` central (independe de pod/PVC):
+
+    * ``tokens_by_model`` — ``{model_id: {in,out,cache_read,cache_write}}``;
+      um dispatch multi-modelo produz N entradas → N registros centrais.
+    * ``model`` — model-id predominante do dispatch (anti ``unknown``: cai no
+      ``cli_model`` do payload quando o CLI não emite modelo no stdout).
     """
 
     ok: bool
     result_text: str = ""
     error_code: Optional[str] = None
     cost_usd: Optional[float] = None
+    tokens_by_model: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    model: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/infra/k8s/cli_worker_server.py
+++ b/infra/k8s/cli_worker_server.py
@@ -33,6 +33,7 @@ import os
 import secrets
 import sys
 import time
+from dataclasses import replace
 from pathlib import Path
 from typing import List, Optional
 
@@ -227,11 +228,13 @@ async def _post_run_gate(
         reason.append("nenhum commit novo desde o início do dispatch")
     if not pushed:
         reason.append(f"branch {branch!r} não confirmado no remote origin")
-    return WorkResult(
+    # ``replace`` preserva tokens_by_model/model (issue #638): mesmo um dispatch
+    # reprovado no gate de push CONSUMIU tokens — o custo precisa ser contabilizado.
+    return replace(
+        work_result,
         ok=False,
         result_text=work_result.result_text or "; ".join(reason),
         error_code="NO_PUSH",
-        cost_usd=work_result.cost_usd,
     )
 
 
@@ -394,6 +397,11 @@ async def resume_info_handler(request: web.Request) -> web.Response:
         "last_result_full": meta.get("last_result_full", ""),
         "last_result_summary": meta.get("last_result_summary", ""),
         "last_error_code": meta.get("last_error_code", ""),
+        # Issue #638: bloco de uso para o reconcile gravar o custo central de
+        # dispatches fire-and-forget (implement paralelo), cuja resposta do 202
+        # foi descartada. ``cli_model`` viaja para o anti model=unknown na ponta.
+        "usage": meta.get("usage") or {},
+        "cli_model": meta.get("cli_model", "") or "",
     })
 
 
@@ -603,6 +611,20 @@ async def dispatch_handler(request: web.Request) -> web.Response:
             work = adapter.parse_output(
                 stdout=result.stdout, stderr=result.stderr, rc=result.returncode,
             )
+            # Observabilidade de custo central (issue #638): enriquece o veredito
+            # do adapter com tokens-por-modelo a partir do parser ÚNICO
+            # (fleet_progress_parse), ANTES da finalização de git (que reconstrói
+            # o WorkResult). Best-effort: extração falha → bloco vazio, dispatch segue.
+            _tokens_by_model, _usage_model = build_usage_block(
+                kind=adapter.kind, stdout=result.stdout,
+                task_id=task_id, cli_model=cli_model,
+            )
+            if _tokens_by_model or _usage_model:
+                work = replace(
+                    work,
+                    tokens_by_model=_tokens_by_model,
+                    model=_usage_model,
+                )
             # session_id nativo (issue #445): opencode/qwen no JSON; codex no
             # thread.started; goose/aider retornam o task_id como sentinela.
             try:
@@ -629,7 +651,10 @@ async def dispatch_handler(request: web.Request) -> web.Response:
                 prev_task_id=meta_prev_task_id, attempt=attempt,
                 cli_model=cli_model,
             )
-            return _build_response(task_id, result, work, session_id=session_id)
+            return _build_response(
+                task_id, result, work, session_id=session_id,
+                worker_kind=adapter.kind,
+            )
         finally:
             stop_hb.set()
             try:
@@ -697,10 +722,8 @@ async def _finalize_git(
         logger.warning("push pós-run falhou task_id=%s: %s", task_id, push_detail)
 
     if error_code != work.error_code:
-        return WorkResult(
-            ok=work.ok, result_text=work.result_text,
-            error_code=error_code, cost_usd=work.cost_usd,
-        )
+        # ``replace`` preserva tokens_by_model/model (issue #638).
+        return replace(work, error_code=error_code)
     return work
 
 
@@ -733,6 +756,10 @@ def _save_task_result(
        ``resume_session_id`` + mesmo workdir.
     3. **Modelo durável (anti model=unknown):** vários CLIs (goose, aider, codex)
        não emitem o modelo no stdout — só no argv. Auditoria lê este meta.
+    4. **Custo central de fire-and-forget (issue #638):** persiste o bloco
+       ``usage`` (tokens-por-modelo) para que o reconcile do pipeline o leia via
+       resume-info e grave no UsageRepository central (o 202 descarta a resposta
+       do dispatch, então sem isto o implement paralelo não teria custo central).
 
     Best-effort: falha de I/O vira warning.
     """
@@ -750,6 +777,10 @@ def _save_task_result(
         "last_result_summary": full[:300],
         "last_error_code": work.error_code or "",
         "last_total_cost_usd": work.cost_usd,
+        "usage": {
+            "model": work.model,
+            "tokens_by_model": work.tokens_by_model or {},
+        },
     }
     path = _result_meta_path(task_id)
     try:
@@ -775,11 +806,13 @@ def _load_task_result(task_id: str) -> Optional[dict]:
 
 def _build_response(
     task_id: str, result, work: WorkResult, *, session_id: str = "",
+    worker_kind: str = "",
 ) -> dict:
     """Monta a resposta JSON do contrato unificado (paridade com claude-worker).
 
     ``session_id`` = id nativo do CLI (issue #445); ``None`` quando o adapter
-    não suporta resume.
+    não suporta resume. ``worker_kind`` (issue #638) viaja no bloco ``usage``
+    para o pipeline atribuir o registro de custo central ao worker correto.
     """
     response = {
         "ok": work.ok,
@@ -792,6 +825,15 @@ def _build_response(
         "total_cost_usd": work.cost_usd,
         "is_error": not work.ok,
         "result": work.result_text,
+        # Observabilidade de custo central (issue #638): bloco estruturado de uso
+        # que o pipeline persiste no UsageRepository (1 registro por modelo).
+        # ``worker`` permite atribuir o registro mesmo quando o endpoint não
+        # revela o kind; ``model`` evita ``unknown`` (cai no cli_model).
+        "usage": {
+            "worker": worker_kind,
+            "model": work.model,
+            "tokens_by_model": work.tokens_by_model or {},
+        },
     }
     if not work.ok:
         response["error_code"] = work.error_code or "WORKER_FAILED"
@@ -879,6 +921,71 @@ def _meta_model_for(task_id: str) -> Optional[str]:
     meta = _load_task_result(task_id) or {}
     m = meta.get("cli_model")
     return m.strip() if isinstance(m, str) and m.strip() else None
+
+
+def _predominant_model(tokens_by_model: dict, cli_model: Optional[str]) -> Optional[str]:
+    """Modelo predominante de um bloco de uso (maior total de tokens).
+
+    Anti ``unknown`` (issue #638): se o único modelo é ``unknown`` (CLIs que não
+    emitem o modelo no stdout — goose/aider/codex), cai no ``cli_model`` do
+    payload. Empate é resolvido determinístico (maior soma, depois nome).
+    """
+    real = {
+        m: sum(int(v or 0) for v in tk.values())
+        for m, tk in tokens_by_model.items()
+        if m and m != "unknown"
+    }
+    if real:
+        return max(sorted(real), key=real.get)
+    return (cli_model or "").strip() or (
+        next(iter(tokens_by_model), None) if tokens_by_model else None
+    )
+
+
+def build_usage_block(
+    *, kind: str, stdout: str, task_id: str, cli_model: Optional[str],
+) -> tuple:
+    """Extrai ``(tokens_by_model, model)`` da saída nativa do CLI (issue #638).
+
+    Fonte ÚNICA de parsing: ``fleet_progress_parse`` (o MESMO parser do
+    harvester do ledger e da auditoria), via :data:`_fpp`. Remapeia ``unknown``
+    → ``cli_model`` do payload (anti model=unknown), espelhando exatamente o
+    ``harvest_progress_to_ledger``. Retorna ``({}, None)`` quando o kind não usa
+    ``.progress`` (claude/deile contabilizam por outras vias) ou o parser está
+    indisponível — best-effort, nunca derruba o dispatch.
+
+    O custo NÃO é calculado aqui: viaja como tokens-por-modelo e o pipeline
+    recompõe o custo via ``jsonl_cost.fleet_cost_of_model`` (fonte única de
+    preço) — paridade com o ledger durável.
+    """
+    if _fpp is None:
+        return {}, (cli_model or "").strip() or None
+    try:
+        parsed = _fpp.parse_progress_text(kind, stdout, task_id)
+    except Exception as exc:  # noqa: BLE001 — extração de uso é best-effort
+        logger.warning("build_usage_block falhou kind=%s task_id=%s: %s",
+                       kind, task_id, exc)
+        return {}, (cli_model or "").strip() or None
+    if parsed is None:
+        return {}, (cli_model or "").strip() or None
+    models = dict(parsed.get("models") or {})
+    cm = (cli_model or "").strip()
+    if cm and "unknown" in models:
+        unk = models.pop("unknown")
+        dst = models.setdefault(cm, {"in": 0, "out": 0, "cc": 0, "cr": 0})
+        for k in ("in", "out", "cc", "cr"):
+            dst[k] = int(dst.get(k, 0)) + int(unk.get(k, 0) or 0)
+    # Normaliza para o contrato do WorkResult: chaves cache_read/cache_write.
+    tokens_by_model = {
+        m: {
+            "in": int(tk.get("in", 0) or 0),
+            "out": int(tk.get("out", 0) or 0),
+            "cache_read": int(tk.get("cr", 0) or 0),
+            "cache_write": int(tk.get("cc", 0) or 0),
+        }
+        for m, tk in models.items()
+    }
+    return tokens_by_model, _predominant_model(models, cli_model)
 
 
 def harvest_progress_to_ledger(

--- a/infra/k8s/fleet_tokens_audit.py
+++ b/infra/k8s/fleet_tokens_audit.py
@@ -5,16 +5,24 @@ Agrega todos os worker-kinds (claude, deile, opencode, codex, qwen, goose,
 aider) numa visão única ``worker-kind × modelo`` — tokens in/out/cache + custo.
 O ``session_tokens_audit.py`` legado cobre apenas o claude-worker.
 
-Camadas (SRP): coleta (I/O via ``kubectl exec``) → normalização
-(``jsonl_cost`` como fonte única de custo, #445) → apresentação (Rich, adaptativo
-ao terminal — princípio 15).
+Fonte PRIMÁRIA (issue #638): o **store central** ``~/.deile/db/usage.db`` —
+o pipeline grava 1 registro por modelo por dispatch da frota CLI (push no
+momento do dispatch). Independe de pod estar de pé: sobrevive a ``replicas=0``
+(scale-to-zero) e a ``force-delete`` de pod. O pull-via-``kubectl exec``
+(``.progress``/ledger por-PVC) vira drill-down de debug local (``--source pods``).
+
+Camadas (SRP): coleta (store central SQLite local + I/O via ``kubectl exec`` para
+os workers núcleo) → normalização (``jsonl_cost`` como fonte única de custo, #445)
+→ apresentação (Rich, adaptativo ao terminal — princípio 15).
 
 Descoberta da frota: ``cli_adapters.ADAPTERS`` é a fonte de truth — registrar um
 adapter novo inclui o worker automaticamente.
 
 Uso::
 
-    python3 infra/k8s/fleet_tokens_audit.py                 # tabela + modo interativo
+    python3 infra/k8s/fleet_tokens_audit.py                 # central + pods, interativo
+    python3 infra/k8s/fleet_tokens_audit.py --source central # só o store central (sem pods)
+    python3 infra/k8s/fleet_tokens_audit.py --source pods    # só pull-via-exec (debug)
     python3 infra/k8s/fleet_tokens_audit.py --by-worker      # resumo por worker
     python3 infra/k8s/fleet_tokens_audit.py --top 40         # 40 sessões mais caras
     python3 infra/k8s/fleet_tokens_audit.py --last 20        # 20 mais recentes
@@ -29,13 +37,12 @@ Interativo: número+Enter = detalhe; ``w`` = by-worker/sessões; ``s`` = ordena�
 
 Fontes de token por worker:
 
-* claude  → ``~/.claude/projects/-home-claude-work-*/*.jsonl``
-* opencode→ ``<root>/.progress/<task>.stdout.log`` NDJSON ``step_finish`` (custo nativo)
-* codex   → ``<root>/.progress/<task>.stdout.log`` ``token_count``/``turn.completed``
-* qwen    → ``<root>/.progress/<task>.stdout.log`` ``result.stats.models``
-* goose   → ``<root>/.progress/<task>.stdout.log`` ``metadata.total_tokens``
-* aider   → ``<root>/.progress/<task>.stdout.log`` texto "Tokens:"/"Cost:"
-* deile   → ``~/.deile/db/usage.db`` SQLite ``usage_records``
+* **frota CLI** → store central ``~/.deile/db/usage.db`` (PRIMÁRIO, #638); para
+  drill-down (``--source pods``), o ``<root>/.progress/<task>.stdout.log`` por PVC:
+  opencode NDJSON ``step_finish``, codex ``token_count``, qwen ``result.stats.models``,
+  goose ``metadata.total_tokens``, aider texto "Tokens:"/"Cost:".
+* claude  → ``~/.claude/projects/-home-claude-work-*/*.jsonl`` (via pods)
+* deile   → ``~/.deile/db/usage.db`` SQLite ``usage_records`` no PVC do pod (via pods)
 """
 
 from __future__ import annotations
@@ -82,6 +89,77 @@ BRT = timezone(timedelta(hours=-3))
 
 #: Núcleo: não vêm do registro de adapters CLI.
 CORE_WORKERS = ("claude", "deile")
+
+#: Store central de custo da frota (issue #638) — SQLite local do pipeline.
+#: O pipeline grava 1 registro por modelo por dispatch (provider_id=worker,
+#: tier=stage, session_id=channel_id, model_id=modelo). Esta é a fonte PRIMÁRIA
+#: do ``[T]okens``: independe de pod estar de pé (sobrevive a replicas=0 e
+#: force-delete). O pull-via-kubectl-exec (``.progress``/ledger PVC) vira
+#: drill-down de debug (``--source pods``).
+_CENTRAL_DB_DEFAULT = os.path.join(
+    os.path.expanduser("~"), ".deile", "db", "usage.db")
+
+
+def _central_db_path() -> str:
+    """Path do store central de custo (override por ``DEILE_USAGE_DB_PATH``)."""
+    return os.environ.get("DEILE_USAGE_DB_PATH", "").strip() or _CENTRAL_DB_DEFAULT
+
+
+def collect_central_store(db_path: str | None = None,
+                          since_mtime: float = 0.0) -> list:
+    """Lê o store central e devolve sessões normalizadas (fonte PRIMÁRIA, #638).
+
+    Agrupa ``usage_records`` por ``(provider_id, session_id)`` — ``provider_id`` é
+    o worker-kind real da frota, ``session_id`` é o channel_id do dispatch
+    (``pipeline-issue-<N>`` / ``pipeline-pr-<N>``, opcionalmente com ``#<task_id>``
+    para fire-and-forget). ``tier`` carrega o stage. O custo já é nativo (gravado
+    pelo pipeline via ``jsonl_cost``), então ``native_cost`` = soma de ``cost_usd``.
+
+    Lê o SQLite DIRETO no host (sem ``kubectl exec``): o store é local ao
+    pipeline/painel. Sessões dos workers núcleo (``deile``/``claude``) NÃO entram
+    aqui — só a frota CLI grava central; o núcleo é coletado via pods.
+    """
+    import sqlite3
+    db = db_path or _central_db_path()
+    if not os.path.isfile(db):
+        return []
+    try:
+        con = sqlite3.connect("file:%s?mode=ro" % db, uri=True)
+        con.row_factory = sqlite3.Row
+        rows = con.execute(
+            "SELECT timestamp, provider_id, model_id, tier, session_id, "
+            "prompt_tokens, completion_tokens, cached_tokens, cost_usd "
+            "FROM usage_records ORDER BY timestamp").fetchall()
+        con.close()
+    except Exception:  # noqa: BLE001 — store indisponível/corrompido → sem central
+        return []
+    sessions: dict = {}
+    for r in rows:
+        worker = (r["provider_id"] or "").strip()
+        # Núcleo é coletado via pods (claude JSONL / deile SQLite do pod);
+        # não duplicar aqui (o deile-worker grava no SQLite do PRÓPRIO pod).
+        if not worker or worker in CORE_WORKERS:
+            continue
+        if since_mtime and r["timestamp"] < since_mtime:
+            continue
+        sid = r["session_id"] or "?"
+        key = (worker, sid)
+        s = sessions.get(key)
+        if s is None:
+            s = {"worker": worker, "task_id": sid, "source": "<central-store>",
+                 "models": {}, "native_cost": 0.0, "first_ts": None,
+                 "last_ts": None, "brief": None, "mtime": r["timestamp"],
+                 "stage": r["tier"] or "", "central": True}
+            sessions[key] = s
+        model = r["model_id"] or "unknown"
+        mm = s["models"].setdefault(model, {"in": 0, "out": 0, "cc": 0, "cr": 0})
+        mm["in"] += int(r["prompt_tokens"] or 0)
+        mm["out"] += int(r["completion_tokens"] or 0)
+        mm["cr"] += int(r["cached_tokens"] or 0)
+        s["native_cost"] = (s["native_cost"] or 0.0) + float(r["cost_usd"] or 0.0)
+        s["mtime"] = max(s["mtime"] or 0, r["timestamp"])
+    return [s for s in sessions.values()
+            if any(sum(v.values()) > 0 for v in s["models"].values())]
 
 
 def _iso_brt(iso_str: str) -> str:
@@ -597,7 +675,8 @@ def enrich(sessions: list, collectors: dict) -> list:
     """Calcula custo por modelo + totais de cada sessão (camada de normalização)."""
     now = datetime.now(timezone.utc)
     for s in sessions:
-        coll = collectors[s["worker"]]
+        # Fallback genérico para kind do store central não mais registrado.
+        coll = collectors.get(s["worker"]) or collector_for(s["worker"], {})
         tot = {"in": 0, "out": 0, "cc": 0, "cr": 0}
         per_model = {}
         cost = 0.0
@@ -609,10 +688,14 @@ def enrich(sessions: list, collectors: dict) -> list:
             for k in tot:
                 tot[k] += tk.get(k, 0)
             per_model[model] = {**tk, "cost": c}
-        # Custo nativo do CLI prevalece sobre o estimado.
+        # Custo nativo prevalece sobre o estimado. Sessões do store central
+        # (issue #638) já trazem o custo computado pelo pipeline via jsonl_cost
+        # (fonte única de preço) — é "nativo" para fins de exibição (✓), qualquer
+        # que seja o worker. Senão, só workers que reportam custo nativo do CLI.
         native = s.get("native_cost")
         s["estimated_cost_usd"] = cost
-        if coll.uses_native_cost and isinstance(native, (int, float)) and native > 0:
+        prefer_native = s.get("central") or coll.uses_native_cost
+        if prefer_native and isinstance(native, (int, float)) and native > 0:
             s["cost_usd"] = float(native)
             s["cost_basis"] = "nativo"
         else:
@@ -883,9 +966,9 @@ def export(sessions: list, outdir: str):
     return jpath, cpath
 
 
-def collect_fleet(kubectl: str, ns: str, kinds: list, collectors: dict,
-                  since_mtime: float = 0.0) -> list:
-    """Varre cada worker da frota (kubectl exec) e devolve sessões enriquecidas."""
+def _collect_pod_sessions(kubectl: str, ns: str, kinds: list,
+                          since_mtime: float = 0.0) -> list:
+    """Varre cada worker via ``kubectl exec`` (raw, sem enrich)."""
     all_sessions = []
     for kind in kinds:
         pod = resolve_pod_for_worker(kubectl, ns, kind)
@@ -897,7 +980,59 @@ def collect_fleet(kubectl: str, ns: str, kinds: list, collectors: dict,
         sess = fetch_worker_sessions(kubectl, ns, kind, pod, since_mtime)
         print(f"    {len(sess)} sessões com tokens.", file=sys.stderr)
         all_sessions.extend(sess)
-    return enrich(all_sessions, collectors)
+    return all_sessions
+
+
+def collect_fleet(kubectl: str, ns: str, kinds: list, collectors: dict,
+                  since_mtime: float = 0.0) -> list:
+    """Varre cada worker da frota (kubectl exec) e devolve sessões enriquecidas."""
+    return enrich(_collect_pod_sessions(kubectl, ns, kinds, since_mtime), collectors)
+
+
+def collect_all(kubectl: str, ns: str, kinds: list, collectors: dict,
+                *, source: str = "both", since_mtime: float = 0.0,
+                db_path: str | None = None) -> list:
+    """Coleta unificada com o STORE CENTRAL como fonte primária (issue #638).
+
+    ``source``:
+
+    * ``central`` — só o store central (independe de pod; sobrevive a replicas=0
+      e force-delete). Workers núcleo (claude/deile) não escrevem central → não
+      aparecem nesse modo.
+    * ``pods`` — só o pull-via-``kubectl exec`` (``.progress``/ledger PVC) —
+      drill-down de debug local; exige pods de pé.
+    * ``both`` (default) — central primário + pods para os workers NÚCLEO
+      (claude/deile, que não têm central) e para os CLI-kinds AUSENTES do central
+      (sem dispatch via pipeline ainda). Central prevalece por
+      ``(worker, session_id)``: a sessão do PVC do mesmo dispatch é suprimida.
+    """
+    central = []
+    if source in ("central", "both"):
+        central = collect_central_store(db_path=db_path, since_mtime=since_mtime)
+        print(f"• store central: {len(central)} sessões (fonte primária).",
+              file=sys.stderr)
+
+    pods = []
+    if source in ("pods", "both"):
+        if source == "pods":
+            pod_kinds = kinds
+        else:
+            # Central cobre a frota CLI; via pods só completamos o NÚCLEO
+            # (sem central) + CLI-kinds que ainda não têm registro central.
+            covered = {s["worker"] for s in central}
+            pod_kinds = [k for k in kinds
+                         if k in CORE_WORKERS or k not in covered]
+        if pod_kinds:
+            pods = _collect_pod_sessions(kubectl, ns, pod_kinds, since_mtime)
+
+    # Dedup central × pods por (worker, session/task) — central prevalece.
+    central_keys = {(s["worker"], s["task_id"]) for s in central}
+    merged = list(central)
+    for s in pods:
+        if (s["worker"], s["task_id"]) in central_keys:
+            continue
+        merged.append(s)
+    return enrich(merged, collectors)
 
 
 SORT_MODES = [
@@ -1163,9 +1298,16 @@ def main():
                     help="ordena por última atividade; com N, só as N mais recentes")
     ap.add_argument("--model", default=None, metavar="SLUG",
                     help="filtra sessões cujo modelo contém SLUG (substring)")
+    ap.add_argument("--source", choices=("both", "central", "pods"), default="both",
+                    help="fonte: central (store SQLite, independe de pod — #638), "
+                         "pods (kubectl exec, drill-down), both (default, central "
+                         "primário + pods para núcleo)")
     args = ap.parse_args()
 
-    kubectl = find_kubectl()
+    # O store central é LOCAL (sem kubectl). Só exigimos kubectl quando a coleta
+    # toca pods (``pods``/``both``) — assim ``--source central`` funciona com a
+    # frota inteira em replicas=0 e sem kubectl no PATH.
+    kubectl = find_kubectl() if args.source in ("pods", "both") else ""
     ns = args.namespace
     kinds = _parse_worker_filter(args.worker, fleet_worker_kinds())
     if not kinds:
@@ -1174,8 +1316,9 @@ def main():
     collectors = {k: collector_for(k, declared) for k in fleet_worker_kinds()}
     console = _console()
 
-    print(f"• namespace={ns}  workers={','.join(kinds)}", file=sys.stderr)
-    sessions = collect_fleet(kubectl, ns, kinds, collectors)
+    print(f"• namespace={ns}  workers={','.join(kinds)}  source={args.source}",
+          file=sys.stderr)
+    sessions = collect_all(kubectl, ns, kinds, collectors, source=args.source)
     sessions = filter_by_model(sessions, args.model)
     if not sessions:
         sys.exit("Nenhuma sessão com tokens encontrada na frota.")
@@ -1205,7 +1348,7 @@ def main():
 
     def refetch():
         try:
-            data = collect_fleet(kubectl, ns, kinds, collectors)
+            data = collect_all(kubectl, ns, kinds, collectors, source=args.source)
             data = filter_by_model(data, args.model)
             if last_n:
                 data.sort(key=lambda x: x.get("mtime") or 0, reverse=True)


### PR DESCRIPTION
## Resumo

Substitui a coleta de custo/token da frota CLI — antes **pull via `kubectl exec`** parseando `.progress` (efêmero) + ledger por-PVC (some no `replicas=0`/`force-delete`) — por **push central no momento do dispatch**: o worker reporta tokens-por-modelo de forma estruturada na resposta do `/v1/dispatch`; o **pipeline** (componente longevo) persiste no **`UsageRepository` (SQLite central)**; a tela `[T]okens` lê do store central.

`Closes #638`

## Os 5 passos → o que entregou e onde

1. **`WorkResult` ganha campos estruturados** (`tokens_by_model`, `model`) — `infra/k8s/cli_adapters/base.py`. Preenchidos pelo **servidor** (não pelos adapters, que têm múltiplos pontos de retorno) a partir do parser ÚNICO `fleet_progress_parse`, via novo helper `build_usage_block` em `cli_worker_server.py`. Reusa exatamente a normalização do harvester do ledger (remap `unknown`→`cli_model`). `_finalize_git`/`_post_run_gate` passam a usar `dataclasses.replace` para **preservar** o uso ao reconstruir o `WorkResult`.
2. **`_build_response` inclui o bloco `usage`** (worker + model + tokens_by_model) na resposta do `/v1/dispatch` — `infra/k8s/cli_worker_server.py`. O meta da task (`_save_task_result`) e o resume-info também passam a carregar `usage` (para o read-back fire-and-forget).
3. **O pipeline persiste 1 registro por modelo** no `UsageRepository` ao consumir a resposta do dispatch — novo módulo `deile/orchestration/pipeline/fleet_cost_recorder.py`, chamado em `WorkerImplementer._dispatch` (caminho `wait`, gated em `is_cli_worker`) e no reconcile (`stages._fetch_reconcile_state`, para o `implement` fire-and-forget cuja resposta do 202 é descartada). O corpo da issue afirmava que o pipeline "já lê `total_cost_usd`" — **não lia** (grep confirmou); o read foi adicionado de fato.
4. **`fleet_tokens_audit` / `[T]okens` com o store central como fonte PRIMÁRIA** — `infra/k8s/fleet_tokens_audit.py`: `collect_central_store` lê o SQLite local DIRETO (sem kubectl); nova flag `--source {both,central,pods}` (`both` default = central primário + pods só para o núcleo claude/deile e CLI-kinds ainda sem central, dedupado por `(worker, session)`). O ledger por-PVC vira drill-down (`--source pods`).
5. **Marcação `✓ nativo` / `≈ estimado` com fonte única de preço** — o custo central é computado por `jsonl_cost.fleet_cost_of_model` (sem duplicar tabela); sessões do central exibem como nativo (✓) para qualquer worker, já que o preço veio da fonte única.

## Decisão de schema (sem migração, sem tabela paralela)

O `UsageRecord` não tem colunas nativas `worker`/`stage`. Em vez de migrar ou criar tabela paralela, **reuso os slots já existentes**, espelhando o que `records_for_stage_model` já fazia (stage codificado no `session_id`):

- `provider_id` ← **worker-kind** (`opencode`/`codex`/… — "quem serviu" o request);
- `tier` ← **stage** (`implement`/`pr_review`/…);
- `session_id` ← **channel_id** do dispatch (`pipeline-issue-<N>` / `pipeline-pr-<N>`; no fire-and-forget usa `<channel>#<task_id>` para dedup idempotente entre ticks do reconcile);
- `model_id` ← **model real** (anti `unknown`: cai no `cli_model` do payload).

Um dispatch multi-modelo vira **N registros** (um por modelo do `tokens_by_model`). Sem duplicação de preço (fonte única `jsonl_cost`). Escrita **best-effort isolada**: falha de SQLite/preço nunca derruba o dispatch nem o tick.

## Evidência dos 6 critérios de aceite

- [x] **Testes existentes passam** — suíte completa determinística: `4 failed, 8235 passed` (as 4 falhas são pré-existentes, ver abaixo). +25 testes novos vs origin/main.
- [x] **`[T]okens` com workers em `replicas=0`** — `--source central` renderiza a frota sem nenhum `kubectl` (smoke E2E + `test_collect_all_central_works_without_kubectl`).
- [x] **Custo sobrevive a `force-delete`** — o registro está no SQLite central, não no emptyDir/PVC do pod (`collect_central_store` independe de pod).
- [x] **Teste de INTEGRAÇÃO da fiação** — `test_fleet_cost_wiring.py`: um dispatch real simulado via `WorkerImplementer` grava 1 registro com tokens+custo+modelo+stage corretos (caminho `wait` E fire-and-forget via reconcile, com dedup).
- [x] **`model` correto sem `unknown`** — `build_usage_block` + recorder remapeiam `unknown`→`cli_model` (`test_model_unknown_falls_back_to_cli_model`, `test_build_usage_block_remaps_unknown_to_cli_model`).
- [x] **Sem duplicar tabela de preço** — custo via `jsonl_cost.fleet_cost_of_model` em ambos os lados (`test_cost_uses_single_price_source`).

## Cobertura de teste nova

- `deile/tests/orchestration/pipeline/test_fleet_cost_recorder.py` — unit do recorder (schema, multi-modelo, anti-unknown, preço único, best-effort, dedup).
- `deile/tests/orchestration/pipeline/test_fleet_cost_wiring.py` — integração ponta-a-ponta (wait + fire-and-forget).
- `deile/tests/infra/test_cli_worker_server.py` — `build_usage_block` + bloco `usage` na resposta/resume-info.
- `deile/tests/infra/test_fleet_tokens_audit.py` — `collect_central_store`, `collect_all` (central/both/sem-kubectl/dedup/since-mtime).
- `deile/tests/infra/test_cli_adapter_registry.py` — contrato dos campos novos do `WorkResult`.

## Falhas pré-existentes (NÃO introduzidas por este PR)

Confirmadas em árvore pristina `origin/main` (mesma ordenação determinística):
- 3 em `deile/tests/orchestration/pipeline/` (`test_classify` / `test_gap_regressions` / `test_reconcile_fire_and_forget`) — testes stale do reaper, já corrigidos no **PR irmão #642** (ainda não mergeado).
- 1 em `deile/tests/infrastructure/test_pod_presence.py::test_cleanup_stale_workspaces_removes_dead_pod_workspace`.

`ruff` e `isort` limpos nos arquivos novos; sem novas violações de isort nos arquivos editados (os de `implementer.py`/`stages.py`/testes já falhavam isort em `origin/main`).