### PR TITLE
fix(tools): make run_tests function-callable + clearer errors in bash/search

### DIFF
--- a/deile/tests/tools/test_tooling_hardening.py
+++ b/deile/tests/tools/test_tooling_hardening.py
@@ -1,0 +1,149 @@
+"""Regression tests for the tooling-hardening audit.
+
+Covers three concrete fixes:
+
+1. ``TestRunnerTool`` (``run_tests``) now carries a ``ToolSchema`` so it is
+   exported to every LLM function-calling provider — previously it was
+   registered but invisible (schema-less tools are skipped by the exporters)
+   even though ``validation_gate`` treats ``run_tests`` as a real tool.
+2. ``BashExecuteTool`` returns a clear error for an invalid ``security_level``
+   instead of leaking ``ValueError: 'x' is not in list``.
+3. ``SearchTool`` returns a clean "cannot be empty" message for a null
+   ``query`` instead of an ``AttributeError`` on ``None.strip()``.
+"""
+
+from __future__ import annotations
+
+from deile.tools.base import ToolContext, ToolSchema
+from deile.tools.bash_tool import BashExecuteTool
+from deile.tools.execution_tools import TestRunnerTool
+from deile.tools.search_tool import SearchTool
+
+# ---------------------------------------------------------------------------
+# 1. run_tests is now function-callable
+# ---------------------------------------------------------------------------
+
+
+def test_run_tests_has_schema():
+    tool = TestRunnerTool()
+    assert tool.schema is not None
+    assert tool.schema.name == "run_tests"
+
+
+def test_run_tests_schema_converts_to_all_providers():
+    """The schema must translate cleanly to all three provider formats."""
+    schema = TestRunnerTool().schema
+    assert isinstance(schema, ToolSchema)
+
+    anthropic = schema.to_anthropic_tool()
+    assert anthropic["name"] == "run_tests"
+    assert anthropic["input_schema"]["type"] == "object"
+
+    openai = schema.to_openai_function()
+    assert openai["function"]["name"] == "run_tests"
+
+    # Gemini conversion is import-guarded; only assert when the SDK is present.
+    try:
+        gemini = schema.to_gemini_function()
+    except ImportError:
+        gemini = None
+    if gemini is not None:
+        assert gemini.name == "run_tests"
+
+
+def test_run_tests_schema_test_type_enum():
+    props = TestRunnerTool().schema.parameters["properties"]
+    assert set(props["test_type"]["enum"]) == {"pytest", "unittest", "nose"}
+
+
+def test_run_tests_exported_by_registry():
+    """A registry with run_tests registered exports it to every provider."""
+    from deile.tools.base import Tool
+    from deile.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    registry.register(TestRunnerTool())
+    assert isinstance(registry.get("run_tests"), Tool)
+    assert any(t["name"] == "run_tests" for t in registry.get_anthropic_tools())
+    assert any(
+        f["function"]["name"] == "run_tests"
+        for f in registry.get_openai_functions()
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. bash_execute rejects an invalid security_level cleanly
+# ---------------------------------------------------------------------------
+
+
+async def test_bash_invalid_security_level_is_clean_error(tmp_path):
+    tool = BashExecuteTool()
+    ctx = ToolContext(
+        user_input="",
+        parsed_args={
+            "command": "echo hi",
+            "working_directory": str(tmp_path),
+            "security_level": "high",  # not a valid level
+        },
+    )
+    result = await tool.execute(ctx)
+    assert result.is_error
+    assert "invalid security_level" in result.message.lower()
+    assert "'high'" in result.message
+
+
+async def test_bash_valid_security_level_still_runs(tmp_path):
+    tool = BashExecuteTool()
+    ctx = ToolContext(
+        user_input="",
+        parsed_args={
+            "command": "echo hardening",
+            "working_directory": str(tmp_path),
+            "security_level": "safe",
+        },
+    )
+    result = await tool.execute(ctx)
+    assert result.is_success
+    assert result.data["exit_code"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. find_in_files handles a null query without AttributeError
+# ---------------------------------------------------------------------------
+
+
+async def test_search_null_query_is_clean_error(tmp_path):
+    tool = SearchTool()
+    ctx = ToolContext(
+        user_input="",
+        parsed_args={"query": None, "path": str(tmp_path)},
+        working_directory=str(tmp_path),
+    )
+    result = await tool.execute(ctx)
+    assert result.is_error
+    assert "cannot be empty" in result.message.lower()
+
+
+async def test_search_empty_query_is_clean_error(tmp_path):
+    tool = SearchTool()
+    ctx = ToolContext(
+        user_input="",
+        parsed_args={"query": "   ", "path": str(tmp_path)},
+        working_directory=str(tmp_path),
+    )
+    result = await tool.execute(ctx)
+    assert result.is_error
+    assert "cannot be empty" in result.message.lower()
+
+
+async def test_search_valid_query_still_matches(tmp_path):
+    (tmp_path / "f.py").write_text("def needle():\n    return 1\n", encoding="utf-8")
+    tool = SearchTool()
+    ctx = ToolContext(
+        user_input="",
+        parsed_args={"query": "needle", "path": str(tmp_path)},
+        working_directory=str(tmp_path),
+    )
+    result = await tool.execute(ctx)
+    assert result.is_success
+    assert result.data["total_matches"] >= 1

--- a/deile/tools/bash_tool.py
+++ b/deile/tools/bash_tool.py
@@ -349,9 +349,14 @@ class BashExecuteTool(SyncTool):
             
             # Security assessment
             risk_level, security_warnings = assess_risk(command)
-            
+
             # Check if risk level is acceptable
             risk_hierarchy = ["safe", "moderate", "dangerous"]
+            if security_level not in risk_hierarchy:
+                raise ToolError(
+                    f"Invalid security_level {security_level!r}; "
+                    f"must be one of {risk_hierarchy}"
+                )
             requested_level_idx = risk_hierarchy.index(security_level)
             actual_level_idx = risk_hierarchy.index(risk_level)
             

--- a/deile/tools/execution_tools.py
+++ b/deile/tools/execution_tools.py
@@ -9,7 +9,8 @@ import tempfile
 from pathlib import Path
 
 from ..core.exceptions import ValidationError
-from .base import SyncTool, ToolContext, ToolResult, ToolStatus
+from .base import (SecurityLevel, SyncTool, ToolCategory, ToolContext,
+                   ToolResult, ToolSchema, ToolStatus)
 
 logger = logging.getLogger(__name__)
 
@@ -303,7 +304,14 @@ class PipInstallTool(SyncTool):
 
 
 class TestRunnerTool(SyncTool):
-    """Ferramenta para execução de testes (implementação futura)"""
+    """Run a project's test suite (pytest / unittest / nose) in a subprocess.
+
+    Until this tool carried a :class:`ToolSchema` it was registered but
+    invisible to every LLM function-calling exporter (they skip tools whose
+    ``schema`` is ``None``), so the agent could never invoke it even though
+    ``validation_gate`` already treated ``run_tests`` as a real validation
+    tool. The inline schema below makes it callable.
+    """
 
     @property
     def name(self) -> str:
@@ -316,6 +324,49 @@ class TestRunnerTool(SyncTool):
     @property
     def category(self) -> str:
         return "testing"
+
+    def __init__(self) -> None:
+        super().__init__(
+            schema=ToolSchema(
+                name="run_tests",
+                description=(
+                    "Run the project's test suite in a subprocess and return "
+                    "stdout/stderr plus pass/fail status. Use after editing code "
+                    "to verify nothing regressed. Defaults to pytest against "
+                    "'tests/'; pass `test_path` to scope to a file or directory "
+                    "and `verbose=true` for per-test output (pytest only)."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "test_path": {
+                            "type": "string",
+                            "description": (
+                                "File or directory to test (e.g. "
+                                "'deile/tests/tools/'). Defaults to 'tests/'. "
+                                "Use '.' to run everything from the working dir."
+                            ),
+                        },
+                        "test_type": {
+                            "type": "string",
+                            "enum": ["pytest", "unittest", "nose"],
+                            "description": "Test runner to use. Defaults to pytest.",
+                        },
+                        "verbose": {
+                            "type": "boolean",
+                            "description": (
+                                "Add -v for per-test output (pytest only). "
+                                "Defaults to false."
+                            ),
+                        },
+                    },
+                },
+                required=[],
+                security_level=SecurityLevel.MODERATE,
+                category=ToolCategory.EXECUTION,
+                max_execution_time=300,
+            )
+        )
 
     def execute_sync(self, context: ToolContext) -> ToolResult:
         """Executa testes do projeto"""

--- a/deile/tools/search_tool.py
+++ b/deile/tools/search_tool.py
@@ -118,8 +118,12 @@ class SearchTool(SyncTool):
             
             # Extract and validate parameters
             args = context.parsed_args
-            query = args.get("query", "")
-            if not query.strip():
+            # ``args.get("query", "")`` returns ``None`` (not the default) when
+            # the key is present with a null value — guard the type before
+            # ``.strip()`` so an LLM passing ``query: null`` gets a clear
+            # "cannot be empty" message instead of an opaque AttributeError.
+            query = args.get("query") or ""
+            if not isinstance(query, str) or not query.strip():
                 raise ToolError("Search query cannot be empty")
 
             path = args.get("path", ".")


### PR DESCRIPTION
Refs #650 (issue de rastreamento da iniciativa tooling-hardening).

## O que este PR entrega

Auditoria sistemática de **todas** as tools em `deile/tools/` (incl. `messaging/`) contra o contrato canônico (`base.py`; pilares 03 §1 Async / §3 Registry / §5 Security / §6 Error Handling / §8 Tool Design; padrões de `12-PADROES-CODIGO.md`). O veredito é que o tooling do DEILE já é maduro e aderente — por isso o PR é cirúrgico: entrega só os 3 achados de maior valor e alta confiança, cada um behavior-preserving ou estritamente melhor, com teste de regressão.

### 1. `run_tests` agora é function-callable (bug de alto valor)

`TestRunnerTool` não declarava `ToolSchema` (nem inline nem JSON em `schemas/`). Como os três exportadores de function-calling (`get_anthropic_tools` / `get_openai_functions` / `get_gemini_functions`) filtram `if tool.schema`, a tool era **registrada mas invisível ao LLM** — apesar de `deile/core/validation_gate.py` tratar `run_tests` como tool de validação real (`VALIDATION_TOOL_NAMES`) e `tool_scenario_kwargs.py` referenciá-la. Adicionado `ToolSchema` inline (`test_path`, `test_type` com enum `pytest|unittest|nose`, `verbose`). A property `category` segue retornando `"testing"`, então o agrupamento do registry e o label de UI não mudam.

### 2. `bash_execute` — erro claro para `security_level` inválido

`risk_hierarchy.index(security_level)` levantava `ValueError` cru (`'high' is not in list`) → mensagem opaca. Agora valida contra a lista permitida antes do `index()`, levantando `ToolError` claro (mapeado para `ToolResult.error_result` pelo guard top-level existente). Caminho de sucesso intacto.

### 3. `find_in_files` (`SearchTool`) — erro claro para `query` null

`args.get("query", "")` devolve `None` (não o default) quando a chave existe com valor null → `None.strip()` levantava `AttributeError` → "Search failed: 'NoneType'...". Agora `args.get("query") or ""` + guarda `isinstance` antes do `.strip()` devolve "cannot be empty". Caminho de sucesso intacto.

## Catálogo de auditoria (tool × achado × ação)

| Tool / módulo | Achado | Ação |
|---|---|---|
| `run_tests` | sem schema → invisível ao LLM | **PR: schema inline** |
| `bash_execute` | `ValueError` cru em security_level inválido | **PR: validação + mensagem clara** |
| `find_in_files` | `AttributeError` em query null | **PR: guarda de tipo** |
| `python_execute`, `pip_install` | sem schema inline (dependem de JSON; funcionam em prod) | **Follow-up #651** |
| cron_create/delete/list, pipeline, pipeline_schedule, worktree, vision, dispatch_deile_task, dispatch_parallel_subagents, preference_*, skill_tools, file_tools (read/write/edit/list/delete), messaging.discord_*/whatsapp_* | aderentes ao contrato (schema completo, erros tipados, async correto, segurança — path containment, SSRF, audit SHA8, approval gate) | sem ação (auditoria honesta) |
| `delete_file` | substring-match conservador (`config` casa `myconfig.py`); erra para o lado seguro | sem ação |
| schemas com `required` duplicado (inner + campo) | inócuo (validador/conversores usam só `schema.required`) | sem ação — remover arriscaria mudança sutil sem ganho |

## O que virou follow-up

- **#651** — migrar `python_execute`/`pip_install` de schema JSON externo para `ToolSchema` inline (consistência + robustez em registries customizados). Funcionam em produção hoje; é dívida de consistência, não bug.

## Testes

Novo `deile/tests/tools/test_tooling_hardening.py` (9 testes): schema de `run_tests` exportado pelos 3 providers; erro limpo de `security_level` inválido + sucesso com nível válido; erro limpo de `query` null/vazia + sucesso com query válida.

Suíte completa (determinística, `-p no:randomly`):
```
4 failed, 8234 passed, 31 skipped, 7 warnings in 247.98s
```
As **4 falhas são pré-existentes** na `origin/main` (confirmado por stash + run pristino), todas em `pipeline/` e `infrastructure/`, **zero em `tools/`**:
- `test_pod_presence::test_cleanup_stale_workspaces_removes_dead_pod_workspace`
- `test_classify::test_tick_calls_classify_before_review`
- `test_gap_regressions::test_gh_error_in_review_increments_gh_errors`
- `test_reconcile_fire_and_forget::test_does_not_reap_refine_resting_without_ledger`

Multi-seed na suíte `deile/tests/tools/` (seeds 0/1/2/42): **350 passed, 2 skipped** em todos. `ruff check` e `isort --check-only` limpos nos arquivos tocados.