### PR TITLE
fix(security): enforce repo allowlist on dispatch (issue #639)

### DIFF
--- a/deile/tests/infra/test_cli_worker_repo_allowlist.py
+++ b/deile/tests/infra/test_cli_worker_repo_allowlist.py
@@ -1,0 +1,191 @@
+"""Integração — enforcement da allowlist de repos no ``cli_worker_server`` (#639).
+
+Prova o BLOQUEIO: um dispatch cujo ``resume.repo`` está fora da allowlist
+retorna 403 ``REPO_NOT_ALLOWED`` e **não chega a clonar** (``_ensure_repo`` nunca
+é chamado). Um dispatch com slug dentro da allowlist passa o portão e segue para
+o ciclo de repo.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import cli_adapters  # noqa: E402
+import cli_worker_server as cws  # noqa: E402
+
+_AUTH_HEADERS = {"Authorization": "Bearer test-token"}
+
+_CONFIGMAP = r"""# allowlist canônica (ConfigMap claude-worker-allowed-repos)
+^https://github\.com/elimarcavalli/(deile|deilebot)(\.git)?$
+^https://gitlab\.com/elimarcavalli/(deile|deilebot)(\.git)?$
+^git@github\.com:elimarcavalli/(deile|deilebot)(\.git)?$
+^git@gitlab\.com:elimarcavalli/(deile|deilebot)(\.git)?$
+"""
+
+
+@pytest.fixture
+def mock_adapter(tmp_path, monkeypatch):
+    """Adapter mock trivial + allowlist canônica apontada por env var."""
+    pkg_dir = Path(cli_adapters.__path__[0])
+    mod_path = pkg_dir / "zzz_mock_allowlist.py"
+    mod_path.write_text(textwrap.dedent('''\
+        from cli_adapters.base import BaseCliAdapter, WorkResult, ModelInfo
+
+
+        class MockAdapter(BaseCliAdapter):
+            def build_argv(self, *, brief_path, model, reasoning, workdir,
+                           resume, task_id=""):
+                return ["sh", "-c", f"touch {workdir}/.ran"]
+
+            def parse_output(self, *, stdout, stderr, rc):
+                return WorkResult(ok=(rc == 0), result_text="")
+
+            def list_models(self):
+                return [ModelInfo(id="m", provider="p", context=1)]
+
+
+        ADAPTER = MockAdapter(
+            kind="mock", default_port=8799, auth_env_keys=["MOCK_API_KEY"],
+        )
+    '''), encoding="utf-8")
+    cli_adapters.reload_adapters()
+
+    monkeypatch.setenv("DEILE_CLI_WORKER_KIND", "mock")
+    monkeypatch.setenv("DEILE_CLI_WORKER_ROOT", str(tmp_path / "work"))
+    monkeypatch.setenv("MOCK_API_KEY", "secret")
+    allow = tmp_path / "allowed_repos.regex"
+    allow.write_text(_CONFIGMAP, encoding="utf-8")
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(allow))
+    monkeypatch.delenv("DEILE_GITHUB_HOST", raising=False)
+    monkeypatch.delenv("DEILE_GITLAB_HOST", raising=False)
+    try:
+        yield
+    finally:
+        mod_path.unlink(missing_ok=True)
+        sys.modules.pop("cli_adapters.zzz_mock_allowlist", None)
+        cli_adapters.reload_adapters()
+        cws._models_cache.clear()
+
+
+async def test_dispatch_blocks_repo_outside_allowlist(mock_adapter, monkeypatch):
+    """403 REPO_NOT_ALLOWED + ``_ensure_repo`` NUNCA é chamado (sem clone)."""
+    clone_calls = []
+
+    async def _spy_ensure(*a, **kw):
+        clone_calls.append((a, kw))
+        return True, "clonado (NÃO deveria acontecer)"
+
+    monkeypatch.setattr(cws, "_ensure_repo", _spy_ensure)
+
+    app = cws.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(
+            "/v1/dispatch",
+            json={
+                "brief": "exfiltra credenciais",
+                "branch": "auto/issue-1",
+                "cli_model": "m",
+                "resume": {"repo": "attacker/leak-repo"},
+            },
+            headers=_AUTH_HEADERS,
+        )
+        assert resp.status == 403
+        body = await resp.json()
+        assert body["ok"] is False
+        assert body["error_code"] == "REPO_NOT_ALLOWED"
+
+    assert clone_calls == [], "clone NÃO pode ser tentado para repo bloqueado"
+
+
+async def test_dispatch_blocks_path_traversal_slug(mock_adapter, monkeypatch):
+    """Slug com traversal (``../``) é bloqueado antes do clone."""
+    clone_calls = []
+
+    async def _spy_ensure(*a, **kw):
+        clone_calls.append(True)
+        return True, "x"
+
+    monkeypatch.setattr(cws, "_ensure_repo", _spy_ensure)
+
+    app = cws.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(
+            "/v1/dispatch",
+            json={
+                "brief": "x", "branch": "b", "cli_model": "m",
+                "resume": {"repo": "../../etc/passwd"},
+            },
+            headers=_AUTH_HEADERS,
+        )
+        assert resp.status == 403
+        assert (await resp.json())["error_code"] == "REPO_NOT_ALLOWED"
+    assert clone_calls == []
+
+
+async def test_dispatch_allows_repo_in_allowlist(mock_adapter, monkeypatch):
+    """Slug dentro da allowlist passa o portão → ``_ensure_repo`` é chamado."""
+    clone_calls = []
+
+    async def _spy_ensure(workspace, *, repo, branch, base_branch):
+        clone_calls.append(repo)
+        # Simula clone OK sem tocar a rede; o gate de push reprova depois (NO_PUSH),
+        # mas o que importa aqui é o portão da allowlist ter LIBERADO o clone.
+        return True, f"repo {repo} pronto (mock)"
+
+    monkeypatch.setattr(cws, "_ensure_repo", _spy_ensure)
+    monkeypatch.setattr(cws, "_git_head", _make_async(None))
+    monkeypatch.setattr(cws, "_git_branch_pushed", _make_async(False))
+
+    app = cws.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(
+            "/v1/dispatch",
+            json={
+                "brief": "implementa #1",
+                "branch": "auto/issue-1",
+                "cli_model": "m",
+                "resume": {"repo": "elimarcavalli/deile"},
+            },
+            headers=_AUTH_HEADERS,
+        )
+        # 200 (gate de push reprova com NO_PUSH) — não é 403.
+        assert resp.status == 200
+        body = await resp.json()
+        assert body.get("error_code") != "REPO_NOT_ALLOWED"
+
+    assert clone_calls == ["elimarcavalli/deile"], (
+        "clone DEVE ser tentado para repo permitido"
+    )
+
+
+async def test_dispatch_without_repo_slug_skips_allowlist(mock_adapter, monkeypatch):
+    """Sem ``resume.repo`` o CLI roda no workspace cru — allowlist não bloqueia."""
+    monkeypatch.setattr(cws, "_git_head", _make_async(None))
+    monkeypatch.setattr(cws, "_git_branch_pushed", _make_async(False))
+
+    app = cws.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(
+            "/v1/dispatch",
+            json={"brief": "x", "branch": "b", "cli_model": "m"},
+            headers=_AUTH_HEADERS,
+        )
+        assert resp.status != 403
+        body = await resp.json()
+        assert body.get("error_code") != "REPO_NOT_ALLOWED"
+
+
+def _make_async(value):
+    async def _coro(*_a, **_kw):
+        return value
+    return _coro

--- a/deile/tests/infra/test_cli_worker_repo_cycle.py
+++ b/deile/tests/infra/test_cli_worker_repo_cycle.py
@@ -144,6 +144,14 @@ def repo_adapter(tmp_path, monkeypatch, patched_clone):
     cli_adapters.reload_adapters()
     monkeypatch.setenv("DEILE_CLI_WORKER_KIND", "zzz_repo_mock")
     monkeypatch.setenv("DEILE_CLI_WORKER_ROOT", str(tmp_path / "work"))
+    # Allowlist de repos (issue #639): o dispatch reverifica ``resume.repo``
+    # contra o ConfigMap ANTES do clone. Estes testes despacham ``owner/repo``,
+    # então a allowlist precisa admiti-lo, senão o handler bloqueia com 403.
+    allow = tmp_path / "allowed_repos.regex"
+    allow.write_text(
+        r"^https://github\.com/owner/repo(\.git)?$" + "\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(allow))
     # A identidade git global existe no ambiente de teste; o push vai para o
     # remote local (path do bare), sem credencial nem rede.
     try:

--- a/deile/tests/infra/test_worker_core_repo_allowlist.py
+++ b/deile/tests/infra/test_worker_core_repo_allowlist.py
@@ -1,0 +1,193 @@
+"""Testes unit do enforcement da allowlist de repos (issue #639).
+
+Cobre a FONTE ÚNICA de verificação por-request em ``_worker_core``:
+``normalize_repo_slug`` / ``repo_slug_allowed`` / ``load_allowed_repo_patterns``
+/ ``check_repo_allowed``. O enforcement de integração nos dois servidores vive em
+``test_cli_worker_repo_allowlist.py`` e ``test_claude_worker_repo_allowlist.py``.
+
+Semântica fail-closed: allowlist ausente/vazia/inválida → bloqueia tudo. É
+consistente com o ``wrapper.py`` que faz ``sys.exit`` no startup (em produção o
+worker nem sobe sem allowlist válida), então fail-closed aqui não quebra deploy
+legítimo — apenas defende contra drift (ConfigMap removido em runtime) e testes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _worker_core as core  # noqa: E402
+
+#: Allowlist canônica (cópia do ConfigMap 47-claude-worker-allowed-repos).
+_CONFIGMAP = r"""# regex por linha — URLs completas
+^https://github\.com/elimarcavalli/(deile|deilebot)(\.git)?$
+^https://gitlab\.com/elimarcavalli/(deile|deilebot)(\.git)?$
+^git@github\.com:elimarcavalli/(deile|deilebot)(\.git)?$
+^git@gitlab\.com:elimarcavalli/(deile|deilebot)(\.git)?$
+"""
+
+
+@pytest.fixture
+def allowlist(tmp_path, monkeypatch):
+    """Escreve o ConfigMap canônico num tmp file e aponta a env var pra ele."""
+    p = tmp_path / "allowed_repos.regex"
+    p.write_text(_CONFIGMAP, encoding="utf-8")
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(p))
+    # Hosts default (evita herdar GHES CSV de outro teste/ambiente).
+    monkeypatch.delenv("DEILE_GITHUB_HOST", raising=False)
+    monkeypatch.delenv("DEILE_GITLAB_HOST", raising=False)
+    return p
+
+
+# --------------------------------------------------------------------------- #
+# normalize_repo_slug
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("raw,expected", [
+    ("elimarcavalli/deile", "elimarcavalli/deile"),
+    ("  elimarcavalli/deile  ", "elimarcavalli/deile"),
+    ("elimarcavalli/deile.git", "elimarcavalli/deile"),
+    ("group/sub/project", "group/sub/project"),
+])
+def test_normalize_accepts_well_formed_slugs(raw, expected):
+    assert core.normalize_repo_slug(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [
+    "",
+    "   ",
+    "single",                       # falta segundo componente
+    "owner/",                       # componente vazio
+    "/repo",                        # / líder
+    "owner//repo",                  # // interno
+    "../../etc/passwd",             # path traversal
+    "owner/repo/../leak",           # traversal por componente
+    "owner/..",                     # componente ".."
+    "owner/.",                      # componente "."
+    "owner/repo@evil",              # auth/host smuggling
+    "owner/repo:branch",            # ":" smuggling
+    "https://github.com/o/r",       # URL inteira como slug
+    "git@github.com:o/r",           # ssh inteiro como slug
+    "owner\\repo",                  # backslash
+    "owner /repo",                  # espaço interno
+])
+def test_normalize_rejects_malformed_or_unsafe(raw):
+    assert core.normalize_repo_slug(raw) is None
+
+
+# --------------------------------------------------------------------------- #
+# load_allowed_repo_patterns (não-exiting, fail-closed)
+# --------------------------------------------------------------------------- #
+
+def test_load_returns_patterns_when_valid(allowlist):
+    patterns, err = core.load_allowed_repo_patterns()
+    assert err is None
+    assert len(patterns) == 4
+
+
+def test_load_fails_closed_when_file_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(tmp_path / "nope.regex"),
+    )
+    patterns, err = core.load_allowed_repo_patterns()
+    assert patterns == []
+    assert err is not None and "ausente" in err
+
+
+def test_load_fails_closed_when_empty(monkeypatch, tmp_path):
+    p = tmp_path / "empty.regex"
+    p.write_text("# só comentário\n\n", encoding="utf-8")
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(p))
+    patterns, err = core.load_allowed_repo_patterns()
+    assert patterns == []
+    assert err is not None and "vazia" in err
+
+
+def test_load_fails_closed_on_invalid_regex(monkeypatch, tmp_path):
+    p = tmp_path / "bad.regex"
+    p.write_text("^[unterminated\n", encoding="utf-8")
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(p))
+    patterns, err = core.load_allowed_repo_patterns()
+    assert patterns == []
+    assert err is not None and "inválida" in err
+
+
+# --------------------------------------------------------------------------- #
+# check_repo_allowed (end-to-end por-request)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("slug", [
+    "elimarcavalli/deile",
+    "elimarcavalli/deilebot",
+    " elimarcavalli/deile ",
+    "elimarcavalli/deile.git",
+])
+def test_check_allows_repos_in_allowlist(allowlist, slug):
+    ok, reason, norm = core.check_repo_allowed(slug)
+    assert ok is True, reason
+    assert reason == ""
+    assert norm == "elimarcavalli/deile" or norm == "elimarcavalli/deilebot"
+
+
+@pytest.mark.parametrize("slug", [
+    "elimarcavalli/leak-repo",      # repo não listado
+    "attacker/deile",               # owner errado
+    "elimarcavalli/Deile",          # case mismatch (allowlist é case-sensitive)
+    "elimarcavalli/deile-secret",   # prefixo do nome permitido, mas não exato
+])
+def test_check_blocks_well_formed_repos_outside_allowlist(allowlist, slug):
+    ok, reason, norm = core.check_repo_allowed(slug)
+    assert ok is False
+    assert "fora da allowlist" in reason
+    assert norm is not None  # slug bem-formado, só não casa
+
+
+@pytest.mark.parametrize("slug", [
+    "../../etc/passwd",
+    "evil.com/elimarcavalli/deile",
+    "elimarcavalli/deile@evil.com",
+    "https://github.com/elimarcavalli/deile",
+])
+def test_check_blocks_malformed_or_unsafe_slugs(allowlist, slug):
+    ok, reason, _norm = core.check_repo_allowed(slug)
+    assert ok is False
+
+
+def test_check_fails_closed_without_allowlist(monkeypatch, tmp_path):
+    """Sem ConfigMap (drift em runtime), NADA é permitido — fail-closed."""
+    monkeypatch.setenv(
+        "DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(tmp_path / "missing.regex"),
+    )
+    ok, reason, _norm = core.check_repo_allowed("elimarcavalli/deile")
+    assert ok is False
+    assert "indisponível" in reason
+
+
+def test_check_honors_ghes_csv_host(monkeypatch, tmp_path):
+    """``DEILE_GITHUB_HOST`` CSV (GHES multi-host) é resolvido na URL canônica."""
+    p = tmp_path / "ghes.regex"
+    p.write_text(r"^https://ghe\.corp\.com/team/app(\.git)?$" + "\n", "utf-8")
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(p))
+    monkeypatch.setenv("DEILE_GITHUB_HOST", "github.com,ghe.corp.com")
+    ok, _reason, norm = core.check_repo_allowed("team/app")
+    assert ok is True
+    assert norm == "team/app"
+
+
+def test_check_matches_gitlab_subgroup(monkeypatch, tmp_path):
+    """Slug GitLab ``group/sub/project`` casa pattern de subgrupo."""
+    p = tmp_path / "gl.regex"
+    p.write_text(
+        r"^https://gitlab\.com/acme/team/service(\.git)?$" + "\n", "utf-8",
+    )
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(p))
+    ok, _reason, norm = core.check_repo_allowed("acme/team/service")
+    assert ok is True
+    assert norm == "acme/team/service"

--- a/deile/tests/infrastructure/test_claude_worker_repo_allowlist.py
+++ b/deile/tests/infrastructure/test_claude_worker_repo_allowlist.py
@@ -1,0 +1,199 @@
+"""Integração — enforcement da allowlist de repos no ``claude_worker_server`` (#639).
+
+Prova o BLOQUEIO: um dispatch fresh cujo ``resume.repo`` está fora da allowlist
+retorna 403 ``REPO_NOT_ALLOWED`` e **não chega a clonar** (``_ensure_repo_cloned``
+e ``_git_fast_forward_workdir`` nunca são chamados, e ``claude`` nunca é
+spawnado). Um slug dentro da allowlist passa o portão e segue para o ciclo de
+repo + spawn.
+
+O módulo vive em ``infra/k8s/`` — carregado via ``importlib.util`` (mesmo padrão
+de ``test_claude_worker_server.py``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+_AUTH_HEADERS = {"Authorization": "Bearer test-token"}
+
+_CONFIGMAP = r"""# allowlist canônica (ConfigMap claude-worker-allowed-repos)
+^https://github\.com/elimarcavalli/(deile|deilebot)(\.git)?$
+^https://gitlab\.com/elimarcavalli/(deile|deilebot)(\.git)?$
+^git@github\.com:elimarcavalli/(deile|deilebot)(\.git)?$
+^git@gitlab\.com:elimarcavalli/(deile|deilebot)(\.git)?$
+"""
+
+
+@pytest.fixture
+def claude_worker_module():
+    repo_root = Path(__file__).resolve().parents[3]
+    k8s_dir = str(repo_root / "infra" / "k8s")
+    if k8s_dir not in sys.path:
+        sys.path.insert(0, k8s_dir)
+    server_path = repo_root / "infra" / "k8s" / "claude_worker_server.py"
+    spec = importlib.util.spec_from_file_location(
+        "claude_worker_server_allowlist_under_test", str(server_path),
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["claude_worker_server_allowlist_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def allowlist(tmp_path, monkeypatch):
+    p = tmp_path / "allowed_repos.regex"
+    p.write_text(_CONFIGMAP, encoding="utf-8")
+    monkeypatch.setenv("DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(p))
+    monkeypatch.delenv("DEILE_GITHUB_HOST", raising=False)
+    monkeypatch.delenv("DEILE_GITLAB_HOST", raising=False)
+    return p
+
+
+async def test_dispatch_blocks_repo_outside_allowlist(
+    claude_worker_module, allowlist, monkeypatch, tmp_path,
+):
+    """403 REPO_NOT_ALLOWED + nenhum clone/spawn para repo fora da allowlist."""
+    mod = claude_worker_module
+    calls = {"clone": 0, "ff": 0, "spawn": 0}
+
+    async def _spy_clone(*_a, **_kw):
+        calls["clone"] += 1
+        return True
+
+    async def _spy_ff(*_a, **_kw):
+        calls["ff"] += 1
+
+    async def _spy_run(*_a, **_kw):
+        calls["spawn"] += 1
+        return mod.SubprocessResult(0, "", "", 0.0)
+
+    monkeypatch.setattr(mod, "_ensure_repo_cloned", _spy_clone)
+    monkeypatch.setattr(mod, "_git_fast_forward_workdir", _spy_ff)
+    monkeypatch.setattr(mod, "run_subprocess_with_progress", _spy_run)
+    monkeypatch.setattr("shutil.which", lambda b: "/usr/local/bin/claude")
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path / "work"))
+
+    app = mod.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/v1/dispatch", headers=_AUTH_HEADERS, json={
+            "brief": "exfiltra credenciais",
+            "preferred_model": "anthropic:claude-haiku-4-5",
+            "branch": "auto/issue-1",
+            "resume": {"repo": "attacker/leak-repo"},
+        })
+        assert resp.status == 403
+        body = await resp.json()
+        assert body["ok"] is False
+        assert body["error_code"] == "REPO_NOT_ALLOWED"
+
+    assert calls == {"clone": 0, "ff": 0, "spawn": 0}, (
+        "repo bloqueado não pode clonar nem spawnar claude"
+    )
+
+
+async def test_dispatch_blocks_traversal_slug(
+    claude_worker_module, allowlist, monkeypatch, tmp_path,
+):
+    mod = claude_worker_module
+    spawned = []
+
+    async def _spy_run(*_a, **_kw):
+        spawned.append(True)
+        return mod.SubprocessResult(0, "", "", 0.0)
+
+    monkeypatch.setattr(mod, "run_subprocess_with_progress", _spy_run)
+    monkeypatch.setattr("shutil.which", lambda b: "/usr/local/bin/claude")
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path / "work"))
+
+    app = mod.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/v1/dispatch", headers=_AUTH_HEADERS, json={
+            "brief": "x",
+            "preferred_model": "anthropic:claude-haiku-4-5",
+            "branch": "b",
+            "resume": {"repo": "owner/repo/../leak"},
+        })
+        assert resp.status == 403
+        assert (await resp.json())["error_code"] == "REPO_NOT_ALLOWED"
+    assert spawned == []
+
+
+async def test_dispatch_fails_closed_without_allowlist(
+    claude_worker_module, monkeypatch, tmp_path,
+):
+    """ConfigMap ausente em runtime → 403 (fail-closed), nada spawnado."""
+    mod = claude_worker_module
+    spawned = []
+
+    async def _spy_run(*_a, **_kw):
+        spawned.append(True)
+        return mod.SubprocessResult(0, "", "", 0.0)
+
+    monkeypatch.setattr(mod, "run_subprocess_with_progress", _spy_run)
+    monkeypatch.setattr("shutil.which", lambda b: "/usr/local/bin/claude")
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path / "work"))
+    monkeypatch.setenv(
+        "DEILE_CLAUDE_ALLOWED_REPOS_FILE", str(tmp_path / "missing.regex"),
+    )
+
+    app = mod.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/v1/dispatch", headers=_AUTH_HEADERS, json={
+            "brief": "x",
+            "preferred_model": "anthropic:claude-haiku-4-5",
+            "branch": "b",
+            "resume": {"repo": "elimarcavalli/deile"},
+        })
+        assert resp.status == 403
+        assert (await resp.json())["error_code"] == "REPO_NOT_ALLOWED"
+    assert spawned == []
+
+
+async def test_dispatch_allows_repo_in_allowlist(
+    claude_worker_module, allowlist, monkeypatch, tmp_path,
+):
+    """Slug permitido passa o portão → clone tentado + claude spawnado."""
+    mod = claude_worker_module
+    calls = {"clone": 0, "spawn": 0}
+
+    async def _spy_clone(workspace, repo):
+        calls["clone"] += 1
+        return True  # finge que ./repo foi restaurado (sem rede)
+
+    async def _spy_run(args, *, cwd, task_id, timeout, lease_path=None):
+        calls["spawn"] += 1
+        import json as _json
+        out = _json.dumps({
+            "is_error": False, "result": "ok", "session_id": "s",
+            "total_cost_usd": 0.0,
+        })
+        return mod.SubprocessResult(0, out, "", 1.0)
+
+    monkeypatch.setattr(mod, "_ensure_repo_cloned", _spy_clone)
+    monkeypatch.setattr(mod, "run_subprocess_with_progress", _spy_run)
+    monkeypatch.setattr("shutil.which", lambda b: "/usr/local/bin/claude")
+    monkeypatch.setenv("DEILE_CLAUDE_WORKER_ROOT", str(tmp_path / "work"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    app = mod.build_app(auth_token="test-token")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/v1/dispatch", headers=_AUTH_HEADERS, json={
+            "brief": "implementa #1",
+            "preferred_model": "anthropic:claude-haiku-4-5",
+            "branch": "auto/issue-1",
+            "resume": {"repo": "elimarcavalli/deile"},
+        })
+        assert resp.status == 200, await resp.text()
+        body = await resp.json()
+        assert body.get("error_code") != "REPO_NOT_ALLOWED"
+
+    # O portão liberou: clone foi tentado (./repo ausente no tmp) E claude rodou.
+    assert calls["clone"] == 1
+    assert calls["spawn"] == 1

--- a/docs/system_design/08-SEGURANCA.md
+++ b/docs/system_design/08-SEGURANCA.md
@@ -103,21 +103,36 @@ e adiciona estes pontos de segurança próprios:
 | Modos de auth | `env` (API key, default, não expira — preferido para automação) vs `oauth_file` (cred OAuth montada, opt-in via `DEILE_<KIND>_AUTH=oauth`). No modo OAuth o initContainer `bootstrap-creds` copia o Secret → PVC writable mode `0600`, com refresh in-pod (espelha o claude-worker); codex é dual-mode por modelo (`OPENAI_API_KEY` env ou ChatGPT OAuth `~/.codex/auth.json`) e o `provision_auth` faz backup antes de sobrescrever a credencial |
 | Gate de sucesso ≠ exit-code | Exit-code dos CLIs não é confiável. O veredito final é `WorkResult.ok = adapter.parse_output(...).ok AND wrapper_gate()`, onde o gate pós-run exige **commit novo desde o `base_sha` + branch pushado** (`brief_driven`) ou commit do próprio CLI + push (`cli_autocommit`, só aider). Um corte por provider (402/429/5xx) é classificado como INCOMPLETO (`_worker_core.classify_provider_error`) → o pipeline RETOMA o trabalho parcial em vez de jogá-lo fora (anti-sangria, issue #445) |
 
-### Gap aberto — allowlist de repos sem enforcement no dispatch (issue #639)
+### Enforcement da allowlist de repos no dispatch (issue #639)
 
-**Risco aberto, pré-requisito de produção.** O `wrapper.py cli-worker` carrega a
-allowlist regex (`claude-worker-allowed-repos`) e faz fail-fast se ela estiver
-ausente/vazia (`_load_allowed_repo_patterns`), mas o `_install_git_repo_guard`
-hoje só publica um **marcador** (`DEILE_CLAUDE_ALLOWED_REPOS_LOADED`) — diferente
-do `deile-shell`, ele **não instala** o guard `~/bin/git` que bloqueia clone/push
-para URL fora da lista, e o `cli_worker_server` **não reverifica** o slug do repo
-no path de `/v1/dispatch` (nenhuma referência à allowlist no server). Consequência:
-um agente CLI vítima de prompt-injection pode exfiltrar via `git push` para um
-repo arbitrário usando o token de forge wirado no pod. Mitigação V1 = isolamento
-de Pod (NetworkPolicy ingress-só-do-pipeline, host inalcançável) + o gate de
-sucesso, mas **não** há contenção do destino do push. Fechar antes de produção:
-pre-receive/clone guard efetivo no modo `cli-worker` + reverificação do slug no
-dispatch.
+**Fechado na camada de dispatch.** A allowlist regex
+(`claude-worker-allowed-repos`, montada em `$DEILE_CLAUDE_ALLOWED_REPOS_FILE`)
+era vendida no threat model como mitigação primária de
+prompt-injection→exfiltração, mas antes só fazia fail-fast no startup
+(`wrapper._load_allowed_repo_patterns`) — os servidores clonavam o `repo_slug`
+do payload sem reverificar. Agora os **dois** `dispatch_handler`
+(`cli_worker_server` e `claude_worker_server`) reverificam o slug **antes de
+qualquer clone** (cli-worker: `_worker_core.ensure_repo_and_branch`;
+claude-worker: `_git_fast_forward_workdir` **e** `_ensure_repo_cloned`),
+retornando **403 `REPO_NOT_ALLOWED`** quando não casa.
+
+Fonte única em `_worker_core.check_repo_allowed` (não a fonte divergente
+`deilebot.yaml clonable_repos`): normaliza o slug forge-agnóstico
+(`owner/repo` GH, `group/(sub/)*project` GL — rejeita `..`, `//`, `@`/`:`,
+backslash, sufixo `.git`, host-prefix), gera as URLs canônicas de clone (https
++ ssh, hosts GH/GHES-CSV/GL) e exige `re.fullmatch` contra ao menos uma regex
+da allowlist. **Postura fail-closed**: allowlist ausente/vazia/inválida em
+runtime bloqueia tudo — consistente com o startup (`wrapper` faz `sys.exit` sem
+allowlist válida), então não quebra deploy legítimo, só defende contra drift
+(ConfigMap removido em runtime). Sem slug no payload o portão não dispara (o CLI
+roda no workspace cru e não clona). O bloqueio é auditado sem vazar segredo
+(cli: `logger.warning`; claude: `dispatch_logger.dispatch_failed`).
+
+**Gap residual (fora de escopo, FU própria #337):** o brief do claude-worker
+ainda pode instruir o `claude -p` (`bypassPermissions`) a clonar/push via shell
+próprio — contenção desse vetor exige o sidecar credential-proxy. A
+NetworkPolicy egress FQDN-aware (limitação do CNI k3s) também fica para CNI
+Cilium futuro.
 
 ### Antigravity GATED
 

--- a/infra/k8s/_worker_core.py
+++ b/infra/k8s/_worker_core.py
@@ -57,6 +57,192 @@ def validate_task_id_for_path(task_id: str) -> bool:
 
 
 # --------------------------------------------------------------------------- #
+# Enforcement da allowlist de repositórios no dispatch (issue #639)
+# --------------------------------------------------------------------------- #
+#
+# A allowlist regex (ConfigMap ``claude-worker-allowed-repos``, montada em
+# ``$DEILE_CLAUDE_ALLOWED_REPOS_FILE``) era vendida no threat model como a
+# mitigação primária de prompt-injection→exfiltração, mas NÃO havia enforcement
+# em runtime: ``wrapper.py`` só fazia fail-fast no startup e os servidores
+# clonavam o ``repo_slug`` do payload sem reverificar. Este bloco é a FONTE
+# ÚNICA de verificação por-request, reusada por ``cli_worker_server`` e
+# ``claude_worker_server`` (os dois caminhos de clone).
+#
+# Fonte canônica dos patterns = o ConfigMap ``allowed_repos.regex`` (URLs
+# completas, uma regex por linha). NÃO usamos a fonte divergente
+# ``deilebot.yaml clonable_repos`` (bug apontado pela issue #639).
+
+#: Path default do ConfigMap; cada worker sobrescreve via
+#: ``DEILE_CLAUDE_ALLOWED_REPOS_FILE`` no manifest (claude → ``/etc/claude-worker``,
+#: cli → ``/etc/cli-worker``). Mantido em sincronia com ``wrapper.CLAUDE_ALLOWED_REPOS_FILE``.
+ALLOWED_REPOS_FILE_DEFAULT = "/etc/claude-worker/allowed_repos.regex"
+
+#: Slug forge-agnóstico: ``owner/repo`` (GitHub) ou ``group/(sub/)*project``
+#: (GitLab). Apenas ``[A-Za-z0-9._-]`` por componente, ``/`` como separador,
+#: ao menos dois componentes. Ancorado: bloqueia ``..``, ``/`` líder/final,
+#: ``//``, espaços, ``@``/``:`` (host/auth smuggling), ``\\`` e backslash.
+_REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+$")
+
+#: Componentes proibidos mesmo dentro do alfabeto permitido (defesa redundante
+#: contra path traversal por componente exato ``.``/``..``).
+_FORBIDDEN_SLUG_PARTS = frozenset({"", ".", ".."})
+
+
+def allowed_repos_file_path() -> Path:
+    """Resolve o path do ConfigMap de allowlist (env var > default).
+
+    Não lê o arquivo — apenas resolve o caminho. Honra
+    ``DEILE_CLAUDE_ALLOWED_REPOS_FILE`` (cada worker o define no manifest e os
+    testes o apontam para um tmp file).
+    """
+    return Path(
+        os.environ.get(
+            "DEILE_CLAUDE_ALLOWED_REPOS_FILE", ALLOWED_REPOS_FILE_DEFAULT,
+        )
+    )
+
+
+def load_allowed_repo_patterns() -> tuple[list[re.Pattern], Optional[str]]:
+    """Carrega as regexes da allowlist para uso POR-REQUEST (não-exiting).
+
+    Diferente de ``wrapper._load_allowed_repo_patterns`` (que faz ``sys.exit``
+    no startup), aqui devolvemos ``(patterns, error)`` para o handler decidir o
+    HTTP. ``error`` é ``None`` quando a allowlist é válida e não-vazia; caso
+    contrário traz o motivo (arquivo ausente, vazio, regex inválida, ou erro de
+    leitura). Postura **fail-closed**: qualquer ``error`` não-``None`` deve
+    bloquear o dispatch — o startup já garante allowlist válida em produção
+    (``wrapper`` fail-fast), então um erro aqui só ocorre em drift/teste.
+
+    Nunca levanta.
+    """
+    path = allowed_repos_file_path()
+    try:
+        if not path.exists():
+            return [], f"allowlist de repos ausente: {path}"
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], f"falha ao ler allowlist {path}: {exc}"
+    patterns: list[re.Pattern] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            patterns.append(re.compile(stripped))
+        except re.error as exc:
+            return [], f"regex inválida na allowlist {path}: {stripped!r}: {exc}"
+    if not patterns:
+        return [], f"allowlist vazia (sem linhas não-comentário): {path}"
+    return patterns, None
+
+
+def normalize_repo_slug(repo_slug: str) -> Optional[str]:
+    """Normaliza e valida o slug forge-agnóstico do payload de dispatch.
+
+    Aceita ``owner/repo`` (GitHub) e ``group/(sub/)*project`` (GitLab). Faz:
+
+      - ``strip()`` de espaços nas pontas;
+      - remoção de UM sufixo ``.git`` final (forma que ``gh``/``glab`` toleram);
+      - rejeição de qualquer slug que case host/auth/traversal (``..``, ``//``,
+        ``@``, ``:``, backslash, ``/`` líder/final, espaço interno).
+
+    Returns o slug canônico (sem ``.git``) ou ``None`` quando inválido — o
+    caller trata ``None`` como REPO_NOT_ALLOWED (fail-closed).
+    """
+    if not repo_slug:
+        return None
+    candidate = repo_slug.strip()
+    if not candidate:
+        return None
+    # Sufixo ``.git`` é removido ANTES da validação (gh/glab o toleram e o clone
+    # canônico não o carrega no slug). Apenas UM sufixo, case-sensitive.
+    if candidate.endswith(".git"):
+        candidate = candidate[: -len(".git")]
+    # Rejeita qualquer caractere fora do alfabeto slug logo de cara (bloqueia
+    # ``@``, ``:``, ``\``, espaço, ``~``, etc. — host/auth/url smuggling).
+    if not _REPO_SLUG_RE.fullmatch(candidate):
+        return None
+    parts = candidate.split("/")
+    if any(part in _FORBIDDEN_SLUG_PARTS for part in parts):
+        return None
+    return candidate
+
+
+def _canonical_clone_urls(slug: str) -> list[str]:
+    """URLs canônicas que os caminhos de clone realmente produzem para *slug*.
+
+    Espelha ``_git_or_gh_clone`` (``gh``/``glab repo clone`` → ``https://<host>/<slug>``,
+    fallback ``git clone https://<host>/<slug>.git``) e o ``_ensure_repo_cloned``
+    do claude-worker (``gh repo clone`` → host GitHub). Cobrimos as formas
+    https (com e sem ``.git``) e ssh para os hosts GitHub e GitLab configurados.
+    O slug já vem normalizado (sem ``.git``, sem host).
+    """
+    gh_host = (os.environ.get("DEILE_GITHUB_HOST", "").strip() or "github.com")
+    gl_host = (os.environ.get("DEILE_GITLAB_HOST", "").strip() or "gitlab.com")
+    # ``DEILE_GITHUB_HOST`` aceita CSV (GHES multi-host, decisão #42).
+    hosts = []
+    for raw in (*gh_host.split(","), gl_host):
+        h = raw.strip()
+        if h and h not in hosts:
+            hosts.append(h)
+    urls: list[str] = []
+    for host in hosts:
+        urls.append(f"https://{host}/{slug}")
+        urls.append(f"https://{host}/{slug}.git")
+        urls.append(f"git@{host}:{slug}")
+        urls.append(f"git@{host}:{slug}.git")
+    return urls
+
+
+def repo_slug_allowed(
+    repo_slug: str, patterns: Iterable[re.Pattern],
+) -> tuple[bool, Optional[str]]:
+    """Decide se *repo_slug* casa a allowlist (fonte canônica de match).
+
+    Normaliza o slug e gera as URLs canônicas de clone; exige que ao menos UMA
+    delas case ao menos UMA regex da allowlist (``re.fullmatch`` — os patterns
+    do ConfigMap já são ancorados ``^...$``, mas usamos ``fullmatch`` para não
+    depender da âncora e impedir match parcial).
+
+    Returns ``(allowed, normalized_slug)``. ``allowed=False`` cobre slug
+    malformado (``normalized_slug=None``) e slug bem-formado que não casa
+    nenhuma regex (``normalized_slug`` preenchido para o log/erro).
+    """
+    normalized = normalize_repo_slug(repo_slug)
+    if normalized is None:
+        return False, None
+    pattern_list = list(patterns)
+    for url in _canonical_clone_urls(normalized):
+        for pat in pattern_list:
+            if pat.fullmatch(url):
+                return True, normalized
+    return False, normalized
+
+
+def check_repo_allowed(repo_slug: str) -> tuple[bool, str, Optional[str]]:
+    """Verificação completa por-request: carrega patterns + casa o slug.
+
+    FONTE ÚNICA chamada pelos ``dispatch_handler`` dos dois servidores, ANTES de
+    qualquer clone. Fail-closed: allowlist ausente/vazia/inválida → bloqueia.
+
+    Returns ``(allowed, reason, normalized_slug)``:
+      - ``allowed=True``  → o slug pode ser clonado (``reason`` vazio).
+      - ``allowed=False`` → bloquear com 403 REPO_NOT_ALLOWED; ``reason`` é uma
+        mensagem segura (sem segredo, sem token) para log/resposta.
+    """
+    patterns, load_err = load_allowed_repo_patterns()
+    if load_err is not None:
+        # Fail-closed: sem allowlist confiável, nada é permitido.
+        return False, f"allowlist indisponível ({load_err})", None
+    allowed, normalized = repo_slug_allowed(repo_slug, patterns)
+    if allowed:
+        return True, "", normalized
+    if normalized is None:
+        return False, "repo slug malformado ou inseguro", None
+    return False, f"repo {normalized!r} fora da allowlist", normalized
+
+
+# --------------------------------------------------------------------------- #
 # Classificação de erro de provider (anti-sangria de custo — issue #445)
 # --------------------------------------------------------------------------- #
 #

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -2041,6 +2041,29 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     # ausente → string vazia → _ensure_repo_cloned não é chamado.
     _resume_block = payload.get("resume") or {}
     _repo_slug: str = str(_resume_block.get("repo") or "").strip()
+    # Enforcement da allowlist (issue #639) — ANTES de qualquer clone
+    # (_git_fast_forward_workdir e _ensure_repo_cloned). Só vale quando há slug;
+    # sem slug o brief pode instruir o claude a clonar pelo próprio shell (gap
+    # de exfil mais profundo coberto pela FU do credential-proxy, #337). Fonte
+    # única em _worker_core.check_repo_allowed. Fail-closed: slug fora da
+    # allowlist (ou allowlist indisponível) → 403 REPO_NOT_ALLOWED.
+    if _repo_slug:
+        _allowed, _reason, _norm = _core.check_repo_allowed(_repo_slug)
+        if not _allowed:
+            logger.warning(
+                "dispatch BLOQUEADO — repo fora da allowlist (issue #639): %s",
+                _reason,
+            )
+            dlog.dispatch_failed(
+                task="",
+                reason="repo_not_allowed",
+                error_code="REPO_NOT_ALLOWED",
+            )
+            return web.json_response({
+                "ok": False,
+                "error_code": "REPO_NOT_ALLOWED",
+                "error": _reason,
+            }, status=403)
     # Modo fire-and-forget: quando False, retorna 202+task_id imediatamente e
     # executa o subprocess em background (asyncio.create_task). Comportamento
     # padrão (True ou ausente) = bloqueante, compatível com clientes legados.

--- a/infra/k8s/cli_worker_server.py
+++ b/infra/k8s/cli_worker_server.py
@@ -433,6 +433,22 @@ async def dispatch_handler(request: web.Request) -> web.Response:
     repo_slug = str(_resume_block.get("repo") or "").strip()
     base_branch = str(_resume_block.get("main_branch") or "").strip()
 
+    # Enforcement da allowlist (issue #639) — ANTES de qualquer clone. Só vale
+    # quando há slug (sem slug o CLI roda no workspace cru, não clona nada).
+    # Fail-closed: slug fora da allowlist (ou allowlist indisponível) → 403.
+    if repo_slug:
+        _allowed, _reason, _norm = _core.check_repo_allowed(repo_slug)
+        if not _allowed:
+            logger.warning(
+                "dispatch BLOQUEADO — repo fora da allowlist (issue #639): %s",
+                _reason,
+            )
+            return web.json_response({
+                "ok": False,
+                "error_code": "REPO_NOT_ALLOWED",
+                "error": _reason,
+            }, status=403)
+
     dispatch_timeout_s: Optional[int] = None
     _raw_timeout = payload.get("timeout_s")
     if _raw_timeout is not None:


### PR DESCRIPTION
## O gap

A allowlist de repositórios (ConfigMap `claude-worker-allowed-repos`, regex) era apresentada no threat model (`docs/superpowers/plans/...:153,379,381`) como a **mitigação primária** de prompt-injection→exfiltração. **Na prática não havia enforcement em runtime no caminho de dispatch**: o `wrapper.py` só fazia fail-fast no startup (`_load_allowed_repo_patterns` → `sys.exit`) e os servidores clonavam o `repo_slug` recebido no payload **sem reverificar** contra os patterns. Um agente CLI vítima de prompt-injection podia exfiltrar via `git push` para um repositório arbitrário usando o token de forge wirado no Pod (a NetworkPolicy egress abre 443 para `0.0.0.0/0` por limitação do CNI k3s).

## O enforcement (2 servidores × 2 caminhos de clone)

Verificação **por-request, antes de qualquer clone**, retornando **403 `REPO_NOT_ALLOWED`** (resposta estruturada, nunca derruba o processo):

| Servidor | Inserido antes de | Caminho de clone coberto |
|---|---|---|
| `cli_worker_server.dispatch_handler` | `_ensure_repo` | `_worker_core.ensure_repo_and_branch` (`gh`/`glab`/`git` fallback) |
| `claude_worker_server.dispatch_handler` | `_git_fast_forward_workdir` **e** `_ensure_repo_cloned` | o **segundo** caminho de clone, próprio do claude-worker, que **não** passa pelo `_worker_core` |

## Fonte única de patterns

Tudo centralizado em `_worker_core.check_repo_allowed` — lê o ConfigMap `allowed_repos.regex` (a fonte **canônica**), **não** a fonte divergente `deilebot.yaml clonable_repos` que a issue apontou como bug (e que só é usada nos modos `deile-shell`/`deile-worker`, nunca no dispatch). A verificação:

1. **Normaliza** o slug forge-agnóstico — `owner/repo` (GitHub) e `group/(sub/)*project` (GitLab). Rejeita `..`, `//`, `@`/`:` (host/auth smuggling), backslash, `/` líder/final, espaço, e remove um sufixo `.git`. URL inteira como slug é rejeitada.
2. **Gera as URLs canônicas de clone** que os caminhos realmente produzem (https + ssh, para os hosts GitHub / GHES-CSV (`DEILE_GITHUB_HOST`) / GitLab).
3. Exige `re.fullmatch` de **ao menos uma** URL canônica contra **ao menos uma** regex da allowlist (os patterns do ConfigMap já são ancorados `^...$`; `fullmatch` evita match parcial mesmo se um operador esquecer a âncora).

## Semântica de allowlist ausente — fail-closed (justificada)

Allowlist ausente/vazia/inválida em runtime → **bloqueia tudo** (403). É a postura segura por default (OWASP: allowlist + canonicalization + positive validation) e **consistente com o comportamento atual**: o `wrapper.py` já faz `sys.exit` no startup sem allowlist válida, então em produção o worker **nem sobe** sem o ConfigMap. Logo, fail-closed aqui **não quebra deploy legítimo** — apenas defende contra drift (ConfigMap removido/corrompido em runtime) e testes. Quando **não há slug** no payload, o portão não dispara (o CLI roda no workspace cru e não clona nada).

O bloqueio é **auditado sem vazar segredo**: cli-worker via `logger.warning`; claude-worker via `dispatch_logger.dispatch_failed(reason=repo_not_allowed)`. A mensagem carrega só o slug normalizado, nunca o token.

## Evidência (teste de bloqueio)

Testes novos (47 casos): unit de normalização/match/fail-closed em `_worker_core` + integração nos **dois** servidores provando que um dispatch com `repo_slug` fora da allowlist retorna **403 `REPO_NOT_ALLOWED` e não chega a clonar** (`_ensure_repo`/`_ensure_repo_cloned`/`_git_fast_forward_workdir` e o spawn do `claude` nunca são alcançados), e que um slug dentro da allowlist passa o portão. Cobre também path-traversal, host-prefix, `@`-smuggling, case mismatch, GHES CSV e subgrupo GitLab.

```
deile/tests/infra/test_worker_core_repo_allowlist.py ........................... (unit)
deile/tests/infra/test_cli_worker_repo_allowlist.py .... (integração cli-worker)
deile/tests/infrastructure/test_claude_worker_repo_allowlist.py .... (integração claude-worker)
47 passed
```

- Suíte completa (com cobertura): `4 failed, 8273 passed, 30 skipped` — as **4 falhas são pré-existentes** na `origin/main` (confirmado com a árvore pristina): 3 em `deile/tests/orchestration/pipeline/` (reaper/classify/gh-error — corrigidas no PR irmão #642) + 1 em `deile/tests/infrastructure/test_pod_presence.py`. **Zero novas falhas.**
- Multi-seed (0/1/2/42) nos dirs tocados: estável, só a falha pré-existente do `test_pod_presence`.
- `ruff`/`isort` limpos nos arquivos que autorei (os 3 warnings residuais em `claude_worker_server.py` são pré-existentes, fora do meu diff).

## Fora de escopo (FU própria)

Sidecar credential-proxy (#337) para o vetor de clone via shell do próprio `claude -p` (`bypassPermissions`); NetworkPolicy FQDN-aware (limitação do CNI k3s).

Closes #639