### PR TITLE
fix(claude-worker): TOCTOU guard honors pod presence when cleaning dead-pod workdir

### DIFF
--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -1486,11 +1486,25 @@ def _workspace_is_stale(
     return (now - hb) >= threshold_s
 
 
-def _has_active_lease(workspace: Path) -> bool:
-    """True se ``<workspace>/.lease.json`` está presente e com heartbeat dentro
-    do TTL. Usado como guarda de segurança imediatamente antes de remover um
-    workdir (fix #520 — TOCTOU: um dispatch pode adquirir lease entre o stale
-    scan e o rmtree).
+def _has_active_lease(
+    workspace: Path, *, alive_pods: Optional[set] = None,
+) -> bool:
+    """True se ``<workspace>/.lease.json`` está presente e genuinamente ativo.
+
+    Usado como guarda de segurança imediatamente antes de remover um workdir
+    (fix #520 — TOCTOU: um dispatch pode adquirir lease entre o stale scan e o
+    rmtree). Um lease é considerado ativo quando o heartbeat está dentro do TTL
+    **e** o pod dono ainda está vivo segundo o registro de presença (issue
+    #495): um heartbeat fresco vindo de um pod já morto é justamente o
+    falso-positivo que a detecção por presença existe para derrubar — sem este
+    cruzamento o guard re-admite o workdir de um pod morto que :func:`_workspace_is_stale`
+    marcou como stale.
+
+    Args:
+        workspace: diretório do workdir candidato a remoção.
+        alive_pods: conjunto de pods vivos (``_get_alive_pods``). ``None`` =
+            presença não inicializada → recai apenas no TTL de heartbeat
+            (comportamento original do fix #520).
 
     Conservador: qualquer erro de I/O → False (não bloqueia remoção de lixo
     que não conseguimos ler; a função é uma camada extra, não a única).
@@ -1501,7 +1515,14 @@ def _has_active_lease(workspace: Path) -> bool:
     try:
         data = json.loads(lease_path.read_text(encoding="utf-8"))
         age = time.time() - float(data.get("heartbeat_at", 0))
-        return age < _LEASE_TTL_S
+        if age >= _LEASE_TTL_S:
+            return False
+        # Heartbeat fresco, mas o pod dono pode estar morto: presença manda.
+        if alive_pods is not None:
+            pod = data.get("pod", "")
+            if pod and pod not in alive_pods:
+                return False
+        return True
     except (OSError, json.JSONDecodeError, ValueError):
         return False
 
@@ -1653,7 +1674,9 @@ def _cleanup_stale_workspaces(
         # Fix #520 — re-verifica o lease imediatamente antes do rmtree para
         # evitar TOCTOU: um dispatch pode ter adquirido o lease entre o scan
         # acima e este ponto (latência de I/O, preempção de thread, etc.).
-        if _has_active_lease(child):
+        # Passa ``alive_pods`` para que um heartbeat fresco de um pod já morto
+        # (issue #495) não re-admita o workdir que o scan marcou como stale.
+        if _has_active_lease(child, alive_pods=alive_pods):
             logger.info(
                 "workspace cleanup skipped task_id=%s — lease ativo adquirido "
                 "após scan stale (TOCTOU guard, fix #520)", child.name,


### PR DESCRIPTION
## Contexto

4ª falha pré-existente da suíte na `main`: `deile/tests/infrastructure/test_pod_presence.py::test_cleanup_stale_workspaces_removes_dead_pod_workspace` (`assert 0 == 1`). Junto com o PR irmão #642 (que corrige as outras 3 — `test_classify`, `test_gap_regressions`, `test_reconcile_fire_and_forget`), este PR zera o baseline, restaurando os **100% verdes** que são pré-condição do quality-gate de merge de toda PR.

Closes #648

## Diagnóstico: bug real de produto (não teste stale)

A limpeza periódica de workspaces do `claude-worker` deixava de remover o workdir de um **pod morto** quando o `.lease.json` ainda carregava um `heartbeat_at` recente.

Rastreio do cenário do teste (pod `dead-worker` com heartbeat fresco; `survivor` vivo na presença):

1. `_get_alive_pods(root)` → `{'survivor'}` (correto: `dead-worker` ausente).
2. `_workspace_is_stale(..., alive_pods={'survivor'})` → `True` — a detecção proativa por presença (issue #495) marca stale corretamente (`infra/k8s/claude_worker_server.py:1481`).
3. **Mas** o guard TOCTOU da issue #520, `_has_active_lease(child)`, retornava `True` por considerar apenas `age < _LEASE_TTL_S` (`claude_worker_server.py:1504`), fazendo o loop pular o `rmtree` (`claude_worker_server.py:1656`). `summary["removed"]` permanecia `0`.

Ou seja: o teste é o **oráculo correto** do contrato da issue #495 (recuperação imediata do workdir de pod morto, sem aguardar o TTL de 30 min do heartbeat); a regressão veio do guard introduzido pela #520, que passou a re-admitir leases frescos sem cruzar a presença. Não é teste stale — é bug latente de produto: em produção, o workdir de um pod morto só seria coletado depois de o heartbeat envelhecer além do TTL, anulando o ganho da #495.

Confirmação empírica (mesmo cenário): `_workspace_is_stale == True` e `_has_active_lease == True` (`_LEASE_TTL_S == 30`) → `removed == 0`.

## O fix

`_has_active_lease` passa a aceitar `alive_pods` e só considera um lease ativo quando **(a)** o heartbeat está dentro do TTL **e** **(b)** o pod dono está vivo segundo a presença. Quando `alive_pods=None` (presença não inicializada), recai no comportamento original do #520 (só heartbeat). O call site em `_cleanup_stale_workspaces` repassa o `alive_pods` já calculado no escopo.

O genuíno race do TOCTOU permanece protegido: um pod vivo que readquire o lease entre o scan e o `rmtree` tem presença fresca e continua em `alive_pods`, então o guard segue retornando `True` e a remoção é corretamente pulada. Verificado empiricamente.

O segundo call site de `_has_active_lease` (`/v1/cleanup`, `claude_worker_server.py:3843`) é presença-agnóstico por design (seleciona candidatos por mtime/JSONL-vazio) e mantém o default `alive_pods=None` — sem mudança de comportamento. Mudança totalmente retrocompatível (kwarg novo com default).

## Verificação

Baseline pristino (origin/main, com cobertura): **4 failed, 8225 passed**.

Após o fix (suíte completa com cobertura — o portão real de CI):

```
3 failed, 8226 passed, 31 skipped, 13 warnings in 109.17s
FAILED deile/tests/orchestration/pipeline/test_classify.py::TestClassifyNewIssues::test_tick_calls_classify_before_review
FAILED deile/tests/orchestration/pipeline/test_reconcile_fire_and_forget.py::TestReaperRefineExtended::test_does_not_reap_refine_resting_without_ledger
FAILED deile/tests/orchestration/pipeline/test_gap_regressions.py::TestGap17_18GhErrorCounting::test_gh_error_in_review_increments_gh_errors
```

`test_pod_presence` saiu da lista de falhas (verde); zero novas falhas; as 3 remanescentes são exatamente as do PR irmão #642.

Multi-seed determinístico no arquivo tocado (seeds 0/1/2/42): **14 passed** em todos. `ruff` limpo nas linhas alteradas (as 3 ocorrências de `ruff`/`isort` no arquivo são pré-existentes na `main`, fora do diff). Nenhum dublê/mock de `_has_active_lease` existe nos testes.

Após este PR + #642, o baseline volta a 100% verde.

