### PR TITLE
test(parsers): add regression coverage and audit findings for parser subsystem

### DIFF
--- a/deile/tests/parsers/__init__.py
+++ b/deile/tests/parsers/__init__.py
@@ -1,0 +1,1 @@
+"""Testes de regressão para o subsistema de parsers (deile/parsers)."""

--- a/deile/tests/parsers/test_command_parser.py
+++ b/deile/tests/parsers/test_command_parser.py
@@ -1,0 +1,85 @@
+"""Regressão de contrato para o CommandParser.
+
+Trava o comportamento observado hoje (sem `config_manager`, isto é, sem
+acesso ao CommandRegistry): qualquer `/<token>` casa, `parse()` devolve um
+único `ParsedCommand` com `action="slash_<nome>"` e nunca deixa exceção
+escapar.
+"""
+
+import pytest
+
+from deile.parsers.base import ParsedCommand, ParseResult, ParseStatus
+from deile.parsers.command_parser import CommandParser
+
+
+@pytest.fixture
+def parser() -> CommandParser:
+    return CommandParser()
+
+
+@pytest.mark.unit
+def test_metadata_contract(parser: CommandParser):
+    assert parser.name == "command_parser"
+    assert parser.priority == 90
+    assert parser.patterns  # padrões declarados não podem ficar vazios
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("/help", True),
+        ("   /status", True),  # whitespace à esquerda é tolerado
+        ("/DOC-HYGIENE arg", True),  # hífen é parte do nome
+        ("hello there", False),
+        ("not /a/command", False),  # só conta quando começa com '/'
+    ],
+)
+def test_can_parse(parser: CommandParser, text: str, expected: bool):
+    assert parser.can_parse(text) is expected
+
+
+@pytest.mark.unit
+def test_parse_command_without_args(parser: CommandParser):
+    result = parser.parse("/help")
+    assert result.status is ParseStatus.SUCCESS
+    assert len(result.commands) == 1
+    cmd = result.commands[0]
+    assert isinstance(cmd, ParsedCommand)
+    assert cmd.action == "slash_help"
+    assert cmd.target is None
+    assert cmd.arguments == {"command_name": "help", "use_command_system": True}
+
+
+@pytest.mark.unit
+def test_parse_command_with_args(parser: CommandParser):
+    result = parser.parse("/DOC-HYGIENE arg1 arg2")
+    cmd = result.commands[0]
+    assert result.status is ParseStatus.SUCCESS
+    assert cmd.action == "slash_doc-hygiene"  # nome normalizado para minúsculo
+    assert cmd.target == "arg1 arg2"
+    assert cmd.arguments["raw_args"] == "arg1 arg2"
+    assert cmd.arguments["use_command_system"] is True
+
+
+@pytest.mark.unit
+def test_parse_non_command_returns_failed(parser: CommandParser):
+    result = parser.parse("just plain text")
+    assert result.status is ParseStatus.FAILED
+    assert result.error_message
+    assert not result.commands
+
+
+@pytest.mark.unit
+def test_get_confidence(parser: CommandParser):
+    assert parser.get_confidence("/help") == pytest.approx(0.95)
+    assert parser.get_confidence("not a command") == 0.0
+
+
+@pytest.mark.unit
+def test_parse_never_raises(parser: CommandParser):
+    """parse() captura qualquer falha e devolve ParseResult, nunca lança."""
+    for weird in ["/", "/\\", "/" + "x" * 5000, ""]:
+        result = parser.parse(weird)
+        assert isinstance(result, ParseResult)
+        assert result.status in (ParseStatus.SUCCESS, ParseStatus.FAILED)

--- a/deile/tests/parsers/test_diff_parser.py
+++ b/deile/tests/parsers/test_diff_parser.py
@@ -1,0 +1,95 @@
+"""Regressão de contrato para o DiffParser.
+
+Documenta o comportamento atual da implementação básica: detecta marcadores
+de diff, extrai os nomes de arquivo das linhas ``+++``/``---`` e devolve
+SUCCESS (com comando ``apply_diff``) ou PARTIAL (apenas marcadores, sem
+cabeçalho de arquivo). Nunca deixa exceção escapar.
+"""
+
+import pytest
+
+from deile.parsers.base import ParseResult, ParseStatus
+from deile.parsers.diff_parser import DiffParser
+
+UNIFIED_DIFF = """diff --git a/foo.py b/foo.py
+--- a/foo.py
++++ b/foo.py
+@@ -1,3 +1,3 @@
+-old
++new
+"""
+
+
+@pytest.fixture
+def parser() -> DiffParser:
+    return DiffParser()
+
+
+@pytest.mark.unit
+def test_metadata_contract(parser: DiffParser):
+    assert parser.name == "diff_parser"
+    assert parser.priority == 70
+    assert parser.patterns
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (UNIFIED_DIFF, True),
+        ("@@ -1 +1 @@", True),
+        ("diff --git a/x b/x", True),
+        ("plain prose with no markers", False),
+        ("", False),
+    ],
+)
+def test_can_parse(parser: DiffParser, text: str, expected: bool):
+    assert parser.can_parse(text) is expected
+
+
+@pytest.mark.unit
+def test_parse_full_diff_is_success(parser: DiffParser):
+    result = parser.parse(UNIFIED_DIFF)
+    assert result.status is ParseStatus.SUCCESS
+    assert result.commands
+    cmd = result.commands[0]
+    assert cmd.action == "apply_diff"
+    assert cmd.arguments["diff_content"] == UNIFIED_DIFF
+    assert result.file_references  # nomes extraídos das linhas +++/---
+    assert result.tool_requests == ["diff_tool"]
+
+
+@pytest.mark.unit
+def test_parse_markers_only_is_partial(parser: DiffParser):
+    """Marcador de hunk sem cabeçalho de arquivo => PARTIAL, sem comandos."""
+    result = parser.parse("@@ -1,2 +1,2 @@")
+    assert result.status is ParseStatus.PARTIAL
+    assert not result.commands
+    assert result.confidence == pytest.approx(0.3)
+
+
+@pytest.mark.unit
+def test_parse_non_diff_returns_failed(parser: DiffParser):
+    result = parser.parse("this is not a diff at all")
+    assert result.status is ParseStatus.FAILED
+    assert result.error_message
+
+
+@pytest.mark.unit
+def test_get_confidence_scales_with_markers(parser: DiffParser):
+    assert parser.get_confidence("not a diff") == 0.0
+    full = parser.get_confidence(UNIFIED_DIFF)
+    sparse = parser.get_confidence("@@ -1 +1 @@")
+    assert full > sparse > 0.0
+
+
+@pytest.mark.unit
+def test_parse_never_raises(parser: DiffParser):
+    for weird in ["", "+++", "@@" * 1000, UNIFIED_DIFF]:
+        result = parser.parse(weird)
+        assert isinstance(result, ParseResult)
+        assert result.status in (
+            ParseStatus.SUCCESS,
+            ParseStatus.PARTIAL,
+            ParseStatus.FAILED,
+        )

--- a/deile/tests/parsers/test_intelligent_file_parser_state.py
+++ b/deile/tests/parsers/test_intelligent_file_parser_state.py
@@ -1,0 +1,48 @@
+"""Documenta o estado atual do IntelligentFileParser.
+
+`IntelligentFileParser` herda de `Parser` mas NÃO implementa os membros
+abstratos `parse` e `patterns` — portanto é abstrato e nunca pode ser
+instanciado nem registrado pela auto-descoberta (o filtro
+`not inspect.isabstract(obj)` em `ParserRegistry._discover_in_package` o
+ignora silenciosamente).
+
+Este teste trava esse fato. Se um follow-up tornar a classe concreta
+(implementando os abstratos), este teste falha de propósito, forçando uma
+decisão consciente sobre ativá-lo no registry (o que MUDA o conjunto de
+parsers ativos e o comportamento de parsing). Ver FU registrada na issue
+de rastreamento.
+"""
+
+import inspect
+
+import pytest
+
+from deile.parsers.base import Parser
+from deile.parsers.intelligent_file_parser import IntelligentFileParser
+
+
+@pytest.mark.unit
+def test_is_a_parser_subclass():
+    assert issubclass(IntelligentFileParser, Parser)
+
+
+@pytest.mark.unit
+def test_is_currently_abstract_and_inert():
+    assert inspect.isabstract(IntelligentFileParser)
+    assert IntelligentFileParser.__abstractmethods__ == frozenset(
+        {"parse", "patterns"}
+    )
+    with pytest.raises(TypeError):
+        IntelligentFileParser()  # type: ignore[abstract]
+
+
+@pytest.mark.unit
+def test_auto_discovery_skips_abstract_parser_without_crashing():
+    from deile.parsers.registry import ParserRegistry
+
+    registry = ParserRegistry()
+    discovered = registry._discover_in_package(
+        "deile.parsers.intelligent_file_parser"
+    )
+    assert discovered == 0
+    assert "intelligent_file_parser" not in registry

--- a/deile/tests/parsers/test_registry.py
+++ b/deile/tests/parsers/test_registry.py
@@ -1,0 +1,159 @@
+"""Regressão de contrato para o ParserRegistry.
+
+Cobre o ponto de orquestração de parsing (resolução por prioridade, cache,
+isolamento de exceções, enable/disable) usando parsers leves que não exigem
+chaves de API nem I/O — sem gasto de token.
+"""
+
+from typing import List
+
+import pytest
+
+from deile.parsers.base import ParsedCommand, Parser, ParseResult, ParseStatus
+from deile.parsers.command_parser import CommandParser
+from deile.parsers.diff_parser import DiffParser
+from deile.parsers.registry import ParserRegistry
+
+
+class _BoomParser(Parser):
+    """Parser que sempre lança — usado para verificar isolamento."""
+
+    @property
+    def name(self) -> str:
+        return "boom"
+
+    @property
+    def description(self) -> str:
+        return "always raises"
+
+    @property
+    def patterns(self) -> List[str]:
+        return [r"boom"]
+
+    def can_parse(self, input_text: str) -> bool:
+        return "boom" in input_text
+
+    def parse(self, input_text: str) -> ParseResult:
+        raise RuntimeError("kaboom")
+
+
+class _LowPriorityParser(Parser):
+    @property
+    def name(self) -> str:
+        return "low_prio"
+
+    @property
+    def description(self) -> str:
+        return "matches anything, low priority"
+
+    @property
+    def patterns(self) -> List[str]:
+        return [r".*"]
+
+    @property
+    def priority(self) -> int:
+        return 1
+
+    def can_parse(self, input_text: str) -> bool:
+        return True
+
+    def parse(self, input_text: str) -> ParseResult:
+        return ParseResult(
+            status=ParseStatus.SUCCESS,
+            commands=[ParsedCommand(action="low", raw_text=input_text)],
+            metadata={"parser": self.name},
+        )
+
+
+@pytest.fixture
+def registry() -> ParserRegistry:
+    reg = ParserRegistry()
+    reg.disable_auto_discovery()
+    return reg
+
+
+@pytest.mark.unit
+async def test_empty_input_fails_fast(registry: ParserRegistry):
+    registry.register(CommandParser())
+    result = await registry.parse("")
+    assert result.status is ParseStatus.FAILED
+    assert "Empty input" in result.error_message
+
+
+@pytest.mark.unit
+async def test_no_enabled_parsers_fails(registry: ParserRegistry):
+    result = await registry.parse("anything")
+    assert result.status is ParseStatus.FAILED
+    assert "No enabled parsers" in result.error_message
+
+
+@pytest.mark.unit
+async def test_priority_order_in_list_all(registry: ParserRegistry):
+    registry.register(DiffParser())       # priority 70
+    registry.register(CommandParser())    # priority 90
+    names = [p.name for p in registry.list_all()]
+    assert names == ["command_parser", "diff_parser"]
+
+
+@pytest.mark.unit
+async def test_slash_command_routes_to_command_parser(registry: ParserRegistry):
+    registry.register(CommandParser())
+    registry.register(DiffParser())
+    result = await registry.parse("/help")
+    assert result.status is ParseStatus.SUCCESS
+    assert result.metadata.get("parser") == "command_parser"
+
+
+@pytest.mark.unit
+async def test_parser_exception_is_isolated(registry: ParserRegistry):
+    """Uma exceção de um parser não pode escapar do registry."""
+    registry.register(_BoomParser())
+    result = await registry.parse("boom now")
+    assert result.status is ParseStatus.FAILED
+    assert "boom" in result.error_message
+
+
+@pytest.mark.unit
+async def test_disabled_parser_does_not_participate(registry: ParserRegistry):
+    registry.register(_LowPriorityParser())
+    assert registry.disable_parser("low_prio") is True
+    assert registry.list_enabled() == []
+    result = await registry.parse("anything")
+    assert result.status is ParseStatus.FAILED  # nenhum habilitado restou
+
+
+@pytest.mark.unit
+async def test_cache_returns_same_result(registry: ParserRegistry):
+    registry.register(CommandParser())
+    first = await registry.parse("/help")
+    second = await registry.parse("/help")
+    assert first is second  # segunda chamada vem do cache
+    assert registry.get_stats()["cache_size"] >= 1
+
+
+@pytest.mark.unit
+async def test_disable_cache_clears_entries(registry: ParserRegistry):
+    registry.register(CommandParser())
+    await registry.parse("/help")
+    registry.disable_cache()
+    assert registry.get_stats()["cache_size"] == 0
+    first = await registry.parse("/help")
+    second = await registry.parse("/help")
+    assert first is not second  # sem cache, instâncias distintas
+
+
+@pytest.mark.unit
+async def test_register_rejects_non_parser(registry: ParserRegistry):
+    from deile.core.exceptions import ValidationError
+
+    with pytest.raises(ValidationError):
+        registry.register(object())  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+async def test_register_rejects_duplicate_name(registry: ParserRegistry):
+    from deile.core.exceptions import ParserError
+
+    registry.register(CommandParser())
+    with pytest.raises(ParserError):
+        registry.register(CommandParser())


### PR DESCRIPTION
Closes #658

## Resumo

Auditoria de qualidade do subsistema de parsers (`deile/parsers/`), concluindo a trilogia de varredura de componentes plugáveis (tools #652 → commands #657 → parsers). Os quatro parsers (`command_parser`, `diff_parser`, `file_parser`, `intelligent_file_parser`) e o `registry` estavam **sem nenhum teste pytest dedicado**. Este PR adiciona a rede de regressão que faltava, **sem alterar nenhum arquivo de produção** — só `deile/tests/parsers/`.

## Catálogo de auditoria

| # | Severidade | Parser | Achado | Tratamento |
|---|---|---|---|---|
| A1 | Média | `intelligent_file_parser` | Herda de `Parser` mas não implementa os abstratos `parse`/`patterns` → é abstrato, nunca instancia, e a auto-descoberta o ignora em silêncio. Componente morto que aparenta estar plugado. | FU (#658). Estado travado por teste. |
| A2 | Baixa | `file_parser` | `__init__` instancia o cliente Google API eagermente → auto-descoberta falha sem `GOOGLE_API_KEY` (registry só loga warning). | FU (#658). |
| A3 | Baixa | `diff_parser` | Extração não remove prefixos `a/`/`b/` → um diff git rende `a/foo.py` E `b/foo.py` como refs separadas. | FU (#658). |
| A4 | Informativo | `file_parser` regex | `@me@example.com` casa `example.com`; `@x.md.` mantém o ponto. Semântica pré-existente. | Sem ação. |

**Aderente (verificado):** `command`/`diff` têm `can_parse` rápido/síncrono, `parse()` sempre devolve `ParseResult` com status correto e nunca propaga exceção; regex lineares (sem ReDoS) compilados uma vez; registry isola exceções e respeita prioridade. Sem `bare except`; `CancelledError` não capturado indevidamente.

## O que entrega

`deile/tests/parsers/` — 35 testes, **sem chaves de API e sem gasto de token**:

- `test_command_parser.py` (11) — contrato do `CommandParser`.
- `test_diff_parser.py` (11) — contrato do `DiffParser` (SUCCESS/PARTIAL/FAILED).
- `test_registry.py` (10) — `ParserRegistry`: prioridade, roteamento, isolamento de exceção, cache, enable/disable, validação.
- `test_intelligent_file_parser_state.py` (3) — trava o estado abstrato/inerte; falha de propósito se A1 for resolvido sem decisão consciente.

## Decisão de escopo

A1–A3 são defeitos reais mas **não behavior-preserving** de corrigir (ativar um parser inerte muda o conjunto ativo; lazy-init toca o hot-path do `FileParser` sem testes prévios). Optei por **auditoria honesta + rede de regressão primeiro**, deixando as correções como follow-ups rastreados em #658.

## Evidência verde

- Baseline pristino (origin/main): `1 failed, 8228 passed, 31 skipped` (falha pré-existente `test_pod_presence` #649).
- Com este PR: `1 failed, 8263 passed, 31 skipped in 248.86s` — os mesmos +35 testes novos, **zero novas falhas** (a única falha é a mesma pré-existente).
- Multi-seed (0/1/2/42) nos testes novos: `35 passed` estável em todas.
- `ruff check` e `isort --check-only` limpos em `deile/tests/parsers/`.