### PR TITLE
fix(storage): warn on silent cost=0 in successful billed usage record

### DIFF
--- a/deile/storage/usage_repository.py
+++ b/deile/storage/usage_repository.py
@@ -131,16 +131,36 @@ class UsageRepository:
 
         tier_value = tier.value if hasattr(tier, "value") else str(tier)
 
+        prompt_tokens = getattr(usage, "prompt_tokens", 0)
+        completion_tokens = getattr(usage, "completion_tokens", 0)
+        cost_usd = getattr(usage, "cost_estimate", 0.0)
+
+        # Observabilidade do "custo silencioso" (regressão do provider Gemini que
+        # gravava cost=0.0 sem aviso): uma chamada bem-sucedida que faturou tokens
+        # mas reporta custo zero é quase sempre pricing ausente/não-computado, não
+        # custo real zero. Logamos em WARNING para tornar o bug detectável sem
+        # alterar o valor persistido (mantém /cost, [T]okens e agregações iguais).
+        # Não dispara em falhas (success=False), nem em chamadas sem tokens
+        # faturáveis (prompt+completion==0), nem em auth por assinatura (sem tokens
+        # reais de API).
+        if success and cost_usd == 0.0 and (prompt_tokens + completion_tokens) > 0:
+            logger.warning(
+                "usage recorded with cost_usd=0 for a successful call with "
+                "billable tokens (provider=%s, model=%s, prompt=%s, completion=%s) "
+                "— pricing likely missing or uncomputed",
+                provider_id, model_id, prompt_tokens, completion_tokens,
+            )
+
         r = UsageRecord(
             provider_id=provider_id,
             model_id=model_id,
             tier=tier_value,
             session_id=session_id,
-            prompt_tokens=getattr(usage, "prompt_tokens", 0),
-            completion_tokens=getattr(usage, "completion_tokens", 0),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
             cached_tokens=getattr(usage, "cached_tokens", 0),
             total_tokens=getattr(usage, "total_tokens", 0),
-            cost_usd=getattr(usage, "cost_estimate", 0.0),
+            cost_usd=cost_usd,
             latency_ms=latency_ms,
             success=success,
             error_type=error_type,

--- a/deile/tests/test_usage_repository.py
+++ b/deile/tests/test_usage_repository.py
@@ -169,6 +169,99 @@ class TestRecordFromProvider:
         assert r.tier == "tier_2"
 
     @pytest.mark.asyncio
+    async def test_record_from_provider_warns_on_silent_zero_cost(self, repo, caplog):
+        """Custo silencioso: chamada bem-sucedida com tokens faturados mas cost=0.
+
+        Regressão da família de bugs do provider Gemini que gravava cost=0.0
+        sem aviso. O valor persistido NÃO muda (continua 0.0); apenas garantimos
+        que o caso vire detectável via WARNING.
+        """
+        class FakeUsage:
+            prompt_tokens = 500
+            completion_tokens = 200
+            cached_tokens = 0
+            total_tokens = 700
+            cost_estimate = 0.0  # pricing ausente/não-computado
+
+        class FakeTier:
+            value = "tier_1"
+
+        with caplog.at_level("WARNING", logger="deile.storage.usage_repository"):
+            await repo.record_from_provider(
+                provider_id="gemini",
+                model_id="gemini-2.5-pro",
+                tier=FakeTier(),
+                session_id="sess-zero",
+                usage=FakeUsage(),
+                latency_ms=400,
+                success=True,
+            )
+
+        # Valor persistido inalterado.
+        stored = repo.records_for_session("sess-zero")[0]
+        assert stored.cost_usd == 0.0
+        assert stored.prompt_tokens == 500
+        # Mas o custo silencioso virou observável.
+        assert any(
+            "cost_usd=0" in rec.message and rec.levelname == "WARNING"
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_record_from_provider_no_warn_on_legitimate_zero_cost(self, repo, caplog):
+        """Casos legítimos de cost=0 NÃO disparam o warning.
+
+        - Falha (success=False): pode ter tokens parciais sem custo cobrado.
+        - Sem tokens faturáveis (prompt+completion==0): nada para faturar
+          (ex.: auth por assinatura/OAuth que não conta tokens de API).
+        """
+        class FailedUsage:
+            prompt_tokens = 300
+            completion_tokens = 0
+            cached_tokens = 0
+            total_tokens = 300
+            cost_estimate = 0.0
+
+        class NoTokenUsage:
+            prompt_tokens = 0
+            completion_tokens = 0
+            cached_tokens = 0
+            total_tokens = 0
+            cost_estimate = 0.0
+
+        class FakeTier:
+            value = "tier_1"
+
+        class FakeError:
+            error_type = "rate_limit"
+
+        with caplog.at_level("WARNING", logger="deile.storage.usage_repository"):
+            await repo.record_from_provider(
+                provider_id="anthropic",
+                model_id="claude-opus-4-8",
+                tier=FakeTier(),
+                session_id="sess-fail",
+                usage=FailedUsage(),
+                latency_ms=100,
+                success=False,
+                error_envelope=FakeError(),
+            )
+            await repo.record_from_provider(
+                provider_id="anthropic",
+                model_id="claude-opus-4-8",
+                tier=FakeTier(),
+                session_id="sess-notoken",
+                usage=NoTokenUsage(),
+                latency_ms=50,
+                success=True,
+            )
+
+        assert not any(
+            "cost_usd=0" in rec.message and rec.levelname == "WARNING"
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
     async def test_record_from_provider_with_error_envelope(self, repo):
         class FakeUsage:
             prompt_tokens = 0


### PR DESCRIPTION
Auditoria de qualidade do subsistema `deile/storage/` com ênfase na integridade da contabilidade de custo (`UsageRepository`/`BudgetGuard`), motivada pelo bug recém-achado em que o provider Gemini gravava `cost=0.0` silenciosamente. Mandato conservador: só o claramente seguro/behavior-preserving + teste; behavior-changing diferido para FU.

Closes #664

## Entregue (1 fix seguro)

`usage_repository.py:132` — `record_from_provider` agora emite **WARNING** quando uma chamada **bem-sucedida** registra **tokens faturados** (`prompt + completion > 0`) com **custo zero** (`cost_estimate == 0.0`). Essa é a assinatura exata do bug do Gemini, que passava em silêncio porque `_record_usage` faz fail-open em DEBUG.

- **Behavior-preserving comprovado:** o valor persistido continua `0.0` (teste assegura). Nenhuma mudança de schema, de retorno ou de agregação. `/cost`, painel `[T]okens` e `BudgetGuard` consomem as mesmas queries (`cost_for_session`, `cost_for_provider_since`, `records_for_session`) — todas inalteradas.
- **Sem ruído:** o WARNING é gateado à assinatura do bug. NÃO dispara em `success=False`, em chamadas sem tokens faturáveis, nem em auth por assinatura/OAuth (sem tokens reais de API).

## Diferido (behavior-changing → FU)

`records_for_stage_model` (`usage_repository.py:192`): o docstring afirma casar o stage por prefixo `pipeline-<stage>-`, mas os `channel_id` reais construídos pelo `WorkerImplementer` (`implementer.py:1369+`) são `pipeline-issue-<N>`/`pipeline-pr-<N>` — **nunca** contêm o nome do stage. Logo o padrão `pipeline-{stage}-%` casa zero linhas e o fallback `%{stage}%` só casaria por substring acidental; o `StageCostEstimator` quase sempre cai no `_FALLBACK_TOKENS`. É consumido defensivamente (`cost_estimator.py:213` trata `len < 2` e exceções), então não quebra — mas a estimativa per-stage é cega ao histórico real. Corrigir exige decidir como carimbar o stage no `session_id` (mudança de contrato), portanto diferido. (FU a abrir.)

## Aderente — sem ação (auditoria honesta)

- **SQL/custo:** 100% parametrizado (sem injection); `COALESCE(SUM,0)` evita `NULL`; janela `timestamp >= since_ts` correta nos limites diário/mensal; dedup por `id` AUTOINCREMENT; `check_provider_monthly` usa janela rolling de 30 dias documentada.
- **SQLite/async:** conexões fechadas em `finally` com rollback tipado; `record_from_provider` é shim async sobre write rápido; `debug_logger` delega write a `to_thread`; `aio_fileio` mantém `open()` fora do loop.
- **Segredos:** `logs.py` não loga prompt/segredo (formato fixo com `[%(process)d]`); `debug_logger` router-events sem segredos.
- `log_rotation.py` (rollover atômico via `os.replace` + GC seguro por regex), `embeddings.py` (stub no-op) — aderentes.

## Evidência verde

Suíte completa com gate de cobertura (raiz, `python3 -m pytest deile/tests/ -q`):

```
1 failed, 8231 passed, 30 skipped, 11 warnings in 144.20s
```

A única falha — `test_pod_presence.py::test_cleanup_stale_workspaces_removes_dead_pod_workspace` — é o **baseline pré-existente** de origin/main (corrigido na PR aberta #649), reproduzido em árvore pristina via `git stash`. **Zero novas falhas.**

Storage + multi-seed (0/1/2/42): `29 passed` estável. `ruff`/`isort` limpos.
