### PR TITLE
fix(models): implement GeminiProvider._compute_cost (Gemini cost was silently zero)

### DIFF
--- a/deile/core/models/gemini_provider.py
+++ b/deile/core/models/gemini_provider.py
@@ -1147,6 +1147,33 @@ class GeminiProvider(ModelProvider):
             logger.debug("Gemini cost calc failed: %s", exc)
         return usage
 
+    def _compute_cost(self, usage: ModelUsage) -> float:
+        """Custo do request em USD a partir do pricing do catálogo.
+
+        O ``prompt_token_count`` do Gemini é o total efetivo do prompt e JÁ
+        INCLUI ``cached_content_token_count`` (docs oficiais do google-genai:
+        UsageMetadata.prompt_token_count). É a mesma semântica de superset que
+        OpenAI/DeepSeek têm — por isso cobramos só a parcela não-cacheada à
+        taxa cheia e a parcela cacheada à taxa de cache, evitando o
+        double-count que o ``estimate_cost`` base (pensado para o Anthropic,
+        cujo ``input_tokens`` exclui o cache) produziria.
+        """
+        p = self.pricing
+        if p is None:
+            return 0.0
+        cached = usage.cached_tokens or 0
+        non_cached_input = max(usage.prompt_tokens - cached, 0)
+        input_cost = (non_cached_input / 1_000_000) * p.input_per_1m_usd
+        output_cost = (usage.completion_tokens / 1_000_000) * p.output_per_1m_usd
+        if cached and p.cached_input_per_1m_usd is not None:
+            cached_cost = (cached / 1_000_000) * p.cached_input_per_1m_usd
+        elif cached:
+            # Sem preço de cache publicado → cobra a parcela cacheada à taxa cheia.
+            cached_cost = (cached / 1_000_000) * p.input_per_1m_usd
+        else:
+            cached_cost = 0.0
+        return round(input_cost + output_cost + cached_cost, 8)
+
     @staticmethod
     def _aggregate_usage(a: ModelUsage, b: ModelUsage) -> ModelUsage:
         """Soma dois `ModelUsage` (multi-turn function calling)."""

--- a/deile/tests/core/models/test_gemini_provider_usage.py
+++ b/deile/tests/core/models/test_gemini_provider_usage.py
@@ -85,6 +85,67 @@ class TestExtractGeminiUsage:
         assert usage.prompt_tokens == 10     # tokens ainda capturados
 
 
+# -------- _compute_cost (real method, sem mock) -----------------------------
+#
+# Regressão: o código chamava ``self._compute_cost(usage)`` mas o método NÃO
+# existia na classe (o nome do catálogo é ``estimate_cost``). O ``AttributeError``
+# era engolido pelo ``except`` de ``_extract_gemini_usage`` (fail-open de cost),
+# então TODA request Gemini reportava ``cost_estimate=0.0`` em silêncio — o exato
+# bug que os comentários do módulo afirmavam estar corrigido. Os testes acima
+# mockam ``prov._compute_cost`` e por isso nunca exerceram o método real.
+# Estes testes constroem um GeminiProvider REAL (sem mock do _compute_cost) e
+# travam a presença + a semântica superset-aware do cálculo.
+
+class _FakeHandle:
+    def __init__(self, pricing) -> None:
+        self.pricing = pricing
+
+
+def _real_gemini_provider(input_per_1m, output_per_1m, cached_per_1m):
+    """GeminiProvider real com pricing stubado — sem init de cliente/SDK."""
+    prov = GeminiProvider.__new__(GeminiProvider)
+    prov._handle = _FakeHandle(SimpleNamespace(
+        input_per_1m_usd=input_per_1m,
+        output_per_1m_usd=output_per_1m,
+        cached_input_per_1m_usd=cached_per_1m,
+    ))
+    return prov
+
+
+class TestComputeCostReal:
+    def test_method_exists_on_class(self):
+        # Trava o nome do método — um rename quebra o cálculo de custo em silêncio.
+        assert hasattr(GeminiProvider, "_compute_cost")
+
+    def test_cost_is_non_zero_for_real_provider(self):
+        prov = _real_gemini_provider(2.0, 12.0, 0.5)
+        resp = _fake_response(_fake_usage_md(
+            prompt=1000, candidates=500, total=1500, cached=100,
+        ))
+        usage = GeminiProvider._extract_gemini_usage(prov, resp, request_time=1.0)
+        # 900 não-cacheado @ $2 + 500 saída @ $12 + 100 cache @ $0.5
+        expected = (900 / 1e6) * 2.0 + (500 / 1e6) * 12.0 + (100 / 1e6) * 0.5
+        assert usage.cost_estimate == pytest.approx(round(expected, 8))
+        assert usage.cost_estimate > 0.0
+
+    def test_cached_tokens_not_double_charged(self):
+        # prompt_token_count do Gemini INCLUI cached_content_token_count (docs
+        # google-genai): a parcela cacheada não pode ser cobrada duas vezes.
+        prov = _real_gemini_provider(5.0, 10.0, 1.0)
+        usage = ModelUsage(
+            prompt_tokens=1_000_000, completion_tokens=0,
+            total_tokens=1_000_000, cached_tokens=700_000,
+        )
+        # 300k @ $5 + 700k @ $1 = $1.50 + $0.70 = $2.20 (base double-cobraria $5.70)
+        assert prov._compute_cost(usage) == pytest.approx(2.20)
+
+    def test_no_pricing_returns_zero(self):
+        prov = GeminiProvider.__new__(GeminiProvider)
+        prov._handle = None
+        usage = ModelUsage(prompt_tokens=1_000_000, cached_tokens=100_000)
+        assert prov._compute_cost(usage) == 0.0
+
+
 # -------- _aggregate_usage --------------------------------------------------
 
 class TestAggregateUsage:


### PR DESCRIPTION
Closes #660

## Contexto

Auditoria de qualidade da camada de providers LLM (`deile/core/models/`) — o caminho mais crítico do sistema. Mandato extra-conservador: entregar apenas o que é inequivocamente seguro e behavior-preserving, com teste; deferir tudo que toque shaping de request/response, streaming, retry/circuit/budget ou o contrato do `ModelProvider`.

**Resultado da auditoria:** a camada está sólida e consistente entre os 5 providers. Foi encontrado **um bug real e seguro de corrigir** (entregue aqui). Nenhum achado behavior-changing de risco foi detectado.

## O bug (entregue)

`_extract_gemini_usage` chama `self._compute_cost(usage)` (`gemini_provider.py:1145`), mas o método **nunca existiu** — o helper de pricing se chama `estimate_cost`. O `AttributeError` era engolido pelo `except` fail-open de custo (`:1146`), então **toda** request Gemini gravava `cost_estimate=0.0` em silêncio. É o bug que os comentários do módulo (`:1106-1112`, `:1216`) afirmavam estar corrigido.

Nenhum teste pegou porque `test_gemini_provider_usage.py` **mockava** `prov._compute_cost`.

### Por que a correção é segura

- Implementa `GeminiProvider._compute_cost` com semântica **superset-aware** de cache (idêntica à de `OpenAIProvider.estimate_cost`). Confirmado nas docs oficiais do `google-genai` (`UsageMetadata.prompt_token_count`): o `prompt_token_count` **já inclui** `cached_content_token_count` — mesma semântica de OpenAI/DeepSeek. Por isso NÃO bastava chamar o `estimate_cost` base (Anthropic-style, que faria double-count do cache).
- Mudança **restrita ao cálculo de custo** (contabilidade). Não toca shaping de request/response, streaming, nem semântica de chamada ao provider. O cálculo segue fail-open.
- Fecha também a divergência cross-provider de cached-token (o eixo que o OpenAI já tratava e o Gemini não).

### Evidência empírica (provider real, sem mock)

`prompt=1000, candidates=500, cached=100`, pricing in=$2 / out=$12 / cache=$0.5 por 1M:
- **Antes:** `cost_estimate = 0.0`
- **Depois:** `cost_estimate = 0.00785` (900 não-cacheado @ $2 + 500 saída @ $12 + 100 cache @ $0.5)

## Catálogo (módulo × achado × ação)

| Categoria | Achado | Ação |
|---|---|---|
| Error handling | `_compute_cost` inexistente → cost Gemini sempre 0 | **Entregue** |
| Error handling | `CancelledError` em streaming/async: todos os `except Exception` são seguros (`CancelledError` é `BaseException`, confirmado em runtime) — nenhum cancelamento engolido | Já aderente |
| Error handling | Erros tipados (`ProviderInvocationError`/`ProviderErrorEnvelope`), classificação compartilhada, `_record_failed_usage` no error-path | Já aderente |
| Async | Gemini usa `to_thread` p/ SDK síncrono; demais async-nativos; sem I/O bloqueante em `async def` | Já aderente |
| Observabilidade | `_record_usage`/`_llm_span`/OTLP best-effort; sem segredo/prompt/body em span ou log | Já aderente |
| Resiliência | `CircuitBreaker.is_open` side-effect-free; budget via `UsageRepository`/`BudgetGuard` | Já aderente |
| Hexagonal | SDKs isolados; `error_mapping`/`tool_execution`/`reasoning` SDK-free | Já aderente |
| Consistência | reasoning família-aware uniforme; cached-token superset agora também no Gemini | **Entregue** |

**Deferidos (NÃO implementados — registrados na issue #660):** nenhum achado behavior-changing de risco. Só observações cosméticas/refactor (`_model_size_mapping` desatualizado p/ modelos novos; `chat_with_tools` legado com `TODO(streaming-cleanup)`), sem alteração de comportamento de chamada.

## Testes

Suíte completa com cobertura (raiz):

```
====== 1 failed, 8233 passed, 30 skipped, 8 warnings in 171.63s (0:02:51) ======
FAILED deile/tests/infrastructure/test_pod_presence.py::test_cleanup_stale_workspaces_removes_dead_pod_workspace - assert 0 == 1
```

A única falha é **pré-existente** (baseline da origin/main: 8229 passed + a mesma falha do `test_pod_presence`, corrigida na PR aberta #649). **Zero novas falhas**; +4 dos testes novos. `ruff`/`isort` limpos. Multi-seed (0/1/2/42) verde em `deile/tests/core/models/`. Sem chamadas reais de API (auditoria estática + testes mockados/provider-real-sem-cliente).