### PR TITLE
fix(memory): offload ProceduralMemory JSON I/O off the event loop

### DIFF
--- a/deile/memory/procedural_memory.py
+++ b/deile/memory/procedural_memory.py
@@ -1,10 +1,11 @@
 """Procedural Memory - Patterns aprendidos e habilidades adquiridas"""
 
-import json
 import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List
+
+from deile.storage.aio_fileio import read_json, write_json
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +30,8 @@ class ProceduralMemory:
             return
 
         if self.patterns_file.exists():
-            with open(self.patterns_file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-                self._patterns.update(data)
+            data = await read_json(self.patterns_file)
+            self._patterns.update(data)
 
         self._is_initialized = True
         logger.info("ProceduralMemory inicializada")
@@ -79,7 +79,6 @@ class ProceduralMemory:
 
     async def shutdown(self) -> None:
         """Finalização - salva patterns"""
-        with open(self.patterns_file, 'w', encoding='utf-8') as f:
-            json.dump(dict(self._patterns), f, ensure_ascii=False, indent=2)
+        await write_json(self.patterns_file, dict(self._patterns))
 
         self._is_initialized = False

--- a/deile/tests/memory/test_procedural_memory_async_io.py
+++ b/deile/tests/memory/test_procedural_memory_async_io.py
@@ -1,0 +1,91 @@
+"""Regression tests for ``ProceduralMemory`` blocking I/O on the event loop.
+
+Bug: ``initialize()`` used a synchronous ``open()`` + ``json.load`` and
+``shutdown()`` a synchronous ``open()`` + ``json.dump`` directly inside the
+``async def`` bodies — blocking the event loop (princípio 03 §1). The
+sibling ``SemanticMemory`` already offloads identical JSON I/O via
+``asyncio.to_thread``; ``ProceduralMemory`` was left behind.
+
+The fix routes both paths through ``deile.storage.aio_fileio`` (which wraps
+the blocking calls in ``asyncio.to_thread``). These tests assert (a) the
+round-trip still works and the on-disk format is preserved, and (b) the
+JSON I/O is delegated to a worker thread (no blocking ``open`` on the loop).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from deile.memory.procedural_memory import ProceduralMemory
+
+
+async def test_patterns_round_trip_through_disk(tmp_path: Path) -> None:
+    """Patterns survive a shutdown/initialize cycle via the JSONL store."""
+    pm = ProceduralMemory(storage_dir=tmp_path, min_frequency=1)
+    await pm.initialize()
+
+    await pm.analyze_interaction({"input_length": 120})
+    await pm.analyze_interaction({"input_length": 130})  # same 100-bucket key
+
+    await pm.shutdown()
+
+    # File written with the expected human-readable format (indent=2).
+    patterns_file = tmp_path / "patterns.json"
+    assert patterns_file.exists()
+    on_disk = json.loads(patterns_file.read_text(encoding="utf-8"))
+    assert on_disk["input_len_100"]["frequency"] == 2
+
+    # A fresh instance re-hydrates the persisted patterns.
+    pm2 = ProceduralMemory(storage_dir=tmp_path, min_frequency=1)
+    await pm2.initialize()
+    relevant = await pm2.get_relevant_patterns("anything")
+    assert any(p["pattern"] == "input_len_100" and p["frequency"] == 2 for p in relevant)
+    await pm2.shutdown()
+
+
+async def test_initialize_offloads_blocking_read(tmp_path: Path, monkeypatch) -> None:
+    """``initialize`` must route the JSON read through ``asyncio.to_thread``."""
+    pm = ProceduralMemory(storage_dir=tmp_path, min_frequency=1)
+    await pm.analyze_interaction({"input_length": 50})
+    await pm.shutdown()
+    assert (tmp_path / "patterns.json").exists()
+
+    import deile.storage.aio_fileio as aio
+
+    to_thread_called = False
+    original = aio.asyncio.to_thread
+
+    async def spy_to_thread(func, *args, **kwargs):
+        nonlocal to_thread_called
+        to_thread_called = True
+        return await original(func, *args, **kwargs)
+
+    monkeypatch.setattr(aio.asyncio, "to_thread", spy_to_thread)
+
+    pm2 = ProceduralMemory(storage_dir=tmp_path, min_frequency=1)
+    await pm2.initialize()
+    assert to_thread_called, "initialize() must offload the blocking read to a thread"
+    await pm2.shutdown()
+
+
+async def test_shutdown_offloads_blocking_write(tmp_path: Path, monkeypatch) -> None:
+    """``shutdown`` must route the JSON write through ``asyncio.to_thread``."""
+    pm = ProceduralMemory(storage_dir=tmp_path, min_frequency=1)
+    await pm.initialize()
+    await pm.analyze_interaction({"input_length": 200})
+
+    import deile.storage.aio_fileio as aio
+
+    to_thread_called = False
+    original = aio.asyncio.to_thread
+
+    async def spy_to_thread(func, *args, **kwargs):
+        nonlocal to_thread_called
+        to_thread_called = True
+        return await original(func, *args, **kwargs)
+
+    monkeypatch.setattr(aio.asyncio, "to_thread", spy_to_thread)
+
+    await pm.shutdown()
+    assert to_thread_called, "shutdown() must offload the blocking write to a thread"


### PR DESCRIPTION
## Resumo

Auditoria de qualidade do subsistema de memória (`deile/memory/` — 4 camadas + `MemoryManager` + `MemoryConsolidator`). Mandato conservador: apenas correções **claramente seguras / behavior-preserving** + teste de regressão; behavior-changing deferido para FUs rastreadas.

**Veredicto:** as camadas Working, Episodic, Semantic e o manager/consolidator já estão aderentes (endurecimentos de PRs anteriores — refs duras de background tasks, immutabilidade do dict do caller, `asyncio.to_thread` para JSONL, `CancelledError` re-raised). **Um único defeito seguro foi corrigido:** `ProceduralMemory` era a última camada fazendo I/O síncrono bloqueante dentro de corrotinas.

`Closes #662`

## Mudança

`ProceduralMemory.initialize()` (`open`+`json.load`) e `shutdown()` (`open`+`json.dump`) bloqueavam o event loop dentro de `async def` — violação do princípio 03 §1 (Async-First). A camada irmã `SemanticMemory` já delega I/O idêntico via `asyncio.to_thread`.

A correção roteia ambos os caminhos pelo helper canônico `deile/storage/aio_fileio.py` (`read_json`/`write_json`, Decisão #36). Formato em disco preservado (mesmo `indent=2, ensure_ascii=False`) — **comportamento inalterado**.

## Catálogo da auditoria (6 módulos)

| Categoria | Achado | Disposição |
|---|---|---|
| **Async/await** | `procedural_memory.py:32` e `:82` — `open`+`json` síncrono em `async def` | **Entregue** |
| Async/await | Working/Episodic/Semantic/Manager — escritas `await`-ed, `to_thread`/`aiosqlite` corretos, sem awaitable solto | Aderente |
| Error handling | `CancelledError` re-raised nos loops; erros logados com contexto + re-raise em runtime fatal | Aderente |
| Segredos/PII | `patterns.json` persiste só lengths/nomes-de-chave/timestamp — sem conteúdo cru. Episodic/Semantic persistem input/response **por design** (spec 06) | Aderente |
| SQLite | `aiosqlite` com `async with` (fecha conexão), queries parametrizadas, índices coerentes — sem injection | Aderente |
| Globals / escolha de camada | Sem cache cross-turn em global/atributo de classe | Aderente |

## Entregue vs. Deferido

**Entregue (seguro):** offload do I/O de `ProceduralMemory` + 3 testes de regressão.

**Deferido (behavior-changing — FUs no #662):**
- FU-1: `update_pattern_effectiveness` é stub (`pass`); `confidence` nunca atualiza.
- FU-2: `max_episodes_per_session`/`retention_days` guardados mas não enforçados (sem poda).
- FU-3: semantic é busca substring linear, não embeddings (stub conhecido).
- FU-4: heurística de pressão de memória (`memory_mb` fixo `0.1`/camada) nunca dispara.

## Evidência verde

- Suíte de memória: `12 passed` (3 novos), estável em seeds `0/1/2/42`.
- Suíte completa com cobertura (`python3 -m pytest deile/tests/ -q`): `2 failed, 8231 passed, 30 skipped`.
- As 2 falhas são **pré-existentes** em `origin/main` (baseline pristina confirmada via stash): `test_pod_presence::test_cleanup_stale_workspaces_removes_dead_pod_workspace` (corrigida na PR #649 aberta) e `test_cli_flags::test_debug_alone_does_not_dispatch_one_shot_command` (ordering). **Zero novas falhas.**
- `ruff` e `isort` limpos nos arquivos alterados.