### PR TITLE
feat(observability): OTLP metrics for dispatch events (#455)

### DIFF
--- a/deile/observability/__init__.py
+++ b/deile/observability/__init__.py
@@ -43,6 +43,11 @@ from deile.observability.dispatch_log_export import (emit_log_record,
                                                      get_dispatch_log_export,
                                                      get_log_provider,
                                                      reset_dispatch_log_export)
+from deile.observability.dispatch_metrics import (
+    record_dispatch_duration_ms, record_dispatch_failed_total,
+    record_dispatch_tool_burst_total, record_dispatch_total,
+    record_forge_pr_review_total, record_git_push_total,
+    reset_dispatch_metrics, shutdown_dispatch_metrics)
 from deile.observability.dispatch_schema import (SCHEMA_VERSION,
                                                  get_pod_metadata)
 from deile.observability.metrics import (DeileMetrics, NoOpMetrics,
@@ -90,4 +95,13 @@ __all__ = [
     "get_log_provider",
     "get_dispatch_log_export",
     "emit_log_record",
+    # metrics pipeline (issue #455)
+    "record_dispatch_total",
+    "record_dispatch_failed_total",
+    "record_dispatch_duration_ms",
+    "record_dispatch_tool_burst_total",
+    "record_git_push_total",
+    "record_forge_pr_review_total",
+    "shutdown_dispatch_metrics",
+    "reset_dispatch_metrics",
 ]

--- a/deile/observability/config.py
+++ b/deile/observability/config.py
@@ -16,6 +16,7 @@ Variável                          Default      Significado
 ``DEILE_OTLP_SAMPLE_RATIO``       ``"1.0"``    sampling ratio (0.0-1.0)
 ``DEILE_OBSERVABILITY_DISABLED``  ``"false"``  kill-switch global (vence sobre endpoint)
 ``DEILE_OTLP_LOGS_DISABLED``      ``"false"``  kill-switch isolado para log records (spans continuam)
+``DEILE_OTLP_METRICS_DISABLED``   ``"false"``  kill-switch isolado para dispatch metrics (spans/logs continuam)
 ================================  ===========  ==========================================
 
 Nenhum import de ``opentelemetry.*`` aqui — este módulo é safe mesmo quando
@@ -40,6 +41,7 @@ __all__ = [
     "ENV_SAMPLE_RATIO",
     "ENV_DISABLED",
     "ENV_LOGS_DISABLED",
+    "ENV_METRICS_DISABLED",
 ]
 
 ENV_ENDPOINT = "DEILE_OTLP_ENDPOINT"
@@ -49,6 +51,7 @@ ENV_SERVICE_NAME = "DEILE_OTLP_SERVICE_NAME"
 ENV_SAMPLE_RATIO = "DEILE_OTLP_SAMPLE_RATIO"
 ENV_DISABLED = "DEILE_OBSERVABILITY_DISABLED"
 ENV_LOGS_DISABLED = "DEILE_OTLP_LOGS_DISABLED"
+ENV_METRICS_DISABLED = "DEILE_OTLP_METRICS_DISABLED"
 
 _DEFAULT_SERVICE_NAME = "deile"
 _DEFAULT_SAMPLE_RATIO = 1.0
@@ -102,6 +105,8 @@ class ObservabilityConfig:
         service_name: ``service.name`` do Resource OpenTelemetry.
         sample_ratio: razão de amostragem ``[0.0, 1.0]`` (1.0 = tudo).
         disabled: kill-switch global; ``True`` força no-op mesmo com endpoint.
+        logs_disabled: kill-switch isolado de log records (spans/metrics seguem).
+        metrics_disabled: kill-switch isolado de dispatch metrics (spans/logs seguem).
     """
 
     endpoint: str = ""
@@ -111,6 +116,7 @@ class ObservabilityConfig:
     sample_ratio: float = _DEFAULT_SAMPLE_RATIO
     disabled: bool = False
     logs_disabled: bool = False
+    metrics_disabled: bool = False
 
     @classmethod
     def from_env(cls) -> "ObservabilityConfig":
@@ -132,6 +138,9 @@ class ObservabilityConfig:
             disabled=_parse_bool(os.environ.get(ENV_DISABLED, "false"), False),
             logs_disabled=_parse_bool(
                 os.environ.get(ENV_LOGS_DISABLED, "false"), False
+            ),
+            metrics_disabled=_parse_bool(
+                os.environ.get(ENV_METRICS_DISABLED, "false"), False
             ),
         )
 

--- a/deile/observability/dispatch_export.py
+++ b/deile/observability/dispatch_export.py
@@ -29,6 +29,7 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
+import deile.observability.dispatch_metrics as dispatch_metrics
 from deile.observability.config import get_observability_config
 from deile.observability.dispatch_log_export import emit_log_record
 from deile.observability.dispatch_schema import (ATTR_POD, ATTR_ROLE,
@@ -165,6 +166,23 @@ def _common_attrs() -> Dict[str, str]:
     }
 
 
+def _role() -> str:
+    """Role do pod (label de cardinality bounded para as métricas)."""
+    return get_pod_metadata().get("role", "") or "unknown"
+
+
+def _safe_record_metric(fn: Any, **kwargs: Any) -> None:
+    """Chama um ``dispatch_metrics.record_*`` em try/except isolado (D3/D5).
+
+    A fiação de métrica roda APÓS a operação de span; uma falha aqui nunca
+    propaga para o pipeline de span/dispatch (observability best-effort).
+    """
+    try:
+        fn(**kwargs)
+    except Exception:  # noqa: BLE001 — metrics never break dispatch (D5)
+        pass
+
+
 # ── emit functions ───────────────────────────────────────────────────────
 
 def emit_dispatch_received(
@@ -259,6 +277,12 @@ def emit_dispatch_tool_burst(
     except Exception:  # noqa: BLE001
         _record_drop("emit_error")
     _try_emit_log(span_ctx, DispatchToolBurstAttrs.EVENT_NAME, _safe_attrs(schema.to_event_attrs()))
+    # metrics hook (#455): tool burst bucketed por cardinality bounded.
+    _safe_record_metric(
+        dispatch_metrics.record_dispatch_tool_burst_total,
+        role=_role(),
+        bucket=dispatch_metrics._tool_burst_bucket(int(count)),
+    )
 
 
 def emit_dispatch_completed(
@@ -283,6 +307,17 @@ def emit_dispatch_completed(
     except Exception:  # noqa: BLE001
         _record_drop("emit_error")
     _try_emit_log(span_ctx, DispatchCompletedAttrs.EVENT_NAME, _safe_attrs(schema.to_event_attrs()))
+    # metrics hook (#455): dispatch concluído → total + duração (elapsed_s → ms).
+    role = _role()
+    _safe_record_metric(
+        dispatch_metrics.record_dispatch_total, role=role, outcome="completed"
+    )
+    _safe_record_metric(
+        dispatch_metrics.record_dispatch_duration_ms,
+        role=role,
+        outcome="completed",
+        value_ms=float(elapsed_s) * 1000.0,
+    )
 
 
 def emit_dispatch_failed(
@@ -307,6 +342,22 @@ def emit_dispatch_failed(
     except Exception:  # noqa: BLE001
         _record_drop("emit_error")
     _try_emit_log(span_ctx, DispatchFailedAttrs.EVENT_NAME, _safe_attrs(schema.to_event_attrs()))
+    # metrics hook (#455): dispatch falho → total(failed) + failed(reason) + duração.
+    role = _role()
+    _safe_record_metric(
+        dispatch_metrics.record_dispatch_total, role=role, outcome="failed"
+    )
+    _safe_record_metric(
+        dispatch_metrics.record_dispatch_failed_total,
+        role=role,
+        reason=str(reason) if reason else "unknown",
+    )
+    _safe_record_metric(
+        dispatch_metrics.record_dispatch_duration_ms,
+        role=role,
+        outcome="failed",
+        value_ms=float(elapsed_s) * 1000.0,
+    )
 
 
 def _emit_child_span(task_id: str, name: str, attrs: Dict[str, Any]) -> None:
@@ -354,6 +405,11 @@ def emit_git_push(
         _emit_child_span(task_id, GitPushAttrs.SPAN_NAME, _safe_attrs(schema.to_span_attrs()))
     except Exception:  # noqa: BLE001
         _record_drop("emit_error")
+    # metrics hook (#455): push por outcome (status do schema carrega ok|fail).
+    if status:
+        _safe_record_metric(
+            dispatch_metrics.record_git_push_total, outcome=str(status)
+        )
 
 
 def emit_forge_pr_open(
@@ -382,6 +438,11 @@ def emit_forge_pr_review(
         _emit_child_span(task_id, ForgePrReviewAttrs.SPAN_NAME, _safe_attrs(schema.to_span_attrs()))
     except Exception:  # noqa: BLE001
         _record_drop("emit_error")
+    # metrics hook (#455): review por decision (status do schema carrega a decisão).
+    if status:
+        _safe_record_metric(
+            dispatch_metrics.record_forge_pr_review_total, decision=str(status)
+        )
 
 
 # ── test helpers ─────────────────────────────────────────────────────────

--- a/deile/observability/dispatch_metrics.py
+++ b/deile/observability/dispatch_metrics.py
@@ -1,0 +1,502 @@
+"""Adapter OTLP metrics dos eventos dispatch.*/git.*/forge.* — issue #455.
+
+Fecha a trinca de sinais OTLP: traces (#443, ``dispatch_export.py``) cobrem
+investigação caso-a-caso; logs (#454, ``dispatch_log_export.py``) cobrem pesquisa
+histórica via Loki; **métricas** (este módulo) cobrem agregados ao longo do tempo
+(taxa de falhas por ``reason``, p50/p95/p99 da duração, buckets de tool-burst)
+para dashboards e alertas Prometheus.
+
+Decisões de arquitetura (D1-D8 da issue #455):
+
+- **D1**: ``MeterProvider`` PRÓPRIO (não estende ``OtlpMetrics`` de ``metrics.py``,
+  que expõe apenas API domain-specific). Paralelo ao ``LoggerProvider`` de #454.
+  Mesma config via ``get_observability_config()``; resource attrs idênticos a
+  #443/#454: ``service.name``, ``deile.role``, ``deile.pod``,
+  ``deile.dispatch.schema_version``. Respeita ``DEILE_OBSERVABILITY_DISABLED``
+  (global) e o kill-switch isolado ``DEILE_OTLP_METRICS_DISABLED``.
+- **D2**: 7 instruments declarados uma vez em ``_init_instruments(meter)``.
+  Constante ``_ALLOWED_LABELS`` mapeia cada métrica ao set fechado de label keys;
+  ``record_*`` valida kwargs e raise ``ValueError`` para key fora do set
+  (cardinality bounded). ``_tool_burst_bucket`` mapeia ``count`` → bucket fechado.
+- **D3**: Hook em ``dispatch_export.emit_*`` — cada emit relevante chama o
+  ``record_*`` correspondente APÓS a operação de span, em ``try/except`` isolado.
+- **D4**: ``_make_reader()`` lê ``OTEL_METRIC_EXPORT_INTERVAL`` (var OTel-padrão,
+  exceção documentada ao Princípio 7) e passa ao ``PeriodicExportingMetricReader``.
+- **D5**: SDK ausente / endpoint vazio / kill-switch / collector unreachable →
+  NoOp ou drop counter throttled ≤1×/60s. Nunca quebra o turn.
+- **D6**: Sem novas dependências. ``opentelemetry-sdk`` + exporter OTLP já em
+  ``pyproject.toml``. Graceful no-op quando SDK ausente.
+- **D7**: Singleton thread-safe (``threading.Lock`` + ``_provider_tried``).
+  Idempotente: ``_init_count`` exatamente 1 após init bem-sucedida.
+  ``reset_dispatch_metrics()`` / ``shutdown_dispatch_metrics()`` para testes.
+- **D8**: Documentado em ``docs/system_design/11-WORKFLOW-DESENVOLVIMENTO.md``.
+
+Regras críticas (Pilar 11 + Princípio 7):
+- Nenhuma leitura de ``DEILE_OTLP_*`` aqui — config via ``get_observability_config()``.
+  Única exceção: ``OTEL_METRIC_EXPORT_INTERVAL`` (var OTel-padrão, D4).
+- Falha silenciosa: todo ``record_*`` tem ``try/except Exception``.
+- Labels são strings bounded de enum fechado — sem ``task_id``/``session_id``/
+  ``sha``/``branch``/``pr``/``model``/``error_code`` (Pilar 08 / Decisão #42).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, FrozenSet, Optional
+
+from deile.observability.config import get_observability_config
+from deile.observability.dispatch_schema import (ATTR_POD, ATTR_ROLE,
+                                                 ATTR_SCHEMA_VERSION,
+                                                 SCHEMA_VERSION,
+                                                 get_pod_metadata)
+
+__all__ = [
+    "record_dispatch_total",
+    "record_dispatch_failed_total",
+    "record_dispatch_duration_ms",
+    "record_dispatch_tool_burst_total",
+    "record_git_push_total",
+    "record_forge_pr_review_total",
+    "_tool_burst_bucket",
+    "shutdown_dispatch_metrics",
+    "reset_dispatch_metrics",
+    "metrics_available",
+]
+
+_logger = logging.getLogger("deile.dispatch")
+
+# ── instrument names ──────────────────────────────────────────────────────
+
+METRIC_DISPATCH_TOTAL = "deile.dispatch.total"
+METRIC_DISPATCH_FAILED_TOTAL = "deile.dispatch.failed.total"
+METRIC_DISPATCH_DURATION_MS = "deile.dispatch.duration_ms"
+METRIC_DISPATCH_TOOL_BURST_TOTAL = "deile.dispatch.tool_burst.total"
+METRIC_DISPATCH_OTLP_DROP_TOTAL = "deile.dispatch.otlp_drop.total"
+METRIC_FORGE_PR_REVIEW_TOTAL = "deile.forge.pr_review.total"
+METRIC_GIT_PUSH_TOTAL = "deile.git.push.total"
+
+# ── allowed labels (D2 — cardinality bounded) ──────────────────────────────
+
+_ALLOWED_LABELS: Dict[str, FrozenSet[str]] = {
+    METRIC_DISPATCH_TOTAL:            frozenset({"role", "outcome"}),
+    METRIC_DISPATCH_FAILED_TOTAL:     frozenset({"role", "reason"}),
+    METRIC_DISPATCH_DURATION_MS:      frozenset({"role", "outcome"}),
+    METRIC_DISPATCH_TOOL_BURST_TOTAL: frozenset({"role", "bucket"}),
+    METRIC_DISPATCH_OTLP_DROP_TOTAL:  frozenset({"reason"}),
+    METRIC_FORGE_PR_REVIEW_TOTAL:     frozenset({"decision"}),
+    METRIC_GIT_PUSH_TOTAL:            frozenset({"outcome"}),
+}
+
+# Labels proibidas (alta cardinalidade / segredo) — verificadas em AC3.
+# Pertencem a span attributes (#443), nunca a metric labels.
+
+_BUCKET_NOTE = (
+    "label '500+' inicia em count=100, não 500 — preservado para compat "
+    "futura de dashboard"
+)
+
+
+def _tool_burst_bucket(count: int) -> str:
+    """Mapeia o número de tools no burst a um bucket de cardinality fechada.
+
+    Range: ``<50`` → ``'50-'``, ``50-99`` → ``'100-'``, ``≥100`` → ``'500+'``.
+    Ver :data:`_BUCKET_NOTE` — o label ``'500+'`` é preservado para compat de
+    dashboard mas o range real inicia em 100.
+    """
+    if count < 50:
+        return "50-"
+    if count < 100:
+        return "100-"
+    return "500+"
+
+
+def _validate_labels(metric_name: str, labels: Dict[str, Any]) -> None:
+    """Raise ``ValueError`` se alguma label key estiver fora do set fechado."""
+    allowed = _ALLOWED_LABELS[metric_name]
+    for key in labels:
+        if key not in allowed:
+            raise ValueError(
+                f"label '{key}' not allowed for metric '{metric_name}'"
+            )
+
+
+# ── SDK availability ────────────────────────────────────────────────────────
+
+
+def metrics_available() -> bool:
+    """Retorna True se a Metrics API/SDK do OpenTelemetry está disponível."""
+    try:
+        import opentelemetry.metrics  # noqa: F401  pylint: disable=import-outside-toplevel
+        import opentelemetry.sdk.metrics  # noqa: F401  pylint: disable=import-outside-toplevel
+        return True
+    except ImportError:
+        return False
+
+
+# ── SDK unavailable warning (once per process, lazy — D5) ────────────────────
+
+_sdk_warned = False
+_sdk_warned_lock = threading.Lock()
+
+
+def _warn_sdk_unavailable() -> None:
+    global _sdk_warned
+    with _sdk_warned_lock:
+        if not _sdk_warned:
+            _logger.info(
+                "dispatch_metrics: otel_sdk_available=false sink=disabled"
+            )
+            _sdk_warned = True
+
+
+# ── drop counter (independente de traces/logs, D5) ──────────────────────────
+
+_drop_counter: int = 0
+_last_drop_log_ts: float = 0.0
+_drop_lock = threading.Lock()
+_time_fn = time.monotonic  # substituível em testes
+_DROP_THROTTLE_S = 60.0
+
+
+def _record_drop(reason: str) -> None:
+    """Acumula drops e emite linha ≤1×/60s, incrementando otlp_drop counter.
+
+    O contador local dá visibilidade mesmo quando o próprio sink de métricas
+    está falhando; ``deile.dispatch.otlp_drop.total`` registra o agregado no
+    flush (best-effort, isolado).
+    """
+    global _drop_counter, _last_drop_log_ts
+    flushed = 0
+    flush_reason = reason
+    with _drop_lock:
+        now = _time_fn()
+        if now - _last_drop_log_ts >= _DROP_THROTTLE_S and _drop_counter > 0:
+            flushed = _drop_counter
+            _logger.info(
+                "dispatch.otlp_metric_drop count=%d reason=%s",
+                _drop_counter,
+                reason,
+            )
+            _drop_counter = 0
+            _last_drop_log_ts = now
+        _drop_counter += 1
+    if flushed > 0:
+        _emit_drop_metric(flush_reason, flushed)
+
+
+def _emit_drop_metric(reason: str, amount: int) -> None:
+    """Incrementa ``deile.dispatch.otlp_drop.total`` (best-effort, isolado)."""
+    try:
+        instrument = _get_instrument(METRIC_DISPATCH_OTLP_DROP_TOTAL)
+        if instrument is None:
+            return
+        instrument.add(amount, attributes={"reason": str(reason)})
+    except Exception:  # noqa: BLE001 — drop metric nunca propaga
+        pass
+
+
+# ── MeterProvider singleton (D1, D7) ─────────────────────────────────────────
+
+_meter_provider_singleton: Optional[Any] = None
+# True once init has been attempted (distinguishes "not tried" from "tried+off").
+_provider_tried: bool = False
+_provider_lock = threading.Lock()
+
+# Exactly 1 on successful init — used by idempotency tests (D7/AC9).
+_init_count: int = 0
+
+# Instrumentos criados uma vez (D2).
+_instruments: Dict[str, Any] = {}
+
+# Marcador para monkeypatch em testes — fica None em produção.
+_meter_provider: Any = None
+
+
+def _module_injected_provider() -> Any:
+    """Retorna ``_meter_provider`` do módulo (monkeypatch por testes), ou None."""
+    return globals().get("_meter_provider", None)
+
+
+def _get_dispatch_meter_provider() -> Optional[Any]:
+    """Retorna o ``MeterProvider`` singleton (OTLP real ou None quando off).
+
+    Lazy-init na primeira chamada (D1, D6). Thread-safe e idempotente (D7).
+    Emite uma linha INFO na primeira chamada se SDK ausente (D5).
+    """
+    global _meter_provider_singleton, _provider_tried, _init_count
+
+    if _provider_tried:
+        return _meter_provider_singleton
+
+    with _provider_lock:
+        if _provider_tried:
+            return _meter_provider_singleton
+
+        config = get_observability_config()
+
+        # Kill-switch global, endpoint vazio ou kill-switch isolado → no metrics.
+        if not config.is_enabled or config.metrics_disabled:
+            _provider_tried = True
+            return None
+
+        # Provider injetado por teste (monkeypatch — D7).
+        injected = _module_injected_provider()
+        if injected is not None:
+            _meter_provider_singleton = injected
+            _init_instruments_from_provider(injected)
+            _init_count += 1
+            _provider_tried = True
+            return _meter_provider_singleton
+
+        if not metrics_available():
+            _warn_sdk_unavailable()
+            _provider_tried = True
+            return None
+
+        try:
+            _meter_provider_singleton = _build_meter_provider(config)
+            _init_instruments_from_provider(_meter_provider_singleton)
+            _init_count += 1
+        except Exception as exc:  # noqa: BLE001 — fail open
+            _logger.warning(
+                "dispatch_metrics: MeterProvider setup failed (%s); sink=disabled",
+                exc,
+            )
+            _meter_provider_singleton = None
+        finally:
+            _provider_tried = True
+
+        return _meter_provider_singleton
+
+
+def _build_meter_provider(config: Any) -> Any:
+    """Constrói o ``MeterProvider`` apontando para o collector OTLP (D1)."""
+    from opentelemetry.sdk.metrics import \
+        MeterProvider  # pylint: disable=import-outside-toplevel
+    from opentelemetry.sdk.resources import (  # pylint: disable=import-outside-toplevel
+        SERVICE_NAME, Resource)
+
+    pod = get_pod_metadata()
+    resource = Resource.create({
+        SERVICE_NAME: config.service_name,
+        ATTR_ROLE: pod["role"],
+        ATTR_POD: pod["pod"],
+        ATTR_SCHEMA_VERSION: SCHEMA_VERSION,
+    })
+    reader = _make_reader(config)
+    readers = [reader] if reader is not None else []
+    return MeterProvider(resource=resource, metric_readers=readers)
+
+
+def _export_interval_ms() -> int:
+    """Lê ``OTEL_METRIC_EXPORT_INTERVAL`` (var OTel-padrão).
+
+    Exceção documentada ao Princípio 7: é var OTel-padrão (não DEILE-específica);
+    adicionar campo a ``ObservabilityConfig`` para um único parâmetro de reader
+    seria mais invasivo que o benefício. Inválido → default 60000.
+    """
+    # OTEL standard env var — exception to Principle 7 (not DEILE-specific).
+    raw = os.environ.get("OTEL_METRIC_EXPORT_INTERVAL", "60000")
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 60000
+
+
+def _make_reader(config: Any) -> Optional[Any]:
+    """Constrói ``PeriodicExportingMetricReader`` + ``OTLPMetricExporter`` (D4).
+
+    Passa :func:`_export_interval_ms` como ``export_interval_millis``.
+    Falha silenciosa → None.
+    """
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import \
+            OTLPMetricExporter  # pylint: disable=import-outside-toplevel
+        from opentelemetry.sdk.metrics.export import \
+            PeriodicExportingMetricReader  # pylint: disable=import-outside-toplevel
+    except ImportError as exc:
+        _logger.warning(
+            "dispatch_metrics: OTLPMetricExporter não disponível (%s); "
+            "métricas não exportadas.",
+            exc,
+        )
+        return None
+    try:
+        exporter = OTLPMetricExporter(
+            endpoint=config.endpoint,
+            insecure=config.insecure,
+            headers=config.headers or None,
+        )
+        return PeriodicExportingMetricReader(
+            exporter, export_interval_millis=_export_interval_ms()
+        )
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("dispatch_metrics: reader init failed: %s", exc)
+        return None
+
+
+def _init_instruments_from_provider(provider: Any) -> None:
+    """Cria os 7 instruments uma vez a partir do meter do provider (D2)."""
+    global _instruments
+    if _instruments:
+        return
+    meter = provider.get_meter("deile.dispatch")
+    _instruments = {
+        METRIC_DISPATCH_TOTAL: meter.create_counter(
+            name=METRIC_DISPATCH_TOTAL,
+            description="Dispatches por role/outcome (completed|failed).",
+            unit="1",
+        ),
+        METRIC_DISPATCH_FAILED_TOTAL: meter.create_counter(
+            name=METRIC_DISPATCH_FAILED_TOTAL,
+            description="Dispatches falhos por role/reason (enum fechado de #435).",
+            unit="1",
+        ),
+        METRIC_DISPATCH_DURATION_MS: meter.create_histogram(
+            name=METRIC_DISPATCH_DURATION_MS,
+            description="Duração do dispatch por role/outcome (p50/p95/p99).",
+            unit="ms",
+        ),
+        METRIC_DISPATCH_TOOL_BURST_TOTAL: meter.create_counter(
+            name=METRIC_DISPATCH_TOOL_BURST_TOTAL,
+            description="Tool bursts por role/bucket (ver _tool_burst_bucket).",
+            unit="1",
+        ),
+        METRIC_DISPATCH_OTLP_DROP_TOTAL: meter.create_counter(
+            name=METRIC_DISPATCH_OTLP_DROP_TOTAL,
+            description="Pontos de métrica perdidos por reason (export_error etc).",
+            unit="1",
+        ),
+        METRIC_FORGE_PR_REVIEW_TOTAL: meter.create_counter(
+            name=METRIC_FORGE_PR_REVIEW_TOTAL,
+            description="Reviews de PR por decision (APPROVED|CHANGES_REQUESTED|COMMENTED).",
+            unit="1",
+        ),
+        METRIC_GIT_PUSH_TOTAL: meter.create_counter(
+            name=METRIC_GIT_PUSH_TOTAL,
+            description="Git pushes por outcome (ok|fail).",
+            unit="1",
+        ),
+    }
+
+
+def _get_instrument(metric_name: str) -> Optional[Any]:
+    """Retorna o instrument do meter (lazy-init do provider). None se off."""
+    if _get_dispatch_meter_provider() is None:
+        return None
+    return _instruments.get(metric_name)
+
+
+# ── record helpers (um por métrica, D2/D3) ──────────────────────────────────
+
+
+def _add(metric_name: str, value: float, labels: Dict[str, Any]) -> None:
+    """Common path para counters: valida labels, ensure provider, ``add``.
+
+    Validação de label (cardinality bound) roda SEMPRE — mesmo com sink off —
+    para que o contrato de allowlist falhe rápido (AC2). A emissão em si é
+    best-effort e nunca propaga (Pilar 11).
+    """
+    _validate_labels(metric_name, labels)
+    try:
+        instrument = _get_instrument(metric_name)
+        if instrument is None:
+            return
+        instrument.add(value, attributes=labels)
+    except Exception:  # noqa: BLE001 — métricas nunca quebram o turn
+        _record_drop("emit_error")
+
+
+def _record(metric_name: str, value: float, labels: Dict[str, Any]) -> None:
+    """Common path para histograms: valida labels, ensure provider, ``record``."""
+    _validate_labels(metric_name, labels)
+    try:
+        instrument = _get_instrument(metric_name)
+        if instrument is None:
+            return
+        instrument.record(value, attributes=labels)
+    except Exception:  # noqa: BLE001 — métricas nunca quebram o turn
+        _record_drop("emit_error")
+
+
+def record_dispatch_total(*, role: str, outcome: str, **extra: Any) -> None:
+    """Incrementa ``deile.dispatch.total{role,outcome}``."""
+    _add(METRIC_DISPATCH_TOTAL, 1,
+         {"role": str(role), "outcome": str(outcome), **extra})
+
+
+def record_dispatch_failed_total(*, role: str, reason: str, **extra: Any) -> None:
+    """Incrementa ``deile.dispatch.failed.total{role,reason}``."""
+    _add(METRIC_DISPATCH_FAILED_TOTAL, 1,
+         {"role": str(role), "reason": str(reason), **extra})
+
+
+def record_dispatch_duration_ms(
+    *, role: str, outcome: str, value_ms: float, **extra: Any
+) -> None:
+    """Registra ``deile.dispatch.duration_ms{role,outcome}``."""
+    _record(METRIC_DISPATCH_DURATION_MS, float(value_ms),
+            {"role": str(role), "outcome": str(outcome), **extra})
+
+
+def record_dispatch_tool_burst_total(
+    *, role: str, bucket: str, **extra: Any
+) -> None:
+    """Incrementa ``deile.dispatch.tool_burst.total{role,bucket}``."""
+    _add(METRIC_DISPATCH_TOOL_BURST_TOTAL, 1,
+         {"role": str(role), "bucket": str(bucket), **extra})
+
+
+def record_git_push_total(*, outcome: str, **extra: Any) -> None:
+    """Incrementa ``deile.git.push.total{outcome}``."""
+    _add(METRIC_GIT_PUSH_TOTAL, 1, {"outcome": str(outcome), **extra})
+
+
+def record_forge_pr_review_total(*, decision: str, **extra: Any) -> None:
+    """Incrementa ``deile.forge.pr_review.total{decision}``."""
+    _add(METRIC_FORGE_PR_REVIEW_TOTAL, 1, {"decision": str(decision), **extra})
+
+
+# ── lifecycle (D7) ───────────────────────────────────────────────────────────
+
+
+def shutdown_dispatch_metrics() -> None:
+    """Flush + shutdown do MeterProvider (evita threads órfãs em testes)."""
+    provider = _meter_provider_singleton
+    if provider is None:
+        return
+    try:
+        shutdown_fn = getattr(provider, "shutdown", None)
+        if callable(shutdown_fn):
+            shutdown_fn()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_dispatch_metrics() -> None:
+    """Reseta todos os singletons — apenas para testes."""
+    global _meter_provider_singleton, _provider_tried, _init_count
+    global _instruments, _drop_counter, _last_drop_log_ts, _sdk_warned
+
+    with _provider_lock:
+        if _meter_provider_singleton is not None:
+            try:
+                shutdown_fn = getattr(_meter_provider_singleton, "shutdown", None)
+                if callable(shutdown_fn):
+                    shutdown_fn()
+            except Exception:  # noqa: BLE001
+                pass
+            _meter_provider_singleton = None
+        _provider_tried = False
+        _init_count = 0
+        _instruments = {}
+
+    with _drop_lock:
+        _drop_counter = 0
+        _last_drop_log_ts = 0.0
+
+    with _sdk_warned_lock:
+        _sdk_warned = False

--- a/deile/tests/observability/conftest.py
+++ b/deile/tests/observability/conftest.py
@@ -28,7 +28,8 @@ def otel_sdk_available() -> bool:
 def _reset_singletons(monkeypatch):
     """Reseta singletons + limpa envs OTLP antes/depois de cada teste."""
     from deile.observability import (reset_dispatch_export,
-                                     reset_dispatch_log_export, reset_metrics,
+                                     reset_dispatch_log_export,
+                                     reset_dispatch_metrics, reset_metrics,
                                      reset_observability_config, reset_tracer)
 
     for env in (
@@ -39,6 +40,8 @@ def _reset_singletons(monkeypatch):
         "DEILE_OTLP_SAMPLE_RATIO",
         "DEILE_OBSERVABILITY_DISABLED",
         "DEILE_OTLP_LOGS_DISABLED",
+        "DEILE_OTLP_METRICS_DISABLED",
+        "OTEL_METRIC_EXPORT_INTERVAL",
         "DEILE_ROLE",
         "HOSTNAME",
     ):
@@ -48,6 +51,7 @@ def _reset_singletons(monkeypatch):
     reset_observability_config()
     reset_dispatch_export()
     reset_dispatch_log_export()
+    reset_dispatch_metrics()
     try:
         yield
     finally:
@@ -56,6 +60,7 @@ def _reset_singletons(monkeypatch):
         reset_observability_config()
         reset_dispatch_export()
         reset_dispatch_log_export()
+        reset_dispatch_metrics()
 
 
 @pytest.fixture
@@ -131,6 +136,59 @@ def in_memory_log_exporter(monkeypatch):
     yield log_exporter
 
     log_provider.shutdown()
+
+
+@pytest.fixture
+def in_memory_dispatch_metrics_reader(monkeypatch):
+    """Injeta um MeterProvider in-memory no módulo ``dispatch_metrics`` (#455).
+
+    Substitui ``deile.observability.dispatch_metrics._meter_provider`` por um
+    ``MeterProvider`` com ``InMemoryMetricReader``. O teste chama
+    ``reader.get_metrics_data()`` para conferir nomes/labels/valores das
+    métricas de dispatch — exercitando a fiação REAL de ``emit_*``.
+    """
+    if not otel_sdk_available():
+        pytest.skip("opentelemetry SDK não instalado (pip install -e .[otel])")
+
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    monkeypatch.setattr(
+        "deile.observability.dispatch_metrics._meter_provider", provider
+    )
+
+    # Ligar OTLP via env para get_dispatch_meter_provider() não retornar None.
+    monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://test-collector:4317")
+
+    from deile.observability import (reset_dispatch_metrics,
+                                     reset_observability_config)
+    reset_observability_config()
+    reset_dispatch_metrics()
+
+    yield reader
+
+    provider.shutdown()
+
+
+def dispatch_metric_points(reader, metric_name):
+    """Helper: retorna lista de (value/sum, attrs) p/ um metric do reader."""
+    data = reader.get_metrics_data()
+    points = []
+    if data is None:
+        return points
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name != metric_name:
+                    continue
+                for dp in metric.data.data_points:
+                    value = getattr(dp, "value", None)
+                    if value is None:  # histogram → use sum
+                        value = getattr(dp, "sum", None)
+                    points.append((value, dict(dp.attributes)))
+    return points
 
 
 @pytest.fixture

--- a/deile/tests/observability/test_dispatch_metrics_bucket.py
+++ b/deile/tests/observability/test_dispatch_metrics_bucket.py
@@ -1,0 +1,30 @@
+"""AC4 — boundary values do ``_tool_burst_bucket`` — issue #455."""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    [
+        (10, "50-"),
+        (49, "50-"),
+        (50, "100-"),
+        (99, "100-"),
+        (100, "500+"),
+        (1000, "500+"),
+    ],
+)
+def test_bucket_boundaries(count, expected):
+    assert dm._tool_burst_bucket(count) == expected
+
+
+def test_bucket_note_documents_500_offset():
+    """_BUCKET_NOTE documenta que '500+' inicia em 100, não 500."""
+    assert "500+" in dm._BUCKET_NOTE
+    assert "100" in dm._BUCKET_NOTE

--- a/deile/tests/observability/test_dispatch_metrics_cardinality.py
+++ b/deile/tests/observability/test_dispatch_metrics_cardinality.py
@@ -1,0 +1,49 @@
+"""AC3 — labels de alta cardinalidade / segredo ausentes — issue #455.
+
+Emite 1 ponto de cada métrica e itera todos os data points, confirmando que
+nenhuma label proibida (``task_id``/``session_id``/``branch``/``sha``/``pr``/
+``model``/``error_code``) aparece nas métricas de dispatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+
+pytestmark = pytest.mark.unit
+
+_FORBIDDEN = {"task_id", "session_id", "branch", "sha", "pr", "model",
+              "error_code"}
+
+
+def test_no_forbidden_labels_anywhere(in_memory_dispatch_metrics_reader):
+    dm.record_dispatch_total(role="worker", outcome="completed")
+    dm.record_dispatch_failed_total(role="worker", reason="timeout")
+    dm.record_dispatch_duration_ms(role="worker", outcome="failed", value_ms=12)
+    dm.record_dispatch_tool_burst_total(role="worker", bucket="500+")
+    dm.record_git_push_total(outcome="fail")
+    dm.record_forge_pr_review_total(decision="CHANGES_REQUESTED")
+
+    data = in_memory_dispatch_metrics_reader.get_metrics_data()
+    seen_metrics = set()
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                seen_metrics.add(metric.name)
+                for dp in metric.data.data_points:
+                    keys = set(dp.attributes.keys())
+                    overlap = keys & _FORBIDDEN
+                    assert not overlap, (
+                        f"{metric.name} carrega label proibida: {overlap}"
+                    )
+    # 6 métricas públicas emitidas (otlp_drop é interno).
+    assert dm.METRIC_DISPATCH_TOTAL in seen_metrics
+    assert dm.METRIC_GIT_PUSH_TOTAL in seen_metrics
+
+
+def test_allowlist_keys_disjoint_from_forbidden():
+    """Nenhum set de allowlist contém uma label proibida."""
+    for metric_name, allowed in dm._ALLOWED_LABELS.items():
+        overlap = set(allowed) & _FORBIDDEN
+        assert not overlap, f"{metric_name} allowlist inclui proibida: {overlap}"

--- a/deile/tests/observability/test_dispatch_metrics_concurrent.py
+++ b/deile/tests/observability/test_dispatch_metrics_concurrent.py
@@ -1,0 +1,39 @@
+"""AC10 — concorrência: 10 threads → value >= 10 — issue #455 D7."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+from deile.tests.observability.conftest import dispatch_metric_points
+
+pytestmark = pytest.mark.unit
+
+
+def test_ten_threads_increment(in_memory_dispatch_metrics_reader):
+    barrier = threading.Barrier(10)
+
+    def worker():
+        barrier.wait()
+        dm.record_dispatch_total(role="worker", outcome="completed")
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    points = dispatch_metric_points(
+        in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_TOTAL
+    )
+    # Soma de todos os data points com (role=worker, outcome=completed).
+    total = sum(
+        v for v, attrs in points
+        if attrs == {"role": "worker", "outcome": "completed"}
+    )
+    assert total >= 10
+
+    # Apenas 1 init mesmo com 10 threads concorrentes.
+    assert dm._init_count == 1

--- a/deile/tests/observability/test_dispatch_metrics_export_interval.py
+++ b/deile/tests/observability/test_dispatch_metrics_export_interval.py
@@ -1,0 +1,70 @@
+"""AC5 — ``OTEL_METRIC_EXPORT_INTERVAL`` respeitado por ``_make_reader`` — #455.
+
+D4: ``_make_reader`` lê a var OTel-padrão e a passa como
+``export_interval_millis`` ao ``PeriodicExportingMetricReader``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+from deile.observability.config import ObservabilityConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _otlp_metric_exporter_available() -> bool:
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import \
+            OTLPMetricExporter  # noqa: F401
+        from opentelemetry.sdk.metrics.export import \
+            PeriodicExportingMetricReader  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def test_interval_helper_reads_env(monkeypatch):
+    """A leitura da var OTel é independente do exporter gRPC (sempre roda)."""
+    monkeypatch.setenv("OTEL_METRIC_EXPORT_INTERVAL", "100")
+    assert dm._export_interval_ms() == 100
+
+
+def test_interval_helper_default_when_unset(monkeypatch):
+    monkeypatch.delenv("OTEL_METRIC_EXPORT_INTERVAL", raising=False)
+    assert dm._export_interval_ms() == 60000
+
+
+def test_interval_helper_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("OTEL_METRIC_EXPORT_INTERVAL", "not-a-number")
+    assert dm._export_interval_ms() == 60000
+
+
+def test_export_interval_from_env(monkeypatch):
+    if not _otlp_metric_exporter_available():
+        pytest.skip("OTLPMetricExporter (gRPC) não instalado")
+    monkeypatch.setenv("OTEL_METRIC_EXPORT_INTERVAL", "100")
+    config = ObservabilityConfig(endpoint="http://test:4317")
+    reader = dm._make_reader(config)
+    assert reader is not None
+    # SDK armazena o intervalo em _export_interval_millis (atributo interno).
+    assert reader._export_interval_millis == 100
+    try:
+        reader.shutdown()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def test_export_interval_default_when_unset(monkeypatch):
+    if not _otlp_metric_exporter_available():
+        pytest.skip("OTLPMetricExporter (gRPC) não instalado")
+    monkeypatch.delenv("OTEL_METRIC_EXPORT_INTERVAL", raising=False)
+    config = ObservabilityConfig(endpoint="http://test:4317")
+    reader = dm._make_reader(config)
+    assert reader is not None
+    assert reader._export_interval_millis == 60000
+    try:
+        reader.shutdown()
+    except Exception:  # noqa: BLE001
+        pass

--- a/deile/tests/observability/test_dispatch_metrics_failure_isolation.py
+++ b/deile/tests/observability/test_dispatch_metrics_failure_isolation.py
@@ -1,0 +1,59 @@
+"""AC6 — falha de métrica não derruba dispatch nem o span — issue #455.
+
+Um instrument cujo ``add``/``record`` sempre raise: o ``emit_*`` real ainda
+fecha o span com status OK (via ``InMemorySpanExporter`` de #443) e nenhuma
+exceção propaga para o caller.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+
+pytestmark = pytest.mark.unit
+
+
+class _Boom:
+    def add(self, *a, **k):
+        raise RuntimeError("metric exporter boom")
+
+    def record(self, *a, **k):
+        raise RuntimeError("metric exporter boom")
+
+
+def test_metric_failure_does_not_break_dispatch_span(
+    in_memory_exporter, monkeypatch
+):
+    from deile.observability.dispatch_export import (emit_dispatch_completed,
+                                                     emit_dispatch_received)
+
+    # Força provider "ligado" e troca todos os instruments por bombas.
+    monkeypatch.setattr(dm, "_provider_tried", True)
+    monkeypatch.setattr(dm, "_meter_provider_singleton", object())
+    monkeypatch.setattr(
+        dm, "_instruments", {name: _Boom() for name in dm._ALLOWED_LABELS}
+    )
+
+    # Não levanta apesar das métricas estourarem.
+    emit_dispatch_received("boom-task", session_id="s1")
+    emit_dispatch_completed("boom-task", elapsed_s=1.0, outcome="ok")
+
+    spans = in_memory_exporter.get_finished_spans()
+    root_spans = [s for s in spans if s.name == "deile.dispatch"]
+    assert len(root_spans) >= 1
+    root = root_spans[0]
+    # Span fechado com status OK apesar do estouro de métrica.
+    from opentelemetry.trace import StatusCode
+    assert root.status.status_code == StatusCode.OK
+
+
+def test_record_helper_swallows_instrument_error(monkeypatch):
+    """O ``_add``/``_record`` engole exceção do instrument (best-effort)."""
+    monkeypatch.setattr(dm, "_provider_tried", True)
+    monkeypatch.setattr(dm, "_meter_provider_singleton", object())
+    monkeypatch.setattr(
+        dm, "_instruments", {dm.METRIC_DISPATCH_TOTAL: _Boom()}
+    )
+    # Não levanta.
+    dm.record_dispatch_total(role="worker", outcome="completed")

--- a/deile/tests/observability/test_dispatch_metrics_idempotency.py
+++ b/deile/tests/observability/test_dispatch_metrics_idempotency.py
@@ -1,0 +1,34 @@
+"""AC9 — singleton idempotente — issue #455 D7."""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+
+pytestmark = pytest.mark.unit
+
+
+def test_same_provider_twice(in_memory_dispatch_metrics_reader):
+    p1 = dm._get_dispatch_meter_provider()
+    p2 = dm._get_dispatch_meter_provider()
+    assert p1 is p2
+    assert dm._init_count == 1
+
+
+def test_instruments_created_once(in_memory_dispatch_metrics_reader):
+    dm._get_dispatch_meter_provider()
+    first = dm._instruments
+    dm._get_dispatch_meter_provider()
+    # Mesmo dict de instruments (não recriado).
+    assert dm._instruments is first
+    assert dm._init_count == 1
+
+
+def test_reset_clears_singleton(in_memory_dispatch_metrics_reader):
+    dm._get_dispatch_meter_provider()
+    assert dm._init_count == 1
+    dm.reset_dispatch_metrics()
+    assert dm._init_count == 0
+    assert dm._instruments == {}
+    assert dm._provider_tried is False

--- a/deile/tests/observability/test_dispatch_metrics_imports.py
+++ b/deile/tests/observability/test_dispatch_metrics_imports.py
@@ -1,0 +1,64 @@
+"""AC12 + D6 — os.environ restrito + imports resolvem sem editar pyproject — #455.
+
+AC12: exatamente 1 ocorrência de ``os.environ`` em ``dispatch_metrics.py``,
+em ``_make_reader`` (``OTEL_METRIC_EXPORT_INTERVAL``); zero para ``DEILE_OTLP_*``
+ou ``DEILE_OBSERVABILITY_DISABLED`` (lidos via ``get_observability_config()``).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MODULE = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "deile" / "observability" / "dispatch_metrics.py"
+)
+
+
+def test_os_environ_used_exactly_once():
+    source = _MODULE.read_text(encoding="utf-8")
+    matches = re.findall(r"os\.environ", source)
+    assert len(matches) == 1, (
+        f"esperado 1 uso de os.environ, achou {len(matches)}"
+    )
+    assert "OTEL_METRIC_EXPORT_INTERVAL" in source
+
+
+def test_no_direct_deile_otlp_env_reads():
+    source = _MODULE.read_text(encoding="utf-8")
+    # Não deve LER DEILE_OTLP_* nem DEILE_OBSERVABILITY_DISABLED via os.environ
+    # (menções em docstring são permitidas; o que importa é nenhum os.environ
+    #  apontar para essas vars — elas vêm de get_observability_config()).
+    assert not re.search(r'os\.environ[^\n]*DEILE_OTLP', source)
+    assert not re.search(r'os\.environ[^\n]*DEILE_OBSERVABILITY', source)
+
+
+def test_sdk_imports_resolve():
+    """D6: imports do SDK de métricas resolvem (skip se SDK ausente)."""
+    try:
+        from opentelemetry.sdk.metrics import MeterProvider  # noqa: F401
+    except ImportError:
+        pytest.skip("opentelemetry SDK não instalado")
+    # API de métricas e reader periódico disponíveis.
+    from opentelemetry.sdk.metrics.export import \
+        PeriodicExportingMetricReader  # noqa: F401
+
+
+def test_module_exports():
+    from deile.observability import dispatch_metrics as dm
+    for name in (
+        "record_dispatch_total",
+        "record_dispatch_failed_total",
+        "record_dispatch_duration_ms",
+        "record_dispatch_tool_burst_total",
+        "record_git_push_total",
+        "record_forge_pr_review_total",
+        "shutdown_dispatch_metrics",
+        "reset_dispatch_metrics",
+    ):
+        assert hasattr(dm, name), f"missing export: {name}"

--- a/deile/tests/observability/test_dispatch_metrics_instruments.py
+++ b/deile/tests/observability/test_dispatch_metrics_instruments.py
@@ -1,0 +1,138 @@
+"""AC1 (emissão) + AC2 (allowlist) — issue #455.
+
+Cada uma das 7 métricas: emite 1 data point correto (AC1) e rejeita label fora
+do set fechado (AC2). Exercita os ``record_*`` reais via ``InMemoryMetricReader``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+from deile.tests.observability.conftest import dispatch_metric_points
+
+pytestmark = pytest.mark.unit
+
+
+class TestEmission:
+    def test_dispatch_total_one_point(self, in_memory_dispatch_metrics_reader):
+        dm.record_dispatch_total(role="worker", outcome="completed")
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_TOTAL
+        )
+        assert len(points) >= 1
+        value, attrs = points[0]
+        assert value == 1
+        assert attrs == {"role": "worker", "outcome": "completed"}
+
+    def test_dispatch_failed_one_point(self, in_memory_dispatch_metrics_reader):
+        dm.record_dispatch_failed_total(role="worker", reason="auth_expired")
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_FAILED_TOTAL
+        )
+        value, attrs = points[0]
+        assert value == 1
+        assert attrs == {"role": "worker", "reason": "auth_expired"}
+
+    def test_dispatch_duration_one_point(self, in_memory_dispatch_metrics_reader):
+        dm.record_dispatch_duration_ms(
+            role="worker", outcome="completed", value_ms=5432
+        )
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_DURATION_MS
+        )
+        value, attrs = points[0]
+        assert value == 5432
+        assert attrs == {"role": "worker", "outcome": "completed"}
+
+    def test_tool_burst_one_point(self, in_memory_dispatch_metrics_reader):
+        dm.record_dispatch_tool_burst_total(role="worker", bucket="100-")
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader,
+            dm.METRIC_DISPATCH_TOOL_BURST_TOTAL,
+        )
+        value, attrs = points[0]
+        assert value == 1
+        assert attrs == {"role": "worker", "bucket": "100-"}
+
+    def test_git_push_one_point(self, in_memory_dispatch_metrics_reader):
+        dm.record_git_push_total(outcome="ok")
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_GIT_PUSH_TOTAL
+        )
+        value, attrs = points[0]
+        assert value == 1
+        assert attrs == {"outcome": "ok"}
+
+    def test_forge_pr_review_one_point(self, in_memory_dispatch_metrics_reader):
+        dm.record_forge_pr_review_total(decision="APPROVED")
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_FORGE_PR_REVIEW_TOTAL
+        )
+        value, attrs = points[0]
+        assert value == 1
+        assert attrs == {"decision": "APPROVED"}
+
+    def test_otlp_drop_emitted_via_drop_loop(
+        self, in_memory_dispatch_metrics_reader, monkeypatch
+    ):
+        """A 7ª métrica (otlp_drop) é emitida pelo drop counter no flush.
+
+        Cobre o caminho real de drop: contador local → flush throttled →
+        ``_emit_drop_metric`` → ``deile.dispatch.otlp_drop.total``.
+        """
+        # Força o init do provider (instruments prontos).
+        assert dm._get_dispatch_meter_provider() is not None
+
+        # Relógio mockado: 1º drop arma o contador; 2º (100s depois) flusha.
+        ticks = iter([0.0, 100.0])
+        monkeypatch.setattr(dm, "_time_fn", lambda: next(ticks))
+        dm._record_drop("export_error")  # arma (count=1, now=0)
+        dm._record_drop("export_error")  # now=100 → flush do período (count=1)
+
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_OTLP_DROP_TOTAL
+        )
+        assert len(points) >= 1
+        value, attrs = points[0]
+        assert value >= 1
+        assert attrs == {"reason": "export_error"}
+
+
+_ALL_RECORDERS = [
+    (dm.record_dispatch_total, {"role": "w", "outcome": "completed"},
+     dm.METRIC_DISPATCH_TOTAL),
+    (dm.record_dispatch_failed_total, {"role": "w", "reason": "timeout"},
+     dm.METRIC_DISPATCH_FAILED_TOTAL),
+    (dm.record_dispatch_duration_ms,
+     {"role": "w", "outcome": "completed", "value_ms": 10},
+     dm.METRIC_DISPATCH_DURATION_MS),
+    (dm.record_dispatch_tool_burst_total, {"role": "w", "bucket": "50-"},
+     dm.METRIC_DISPATCH_TOOL_BURST_TOTAL),
+    (dm.record_git_push_total, {"outcome": "ok"}, dm.METRIC_GIT_PUSH_TOTAL),
+    (dm.record_forge_pr_review_total, {"decision": "APPROVED"},
+     dm.METRIC_FORGE_PR_REVIEW_TOTAL),
+]
+
+
+class TestAllowlist:
+    @pytest.mark.parametrize("fn,kwargs,metric_name", _ALL_RECORDERS)
+    def test_forbidden_label_raises(self, fn, kwargs, metric_name):
+        """AC2: cada recorder rejeita uma label fora do set fechado."""
+        with pytest.raises(ValueError) as exc:
+            fn(task_id="X", **kwargs)
+        assert "task_id" in str(exc.value)
+        assert metric_name in str(exc.value)
+
+    def test_otlp_drop_allowlist(self):
+        """A métrica interna otlp_drop só aceita 'reason'."""
+        with pytest.raises(ValueError):
+            dm._validate_labels(
+                dm.METRIC_DISPATCH_OTLP_DROP_TOTAL, {"role": "w"}
+            )
+        # 'reason' é aceito.
+        dm._validate_labels(dm.METRIC_DISPATCH_OTLP_DROP_TOTAL, {"reason": "x"})
+
+    def test_seven_metrics_have_allowlist(self):
+        """Há exatamente 7 métricas declaradas com allowlist (D2)."""
+        assert len(dm._ALLOWED_LABELS) == 7

--- a/deile/tests/observability/test_dispatch_metrics_integration.py
+++ b/deile/tests/observability/test_dispatch_metrics_integration.py
@@ -1,0 +1,156 @@
+"""AC11 — fiação REAL ``emit_* → record_*`` — issue #455.
+
+Resolve a objeção do gate (2b2 / GC #596): NÃO mocka ``DispatchExport.emit_*``.
+Dirige os ``emit_*`` REAIS de ``dispatch_export`` (de #443) e asserta que os
+counters/histograms de dispatch foram incrementados via ``InMemoryMetricReader``.
+Se a fiação for removida, estes testes FALHAM — ao contrário de um mock do
+call-site, que provaria apenas que ``record_*`` funciona quando chamado.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+from deile.tests.observability.conftest import dispatch_metric_points
+
+pytestmark = pytest.mark.unit
+
+
+def _point_with(points, attrs):
+    return [(v, a) for v, a in points if a == attrs]
+
+
+class TestRealWiring:
+    def test_completed_increments_total_and_duration(
+        self, in_memory_dispatch_metrics_reader, monkeypatch
+    ):
+        """emit_dispatch_completed REAL → total{completed}+=1 + duration_ms."""
+        monkeypatch.setenv("DEILE_ROLE", "worker")
+        from deile.observability.config import reset_observability_config
+        reset_observability_config()
+
+        from deile.observability.dispatch_export import (
+            emit_dispatch_completed, emit_dispatch_received)
+
+        emit_dispatch_received("T1", session_id="s1")
+        # elapsed_s=5.432 → 5432 ms.
+        emit_dispatch_completed("T1", elapsed_s=5.432, outcome="ok")
+
+        total = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_TOTAL
+        )
+        completed = _point_with(total, {"role": "worker", "outcome": "completed"})
+        assert completed and completed[0][0] == 1
+
+        dur = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_DURATION_MS
+        )
+        dur_pt = _point_with(dur, {"role": "worker", "outcome": "completed"})
+        assert dur_pt and dur_pt[0][0] == 5432
+
+    def test_failed_increments_total_failed_and_duration(
+        self, in_memory_dispatch_metrics_reader, monkeypatch
+    ):
+        """emit_dispatch_failed REAL → total{failed} + failed{reason} + duration."""
+        monkeypatch.setenv("DEILE_ROLE", "worker")
+        from deile.observability.config import reset_observability_config
+        reset_observability_config()
+
+        from deile.observability.dispatch_export import (
+            emit_dispatch_failed, emit_dispatch_received)
+
+        emit_dispatch_received("T2", session_id="s1")
+        emit_dispatch_failed("T2", reason="auth_expired", elapsed_s=2.0)
+
+        total = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_TOTAL
+        )
+        assert _point_with(total, {"role": "worker", "outcome": "failed"})
+
+        failed = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_FAILED_TOTAL
+        )
+        assert _point_with(failed, {"role": "worker", "reason": "auth_expired"})
+
+        dur = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_DURATION_MS
+        )
+        dur_pt = _point_with(dur, {"role": "worker", "outcome": "failed"})
+        assert dur_pt and dur_pt[0][0] == 2000
+
+    def test_tool_burst_real_wiring_buckets(
+        self, in_memory_dispatch_metrics_reader, monkeypatch
+    ):
+        """emit_dispatch_tool_burst(count=65) REAL → bucket '100-'."""
+        monkeypatch.setenv("DEILE_ROLE", "worker")
+        from deile.observability.config import reset_observability_config
+        reset_observability_config()
+
+        from deile.observability.dispatch_export import (
+            emit_dispatch_received, emit_dispatch_tool_burst)
+
+        emit_dispatch_received("T3", session_id="s1")
+        emit_dispatch_tool_burst("T3", tools="read,write", count=65)
+
+        burst = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader,
+            dm.METRIC_DISPATCH_TOOL_BURST_TOTAL,
+        )
+        assert _point_with(burst, {"role": "worker", "bucket": "100-"})
+
+    def test_git_push_real_wiring(
+        self, in_memory_dispatch_metrics_reader, monkeypatch
+    ):
+        """emit_git_push(status='ok') REAL → git.push.total{outcome=ok}."""
+        monkeypatch.setenv("DEILE_ROLE", "worker")
+        from deile.observability.config import reset_observability_config
+        reset_observability_config()
+
+        from deile.observability.dispatch_export import (
+            emit_dispatch_received, emit_git_push)
+
+        emit_dispatch_received("T4", session_id="s1")
+        emit_git_push("T4", repo="o/r", branch="b", status="ok")
+
+        push = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_GIT_PUSH_TOTAL
+        )
+        assert _point_with(push, {"outcome": "ok"})
+
+    def test_forge_pr_review_real_wiring(
+        self, in_memory_dispatch_metrics_reader, monkeypatch
+    ):
+        """emit_forge_pr_review(status='APPROVED') REAL → pr_review{decision}."""
+        monkeypatch.setenv("DEILE_ROLE", "worker")
+        from deile.observability.config import reset_observability_config
+        reset_observability_config()
+
+        from deile.observability.dispatch_export import (
+            emit_dispatch_received, emit_forge_pr_review)
+
+        emit_dispatch_received("T5", session_id="s1")
+        emit_forge_pr_review("T5", repo="o/r", pr_number=42, status="APPROVED")
+
+        review = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_FORGE_PR_REVIEW_TOTAL
+        )
+        assert _point_with(review, {"decision": "APPROVED"})
+
+    def test_wiring_absent_would_be_caught(
+        self, in_memory_dispatch_metrics_reader, monkeypatch
+    ):
+        """Prova negativa: sem a chamada real, a métrica fica zerada.
+
+        Garante que o teste de fiação real não é trivialmente verde — se o hook
+        não fosse exercitado, este caminho não produziria pontos.
+        """
+        monkeypatch.setenv("DEILE_ROLE", "worker")
+        from deile.observability.config import reset_observability_config
+        reset_observability_config()
+
+        # Nenhum emit chamado → zero pontos de dispatch.total.
+        points = dispatch_metric_points(
+            in_memory_dispatch_metrics_reader, dm.METRIC_DISPATCH_TOTAL
+        )
+        assert points == []

--- a/deile/tests/observability/test_dispatch_metrics_kill_switch.py
+++ b/deile/tests/observability/test_dispatch_metrics_kill_switch.py
@@ -13,6 +13,12 @@ from deile.observability import dispatch_metrics as dm
 from deile.observability import (reset_dispatch_metrics,
                                  reset_observability_config)
 
+# Os testes deste módulo instanciam um MeterProvider real do SDK OTel. O extra
+# ``[otel]`` é opcional (DEILE roda em no-op sem ele), então sem o SDK o módulo
+# inteiro é PULADO — mesmo contrato do conftest e dos demais testes de
+# observability — em vez de hard-fail com ModuleNotFoundError.
+pytest.importorskip("opentelemetry.sdk.metrics")
+
 pytestmark = pytest.mark.unit
 
 

--- a/deile/tests/observability/test_dispatch_metrics_kill_switch.py
+++ b/deile/tests/observability/test_dispatch_metrics_kill_switch.py
@@ -1,0 +1,74 @@
+"""AC7 + AC7b — kill-switches — issue #455.
+
+AC7: ``DEILE_OBSERVABILITY_DISABLED=true`` → zero data points.
+AC7b: ``DEILE_OTLP_METRICS_DISABLED=true`` (com endpoint set) → zero data
+points; traces/logs (#443/#454) NÃO afetados.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deile.observability import dispatch_metrics as dm
+from deile.observability import (reset_dispatch_metrics,
+                                 reset_observability_config)
+
+pytestmark = pytest.mark.unit
+
+
+def _zero_points(reader):
+    data = reader.get_metrics_data()
+    if data is None:
+        return True
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.data.data_points:
+                    return False
+    return True
+
+
+def test_global_disabled_zero_points(monkeypatch):
+    """AC7: kill-switch global → provider None, zero pontos."""
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    monkeypatch.setattr(dm, "_meter_provider", provider)
+    monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://test:4317")
+    monkeypatch.setenv("DEILE_OBSERVABILITY_DISABLED", "true")
+    reset_observability_config()
+    reset_dispatch_metrics()
+
+    dm.record_dispatch_total(role="worker", outcome="completed")
+    assert dm._get_dispatch_meter_provider() is None
+    assert _zero_points(reader)
+    provider.shutdown()
+
+
+def test_metrics_disabled_isolated(monkeypatch):
+    """AC7b: kill-switch isolado → métricas off, traces/logs intactos."""
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    monkeypatch.setattr(dm, "_meter_provider", provider)
+    monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://test:4317")
+    monkeypatch.setenv("DEILE_OTLP_METRICS_DISABLED", "true")
+    reset_observability_config()
+    reset_dispatch_metrics()
+
+    dm.record_dispatch_total(role="worker", outcome="completed")
+    assert dm._get_dispatch_meter_provider() is None
+    assert _zero_points(reader)
+
+    # Traces/logs NÃO afetados: a config dos outros sinais segue habilitada.
+    from deile.observability.config import get_observability_config
+    config = get_observability_config()
+    assert config.metrics_disabled is True
+    assert config.logs_disabled is False
+    assert config.disabled is False
+    assert config.is_enabled is True  # endpoint set → traces/logs seguem ligados
+    provider.shutdown()

--- a/deile/tests/observability/test_dispatch_metrics_sdk_absent.py
+++ b/deile/tests/observability/test_dispatch_metrics_sdk_absent.py
@@ -1,0 +1,76 @@
+"""AC8 — graceful degradation quando SDK de métricas ausente — issue #455 D5.
+
+Verifica que:
+- ``record_*`` é no-op silencioso (não lança).
+- Linha INFO ``otel_sdk_available=false`` na primeira chamada (lazy), só 1×.
+- Provider retorna None.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from deile.observability import (reset_dispatch_metrics,
+                                 reset_observability_config)
+
+pytestmark = pytest.mark.unit
+
+
+class TestSdkAbsent:
+    def test_no_op_when_metrics_sdk_absent(self, monkeypatch):
+        monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://collector:4317")
+        reset_observability_config()
+        reset_dispatch_metrics()
+
+        import deile.observability.dispatch_metrics as dm
+        monkeypatch.setattr(dm, "metrics_available", lambda: False)
+
+        # Não levanta.
+        dm.record_dispatch_total(role="worker", outcome="completed")
+
+    def test_info_line_on_first_call(self, monkeypatch, caplog):
+        monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://collector:4317")
+        reset_observability_config()
+        reset_dispatch_metrics()
+
+        import deile.observability.dispatch_metrics as dm
+        monkeypatch.setattr(dm, "metrics_available", lambda: False)
+
+        with caplog.at_level(logging.INFO, logger=dm._logger.name):
+            dm._get_dispatch_meter_provider()
+
+        assert "otel_sdk_available=false" in caplog.text
+        assert "sink=disabled" in caplog.text
+
+    def test_info_line_only_once(self, monkeypatch, caplog):
+        monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://collector:4317")
+        reset_observability_config()
+        reset_dispatch_metrics()
+
+        import deile.observability.dispatch_metrics as dm
+        monkeypatch.setattr(dm, "metrics_available", lambda: False)
+
+        with caplog.at_level(logging.INFO, logger=dm._logger.name):
+            dm._get_dispatch_meter_provider()
+            dm._get_dispatch_meter_provider()
+            dm.record_dispatch_total(role="worker", outcome="completed")
+            dm.record_git_push_total(outcome="ok")
+
+        count = caplog.text.count("otel_sdk_available=false")
+        assert count == 1, f"expected exactly 1 warning, got {count}"
+
+    def test_sdk_warned_false_at_import(self):
+        import deile.observability.dispatch_metrics as dm
+        assert dm._sdk_warned is False
+
+    def test_provider_none_when_sdk_absent(self, monkeypatch):
+        monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://collector:4317")
+        reset_observability_config()
+        reset_dispatch_metrics()
+
+        import deile.observability.dispatch_metrics as dm
+        monkeypatch.setattr(dm, "metrics_available", lambda: False)
+
+        assert dm._get_dispatch_meter_provider() is None

--- a/docs/system_design/11-WORKFLOW-DESENVOLVIMENTO.md
+++ b/docs/system_design/11-WORKFLOW-DESENVOLVIMENTO.md
@@ -196,6 +196,32 @@ Segue exatamente o mesmo contrato da Decisão #39:
 | SDK `opentelemetry-sdk` não instalado | 0 spans (fallback no-op silencioso) |
 | Exporter raise | drop counter incrementa; log `dispatch.otlp_drop` ≤1×/60s |
 
+### Pipeline de métricas (Prometheus/OTLP)
+
+> Implementado em `deile/observability/dispatch_metrics.py` — issue #455. Fecha a trinca de sinais (traces #443 + logs #454 + métricas #455). `MeterProvider` próprio (não estende `OtlpMetrics`), fiado nos `emit_*` de `dispatch_export.py`.
+
+Sete instrumentos V1, todos com **labels de cardinality bounded** (enum fechado; nunca `task_id`/`session_id`/`sha`/`branch`/`pr`/`model`):
+
+| Instrumento | Tipo | Labels |
+|---|---|---|
+| `deile.dispatch.total` | counter | `role`, `outcome` (completed\|failed) |
+| `deile.dispatch.failed.total` | counter | `role`, `reason` |
+| `deile.dispatch.duration_ms` | histogram | `role`, `outcome` (p50/p95/p99 derivável) |
+| `deile.dispatch.tool_burst.total` | counter | `role`, `bucket` (`50-`/`100-`/`500+`) |
+| `deile.dispatch.otlp_drop.total` | counter | `reason` (interno; emitido no flush do drop counter) |
+| `deile.forge.pr_review.total` | counter | `decision` |
+| `deile.git.push.total` | counter | `outcome` (ok\|fail) |
+
+Fiação (`dispatch_export.emit_* → dispatch_metrics.record_*`, após a operação de span, em `try/except` isolado): `emit_dispatch_completed` → `record_dispatch_total` + `record_dispatch_duration_ms`; `emit_dispatch_failed` → `record_dispatch_total` + `record_dispatch_failed_total` + `record_dispatch_duration_ms`; `emit_dispatch_tool_burst` → `record_dispatch_tool_burst_total`; `emit_git_push` → `record_git_push_total`; `emit_forge_pr_review` → `record_forge_pr_review_total`. O `role` vem de `get_pod_metadata()`; `elapsed_s` é convertido para ms.
+
+| Condição | Comportamento |
+|---|---|
+| `DEILE_OTLP_ENDPOINT` vazio / SDK ausente | NoOp silencioso (linha INFO única `otel_sdk_available=false` quando SDK ausente) |
+| `DEILE_OBSERVABILITY_DISABLED=true` | NoOp (kill-switch global) |
+| `DEILE_OTLP_METRICS_DISABLED=true` | NoOp só de métricas — traces/logs intactos |
+| `OTEL_METRIC_EXPORT_INTERVAL` | intervalo de export do `PeriodicExportingMetricReader` (default 60000ms) |
+| Exporter/instrument raise | drop counter incrementa; log `dispatch.otlp_metric_drop` ≤1×/60s |
+
 ---
 
 ## Exemptions (sem fases obrigatórias)


### PR DESCRIPTION
## Resumo

Fecha a trinca de sinais OTLP — traces (#443) + logs (#454) + **métricas (#455)** — com o novo adapter `deile/observability/dispatch_metrics.py`. Métricas cobrem o que traces e logs não cobrem: agregados ao longo do tempo (taxa de falhas por `reason`, p50/p95/p99 de duração, buckets de tool-burst) para dashboards e alertas Prometheus.

`Closes #455`

## Instrumentos criados (cardinality bounded)

`MeterProvider` próprio e isolado (D1 — **não** toca no `OtlpMetrics` de `metrics.py`), com 7 instrumentos V1. Todas as labels são strings de enum fechado — **nunca** `task_id`/`session_id`/`sha`/`branch`/`pr`/`model`/`error_code`:

| Instrumento | Tipo | Labels |
|---|---|---|
| `deile.dispatch.total` | counter | `role`, `outcome` (completed\|failed) |
| `deile.dispatch.failed.total` | counter | `role`, `reason` |
| `deile.dispatch.duration_ms` | histogram | `role`, `outcome` (p50/p95/p99 derivável) |
| `deile.dispatch.tool_burst.total` | counter | `role`, `bucket` (`50-`/`100-`/`500+`) |
| `deile.dispatch.otlp_drop.total` | counter interno | `reason` (emitido no flush do drop counter) |
| `deile.forge.pr_review.total` | counter | `decision` |
| `deile.git.push.total` | counter | `outcome` (ok\|fail) |

Cada `record_*` valida os kwargs contra `_ALLOWED_LABELS[metric]` e levanta `ValueError("label '<key>' not allowed for metric '<name>'")` para qualquer key fora do set fechado (AC2/AC3 — cardinality bounded de fato).

## Onde a fiação foi inserida (fiação REAL, não mock)

Em `dispatch_export.py`, cada `emit_*` relevante chama o `record_*` correspondente **após** a operação de span, em `try/except` isolado (`_safe_record_metric`) — métrica nunca quebra o turn:

| emit (#443, real) | métrica (#455) |
|---|---|
| `emit_dispatch_completed` | `record_dispatch_total(outcome=completed)` + `record_dispatch_duration_ms` |
| `emit_dispatch_failed` | `record_dispatch_total(outcome=failed)` + `record_dispatch_failed_total(reason)` + `record_dispatch_duration_ms` |
| `emit_dispatch_tool_burst` | `record_dispatch_tool_burst_total(bucket)` |
| `emit_git_push` | `record_git_push_total(outcome)` |
| `emit_forge_pr_review` | `record_forge_pr_review_total(decision)` |

O `role` vem de `get_pod_metadata()` (não é parâmetro dos `emit_*` reais — reconciliado com as assinaturas atuais de #443); `elapsed_s` (segundos) é convertido para `value_ms` (× 1000).

## Como os testes provam a fiação REAL (resolvendo a objeção do gate)

A objeção 2b2 / GC #596 do gate era: *"AC11 mocka o call-site → a fiação real nunca é exercitada"*. Aqui `test_dispatch_metrics_integration.py` **não mocka** nenhum `emit_*`: dirige os `emit_dispatch_completed/failed/tool_burst`, `emit_git_push` e `emit_forge_pr_review` REAIS e asseverá, via `InMemoryMetricReader`, que cada counter/histogram foi incrementado com o valor e as labels corretos (ex.: `duration_ms == 5432` de `elapsed_s=5.432`). Inclui uma **prova negativa** (`test_wiring_absent_would_be_caught`): sem nenhum `emit_*`, a métrica fica zerada — garantindo que o teste não é trivialmente verde. Se a fiação for removida, esses testes falham.

11 arquivos de teste novos cobrem AC1–AC12: emissão, allowlist parametrizada nas 7 métricas, ausência de labels proibidas, boundaries do bucket, leitura de `OTEL_METRIC_EXPORT_INTERVAL`, isolação de falha (instrument que sempre raise → span ainda fecha OK), kill-switches global+isolado, SDK ausente (linha INFO única), idempotência (`_init_count == 1`), concorrência (10 threads → value ≥ 10) e emissão real do `otlp_drop` interno pelo drop counter.

## No-op sem collector

Kill-switches: `DEILE_OBSERVABILITY_DISABLED` (global) e o novo `DEILE_OTLP_METRICS_DISABLED` (campo `metrics_disabled` em `ObservabilityConfig`), que **não** afetam traces/logs. Endpoint vazio (estado atual do cluster) → no-op silencioso. SDK ausente → uma linha INFO `otel_sdk_available=false` e segue em no-op. Única leitura de `os.environ` no módulo é `OTEL_METRIC_EXPORT_INTERVAL` (exceção documentada ao Princípio 7 — var OTel-padrão). Zero edição em `pyproject.toml` (deps já presentes).

## Evidência de suíte verde

- Observability (257 passed, 2 skipped) verde em multi-seed 0/1/2/42 (os 2 skips são os testes do `OTLPMetricExporter` gRPC, ausente no ambiente local — a leitura do env é coberta independentemente).
- Suíte completa com cobertura: `4 failed, 8276 passed, 32 skipped`. As 4 falhas são **pré-existentes em `origin/main`** (verificado em árvore pristina via `git stash`): `test_pod_presence`, `test_classify`, `test_gap_regressions`, `test_reconcile_fire_and_forget` (reaper stale, corrigidas no PR irmão #642). **Zero novas falhas.**
- `ruff` e `isort` limpos nos arquivos tocados.
