### PR TITLE
refactor(commands): harden slash command subsystem (parity with tools audit)

### DIFF
--- a/deile/commands/builtin/_git_helpers.py
+++ b/deile/commands/builtin/_git_helpers.py
@@ -92,19 +92,25 @@ def ensure_git_repo(cwd: str | Path | None = None) -> Path:
         raise CommandError("O diretório atual não é um repositório git.") from exc
 
 
-def ensure_gh_authenticated() -> None:
+def ensure_gh_authenticated(*, timeout: int = _DEFAULT_TIMEOUT_SECONDS) -> None:
     """Garante que a ``gh`` CLI está instalada e autenticada.
 
     Levanta :class:`CommandError` com mensagem PT-BR quando ``gh`` não
-    está instalada ou ``gh auth status`` retorna código de saída
-    diferente de zero.
+    está instalada, ``gh auth status`` excede ``timeout`` ou retorna código
+    de saída diferente de zero. O ``timeout`` evita que um ``gh auth status``
+    travado (ex.: prompt de credencial interativo) bloqueie o comando
+    indefinidamente.
     """
     if not shutil.which("gh"):
         raise CommandError("GitHub CLI (gh) não está instalada.")
-    res = subprocess.run(
-        ["gh", "auth", "status"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        res = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CommandError(f"gh auth status timeout: {exc}") from exc
     if res.returncode != 0:
         raise CommandError("CLI do GitHub (gh) não está autenticada.")

--- a/deile/commands/builtin/_standup_collectors.py
+++ b/deile/commands/builtin/_standup_collectors.py
@@ -161,9 +161,11 @@ async def collect_standup_data(since_spec: str) -> StandupData:
     ``asyncio.run``. Commits permanecem síncronos (``git log``) e rodam em
     :func:`asyncio.to_thread` para não bloquear o event loop.
     """
-    # Pre-condition gates — git/gh disponíveis e autenticados.
-    ensure_git_repo()
-    ensure_gh_authenticated()
+    # Pre-condition gates — git/gh disponíveis e autenticados. Disparam
+    # subprocess síncrono, então rodam em ``asyncio.to_thread`` (Pilar 03 §1)
+    # para não bloquear o event loop.
+    await asyncio.to_thread(ensure_git_repo)
+    await asyncio.to_thread(ensure_gh_authenticated)
 
     delta = parse_since(since_spec)
     since_date = datetime.now(timezone.utc) - delta
@@ -172,7 +174,7 @@ async def collect_standup_data(since_spec: str) -> StandupData:
     # Late import — evita ciclo de import no carregamento do command package.
     from ...orchestration.pipeline.github_client import GitHubClient
 
-    repo = _resolve_repo_from_git()
+    repo = await asyncio.to_thread(_resolve_repo_from_git)
     client = GitHubClient(repo)
 
     commits = await asyncio.to_thread(collect_commits, since_iso)

--- a/deile/commands/builtin/backlog_command.py
+++ b/deile/commands/builtin/backlog_command.py
@@ -15,6 +15,7 @@ coleta/bucketização vive em :mod:`._backlog_collectors` (delegação via
 
 from __future__ import annotations
 
+import asyncio
 from typing import Optional
 
 from rich.console import Group
@@ -143,10 +144,16 @@ class BacklogCommand(DirectCommand):
         )
 
         repo_override = _parse_args(context.args)
-        ensure_git_repo()
-        ensure_gh_authenticated()
+        # Pilar 03 §1: os gates e a resolução do remote disparam ``git``/``gh``
+        # via subprocess síncrono — isolados em ``to_thread`` para não bloquear
+        # o event loop.
+        await asyncio.to_thread(ensure_git_repo)
+        await asyncio.to_thread(ensure_gh_authenticated)
 
-        repo = repo_override if repo_override is not None else _resolve_repo_from_git()
+        if repo_override is not None:
+            repo = repo_override
+        else:
+            repo = await asyncio.to_thread(_resolve_repo_from_git)
         data = await collect_backlog_data(repo)
 
         return CommandResult.success_result(

--- a/deile/commands/builtin/model_command.py
+++ b/deile/commands/builtin/model_command.py
@@ -379,7 +379,8 @@ EXAMPLES:
         try:
             old_router = get_tier_router()
             old_providers = list(old_router.registered_providers().values())
-        except Exception:
+        except Exception as exc:
+            logger.debug("could not snapshot providers from old TierRouter: %s", exc)
             old_providers = []
 
         reset_tier_router()
@@ -389,8 +390,8 @@ EXAMPLES:
         for p in old_providers:
             try:
                 new_router.register_provider(p)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("could not re-register provider on new TierRouter: %s", exc)
 
         # Sync the legacy ModelRouter.strategy (consulted when tier classification fails)
         try:


### PR DESCRIPTION
## Resumo

Auditoria de qualidade dos slash commands (`deile/commands/builtin/`, 52 arquivos / **42 comandos descobertos**), estendendo ao subsistema de comandos a mesma varredura que endureceu as tools (PR #652). Auditoria honesta: a **maioria já está aderente** ao contrato — o PR corrige apenas os achados reais, de alto valor e seguros.

`Refs #655` (tracking). Follow-up deferido em #656.

## Catálogo — comando × achado × ação

| Categoria auditada | Resultado | Ação |
|---|---|---|
| Contrato `CommandResult` (sem exceção vazando) | Aderente: `_shared.wrap_command_errors` + rede de segurança do registry (`execute_command` converte exceção vazada em `error_result`) | — |
| `bare except` | Nenhum | — |
| `print()` direto a stdout | Nenhum (só `console.print` Rich) | — |
| `asyncio.CancelledError` capturado sem re-raise | Nenhum | — |
| Colisão de `name`/`alias`/CLI flag | Nenhuma (verificado programaticamente no registry + `build_cli_flag_specs`) | — |
| UI adaptativa (Pilar 15): `width=<int>`, `Console(width=N)`, box-drawing manual | Aderente (só `max_width` permitido em `todo_command`) | — |
| Registry / duplicação / `isinstance`-chains | Aderente | — |
| **Async (Pilar 1): I/O bloqueante em path async** | **2 violações reais** | **Corrigido** |
| **Robustez: subprocess sem timeout** | **1 latente (hang)** | **Corrigido** |
| **Observabilidade (Pilar 6): swallow silencioso** | **1 em swap de estado** | **Corrigido** |

### Corrigido neste PR

1. **`backlog_command.execute` + `_standup_collectors.collect_standup_data`** — chamavam `ensure_git_repo()` / `ensure_gh_authenticated()` / `_resolve_repo_from_git()` (todos `subprocess.run` síncrono) **diretamente no event loop**, enquanto os comandos análogos (`loc_command`, `todo_command`) já isolavam em `asyncio.to_thread`. Ação: envolver a tríade de pré-flight em `asyncio.to_thread`. (`backlog_command.py` continua **sem** `import subprocess` — o teste-guarda `test_command_module_has_no_subprocess_import` segue verde.)
2. **`_git_helpers.ensure_gh_authenticated`** — `gh auth status` **sem `timeout`**: um `gh` travado (ex.: prompt interativo) bloquearia o comando indefinidamente. Ação: `timeout` (default 30s, paridade com os demais helpers) + `TimeoutExpired` → `CommandError` PT-BR.
3. **`model_command`** — suprimia silenciosamente (`except Exception: pass`) falhas ao snapshot/re-registrar providers durante o swap de `TierRouter`, divergindo da convenção do próprio arquivo (linha 406 já loga DEBUG antes de suprimir). Ação: `logger.debug` nos dois blocos. Comportamento idêntico, falha agora observável.

### Deferido → #656

~11 blocos `except Exception: pass` de degradação best-effort em `export_command`, `memory_command`, `loc_command` (subsistema indisponível não deve abortar o comando). São defensáveis mas divergem da convenção `_shared.emit_audit_event` (DEBUG-then-suppress). `export_command`/`memory_command` não têm logger de módulo — converter exigiria adicionar logger + ~11 linhas em 3 arquivos: baixo valor, fora do PR coeso.

## Por que é seguro

Nenhuma mudança de comportamento observável: `to_thread` preserva a semântica (mocks módulo-level dos testes seguem compatíveis — `to_thread` invoca o callable patchado); o `timeout` é puramente defensivo; o `logger.debug` não altera fluxo.

## Evidência de testes

- **Suíte completa com cobertura** (`python3 -m pytest deile/tests/ -q`): `4 failed, 8226 passed, 30 skipped` em 173s. As 4 falhas são **exatamente** baseline pré-existente (`test_pod_presence`, `test_reconcile_fire_and_forget`, `test_classify`, `test_gap_regressions` — confirmadas idênticas em árvore pristina via `git stash`). A 5ª baseline (`test_cli_flags`, ordering-sensitive) não tripou nesta ordem e passa em isolamento. **Zero novas falhas.**
- **`test_cli_flags` + `test_table_widths_adaptive` isolados** (`-p no:randomly`): `64 passed` antes e depois do diff — não houve regressão real.
- **Suíte de comandos** (`deile/tests/commands/` + `cli/test_cli_flags.py`): `1030 passed, 1 skipped`.
- **Multi-seed** `deile/tests/commands/` (0/1/2/42): `983 passed, 1 skipped` em cada seed.
- **Touched-file tests** (`test_backlog_command` + `test_standup_command` + `test_model_command`): `147 passed`.
- `ruff` e `isort` limpos nos 4 arquivos tocados.
