### PR TITLE
fix(panel): restore Actions view on [A], fix Activity focus trap

### DIFF
--- a/deile/tests/infra/test_panel_activity_drilldown.py
+++ b/deile/tests/infra/test_panel_activity_drilldown.py
@@ -104,6 +104,16 @@ class TestDashboardViewFocusToggle:
         assert result.kind == panel.Action.REFRESH
 
     def test_escape_exits_focus(self):
+        # KeyReader emite o token "ESC" para o escape (ver KeyReader.read).
+        v = panel.DashboardView()
+        v._activity_focused = True
+        v._last_activity_events = [_event()]
+        result = v.handle_key("ESC", _mock_app())
+        assert v._activity_focused is False
+        assert result.kind == panel.Action.REFRESH
+
+    def test_escape_raw_token_also_exits_focus(self):
+        # Retrocompat: o token raw "\x1b" continua aceito.
         v = panel.DashboardView()
         v._activity_focused = True
         v._last_activity_events = [_event()]
@@ -125,11 +135,22 @@ class TestDashboardViewCursorNavigation:
         return v
 
     def test_up_arrow_wraps(self):
+        # KeyReader emite "UP"/"DOWN" para as setas (ver KeyReader._ARROW).
         v = self._view_with_events(3)
-        v.handle_key("\x1b[A", _mock_app())
+        v.handle_key("UP", _mock_app())
         assert v._activity_cursor == 2  # 0 - 1 mod 3
 
     def test_down_arrow_advances(self):
+        v = self._view_with_events(3)
+        v.handle_key("DOWN", _mock_app())
+        assert v._activity_cursor == 1
+
+    def test_up_arrow_raw_token_also_wraps(self):
+        v = self._view_with_events(3)
+        v.handle_key("\x1b[A", _mock_app())
+        assert v._activity_cursor == 2
+
+    def test_down_arrow_raw_token_also_advances(self):
         v = self._view_with_events(3)
         v.handle_key("\x1b[B", _mock_app())
         assert v._activity_cursor == 1
@@ -213,6 +234,13 @@ class TestDashboardViewDrillDown:
 
 class TestDashboardViewInterceptsKey:
     def test_intercepts_esc_when_focused(self):
+        # Token de produção do KeyReader é "ESC" — interceptar é o que evita
+        # o focus-trap (sem isto o ESC cai no _handle_global → pop() no-op).
+        v = panel.DashboardView()
+        v._activity_focused = True
+        assert v.intercepts_key("ESC") is True
+
+    def test_intercepts_esc_raw_token_when_focused(self):
         v = panel.DashboardView()
         v._activity_focused = True
         assert v.intercepts_key("\x1b") is True
@@ -220,17 +248,20 @@ class TestDashboardViewInterceptsKey:
     def test_intercepts_up_arrow_when_focused(self):
         v = panel.DashboardView()
         v._activity_focused = True
+        assert v.intercepts_key("UP") is True
         assert v.intercepts_key("\x1b[A") is True
 
     def test_intercepts_down_arrow_when_focused(self):
         v = panel.DashboardView()
         v._activity_focused = True
+        assert v.intercepts_key("DOWN") is True
         assert v.intercepts_key("\x1b[B") is True
 
     def test_intercepts_enter_when_focused(self):
         v = panel.DashboardView()
         v._activity_focused = True
         assert v.intercepts_key("\r") is True
+        assert v.intercepts_key("\n") is True
 
     def test_intercepts_j_k_when_focused(self):
         v = panel.DashboardView()
@@ -239,13 +270,21 @@ class TestDashboardViewInterceptsKey:
         assert v.intercepts_key("k") is True
 
     def test_does_not_intercept_r_when_focused(self):
+        # [r] não é da Activity — não pode ser interceptado (segue global/view).
         v = panel.DashboardView()
         v._activity_focused = True
         assert v.intercepts_key("r") is False
 
+    def test_does_not_intercept_q_when_focused(self):
+        # [q] sempre encerra o painel (global), mesmo dentro do modo focused.
+        v = panel.DashboardView()
+        v._activity_focused = True
+        assert v.intercepts_key("q") is False
+
     def test_does_not_intercept_esc_when_not_focused(self):
         v = panel.DashboardView()
         v._activity_focused = False
+        assert v.intercepts_key("ESC") is False
         assert v.intercepts_key("\x1b") is False
 
 
@@ -258,3 +297,211 @@ class TestLiveSessionViewRegistered:
         views = panel._build_views()
         assert "live-session" in views
         assert isinstance(views["live-session"], panel.LiveSessionView)
+
+
+# ---------------------------------------------------------------------------
+# Regressão: [A] reabilita a ActionsView (que ficou órfã ao [a] ser
+# repurposed para a Activity em #436/#446).
+# ---------------------------------------------------------------------------
+
+class TestActionsViewHotkey:
+    def test_uppercase_A_navs_to_actions(self):
+        v = panel.DashboardView()
+        result = v.handle_key("A", _mock_app())
+        assert result.kind == panel.Action.NAV
+        assert result.target == "actions"
+
+    def test_uppercase_A_does_not_enter_activity_focus(self):
+        # [A] é Actions, NÃO entra no modo cursor da Activity.
+        v = panel.DashboardView()
+        v.handle_key("A", _mock_app())
+        assert v._activity_focused is False
+
+    def test_lowercase_a_enters_activity_not_actions(self):
+        # [a] minúsculo continua sendo a Activity (não navega para actions).
+        v = panel.DashboardView()
+        result = v.handle_key("a", _mock_app())
+        assert v._activity_focused is True
+        assert result.kind == panel.Action.REFRESH
+
+    def test_actions_view_registered(self):
+        views = panel._build_views()
+        assert "actions" in views
+        assert isinstance(views["actions"], panel.ActionsView)
+
+    def test_actions_view_renders_without_data(self):
+        # A view não pode crashar sem cluster/dados (k8s offline).
+        view = panel.ActionsView(data=None)
+        app = panel.PanelApp(views={"actions": view}, root="actions")
+        out = view.render(app)
+        assert out is not None
+
+
+# ---------------------------------------------------------------------------
+# Regressão: ciclo de foco da Activity não pode prender teclas globais.
+# Com o token correto do KeyReader ("ESC"/"UP"/"DOWN"), entrar→mover→sair
+# devolve o controle global.
+# ---------------------------------------------------------------------------
+
+class TestActivityFocusCycle:
+    def test_enter_move_esc_releases_global(self):
+        v = panel.DashboardView()
+        v._last_activity_events = [_event() for _ in range(3)]
+        # entra no modo cursor
+        v.handle_key("a", _mock_app())
+        assert v._activity_focused is True
+        # move com setas (tokens de produção)
+        v.handle_key("DOWN", _mock_app())
+        assert v._activity_cursor == 1
+        v.handle_key("UP", _mock_app())
+        assert v._activity_cursor == 0
+        # ESC sai do modo focused
+        v.handle_key("ESC", _mock_app())
+        assert v._activity_focused is False
+        # após ESC, as teclas globais voltam a navegar
+        result = v.handle_key("1", _mock_app())
+        assert result.kind == panel.Action.NAV
+        assert result.target == "pod-picker"
+
+    def test_global_nav_swallowed_while_focused(self):
+        # Enquanto focado, [1] não navega — é NOOP (precisa ESC antes).
+        v = panel.DashboardView()
+        v._activity_focused = True
+        v._last_activity_events = [_event()]
+        result = v.handle_key("1", _mock_app())
+        assert result.kind == panel.Action.NOOP
+        assert v._activity_focused is True
+
+    def test_enter_exit_idempotent(self):
+        v = panel.DashboardView()
+        v._last_activity_events = [_event()]
+        v.handle_key("a", _mock_app())
+        v.handle_key("ESC", _mock_app())
+        v.handle_key("a", _mock_app())
+        assert v._activity_focused is True
+        assert v._activity_cursor == 0
+        v.handle_key("ESC", _mock_app())
+        assert v._activity_focused is False
+
+    def test_esc_with_empty_feed_exits(self):
+        # Feed vazio não pode prender o ESC.
+        v = panel.DashboardView()
+        v._activity_focused = True
+        v._last_activity_events = []
+        result = v.handle_key("ESC", _mock_app())
+        assert v._activity_focused is False
+        assert result.kind == panel.Action.REFRESH
+
+    def test_arrows_with_empty_feed_do_not_crash(self):
+        v = panel.DashboardView()
+        v._activity_focused = True
+        v._last_activity_events = []
+        v.handle_key("DOWN", _mock_app())
+        v.handle_key("UP", _mock_app())
+        # cursor permanece em 0 (len_rows=1, % 1 == 0)
+        assert v._activity_cursor == 0
+
+    def test_enter_canonical_token_drilldown(self):
+        ev = _event(actor="claude-worker", source_pod="pod-x", task_id="t-1")
+        v = panel.DashboardView()
+        v._activity_focused = True
+        v._activity_cursor = 0
+        v._last_activity_events = [ev]
+        result = v.handle_key("\r", _mock_app())
+        assert result.kind == panel.Action.NAV
+        assert result.target == "live-session"
+
+
+# ---------------------------------------------------------------------------
+# Render: cursor obsoleto é clampado à janela corrente do feed.
+# ---------------------------------------------------------------------------
+
+class TestActivityCursorClamp:
+    def test_render_clamps_stale_cursor(self):
+        # cursor obsoleto (999) deve ser clampado à janela de linhas visível
+        # após o render — nunca apontar para fora dos limites.
+        v = panel.DashboardView()
+        v._activity_focused = True
+        v._activity_cursor = 999
+        v._activity_panel()
+        n_rows = len(panel._activity_from_data(None, limit=10))
+        assert n_rows > 0
+        assert v._activity_cursor == n_rows - 1
+
+    def test_render_does_not_crash_and_keeps_cursor_valid(self):
+        v = panel.DashboardView()
+        v._activity_focused = True
+        v._activity_cursor = 0
+        out = v._activity_panel()
+        assert out is not None
+        assert v._activity_cursor >= 0
+
+
+# ---------------------------------------------------------------------------
+# Footer HOTKEYS reflete [a]ctivity + [A]ctions e o modo focused.
+# ---------------------------------------------------------------------------
+
+class TestActivityHotkeysFooter:
+    def test_normal_footer_lists_activity_and_actions(self):
+        v = panel.DashboardView()
+        v._activity_focused = False
+        hk = v.HOTKEYS
+        assert "[a]ctivity" in hk
+        assert "[A]ctions" in hk
+
+    def test_focused_footer_shows_cursor_keys_and_esc(self):
+        v = panel.DashboardView()
+        v._activity_focused = True
+        hk = v.HOTKEYS
+        assert "esc" in hk.lower()
+        assert "ACTIVITY" in hk
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via PanelApp: o despacho real (intercepts_key + _handle_global
+# + handle_key) prova que o focus-trap sumiu com os tokens corretos.
+# ---------------------------------------------------------------------------
+
+class TestPanelAppActivityDispatch:
+    def _app(self) -> panel.PanelApp:
+        dash = panel.DashboardView()
+        dash._last_activity_events = [_event() for _ in range(3)]
+        return panel.PanelApp(views={"dashboard": dash}, root="dashboard")
+
+    def _dispatch(self, app: panel.PanelApp, key: str) -> None:
+        """Espelha o caminho de tecla do _run_loop (linhas ~9243-9255)."""
+        view = app.current_view
+        if view.intercepts_key(key):
+            app._apply(view.handle_key(key, app))
+        elif app._handle_global(key):
+            return
+        else:
+            app._apply(view.handle_key(key, app))
+
+    def test_esc_unfocuses_instead_of_global_pop(self):
+        app = self._app()
+        dash = app.current_view
+        # entra no modo focused
+        self._dispatch(app, "a")
+        assert dash._activity_focused is True
+        # ESC é interceptado e sai do modo (não dispara pop global no root)
+        self._dispatch(app, "ESC")
+        assert dash._activity_focused is False
+        # o painel continua vivo (não saiu nem empilhou nada)
+        assert app.running is True
+        assert len(app.stack) == 1
+
+    def test_global_keys_work_after_esc(self):
+        app = self._app()
+        self._dispatch(app, "a")
+        self._dispatch(app, "ESC")
+        # [1] agora navega para pod-picker (empilha a view)
+        app.views["pod-picker"] = panel.PodPickerView(data=None)
+        self._dispatch(app, "1")
+        assert app.current_view.name == "pod-picker"
+
+    def test_uppercase_A_pushes_actions_view(self):
+        app = self._app()
+        app.views["actions"] = panel.ActionsView(data=None)
+        self._dispatch(app, "A")
+        assert app.current_view.name == "actions"

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -1469,15 +1469,17 @@ class DashboardView(View):
     @property
     def HOTKEYS(self) -> str:
         if self._activity_focused:
+            # No modo cursor da ACTIVITY só ↑↓/enter/esc fazem algo — destaca
+            # esse subconjunto e marca como sair (esc). As demais hotkeys
+            # globais ficam dormentes até o esc devolver o controle.
             return (
-                "[1]Pods  [2]Pipeline  [3]Issues/PRs  [4]Logs  "
-                "[t]okens(claude) [T]okens(frota)  [M]onitor  [n]otifier  "
-                "[a]ctivity:[↑↓/enter/esc]  "
-                f"[m]odel/runtime  [d]ispatch  [S]caling  [s]ort:{self.sort_mode}  [?]help  [q]uit"
+                "ACTIVITY: [↑↓]navega  [enter]abre origem  [esc]sai  "
+                "[q]uit"
             )
         return (
             "[1]Pods  [2]Pipeline  [3]Issues/PRs  [4]Logs  "
-            "[t]okens(claude) [T]okens(frota)  [M]onitor  [n]otifier  [m]odel/runtime  "
+            "[t]okens(claude) [T]okens(frota)  [M]onitor  [n]otifier  "
+            "[a]ctivity  [A]ctions  [m]odel/runtime  "
             f"[d]ispatch  [S]caling  [s]ort:{self.sort_mode}  [?]help  [q]uit"
         )
 
@@ -1657,6 +1659,12 @@ class DashboardView(View):
         # Defensive defaults for instances created via __new__ (tests).
         focused = getattr(self, "_activity_focused", False)
         cursor = getattr(self, "_activity_cursor", 0)
+        # Clamp o cursor à janela corrente — o feed encolhe entre renders
+        # (eventos saem da janela de 10) e um cursor obsoleto não pode apontar
+        # fora dos limites nem deixar a highlight órfã.
+        if rows:
+            cursor = min(cursor, len(rows) - 1)
+            self._activity_cursor = cursor
         if not rows:
             body: RenderableType = Text(
                 "· sem atividade recente registrada", style="dim"
@@ -1872,10 +1880,30 @@ class DashboardView(View):
 
     # --- key ---
 
+    # Tokens canônicos do KeyReader (ver classe ``KeyReader.read``): a seta
+    # vira ``"UP"``/``"DOWN"``, o ESC vira ``"ESC"`` e o enter vira ``"\r"``/
+    # ``"\n"``. As variantes raw (``"\x1b"``, ``"\x1b[A"``, ``"\x1b[B"``) são
+    # aceitas só por retrocompat de testes — em produção nunca chegam.
+    _ACTIVITY_UP_KEYS = ("UP", "k", "\x1b[A")
+    _ACTIVITY_DOWN_KEYS = ("DOWN", "j", "\x1b[B")
+    _ACTIVITY_ENTER_KEYS = ("\r", "\n")
+    _ACTIVITY_ESC_KEYS = ("ESC", "\x1b")
+
     def intercepts_key(self, key: str) -> bool:
-        """Intercept cursor/ESC keys when activity panel is focused (issue #446)."""
+        """Intercept cursor/ESC keys when activity panel is focused (issue #446).
+
+        Sem isso, o ESC do KeyReader (``"ESC"``) cairia no handler global
+        (``_handle_global``), que faria ``pop()`` — no-op no dashboard-root —
+        deixando ``_activity_focused`` preso. Interceptar devolve a tecla a
+        ``handle_key`` para que ESC saia do modo focused (issue #446 fix).
+        """
         if self._activity_focused:
-            if key in ("\x1b", "\x1b[A", "\x1b[B", "j", "k", "\r", "\n"):
+            if key in (
+                *self._ACTIVITY_UP_KEYS,
+                *self._ACTIVITY_DOWN_KEYS,
+                *self._ACTIVITY_ENTER_KEYS,
+                *self._ACTIVITY_ESC_KEYS,
+            ):
                 return True
         return super().intercepts_key(key)
 
@@ -1883,15 +1911,13 @@ class DashboardView(View):
         # Activity cursor navigation (issue #446) — handled before global nav.
         if self._activity_focused:
             len_rows = max(1, len(self._last_activity_events))
-            if key in ("\x1b[A", "k"):
-                # UP
+            if key in self._ACTIVITY_UP_KEYS:
                 self._activity_cursor = (self._activity_cursor - 1) % len_rows
                 return ActionResult.refresh()
-            if key in ("\x1b[B", "j"):
-                # DOWN
+            if key in self._ACTIVITY_DOWN_KEYS:
                 self._activity_cursor = (self._activity_cursor + 1) % len_rows
                 return ActionResult.refresh()
-            if key in ("\r", "\n"):
+            if key in self._ACTIVITY_ENTER_KEYS:
                 # ENTER — drill down into selected event.
                 events = self._last_activity_events
                 if events and self._activity_cursor < len(events):
@@ -1908,15 +1934,19 @@ class DashboardView(View):
                                                 pod_name=source_pod,
                                                 pod_role=actor)
                 return ActionResult.refresh()
-            if key == "\x1b":
-                # ESC — exit cursor mode.
+            if key in self._ACTIVITY_ESC_KEYS:
+                # ESC — sai do modo focused e devolve o controle global.
                 self._activity_focused = False
                 return ActionResult.refresh()
-            return ActionResult.refresh()
+            # Qualquer outra tecla no modo focused é ignorada (NOOP) para não
+            # prender hotkeys globais: ESC já desfez o foco acima, então uma
+            # tecla solta aqui não deve consumir nem forçar render.
+            return ActionResult()
 
-        # When "a" is pressed, enter activity cursor mode instead of nav to
-        # "actions".  The old "actions" view is now reached via the [a]ctions
-        # entry in the nav dict below only when NOT in focused mode.
+        # ``[a]`` minúsculo → entra no modo cursor da ACTIVITY (navegar o feed
+        # multi-source + drill-down). ``[A]`` MAIÚSCULO → ActionsView (rollout/
+        # ações do deploy.py), via ``nav`` dict abaixo. O KeyReader distingue
+        # maiúsculo/minúsculo via termios cbreak — sem ambiguidade.
         if key == "a":
             self._activity_focused = True
             self._activity_cursor = 0
@@ -1929,6 +1959,14 @@ class DashboardView(View):
             "4": "logs-split",
             "n": "notifier-echo",
             "m": "model-switcher",
+            # [A] MAIÚSCULO → ActionsView (verbos do deploy.py: rollout
+            # restart, build, up/stop/start, down — cada ação mutadora passa
+            # por confirmação [y/N]). O [a] minúsculo é o modo cursor da
+            # ACTIVITY (tratado acima). Antes (regressão #436/#446) o [a] foi
+            # repurposed para a Activity e a ActionsView ficou órfã — sem
+            # hotkey chegando nela. As ações de rollout do pod selecionado
+            # também seguem na PodPickerView ([1] Pods → r/R/x).
+            "A": "actions",
             # Pipeline Stage Configuration (issue #309 fase 2 — Task 21 cutover):
             # matriz unificada que substitui (a) o flip global de
             # ``DEILE_PIPELINE_DISPATCH_MODE`` da ``DispatchModeView`` (PR #330)
@@ -4957,7 +4995,10 @@ class ActionsView(View):
         actions = self._actions()
         # menu
         menu = Table(box=box.SIMPLE_HEAD, expand=True, pad_edge=False)
-        menu.add_column(" ", width=3)
+        # Larguras adaptativas (pilar #15): sem ``width=<int>`` literal — o
+        # índice [1-9] é curto, então ``no_wrap`` basta para o Rich dimensionar
+        # a coluna a partir de ``console.width`` em cada render.
+        menu.add_column(" ", no_wrap=True)
         menu.add_column("ação", style="bold")
         menu.add_column("comando", style="dim")
         for i, a in enumerate(actions, 1):


### PR DESCRIPTION
## O que estava quebrado

A regressão das issues **#436** (Activity multi-source) e **#446** (cursor/drill-down da Activity) reaproveitou a tecla `[a]` do painel TUI (`infra/k8s/_panel.py`) para o widget Activity e deixou dois defeitos:

1. **`ActionsView` órfã** — a view de rollout/ações do `deploy.py` (`name="actions"`) continua registrada no `_build_views`, mas **nenhum hotkey chegava nela**. O comentário em `handle_key` afirmava que ela era alcançada "via the `[a]ctions` entry in the nav dict" — falso/stale: não havia entry nenhum.
2. **Foco travado na Activity** — o `intercepts_key`/`handle_key` do modo focado checavam os tokens crus `"\x1b"`, `"\x1b[A"`, `"\x1b[B"`, que o `KeyReader` de produção **nunca emite** (ele emite `"ESC"`, `"UP"`, `"DOWN"` — ver `KeyReader.read`/`_ARROW`). Resultado em produção: as setas não moviam o cursor e o `ESC` caía no `_handle_global`, que fazia `pop()` (no-op no dashboard-root), prendendo `_activity_focused=True` para sempre e **engolindo as teclas globais** (`[1]`/`[2]`/`[t]`...).

> Os testes antigos passavam porque exercitavam os **mesmos tokens errados** que o código — comentário não é prova, o código é.

## O que `[A]` e `[a]` fazem agora

- **`[A]` MAIÚSCULO → `ActionsView`** (novo entry `"A": "actions"` no `nav` dict). Dispara os verbos do `deploy.py` (restart, build, up/stop/start, down) com confirmação `[y/N]` por ação mutadora; roda sem cluster (k8s offline lista só `status`). Sem colisão: `_handle_global` não vincula `A`.
- **`[a]` minúsculo → modo cursor da Activity** (mantido), agora com o foco que **solta**: entra → `↑↓` move → `enter` drill-down → `ESC` sai e devolve o controle global. As teclas casam os tokens canônicos do `KeyReader` (`UP`/`DOWN`/`ESC`); os tokens crus seguem aceitos por retrocompat. Tecla não-Activity no modo focado vira NOOP (não prende hotkey global).

## Para que serve a navegação da Activity

O feed lista os últimos eventos multi-source; o `enter` faz **drill-down na origem do evento**: `claude-worker` + `task_id` → `live-session`; demais com `source_pod` → `pod-watch`. Feed vazio é tratado graciosamente (mensagem "sem atividade" + `ESC` sai). Cursor é clampado à janela corrente no render (o feed encolhe entre renders).

## Estado do widget Activity

**V1 funcional** — feed multi-source + cursor + drill-down operam. As FUs abertas **#447** (fontes do `MultiSourceActivityProvider` configuráveis via `settings.panel.activity_sources`) e **#606** (hot-reload/enabled/timeout por fonte) seguem válidas e **não foram tocadas**.

## Pillar 15 / limpeza

- Rodapé `HOTKEYS` mostra `[a]ctivity` + `[A]ctions` no modo normal e `↑↓/enter/esc` no modo focado, sem `width=N`.
- `width=3` literal da `ActionsView` (agora alcançável) trocado por `no_wrap=True`.
- Comentário stale removido.

## Testes

- Novos: ciclo de foco (entra/move/ESC-sai), drill-down com tokens canônicos, `[A]`→actions vs `[a]`→activity, teclas globais destravadas após ESC, feed vazio gracioso, clamp de cursor, rodapé, e **despacho end-to-end via `PanelApp`** (`intercepts_key` + `_handle_global` + `handle_key`) provando o fim do focus-trap.
- Existentes atualizados para os tokens canônicos (`UP`/`DOWN`/`ESC`), mantendo cobertura dos tokens crus por retrocompat.

`python3 -m pytest deile/tests/ -q` → **8274 passed, 30 skipped, 1 failed**. A única falha (`test_pod_presence::test_cleanup_stale_workspaces_removes_dead_pod_workspace`) é baseline pré-existente em `origin/main` (confirmada idêntica em árvore pristina via `git stash`; PR #649 aberta), não relacionada a este diff. `test_table_widths_adaptive` verde. Sem novas falhas. `ruff`/`isort` sem novos achados nos arquivos tocados.