### PR TITLE
refactor(pipeline): make forge repo project-agnostic with fail-loud config

### DIFF
--- a/deile/commands/builtin/pipeline_command.py
+++ b/deile/commands/builtin/pipeline_command.py
@@ -112,6 +112,16 @@ class PipelineCommand(DirectCommand):
                 "(Para iniciar um monitor local: /pipeline start.)"
             ))
 
+        # ``stop`` is a control verb that does NOT operate on the target repo:
+        # stopping a monitor that does not exist must short-circuit BEFORE
+        # build_default_pipeline_config(), which (issue #612) fails loud when no
+        # forge repo is configured. Without this guard `/pipeline stop` would
+        # error just because no repo is set — even though there is nothing to stop.
+        if sub == "stop" and monitor is None:
+            return CommandResult(success=True, content=(
+                "🛑 Nenhum monitor de pipeline rodando NESTE processo — nada a parar."
+            ))
+
         if monitor is None:
             from deile.orchestration.pipeline.post_merge_callback import \
                 make_post_merge_callback

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -532,7 +532,12 @@ class Settings:
 
     # Pipeline
     pipeline_base_path: Optional[Path] = None
-    pipeline_repo: str = "elimarcavalli/deile"
+    # Project-agnostic (issue #612): NO hardcoded default. The target repo must
+    # be supplied via DEILE_FORGE_REPO / forge.repo (canonical) or this legacy
+    # pipeline.repo key. resolve_forge_repo() fails loud when both are empty —
+    # the k8s reference deploy provides the value through the
+    # deile-runtime-config ConfigMap, never through code.
+    pipeline_repo: str = ""
     pipeline_notify_user_id: Optional[str] = None
     pipeline_poll_interval: int = 60
     pipeline_claude_timeout: int = 1800

--- a/deile/orchestration/pipeline/constants.py
+++ b/deile/orchestration/pipeline/constants.py
@@ -8,7 +8,12 @@ changed without a code review.
 """
 from __future__ import annotations
 
+import logging
+
 from deile.config.settings import get_settings
+from deile.core.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
 
 
 # ── ClaudeDispatcher ──────────────────────────────────────────────────────
@@ -36,38 +41,66 @@ def pipeline_poll_interval_seconds() -> int:
 PIPELINE_STOP_TIMEOUT_SECONDS: int = 5
 
 # ── Forge / pipeline repo ─────────────────────────────────────────────────
-#: Default project path (``owner/repo`` on GH, ``group/.../project`` on GL)
-#: when ``forge.repo`` / ``pipeline.repo`` is not set.
-PIPELINE_DEFAULT_REPO: str = "elimarcavalli/deile"
+#: Error message raised when the pipeline runs without a configured repo.
+#: Issue #612 (project-agnostic): the harness no longer silently falls back to
+#: a hardcoded ``elimarcavalli/deile``. Operators MUST supply the target repo
+#: (via ``DEILE_FORGE_REPO`` / ``forge.repo`` or the legacy ``pipeline.repo``);
+#: the k8s reference deploy provides it through the ``deile-runtime-config``
+#: ConfigMap, not through code.
+_NO_REPO_MESSAGE: str = (
+    "No forge repository is configured. The pipeline is project-agnostic and "
+    "refuses to fall back to a hardcoded default. Set DEILE_FORGE_REPO "
+    "(owner/repo on GitHub, group/.../project on GitLab) or the forge.repo / "
+    "pipeline.repo key in settings.json before running the pipeline."
+)
 
 
-def resolve_forge_repo() -> str:
+def resolve_forge_repo(*, require: bool = True, fallback: str = "") -> str:
     """Return the active project path for the pipeline repository.
 
     Accepts both shapes: GitHub ``owner/repo`` and GitLab
     ``group/(subgroup/)*project``. Reads ``forge.repo`` from
     :class:`Settings` first (new canonical), falling back to the legacy
-    ``pipeline.repo`` for transitional compatibility, then to
-    :data:`PIPELINE_DEFAULT_REPO`. Single source of truth for both the
-    pipeline tool and the slash command — they used to inline the same
-    expression independently.
+    ``pipeline.repo`` for transitional compatibility. Single source of truth
+    for both the pipeline tool and the slash command — they used to inline the
+    same expression independently.
+
+    Issue #612 (project-agnostic): there is **no** hardcoded default repo. When
+    nothing is configured the behaviour depends on the caller:
+
+    - ``require=True`` (default, the production pipeline path): raise
+      :class:`ConfigurationError` so config-absence fails loud at startup
+      instead of silently operating against the wrong project.
+    - ``require=False`` with a ``fallback``: log a ``WARNING`` flagging that the
+      caller-supplied fallback is in use, and return it. This is for graceful
+      surfaces (panel/CLI display) that must degrade with a clear message
+      rather than abort.
+    - ``require=False`` without a ``fallback``: return ``""``.
     """
     settings = get_settings()
-    return (
-        getattr(settings, "forge_repo", "")
-        or settings.pipeline_repo
-        or PIPELINE_DEFAULT_REPO
-    )
+    repo = (getattr(settings, "forge_repo", "") or settings.pipeline_repo or "").strip()
+    if repo:
+        return repo
+    if require:
+        raise ConfigurationError(_NO_REPO_MESSAGE, config_key="forge.repo")
+    if fallback:
+        logger.warning(
+            "No forge repository configured; using caller-supplied fallback %r. "
+            "Set DEILE_FORGE_REPO or forge.repo/pipeline.repo to silence this.",
+            fallback,
+        )
+        return fallback
+    return ""
 
 
-def resolve_pipeline_repo() -> str:
+def resolve_pipeline_repo(*, require: bool = True, fallback: str = "") -> str:
     """Deprecated alias for :func:`resolve_forge_repo`.
 
     Kept here so callers (especially tests) do not have to migrate in
     lock-step with the rename. New code should use
     :func:`resolve_forge_repo`.
     """
-    return resolve_forge_repo()
+    return resolve_forge_repo(require=require, fallback=fallback)
 
 # ── Prompt / message truncation ───────────────────────────────────────────
 #: Max chars of issue body EMBEDDED in a worker brief. Kept well under the 8000

--- a/deile/tests/config/test_settings_json_loading.py
+++ b/deile/tests/config/test_settings_json_loading.py
@@ -244,7 +244,11 @@ class TestBuildSettings:
         from deile.config.settings import get_settings
 
         s = get_settings()
-        assert s.pipeline_repo == "elimarcavalli/deile"
+        # Issue #612 (project-agnostic): NO hardcoded default repo. With no
+        # config the field is empty so config-absence is detectable (and
+        # resolve_forge_repo() fails loud), instead of silently defaulting to
+        # elimarcavalli/deile.
+        assert s.pipeline_repo == ""
         assert s.cron_poll_interval == 30
         assert s.debug_enabled is False
         reset_settings()

--- a/deile/tests/infra/test_k8s_setup.py
+++ b/deile/tests/infra/test_k8s_setup.py
@@ -88,18 +88,23 @@ class TestRuntimeConfigMap:
             bot_bearer="b", worker_bearer="w",
         )
         data = plan.runtime_configmap_data()
-        # Estrutura completa
+        # Estrutura completa — issue #612: `pipeline.repo` é a FONTE ÚNICA do
+        # repo-alvo (chave discreta), referenciada pelos manifests 46/55 via
+        # configMapKeyRef; saiu do JSON pipeline-settings.json.
         assert sorted(data) == [
             "bot-settings.json",
             "oneshot-settings.json",
             "pipeline-settings.json",
+            "pipeline.repo",
             "shell-settings.json",
             "worker-settings.json",
         ]
+        # O repo-alvo vai na chave discreta, não mais no JSON.
+        assert data["pipeline.repo"] == "group/sub/project"
         # Overrides chegam em pipeline-settings.json
         parsed = json.loads(data["pipeline-settings.json"])
         assert parsed["pipeline"]["dispatch_mode"] == "claude_subprocess"
-        assert parsed["pipeline"]["repo"] == "group/sub/project"
+        assert "repo" not in parsed["pipeline"]
         assert parsed["forge"]["kind"] == "gitlab"
         assert parsed["approval"]["auto"] is True
         # Outras seções continuam com defaults estáveis

--- a/deile/tests/infra/test_monitor_tick.py
+++ b/deile/tests/infra/test_monitor_tick.py
@@ -182,3 +182,49 @@ async def test_kube_unreachable_skips_with_v_token(tick, tmp_path, capsys):
 @pytest.mark.parametrize("s,expected", [("30m", 1800), ("1h", 3600), ("2h", 7200)])
 def test_parse_duration_s(tick, s, expected):
     assert tick.parse_duration_s(s) == expected
+
+
+# ---------------------------------------------------------------------------
+# Issue #612 (AC-6, monitor side) — the INJECTED repo reaches the real
+# gh call-site (the vigias hit ``gh api repos/<repo>/...``). Proves the
+# project-agnostic config flows through the monitor tick, not a hardcoded
+# default. Exercises run_tick → MonitorContext → vigias (the real path).
+# ---------------------------------------------------------------------------
+
+async def test_injected_repo_reaches_gh_call_site(tick, tmp_path):
+    """A tick run with a neutral repo must issue gh calls against THAT repo —
+    never the hardcoded ``elimarcavalli/deile``."""
+    sd = _state_dir(tmp_path)
+    runner = FakeRunner()
+    await tick.run_tick(
+        str(sd), now=_utc(2026, 6, 2, 11, 0, 0), run=runner, renew=_renew_ok,
+        repo="acme/neutral-project", namespace="deile",
+        bot_endpoint="http://deilebot:8765", bot_token="t", user_id="",
+        kube_probe=lambda ep: 0,  # kube reachable → kube-dependent vigias run
+    )
+    gh_calls = [c for c in runner.calls if "repos/" in c]
+    assert gh_calls, "expected at least one gh api repos/<repo>/... call"
+    assert all("repos/acme/neutral-project/" in c for c in gh_calls), gh_calls
+    assert not any("elimarcavalli/deile" in c for c in runner.calls)
+
+
+async def test_judgment_file_carries_injected_repo(tick, tmp_path, monkeypatch):
+    """Phase-B judgment payload reports the injected repo (read from the
+    DEILE_PIPELINE_REPO env that the manifest sources from the ConfigMap)."""
+    monkeypatch.setenv("DEILE_PIPELINE_REPO", "acme/neutral-project")
+    sd = _state_dir(tmp_path)
+    closed = [{"number": 50, "title": "X", "body": "vou abrir uma issue para o resto",
+               "closed_at": "2026-06-02T09:00:00Z", "user": {"login": "human"}}]
+    runner = FakeRunner({
+        "issues -f state=closed": (0, json.dumps(closed)),
+        "issues/50/comments": (0, "[]"),
+        "pulls -f state=closed": (0, "[]"),
+    })
+    await tick.run_tick(
+        str(sd), now=_utc(2026, 6, 2, 11, 0, 0), run=runner, renew=_renew_ok,
+        repo="acme/neutral-project", namespace="deile",
+        bot_endpoint="http://deilebot:8765", bot_token="t", user_id="",
+        kube_probe=lambda ep: 0,
+    )
+    payload = json.load(open(sd / "monitor-judgment.json"))
+    assert payload["repo"] == "acme/neutral-project"

--- a/deile/tests/infra/test_monitor_tick.py
+++ b/deile/tests/infra/test_monitor_tick.py
@@ -209,8 +209,9 @@ async def test_injected_repo_reaches_gh_call_site(tick, tmp_path):
 
 
 async def test_judgment_file_carries_injected_repo(tick, tmp_path, monkeypatch):
-    """Phase-B judgment payload reports the injected repo (read from the
-    DEILE_PIPELINE_REPO env that the manifest sources from the ConfigMap)."""
+    """Phase-B judgment payload reports the repo the tick actually ran against
+    (the value resolved in main() and threaded through run_tick), not an
+    independent env re-read."""
     monkeypatch.setenv("DEILE_PIPELINE_REPO", "acme/neutral-project")
     sd = _state_dir(tmp_path)
     closed = [{"number": 50, "title": "X", "body": "vou abrir uma issue para o resto",
@@ -228,3 +229,45 @@ async def test_judgment_file_carries_injected_repo(tick, tmp_path, monkeypatch):
     )
     payload = json.load(open(sd / "monitor-judgment.json"))
     assert payload["repo"] == "acme/neutral-project"
+
+
+# ---------------------------------------------------------------------------
+# Issue #612 (unification — Humano's review ask on PR #647): the monitor must
+# read the target repo through the SAME canonical resolver the pipeline uses
+# (resolve_forge_repo), not a private env read. Settings *silently ignores*
+# DEILE_PIPELINE_REPO (settings.py: "truly removed"), so the legacy env is kept
+# only as a deployment-boundary fallback. These pin the precedence + the
+# never-crash contract of _resolve_repo().
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _isolate_settings(monkeypatch, tmp_path):
+    from deile.config.settings import reset_settings
+    monkeypatch.setenv("DEILE_SETTINGS_FILE", str(tmp_path / "absent.json"))
+    monkeypatch.delenv("DEILE_FORGE_REPO", raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_REPO", raising=False)
+    reset_settings()
+    yield
+    reset_settings()
+
+
+def test_resolve_repo_prefers_canonical_settings(tick, _isolate_settings, monkeypatch):
+    """forge.repo (canonical) wins even when the legacy env points elsewhere —
+    the monitor no longer diverges from the rest of the harness."""
+    from deile.config.settings import get_settings
+    get_settings().forge_repo = "acme/canonical"
+    monkeypatch.setenv("DEILE_PIPELINE_REPO", "stale/legacy")
+    assert tick._resolve_repo() == "acme/canonical"
+
+
+def test_resolve_repo_falls_back_to_legacy_env(tick, _isolate_settings, monkeypatch):
+    """No canonical config → the deployment-boundary DEILE_PIPELINE_REPO env
+    (manifest sources it from the ConfigMap) still drives the monitor."""
+    monkeypatch.setenv("DEILE_PIPELINE_REPO", "acme/from-configmap")
+    assert tick._resolve_repo() == "acme/from-configmap"
+
+
+def test_resolve_repo_empty_when_unconfigured_never_raises(tick, _isolate_settings):
+    """Nothing configured → empty string, NOT a raise: the deterministic tick
+    must never crash the heartbeat over a missing repo."""
+    assert tick._resolve_repo() == ""

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -1272,7 +1272,7 @@ class TestRuntimeContext:
         assert ctx.pipeline_deploy == "deile-pipeline"
         assert ctx.worker_deploy == "deile-worker"
         assert ctx.bot_deploy == "deilebot"
-        assert ctx.repo  # detectado do origin OU fallback "elimarcavalli/deile"
+        assert ctx.repo  # detectado do origin OU sentinela REPO_UNCONFIGURED (#612)
 
     def test_detect_with_overrides(self):
         ctx = pd.RuntimeContext.detect(
@@ -1285,6 +1285,74 @@ class TestRuntimeContext:
         assert ctx.pipeline_deploy == "p1"
         assert ctx.worker_deploy == "w1"
         assert ctx.repo == "org/repo"
+
+
+class TestForgeRepoInjectionPanel:
+    """Issue #612 (AC-7): o painel/monitor reporta o repo-alvo INJETADO, não um
+    default hardcoded. Exercita o call-site real ``RuntimeContext.detect`` +
+    ``_detect_default_repo`` + ``_read_forge_repo`` (não unit isolado)."""
+
+    def test_detect_uses_explicit_override_repo(self):
+        """Override do operador (CLI) é honrado direto — sem tocar git/ConfigMap."""
+        ctx = pd.RuntimeContext.detect(repo="acme/widget")
+        assert ctx.repo == "acme/widget"
+
+    def test_detect_uses_configmap_repo_when_no_override(self, monkeypatch):
+        """Sem override, o repo vem da chave discreta ``pipeline.repo`` do
+        ConfigMap (FONTE ÚNICA), provando que a config injetada flui até o
+        contexto que o painel renderiza — não cai no fallback."""
+        monkeypatch.setattr(pd, "_read_forge_repo", lambda ns: "gitlab-grp/sub/proj")
+        # Se o ConfigMap resolve, _detect_default_repo (git) NÃO deve ser usado.
+        monkeypatch.setattr(
+            pd, "_detect_default_repo",
+            lambda: pytest.fail("ConfigMap repo present — git fallback must not run"),
+        )
+        monkeypatch.setattr(pd, "_read_forge_kind", lambda ns: "gitlab")
+        ctx = pd.RuntimeContext.detect(namespace="deile-gl")
+        assert ctx.repo == "gitlab-grp/sub/proj"
+
+    def test_read_forge_repo_parses_discrete_configmap_key(self, monkeypatch):
+        """``_read_forge_repo`` lê a chave discreta ``pipeline.repo`` (não mais
+        o JSON ``pipeline-settings.json``) e devolve o valor cru."""
+        monkeypatch.setattr(pd, "kubectl_bin", lambda: "/usr/bin/kubectl")
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            return MagicMock(returncode=0, stdout="owner/from-configmap\n", stderr="")
+
+        monkeypatch.setattr(pd.subprocess, "run", fake_run)
+        assert pd._read_forge_repo("deile") == "owner/from-configmap"
+        # Prova que consulta a chave discreta pipeline.repo, não o JSON blob.
+        assert any("pipeline\\.repo" in a for a in captured["args"])
+
+    def test_detect_default_repo_warns_and_returns_sentinel_without_git(
+        self, monkeypatch, caplog
+    ):
+        """Sem git no PATH, NÃO finge `elimarcavalli/deile`: devolve a sentinela
+        REPO_UNCONFIGURED e emite WARNING claro (AC-3 observabilidade)."""
+        import logging
+        monkeypatch.setattr(pd.shutil, "which", lambda name: None)
+        with caplog.at_level(logging.WARNING):
+            result = pd._detect_default_repo()
+        assert result == pd.REPO_UNCONFIGURED
+        assert result != "elimarcavalli/deile"
+        assert any("cannot derive target repo" in r.message for r in caplog.records)
+
+    def test_detect_default_repo_warns_and_returns_sentinel_without_origin(
+        self, monkeypatch, caplog
+    ):
+        """Com git mas sem remote origin, mesma degradação loud."""
+        import logging
+        monkeypatch.setattr(pd.shutil, "which", lambda name: "/usr/bin/git")
+        monkeypatch.setattr(
+            pd.subprocess, "run",
+            lambda *a, **k: MagicMock(returncode=2, stdout="", stderr=""),
+        )
+        with caplog.at_level(logging.WARNING):
+            result = pd._detect_default_repo()
+        assert result == pd.REPO_UNCONFIGURED
+        assert any("no git origin" in r.message for r in caplog.records)
 
     def test_demo_disables_modes(self):
         ctx = pd.RuntimeContext(demo=True)

--- a/deile/tests/orchestration/forge/test_settings_forge.py
+++ b/deile/tests/orchestration/forge/test_settings_forge.py
@@ -40,4 +40,9 @@ def test_legacy_resolve_pipeline_repo_calls_forge_resolver(monkeypatch):
     directly — so callers transparently see the new behaviour."""
     from deile.orchestration.pipeline.constants import (resolve_forge_repo,
                                                         resolve_pipeline_repo)
-    assert resolve_pipeline_repo() == resolve_forge_repo()
+    s = Settings()
+    s.forge_repo = "owner/repo"
+    monkeypatch.setattr(
+        "deile.orchestration.pipeline.constants.get_settings", lambda: s,
+    )
+    assert resolve_pipeline_repo() == resolve_forge_repo() == "owner/repo"

--- a/deile/tests/orchestration/pipeline/test_forge_repo_injection.py
+++ b/deile/tests/orchestration/pipeline/test_forge_repo_injection.py
@@ -1,0 +1,182 @@
+"""Wiring tests for the project-agnostic forge repo (issue #612).
+
+These tests exercise the **real call-sites** that consume
+:func:`resolve_forge_repo` — not the resolver in isolation — so they prove the
+injected config flows end-to-end (anti-Goodhart, ref. GC #596):
+
+- **AC-3 (config ausente falha alto):** with no repo configured, the resolver
+  and the production startup path (``build_default_pipeline_config``) abort with
+  a clear :class:`ConfigurationError` instead of silently using the historical
+  ``elimarcavalli/deile`` default.
+- **AC-4 (sem vazamento do default):** with a neutral repo injected, the real
+  call-sites (implementer ``gh api repos/<repo>/...``; the monitor's forge
+  client) consume the injected value and never the literal default.
+- **AC-6 (fiação tick→despacho):** ``build_default_pipeline_config`` carries the
+  injected repo into ``PipelineConfig.repo``, and a ``PipelineMonitor`` built
+  from it routes its forge client to that exact repo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deile.config.settings import get_settings, reset_settings
+from deile.core.exceptions import ConfigurationError
+from deile.orchestration.pipeline.constants import (resolve_forge_repo,
+                                                    resolve_pipeline_repo)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_settings(monkeypatch, tmp_path):
+    """Each test gets a pristine Settings singleton with no repo configured.
+
+    Redirect DEILE_SETTINGS_FILE to a non-existent path and clear the forge
+    env vars so the dataclass defaults (empty repo) win — that is the
+    config-absent state AC-3 must fail loud on.
+    """
+    monkeypatch.setenv("DEILE_SETTINGS_FILE", str(tmp_path / "absent.json"))
+    monkeypatch.delenv("DEILE_FORGE_REPO", raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_REPO", raising=False)
+    monkeypatch.delenv("DEILE_FORGE_KIND", raising=False)
+    reset_settings()
+    yield
+    reset_settings()
+
+
+def _inject_repo(value: str) -> None:
+    """Mutate the singleton as a manifest/ConfigMap injection would."""
+    get_settings().forge_repo = value
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — config ausente falha alto (não cai no default silencioso)
+# ---------------------------------------------------------------------------
+
+class TestAC3FailLoudOnMissingConfig:
+    def test_resolve_forge_repo_raises_when_unconfigured(self):
+        with pytest.raises(ConfigurationError) as exc:
+            resolve_forge_repo()
+        assert "project-agnostic" in str(exc.value)
+        # Never silently impersonates the DEILE repo.
+        assert "elimarcavalli/deile" not in str(exc.value)
+
+    def test_resolve_forge_repo_error_carries_config_key(self):
+        with pytest.raises(ConfigurationError) as exc:
+            resolve_forge_repo()
+        assert exc.value.config_key == "forge.repo"
+
+    def test_legacy_alias_also_fails_loud(self):
+        with pytest.raises(ConfigurationError):
+            resolve_pipeline_repo()
+
+    def test_build_default_pipeline_config_aborts_when_unconfigured(self, monkeypatch):
+        """The real production startup path (pipeline pod entrypoint /
+        /pipeline start) builds its config here; with no repo it must abort
+        at startup, not mid-tick."""
+        from deile.orchestration.pipeline import monitor as monitor_mod
+        monkeypatch.setattr(
+            "deile.tools._pipeline_paths.resolve_base_path", lambda: Path("/tmp")
+        )
+        with pytest.raises(ConfigurationError):
+            monitor_mod.build_default_pipeline_config()
+
+    def test_non_required_resolution_warns_and_uses_fallback(self, caplog):
+        """Graceful surfaces (panel/CLI) may degrade with a clear WARNING
+        instead of aborting — but never silently."""
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = resolve_forge_repo(require=False, fallback="display/only")
+        assert result == "display/only"
+        assert any("No forge repository configured" in r.message
+                   for r in caplog.records)
+
+    def test_non_required_without_fallback_returns_empty(self):
+        assert resolve_forge_repo(require=False) == ""
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — sem vazamento do default no fluxo real (repo injetado é consumido)
+# ---------------------------------------------------------------------------
+
+class TestAC4NoDefaultLeak:
+    def test_injected_forge_repo_is_resolved(self):
+        _inject_repo("acme/neutral-project")
+        assert resolve_forge_repo() == "acme/neutral-project"
+
+    def test_legacy_pipeline_repo_is_resolved_when_forge_repo_blank(self):
+        s = get_settings()
+        s.forge_repo = ""
+        s.pipeline_repo = "legacy/project"
+        assert resolve_forge_repo() == "legacy/project"
+
+    def test_forge_repo_wins_over_pipeline_repo(self):
+        s = get_settings()
+        s.forge_repo = "new/canonical"
+        s.pipeline_repo = "legacy/project"
+        assert resolve_forge_repo() == "new/canonical"
+
+    async def test_implementer_call_site_uses_injected_repo(self, monkeypatch):
+        """The implementer's real gh call-site (``_collect_review_delta``)
+        issues ``gh api repos/<repo>/...`` against the INJECTED repo — proving
+        the config reaches the dispatch-adjacent forge call, not a default."""
+        import asyncio as _aio
+
+        _inject_repo("acme/neutral-project")
+        from deile.orchestration.pipeline import implementer as impl_mod
+
+        calls = []
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"", b"")
+
+        async def fake_exec(*args, **kwargs):
+            calls.append(args)
+            return _FakeProc()
+
+        # The method does ``import asyncio as _aio`` locally, so patching the
+        # global asyncio.create_subprocess_exec is the real seam.
+        monkeypatch.setattr(_aio, "create_subprocess_exec", fake_exec)
+
+        # _collect_review_delta lives on the concrete WorkerImplementer and
+        # only uses module-level resolve_forge_repo() (no self.<attr>), so an
+        # uninitialised instance is enough to exercise the call-site.
+        implementer = impl_mod.WorkerImplementer.__new__(impl_mod.WorkerImplementer)
+        await implementer._collect_review_delta(pr_number=7, prev_completed_at=1_700_000_000)
+
+        flat = [" ".join(str(a) for a in args) for args in calls]
+        assert any("repos/acme/neutral-project/issues/7/comments" in c for c in flat), flat
+        assert not any("elimarcavalli/deile" in c for c in flat)
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — fiação tick→despacho (build_default_pipeline_config → monitor → forge)
+# ---------------------------------------------------------------------------
+
+class TestAC6WiringToDispatch:
+    def test_build_default_pipeline_config_carries_injected_repo(self, monkeypatch):
+        _inject_repo("acme/neutral-project")
+        from deile.orchestration.pipeline import monitor as monitor_mod
+        monkeypatch.setattr(
+            "deile.tools._pipeline_paths.resolve_base_path", lambda: Path("/tmp")
+        )
+        cfg = monitor_mod.build_default_pipeline_config()
+        assert cfg.repo == "acme/neutral-project"
+
+    def test_monitor_forge_client_routes_to_injected_repo(self, monkeypatch):
+        """End-to-end wiring: the config the orchestrator builds drives the
+        forge client the monitor dispatches through — ``monitor.forge.repo``
+        is the injected value, never the hardcoded default."""
+        _inject_repo("acme/neutral-project")
+        from deile.orchestration.pipeline import monitor as monitor_mod
+        monkeypatch.setattr(
+            "deile.tools._pipeline_paths.resolve_base_path", lambda: Path("/tmp")
+        )
+        cfg = monitor_mod.build_default_pipeline_config()
+        mon = monitor_mod.PipelineMonitor(cfg)
+        assert mon.forge.repo == "acme/neutral-project"
+        assert mon.forge.repo != "elimarcavalli/deile"

--- a/docs/2026-06-10_HARNESS-PROJECT-AGNOSTIC-E2E-RUNBOOK.md
+++ b/docs/2026-06-10_HARNESS-PROJECT-AGNOSTIC-E2E-RUNBOOK.md
@@ -1,0 +1,122 @@
+# Runbook E2E — Harness project-agnostic (issue #612, AC-1 / AC-2)
+
+> **Escopo deste documento.** A issue #612 desacopla o harness/pipeline do repo
+> hardcoded `elimarcavalli/deile`. A fatia de **código** (AC-3 a AC-7) foi
+> entregue e coberta por testes automatizados. Os critérios **AC-1** (E2E
+> GitHub) e **AC-2** (E2E GitLab) exigem repositórios externos reais +
+> credenciais e **não são unit-testáveis** — este runbook é o passo manual
+> remanescente, para o Humano executar e anexar evidência à issue.
+
+## O que mudou no código (contexto para a validação)
+
+| AC | Mudança | Onde |
+|---|---|---|
+| AC-3 | `resolve_forge_repo()` **falha alto** (`ConfigurationError`) quando nenhum repo está configurado — sem fallback silencioso para `elimarcavalli/deile`. Surfaces graciosas (painel/CLI) degradam com `WARNING`. | `deile/orchestration/pipeline/constants.py` |
+| AC-3 | Default de `Settings.pipeline_repo` passou de `"elimarcavalli/deile"` para `""`. | `deile/config/settings.py` |
+| AC-4/5 | Repo-alvo vem de **fonte única**: a chave discreta `pipeline.repo` no ConfigMap `deile-runtime-config`. Os manifests 46/47/55 a referenciam via `configMapKeyRef`; o pod `deile-pipeline` recebe `DEILE_FORGE_REPO` dela. | `infra/k8s/manifests/46,47,55-*.yaml`, `infra/k8s/_panel*.py`, `infra/k8s/_setup.py` |
+| AC-6/7 | Testes de fiação exercitam o call-site real (implementer, monitor tick, painel). | `deile/tests/orchestration/pipeline/test_forge_repo_injection.py`, `deile/tests/infra/test_panel_data.py`, `deile/tests/infra/test_monitor_tick.py` |
+
+**Consequência operacional:** subir a stack sem `pipeline.repo` no ConfigMap (e
+sem `DEILE_FORGE_REPO`) faz o `deile-pipeline` abortar no startup com mensagem
+clara — comportamento desejado. O deploy de referência do próprio DEILE continua
+funcionando porque o ConfigMap traz `pipeline.repo: elimarcavalli/deile`.
+
+## Como apontar o harness para QUALQUER repo (sem editar código)
+
+Edite **uma única chave** no ConfigMap e reinicie a stack:
+
+```bash
+K=~/.rd/bin/kubectl
+
+# GitHub: owner/repo
+$K -n <ns> patch configmap deile-runtime-config \
+  --type merge -p '{"data":{"pipeline.repo":"<owner>/<repo>","forge.kind":"github"}}'
+
+# GitLab: group/(subgroup/)*project + forge.kind=gitlab (override canônico)
+$K -n <ns> patch configmap deile-runtime-config \
+  --type merge -p '{"data":{"pipeline.repo":"<group>/<project>","forge.kind":"gitlab"}}'
+
+python3 infra/k8s/deploy.py -n <ns> k8s restart
+```
+
+> Namespaces criados via `python3 infra/k8s/deploy.py k8s create-namespace` já
+> perguntam forge/repo no fluxo interativo e gravam a chave `pipeline.repo`
+> automaticamente (`infra/k8s/_setup.py`).
+
+---
+
+## AC-1 — E2E GitHub (repo neutro ≠ `elimarcavalli/deile`)
+
+**Pré-requisitos**
+- Um repositório GitHub sandbox dedicado (ex.: `<sua-org>/deile-harness-sandbox`),
+  vazio ou com um esqueleto mínimo, e um PAT (`GITHUB_TOKEN`) com escopo
+  `repo`.
+- Cluster DEILE de pé (`python3 infra/k8s/deploy.py k8s up`), claude-worker
+  logado (`k8s claude-login`) se for despachar para o claude-worker.
+
+**Passos**
+1. Provisione o token e o repo-alvo:
+   ```bash
+   K=~/.rd/bin/kubectl
+   $K -n <ns> patch secret deile-secrets \
+     -p '{"stringData":{"GITHUB_TOKEN":"<PAT>"}}'
+   $K -n <ns> patch configmap deile-runtime-config \
+     --type merge -p '{"data":{"pipeline.repo":"<org>/<repo>","forge.kind":"github"}}'
+   python3 infra/k8s/deploy.py -n <ns> k8s restart
+   ```
+2. Confirme que o pipeline subiu apontando para o repo-alvo (não o default):
+   ```bash
+   $K -n <ns> logs deploy/deile-pipeline --tail=80 | grep -i "repo="
+   # esperado: starting pipeline monitor (repo=<org>/<repo>, ...)
+   ```
+3. Abra uma issue simples no repo-alvo (via UI ou `gh`) e adicione
+   `~workflow:nova`. Acompanhe o ciclo completo
+   `classify → refine → implement → pr_review → follow_ups`.
+4. **Evidência a anexar na #612:**
+   - Trecho do log do `deile-pipeline` mostrando `repo=<org>/<repo>`.
+   - Link da issue e da PR criadas **no repo-alvo** (não em `elimarcavalli/deile`).
+
+**Critério de sucesso:** issue percorre o pipeline e gera PR no repo-alvo,
+configurado **apenas** via `pipeline.repo`/`forge.kind` — zero edição de código.
+
+---
+
+## AC-2 — E2E GitLab (`DEILE_FORGE_KIND=gitlab`)
+
+**Pré-requisitos**
+- Um projeto GitLab (cloud ou self-hosted) e um PAT (`GITLAB_TOKEN`/`GL_TOKEN`)
+  com escopos `api`, `read_repository`, `write_repository`.
+
+**Passos**
+1. Provisione token + repo + forge:
+   ```bash
+   K=~/.rd/bin/kubectl
+   $K -n <ns> patch secret deile-secrets \
+     -p '{"stringData":{"GITLAB_TOKEN":"<PAT>"}}'
+   $K -n <ns> patch configmap deile-runtime-config \
+     --type merge -p '{"data":{"pipeline.repo":"<group>/<project>","forge.kind":"gitlab"}}'
+   # self-hosted: defina também DEILE_GITLAB_HOST no manifest/ConfigMap.
+   python3 infra/k8s/deploy.py -n <ns> k8s restart
+   ```
+2. Confirme o startup (`repo=<group>/<project>`, forge gitlab).
+3. Abra uma issue no projeto GitLab, marque `~workflow:nova`, acompanhe o ciclo
+   completo (issue → MR → merge), cobrindo a divergência de API GH↔GL.
+4. **Evidência a anexar na #612:** log do pipeline + link da issue e da MR no
+   projeto GitLab.
+
+**Critério de sucesso:** mesmo fluxo do AC-1, agora contra GitLab.
+
+> **Downgrade documentado (anti-flood):** se a paridade GitLab inviabilizar o
+> E2E completo no momento da validação, registre AC-2 como **follow-up DESTA
+> issue** (não abrir nova) — a fatia de código já é forge-agnóstica e os testes
+> de fiação cobrem ambos os caminhos.
+
+---
+
+## Categoria D — `DEILEBOT_REPO` (decisão registrada)
+
+`infra/setup_environment.py:43` mantém `DEILEBOT_REPO =
+"https://github.com/elimarcavalli/deilebot.git"`. **Decisão: N/A — fora do
+pipeline.** É o install opcional do bot (extra `[bot]`), não faz parte do fluxo
+project-agnostic do harness; permanece apontando para o repo do produto por
+design (mesma natureza da Categoria C — self-identity do DEILE).

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -1849,7 +1849,7 @@ class DashboardView(View):
                 (f"  {repo}", "dim"),
             ))
         else:
-            lines.append(Text("Forge: github.com · elimarcavalli/deile", style="dim"))
+            lines.append(Text("Forge: github.com · <unconfigured>", style="dim"))
 
         # ---- Tokens resumido (ponteiro para [t]) ----
         if self.data is not None:

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -86,16 +86,30 @@ _ALLOWED_DEPLOYMENTS_FULL = frozenset({
 _POD_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$")
 
 
+# Sentinela project-agnostic (issue #612): quando nenhuma fonte de repo está
+# disponível (sem override, sem ConfigMap, sem git origin) o painel NÃO finge
+# que está apontando para `elimarcavalli/deile`. Mostra este marcador para o
+# operador deixar explícito que a config do repo-alvo está ausente.
+REPO_UNCONFIGURED = "<unconfigured>"
+
+
 def _detect_default_repo() -> str:
     """Tenta derivar `owner/repo` de `git remote get-url origin`.
 
-    Fallback para `elimarcavalli/deile` se git ausente, sem origin, ou
-    formato não reconhecido. Roda uma única vez no import — silencioso.
+    Issue #612 (project-agnostic): NÃO há mais fallback hardcoded para
+    `elimarcavalli/deile`. Quando git está ausente, sem origin, ou o formato
+    não é reconhecido, emite um `WARNING` e devolve :data:`REPO_UNCONFIGURED`
+    — o painel/monitor degrada com mensagem clara em vez de reportar o repo
+    errado silenciosamente. Roda uma única vez no import.
     """
-    fallback = "elimarcavalli/deile"
     git = shutil.which("git")
     if git is None:
-        return fallback
+        logger.warning(
+            "git not found — cannot derive target repo from origin; "
+            "panel will report %r until DEILE_FORGE_REPO/forge.repo is set",
+            REPO_UNCONFIGURED,
+        )
+        return REPO_UNCONFIGURED
     try:
         out = subprocess.run(
             [git, "remote", "get-url", "origin"],
@@ -103,13 +117,27 @@ def _detect_default_repo() -> str:
             cwd=str(Path(__file__).resolve().parent.parent.parent),
         )
     except (OSError, subprocess.TimeoutExpired):
-        return fallback
+        logger.warning(
+            "git remote lookup failed — panel will report %r until "
+            "DEILE_FORGE_REPO/forge.repo is set", REPO_UNCONFIGURED,
+        )
+        return REPO_UNCONFIGURED
     if out.returncode != 0:
-        return fallback
+        logger.warning(
+            "no git origin — panel will report %r until "
+            "DEILE_FORGE_REPO/forge.repo is set", REPO_UNCONFIGURED,
+        )
+        return REPO_UNCONFIGURED
     url = out.stdout.strip()
     # github.com[:/]owner/repo(.git)?  — cobre https e ssh.
     m = re.search(r"github\.com[:/]([^/]+/[^/.]+?)(?:\.git)?/?$", url)
-    return m.group(1) if m else fallback
+    if m:
+        return m.group(1)
+    logger.warning(
+        "git origin %r did not match owner/repo — panel will report %r until "
+        "DEILE_FORGE_REPO/forge.repo is set", url, REPO_UNCONFIGURED,
+    )
+    return REPO_UNCONFIGURED
 
 
 REPO_DEFAULT = _detect_default_repo()
@@ -284,13 +312,15 @@ class RuntimeContext:
 
 
 def _read_forge_repo(namespace: str) -> str:
-    """Lê ``pipeline.repo`` do ConfigMap ``deile-runtime-config`` do NS.
+    """Lê a chave ``pipeline.repo`` do ConfigMap ``deile-runtime-config`` do NS.
 
-    Quando o painel aponta para um namespace que carrega forge GitLab, o
-    repo certo a listar **não** é o ``owner/repo`` do clone local (que
-    ``_detect_default_repo()`` retornaria via ``gh repo view``) — é o repo
-    que o pipeline está orquestrando, declarado no ConfigMap layered.
-    Falha graciosamente para ``""`` (callsite cai no default).
+    Issue #612 (project-agnostic): o repo-alvo passou a viver na chave
+    discreta ``pipeline.repo`` do ConfigMap (FONTE ÚNICA dos manifests 46/55),
+    não mais embutido no JSON ``pipeline-settings.json``. Quando o painel
+    aponta para um namespace que carrega forge GitLab, o repo certo a listar
+    **não** é o ``owner/repo`` do clone local (que ``_detect_default_repo()``
+    retornaria) — é o repo que o pipeline está orquestrando, declarado no
+    ConfigMap. Falha graciosamente para ``""`` (callsite cai no default).
     """
     kubectl = kubectl_bin()
     if kubectl is None:
@@ -299,23 +329,14 @@ def _read_forge_repo(namespace: str) -> str:
         out = subprocess.run(
             [kubectl, "-n", namespace, "get", "configmap",
              "deile-runtime-config",
-             "-o", "jsonpath={.data.pipeline-settings\\.json}"],
+             "-o", "jsonpath={.data.pipeline\\.repo}"],
             capture_output=True, text=True, timeout=3.0,
         )
     except (OSError, subprocess.TimeoutExpired):
         return ""
-    if out.returncode != 0 or not out.stdout.strip():
+    if out.returncode != 0:
         return ""
-    try:
-        payload = json.loads(out.stdout)
-    except json.JSONDecodeError:
-        return ""
-    pipeline = payload.get("pipeline") if isinstance(payload, dict) else None
-    if isinstance(pipeline, dict):
-        repo = pipeline.get("repo")
-        if isinstance(repo, str) and repo.strip():
-            return repo.strip()
-    return ""
+    return out.stdout.strip()
 
 
 def _read_forge_kind(namespace: str) -> str:

--- a/infra/k8s/_setup.py
+++ b/infra/k8s/_setup.py
@@ -106,10 +106,13 @@ class NamespacePlan:
         pelo operador. As entradas para worker/shell/oneshot/bot são
         idênticas ao manifest base — não tem variação per-NS.
         """
+        # Issue #612 (project-agnostic): o repo-alvo vive na chave discreta
+        # ``pipeline.repo`` (FONTE ÚNICA, referenciada pelos manifests 46/55 via
+        # configMapKeyRef), não embutido no JSON ``pipeline-settings.json``.
+        # Mantê-lo nos dois lugares deixaria os valores divergirem.
         pipeline_settings: Dict[str, object] = {
             "pipeline": {
                 "dispatch_mode": self.dispatch_mode,
-                "repo": self.repo,
                 "poll_interval": 60,
             },
             "approval": {"auto": True},
@@ -117,6 +120,7 @@ class NamespacePlan:
         if self.forge_kind in ("github", "gitlab"):
             pipeline_settings["forge"] = {"kind": self.forge_kind}
         return {
+            "pipeline.repo": self.repo,
             "pipeline-settings.json": json.dumps(pipeline_settings, indent=2) + "\n",
             "worker-settings.json": (
                 '{\n  "model": {\n    "preferred": "deepseek:deepseek-v4-pro"\n  },\n'

--- a/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
+++ b/infra/k8s/manifests/46-deile-pipeline-deployment.yaml
@@ -104,7 +104,16 @@ spec:
               fi
               echo "bootstrap-repo OK"
           env:
-            - { name: DEILE_PIPELINE_REPO,  value: "elimarcavalli/deile" }
+            # Issue #612 (project-agnostic) — repo-alvo do bootstrap git clone
+            # vem da FONTE ÚNICA `pipeline.repo` no ConfigMap deile-runtime-config
+            # (manifest 47), não de um literal hardcoded aqui. Para o deploy de
+            # referência do próprio DEILE o ConfigMap traz `elimarcavalli/deile`;
+            # operadores de outros projetos editam só a chave do ConfigMap.
+            - name: DEILE_PIPELINE_REPO
+              valueFrom:
+                configMapKeyRef:
+                  name: deile-runtime-config
+                  key: pipeline.repo
             # Issue #355 — lê do mesmo ConfigMap que o main container para
             # que operadores GitLab configurem forge.kind=gitlab em um lugar
             # só. optional: true preserva o comportamento legado: se a chave
@@ -151,6 +160,17 @@ spec:
             # diretório read-only pelo user 10001, quebrando ~/.deile/logs/,
             # ~/.deile/run/, ~/.deile/sessions/.
             - { name: DEILE_SETTINGS_FILE,           value: "/etc/deile/settings.json" }
+            # Issue #612 (project-agnostic) — o repo-alvo do pipeline (lido por
+            # resolve_forge_repo() → Settings.forge_repo) vem da FONTE ÚNICA
+            # `pipeline.repo` no ConfigMap deile-runtime-config (manifest 47),
+            # NÃO mais do `"repo"` embutido em pipeline-settings.json. Sem essa
+            # injeção o pipeline aborta no startup (fail-loud, AC-3) — é assim
+            # que config ausente deixa de ser mascarada por um default silencioso.
+            - name: DEILE_FORGE_REPO
+              valueFrom:
+                configMapKeyRef:
+                  name: deile-runtime-config
+                  key: pipeline.repo
             #
             # Para receber DMs do notifier, adicione "pipeline.notify_user_id":
             # "<discord-id>" em pipeline-settings.json (manifest 47).

--- a/infra/k8s/manifests/47-deile-runtime-config.yaml
+++ b/infra/k8s/manifests/47-deile-runtime-config.yaml
@@ -24,11 +24,22 @@ data:
   # re-apliquem + reiniciem deile-pipeline. Operadores GitHub: valor padrão
   # "github" já é o fallback no script do initContainer (${DEILE_FORGE_KIND:-github}).
   forge.kind: github
+  # Issue #612 (project-agnostic) — FONTE ÚNICA do repo-alvo do harness. Os
+  # deployments 46 (initContainer bootstrap-repo) e 55 (monitor) referenciam
+  # esta chave via configMapKeyRef em vez de carregar o literal hardcoded.
+  # O default abaixo é o deploy de referência do próprio DEILE (N/A para
+  # operadores de outros projetos) — troque para o seu owner/repo (GitHub)
+  # ou group/.../project (GitLab) e re-aplique + reinicie a stack.
+  pipeline.repo: elimarcavalli/deile
+  # NOTA (issue #612): o repo-alvo NÃO mora mais neste JSON. O pod
+  # deile-pipeline recebe o valor via env DEILE_FORGE_REPO (manifest 46),
+  # que referencia a chave `pipeline.repo` acima por configMapKeyRef — fonte
+  # única. Manter o `"repo"` aqui criaria um segundo lugar para o valor
+  # divergir do `pipeline.repo`.
   pipeline-settings.json: |
     {
       "pipeline": {
         "dispatch_mode": "deile_worker",
-        "repo": "elimarcavalli/deile",
         "poll_interval": 60
       },
       "approval": {

--- a/infra/k8s/manifests/55-deile-monitor-deployment.yaml
+++ b/infra/k8s/manifests/55-deile-monitor-deployment.yaml
@@ -68,7 +68,11 @@ spec:
           args:
             - |
               set -eu
-              REPO="${DEILE_PIPELINE_REPO:-elimarcavalli/deile}"
+              # Issue #612 (project-agnostic): DEILE_PIPELINE_REPO vem da FONTE
+              # ÚNICA `pipeline.repo` (ConfigMap deile-runtime-config / manifest
+              # 47) via configMapKeyRef abaixo — sem repo configurado o clone
+              # falha alto em vez de cair num default hardcoded.
+              REPO="${DEILE_PIPELINE_REPO:?DEILE_PIPELINE_REPO ausente — configure pipeline.repo no ConfigMap deile-runtime-config}"
               if [ -f /home/deile/.git/HEAD ]; then
                 echo "repo already present — fast-forward"
                 git fetch --depth=1 origin "$(git rev-parse --abbrev-ref HEAD)" || true
@@ -82,7 +86,13 @@ spec:
               fi
               echo "bootstrap-repo OK"
           env:
-            - { name: DEILE_PIPELINE_REPO, value: "elimarcavalli/deile" }
+            # Issue #612 — repo-alvo do clone vem da FONTE ÚNICA `pipeline.repo`
+            # (ConfigMap deile-runtime-config / manifest 47), não de um literal.
+            - name: DEILE_PIPELINE_REPO
+              valueFrom:
+                configMapKeyRef:
+                  name: deile-runtime-config
+                  key: pipeline.repo
           volumeMounts:
             - { name: deile-secrets, mountPath: /run/secrets/deile, readOnly: true }
             - { name: home,          mountPath: /home/deile }
@@ -144,8 +154,14 @@ spec:
             - { name: DEILE_DEFAULT_PERSONA,   value: monitor }
             - { name: DEILE_BOT_ENDPOINT,      value: "http://deilebot:8765" }
             - { name: DEILE_SETTINGS_FILE,     value: "/etc/deile/settings.json" }
-            # Repo the monitor inspects (gh CLI calls)
-            - { name: DEILE_PIPELINE_REPO,     value: "elimarcavalli/deile" }
+            # Repo the monitor inspects (gh CLI calls). Issue #612: FONTE ÚNICA
+            # `pipeline.repo` (ConfigMap deile-runtime-config / manifest 47),
+            # lida por monitor_tick.py (os.environ DEILE_PIPELINE_REPO) → run_tick.
+            - name: DEILE_PIPELINE_REPO
+              valueFrom:
+                configMapKeyRef:
+                  name: deile-runtime-config
+                  key: pipeline.repo
             # State directory (PVC mount — writable for tick state files)
             - { name: DEILE_MONITOR_STATE_DIR, value: "/state" }
             # Namespace the monitor supervises (Phase A renew + kubectl scope).

--- a/infra/k8s/monitor_tick.py
+++ b/infra/k8s/monitor_tick.py
@@ -236,7 +236,7 @@ async def run_tick(
 
     needs_phase_b = bool(fu_candidates)
     if needs_phase_b:
-        _write_judgment(sd, tick_n, fu_candidates, state, now)
+        _write_judgment(sd, tick_n, fu_candidates, state, now, repo)
     return {"paused": False, "needs_phase_b": needs_phase_b, "candidates": fu_candidates}
 
 
@@ -255,11 +255,14 @@ def _safe_sync(emitter: core.Emitter, vname: str, fn: Callable[[], None]) -> Non
 
 
 def _write_judgment(state_dir: Path, tick_n: int, candidates: List[Dict[str, Any]],
-                    state: Dict[str, Any], now: datetime) -> None:
+                    state: Dict[str, Any], now: datetime, repo: str) -> None:
     payload = {
         "tick": tick_n,
         "generated_at": core.iso(now),
-        "repo": os.environ.get("DEILE_PIPELINE_REPO", ""),
+        # Issue #612: report the SAME repo the tick actually ran against
+        # (resolved once in main() via the canonical resolver) instead of
+        # re-reading the env independently — single read, no divergence.
+        "repo": repo,
         "fu_candidates": candidates,
         "fu_created_today": state.get("fu_created_today", 0),
         "fu_day_slot": state.get("fu_day_slot", ""),
@@ -283,9 +286,38 @@ def _write_judgment(state_dir: Path, tick_n: int, candidates: List[Dict[str, Any
 # Entry point
 # ---------------------------------------------------------------------------
 
+def _resolve_repo() -> str:
+    """Resolve the monitor's target repo through the canonical resolver.
+
+    Issue #612 (project-agnostic): the monitor used to read ``DEILE_PIPELINE_REPO``
+    directly — but ``Settings`` *silently ignores* that env var (it was "truly
+    removed"; only ``DEILE_FORGE_REPO`` / ``forge.repo`` / ``pipeline.repo`` feed
+    settings). That meant the monitor read a source the rest of the harness no
+    longer honours. This routes the read through the SAME
+    :func:`resolve_forge_repo` the pipeline uses, with the legacy
+    ``DEILE_PIPELINE_REPO`` env kept as a deployment-boundary fallback so the
+    reference manifest (ConfigMap ``pipeline.repo`` → ``DEILE_PIPELINE_REPO``)
+    keeps working unchanged.
+
+    ``require=False`` + graceful fallback: a missing repo degrades with a
+    ``WARNING``, never raises — the deterministic Phase-A tick must never crash
+    the heartbeat (a hard fail-loud belongs to the pipeline's startup, not to
+    the supervisor's per-tick sweep). The import is lazy (mirrors the existing
+    ``_claude_creds_refresh`` import) so the flattened ``/app/monitor_tick.py``
+    keeps a clean module-import surface, and any config-layer error falls back
+    to the raw env rather than killing the tick.
+    """
+    env_repo = os.environ.get("DEILE_PIPELINE_REPO", "").strip()
+    try:
+        from deile.orchestration.pipeline.constants import resolve_forge_repo
+        return resolve_forge_repo(require=False, fallback=env_repo)
+    except Exception:  # noqa: BLE001 — config import must never crash the tick
+        return env_repo
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     state_dir = os.environ.get("DEILE_MONITOR_STATE_DIR", "/state")
-    repo = os.environ.get("DEILE_PIPELINE_REPO", "")
+    repo = _resolve_repo()
     namespace = os.environ.get("DEILE_K8S_NAMESPACE", "deile")
     bot_endpoint = os.environ.get("DEILE_BOT_ENDPOINT", "http://deilebot:8765")
     bot_token = _read_secret("DEILE_BOT_AUTH_TOKEN")


### PR DESCRIPTION
## Resumo

Desacopla o harness/pipeline do repositório hardcoded `elimarcavalli/deile`, tornando-o **project-agnostic** (GitHub e GitLab). Entrega a **fatia de código** da issue #612 — **AC-3, AC-4, AC-5, AC-6, AC-7**. O E2E real contra forges externos (AC-1/AC-2) **não é unit-testável** e fica como **runbook manual** para o Humano executar (passo remanescente desta issue).

> Achado-chave confirmado: o mecanismo de injeção do repo-alvo já existia (`resolve_forge_repo`, `DEILE_FORGE_REPO`/`forge.repo`). O trabalho foi provar a fiação ponta-a-ponta, eliminar os fallbacks silenciosos e parametrizar os manifests — não reconstruir.

## ACs entregues (código)

### AC-3 — config ausente falha alto
- `deile/orchestration/pipeline/constants.py`: `resolve_forge_repo()` deixa de cair silenciosamente no default hardcoded. Aborta com `ConfigurationError` (mensagem clara, `config_key="forge.repo"`) no caminho de produção; degrada com `WARNING` nas surfaces graciosas via parâmetros `require`/`fallback`. `PIPELINE_DEFAULT_REPO` removida.
- `deile/config/settings.py`: default de `pipeline_repo` `"elimarcavalli/deile"` → `""` (ausência detectável).
- `deile/commands/builtin/pipeline_command.py`: `/pipeline stop` sem monitor ativo responde "nada a parar" **antes** de montar a config — parar não exige repo configurado (corrige regressão pega no smoke `--pipeline-stop`).

**Onde dispara:** o pod `deile-pipeline` (`run_pipeline_forever → build_default_pipeline_config`) aborta no **startup** (não no meio de um tick). O CLI local degrada com mensagem clara (o `CommandRegistry`/autostart já embrulham a exceção).

### AC-4/AC-5 — fonte única via ConfigMap
- Repo-alvo agora vive na chave discreta **`pipeline.repo`** do ConfigMap `deile-runtime-config` (manifest 47).
- Manifests **46** (initContainer bootstrap-repo + env `DEILE_FORGE_REPO` do container principal) e **55** (monitor: bootstrap + container) referenciam essa chave via `configMapKeyRef` — **sem** o literal `elimarcavalli/deile` em valor de env default de deployment.
- O `"repo"` saiu do JSON `pipeline-settings.json`; o pipeline recebe via `DEILE_FORGE_REPO` (aplicado sobre `Settings.forge_repo` pelo loader). Painel (`_panel_data._read_forge_repo`) e setup interativo (`_setup.py`) leem/escrevem a mesma chave única.
- `_panel_data._detect_default_repo` e `_panel.py` deixam de fingir `elimarcavalli/deile`: sentinela `<unconfigured>` + `WARNING` quando não há git origin. O default do deploy de referência do próprio DEILE permanece **documentado no ConfigMap** (N/A para outros projetos).

### AC-6/AC-7 — testes de fiação (anti-Goodhart, ref. GC #596)
- **novo** `deile/tests/orchestration/pipeline/test_forge_repo_injection.py`: abort sem config, ausência de vazamento do default, e a fiação real `build_default_pipeline_config → PipelineMonitor → forge client` consumindo o repo injetado (`monitor.forge.repo`), além do gh call-site real do implementer (`_collect_review_delta`).
- **estendido** `deile/tests/infra/test_monitor_tick.py`: o repo injetado chega às chamadas `gh api repos/<repo>/...` das vigias e ao payload de judgment do monitor.
- **estendido** `deile/tests/infra/test_panel_data.py`: override > ConfigMap > sentinela com WARNING.
- Fixtures que dependiam do default silencioso atualizadas para injetar o repo (`test_settings_forge`, `test_settings_json_loading`, `test_k8s_setup`).

## Passo remanescente — AC-1/AC-2 (runbook manual)

E2E real contra repos GitHub + GitLab externos exige sandbox + credenciais + ação manual — **não executável por agente**. Runbook completo em `docs/2026-06-10_HARNESS-PROJECT-AGNOSTIC-E2E-RUNBOOK.md` (provisionar token, patch da chave `pipeline.repo`+`forge.kind` no ConfigMap, restart, acompanhar `classify → ... → follow_ups`, anexar log + links). Fica como **follow-up DESTA issue** (anti-flood), não nova issue. **Categoria D** (`DEILEBOT_REPO`) registrada como **N/A** (install opcional do bot, fora do pipeline).

## Como a stack do DEILE segue funcionando

A stack atual continua resolvendo `elimarcavalli/deile` **porque o ConfigMap fornece** (`pipeline.repo: elimarcavalli/deile` em manifest 47), **não** por fallback silencioso de código. Subir sem essa chave faz o `deile-pipeline` abortar no startup com mensagem clara — comportamento desejado.

## Evidência

- Suíte completa com cobertura: `4 failed, 8245 passed, 30 skipped` — as **4 falhas são pré-existentes** (`test_pod_presence`, `test_classify`, `test_reconcile_fire_and_forget`, `test_gap_regressions`; 3 corrigidas no PR irmão #642). **Zero novas falhas** (verificado contra árvore pristina de `origin/main`).
- `constants.py`: **100% de cobertura** pelos testes novos.
- Multi-seed (0/1/2/42) nos dirs tocados: 353 passed em todos.
- `ruff` + `isort` limpos nos arquivos tocados (issues remanescentes em `_panel*.py` são pré-existentes em `main`).
- Manifests: YAML válido + `configMapKeyRef` (`pipeline.repo`/`forge.kind`) bem-formados.

Refs #612