### PR TITLE
fix(pipeline): cap claude-worker concurrency by live-lease count (409); exclude bloqueada from critique

### DIFF
--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -507,16 +507,16 @@ async def _collect_mention_triggers(
 
     Sticky trigger behaviour by source:
 
-    * **reviewer (PR)** — filtered by ``~mention:processado``. A review request
-      is a one-shot, not a retry: GitHub keeps ``deile-one`` in
-      ``requested_reviewers`` until a *formal* review is submitted, so without
-      the gate the unified PR brief runs a full (and, on opus, expensive) review
-      on EVERY tick — a 401/transient failure or a comment-only verdict never
-      clears the request, and ``nowait=True`` dispatches never advance the
-      attempt-ceiling, so the loop is unbounded. The marker is applied on
-      sticky-success (``_mark_mention_done``); honoring it here makes that site's
-      comment true ("evita re-dispatch redundante no próximo tick"). A human
-      removes ``~mention:processado`` to force a re-review.
+    * **reviewer (PR)** — NOT filtered by ``~mention:processado``. A review
+      request self-clears when a *formal* review is submitted (GitHub drops
+      ``deile-one`` from ``requested_reviewers``), so the natural PR state
+      already dedups; a review that failed (401/transient/comment-only)
+      legitimately retries on the next tick without a marker that would block
+      it. Concurrency is NOT inferred here by summing labels — the authority on
+      "how many claude run" is the claude-worker, which counts live leases on
+      the shared PVC and returns 409 when full (global cross-pod cap,
+      ``_count_live_leases``/``DEILE_CLAUDE_MAX_CONCURRENT``); the pipeline just
+      dispatches and retries on 409.
     * **assignee (PR)** — NOT filtered by ``~mention:processado``.
       Discovery-by-state: ``assignee`` routes to ``work_merge`` which legitimately
       retries (CI pending, threads open) until merged/closed terminates it.
@@ -562,11 +562,12 @@ async def _collect_mention_triggers(
     # ``assignee`` (PR/issue) segue descoberta-por-estado: o worker abre a PR e
     # decide pelo estado real (HEAD vs último review, threads abertas) — assignee
     # roteia p/ ``work_merge``, que legitimamente re-tenta até merge/close.
-    # ``reviewer`` e ``body`` SÃO gateados por ``~mention:processado``: ambos são
-    # one-shot (o request de review e o corpo são estáticos) e, sem o gate,
-    # re-disparariam um review/brief completo a cada tick — caro e ilimitado
-    # (o ``nowait=True`` nem avança o attempt-ceiling). O humano remove o marker
-    # para forçar re-handle.
+    # ``reviewer`` NÃO é gateado por ``~mention:processado``: o review-request se
+    # auto-limpa quando um review formal é submetido (o GitHub tira ``deile-one``
+    # de ``requested_reviewers``) e um review que falhou re-tenta sozinho — a
+    # concorrência é capada no claude-worker (409 por lease viva, ver bloco
+    # abaixo), não inferida aqui. Só ``body`` é gateado: corpo estático, sem o
+    # marker re-dispararia a cada tick indefinidamente.
     async def _poll(label: str, coro) -> list:
         try:
             return list(await coro)

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -507,9 +507,19 @@ async def _collect_mention_triggers(
 
     Sticky trigger behaviour by source:
 
-    * **assignee/reviewer (PR)** — NOT filtered by ``~mention:processado``.
-      Discovery-by-state: the unified PR brief opens the PR and decides whether
-      there is real work to do.  Sticky-success marks the marker to avoid churn.
+    * **reviewer (PR)** — filtered by ``~mention:processado``. A review request
+      is a one-shot, not a retry: GitHub keeps ``deile-one`` in
+      ``requested_reviewers`` until a *formal* review is submitted, so without
+      the gate the unified PR brief runs a full (and, on opus, expensive) review
+      on EVERY tick — a 401/transient failure or a comment-only verdict never
+      clears the request, and ``nowait=True`` dispatches never advance the
+      attempt-ceiling, so the loop is unbounded. The marker is applied on
+      sticky-success (``_mark_mention_done``); honoring it here makes that site's
+      comment true ("evita re-dispatch redundante no próximo tick"). A human
+      removes ``~mention:processado`` to force a re-review.
+    * **assignee (PR)** — NOT filtered by ``~mention:processado``.
+      Discovery-by-state: ``assignee`` routes to ``work_merge`` which legitimately
+      retries (CI pending, threads open) until merged/closed terminates it.
     * **assignee (issue)** — NOT filtered by ``~mention:processado``, but IS
       gated by ``~workflow:*``: issues already owned by the pipeline (gate label
       present) are skipped to prevent EVENTS panel flooding (issue #483).
@@ -549,13 +559,14 @@ async def _collect_mention_triggers(
 
     # ---- 2-4. Sticky triggers (assignee / reviewer / body) --------------
     #
-    # Antes da refactor "PR é o quadro", os sticky triggers eram gateados por
-    # ``~mention:processado`` para impedir re-disparo cross-tick. Isso é
-    # incompatível com o princípio de descoberta-por-estado: o worker abre a
-    # PR e decide pelo estado real (HEAD vs último review, threads abertas,
-    # comentários sem resposta) — se nada precisa ser feito, o brief unificado
-    # comenta curto e sai. Já o trigger ``body`` continua gateado porque o
-    # corpo é estático: sem o marker ele re-disparia infinitamente.
+    # ``assignee`` (PR/issue) segue descoberta-por-estado: o worker abre a PR e
+    # decide pelo estado real (HEAD vs último review, threads abertas) — assignee
+    # roteia p/ ``work_merge``, que legitimamente re-tenta até merge/close.
+    # ``reviewer`` e ``body`` SÃO gateados por ``~mention:processado``: ambos são
+    # one-shot (o request de review e o corpo são estáticos) e, sem o gate,
+    # re-disparariam um review/brief completo a cada tick — caro e ilimitado
+    # (o ``nowait=True`` nem avança o attempt-ceiling). O humano remove o marker
+    # para forçar re-handle.
     async def _poll(label: str, coro) -> list:
         try:
             return list(await coro)
@@ -581,6 +592,13 @@ async def _collect_mention_triggers(
             )
         )
     for pr in await _poll("review requests", monitor.forge.list_prs_with_review_requests(gh_login)):
+        # Gate one-shot review requests by ~mention:processado: the request
+        # lingers on the PR until a formal review is submitted, so re-firing
+        # every tick would re-run a full (expensive) review indefinitely. The
+        # marker is applied on sticky-success; a human removes it to re-review.
+        if MENTION_DONE in pr.labels:
+            log_routing_dropped(target_kind="pr", target=pr.number, reason="reviewer_already_processed")
+            continue
         triggers.append(
             MentionTrigger(
                 trigger_type="reviewer", pr=pr, trigger_author=gh_login,

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -950,9 +950,16 @@ async def review_one_new_issue(monitor: "PipelineMonitor") -> None:
         return
     # Shard filter: only consider issues whose hash falls in our shard.
     # Sort by priority so the most urgent issue is critiqued first.
+    # ``~workflow:bloqueada`` é um hard-block: congela a issue em TODOS os
+    # estágios (não só o auto-resume). Sem esta exclusão, uma issue ``nova`` que
+    # um humano travou ainda seria critecada uma vez (nova→em_revisao) — gasto
+    # não-intencional — antes de os selectors downstream (refine/implement) a
+    # congelarem. Espelha o filtro já presente no reconcile e no implement.
     candidates = [
         i for i in sort_by_priority(issues)
-        if i.batch_id is None and monitor.identity.owns(i.title)
+        if i.batch_id is None
+        and monitor.identity.owns(i.title)
+        and WORKFLOW_BLOCKED not in i.labels
     ]
     if not candidates:
         return

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -591,34 +591,23 @@ async def _collect_mention_triggers(
                 trigger_type="assignee", pr=pr, trigger_author=gh_login,
             )
         )
-    # Review requests são one-shot E limitados por concorrência. Cada review é
-    # um dispatch opus caro (~$2-5, suíte in-pod); rodar muitos em paralelo num
-    # único claude-worker thrasha o pod e queima custo concorrente. Gateamos em
-    # DUAS dimensões:
-    #   1. ``~mention:processado`` (one-shot): o request persiste no PR até um
-    #      review FORMAL ser submetido — sem o marker, re-disparia a cada tick.
-    #      Um PR com marker E ainda requested = review JÁ despachada e em voo
-    #      (o review formal, ao ser submetido, limpa o request → deixa de contar).
-    #   2. ``max_parallel`` (concorrência): só despacha ``max_parallel`` menos os
-    #      que já estão em voo. Os excedentes NÃO recebem o marker, então
-    #      re-entram como candidatos no próximo tick, conforme os slots liberam.
-    review_prs = await _poll(
+    # Reviewer-request → um review por PR. NÃO contamos concorrência aqui: a
+    # AUTORIDADE de "quantos claude rodam" é o claude-worker, que conta leases
+    # vivas no PVC compartilhado e devolve 409 quando cheio (cap GLOBAL cross-pod
+    # — ``_count_live_leases``/``DEILE_CLAUDE_MAX_CONCURRENT``). O pipeline é
+    # burro: dispara; se 409, re-tenta no próximo tick. Somar labels p/ inferir
+    # paralelos era frágil (ignorava comment/assignee; contava sessão morta pra
+    # sempre → deadlock). Dedup do MESMO PR em voo = guarda per-channel do
+    # worker; "já revisado" = o GitHub limpa o review-request ao submeter; review
+    # que falhou re-tenta sozinho (sem marker que trave o retry).
+    for pr in await _poll(
         "review requests", monitor.forge.list_prs_with_review_requests(gh_login)
-    )
-    in_flight_reviews = sum(1 for pr in review_prs if MENTION_DONE in pr.labels)
-    review_slots = max(0, monitor.config.max_parallel - in_flight_reviews)
-    fresh_review_prs = [pr for pr in review_prs if MENTION_DONE not in pr.labels]
-    for pr in review_prs:
-        if MENTION_DONE in pr.labels:
-            log_routing_dropped(target_kind="pr", target=pr.number, reason="reviewer_already_processed")
-    for pr in fresh_review_prs[:review_slots]:
+    ):
         triggers.append(
             MentionTrigger(
                 trigger_type="reviewer", pr=pr, trigger_author=gh_login,
             )
         )
-    for pr in fresh_review_prs[review_slots:]:
-        log_routing_dropped(target_kind="pr", target=pr.number, reason="reviewer_queue_capacity")
 
     try:
         body_issues, body_prs = await monitor.forge.search_items_mentioning(handle)

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -591,19 +591,34 @@ async def _collect_mention_triggers(
                 trigger_type="assignee", pr=pr, trigger_author=gh_login,
             )
         )
-    for pr in await _poll("review requests", monitor.forge.list_prs_with_review_requests(gh_login)):
-        # Gate one-shot review requests by ~mention:processado: the request
-        # lingers on the PR until a formal review is submitted, so re-firing
-        # every tick would re-run a full (expensive) review indefinitely. The
-        # marker is applied on sticky-success; a human removes it to re-review.
+    # Review requests são one-shot E limitados por concorrência. Cada review é
+    # um dispatch opus caro (~$2-5, suíte in-pod); rodar muitos em paralelo num
+    # único claude-worker thrasha o pod e queima custo concorrente. Gateamos em
+    # DUAS dimensões:
+    #   1. ``~mention:processado`` (one-shot): o request persiste no PR até um
+    #      review FORMAL ser submetido — sem o marker, re-disparia a cada tick.
+    #      Um PR com marker E ainda requested = review JÁ despachada e em voo
+    #      (o review formal, ao ser submetido, limpa o request → deixa de contar).
+    #   2. ``max_parallel`` (concorrência): só despacha ``max_parallel`` menos os
+    #      que já estão em voo. Os excedentes NÃO recebem o marker, então
+    #      re-entram como candidatos no próximo tick, conforme os slots liberam.
+    review_prs = await _poll(
+        "review requests", monitor.forge.list_prs_with_review_requests(gh_login)
+    )
+    in_flight_reviews = sum(1 for pr in review_prs if MENTION_DONE in pr.labels)
+    review_slots = max(0, monitor.config.max_parallel - in_flight_reviews)
+    fresh_review_prs = [pr for pr in review_prs if MENTION_DONE not in pr.labels]
+    for pr in review_prs:
         if MENTION_DONE in pr.labels:
             log_routing_dropped(target_kind="pr", target=pr.number, reason="reviewer_already_processed")
-            continue
+    for pr in fresh_review_prs[:review_slots]:
         triggers.append(
             MentionTrigger(
                 trigger_type="reviewer", pr=pr, trigger_author=gh_login,
             )
         )
+    for pr in fresh_review_prs[review_slots:]:
+        log_routing_dropped(target_kind="pr", target=pr.number, reason="reviewer_queue_capacity")
 
     try:
         body_issues, body_prs = await monitor.forge.search_items_mentioning(handle)

--- a/deile/tests/infra/test_claude_worker_lease.py
+++ b/deile/tests/infra/test_claude_worker_lease.py
@@ -569,3 +569,71 @@ class TestDispatch409WhenLeaseHeld:
         body = json.loads(response.body)
         assert body["error_code"] == "TASK_ALREADY_RUNNING"
         assert body["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Cap GLOBAL de concorrência via contagem de leases (fonte de verdade, cross-pod)
+# ---------------------------------------------------------------------------
+
+
+class TestCountLiveLeases:
+    """``_count_live_leases`` conta dispatches EM VOO = leases com heartbeat
+    fresco no PVC compartilhado. É a fonte de verdade da concorrência GLOBAL —
+    NÃO soma de labels (frágil) nem pgrep local (cego cross-pod). Auto-cura:
+    lease com heartbeat velho (pod morto) não conta."""
+
+    @pytest.mark.unit
+    def test_counts_only_fresh_leases(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(cws, "_LEASE_TTL_S", 30)
+        root = tmp_path / "work"
+        root.mkdir()
+        for tid in ("a" * 16, "b" * 16):  # 2 frescas
+            d = root / tid
+            d.mkdir()
+            _make_lease(d, age_s=0.0)
+        stale = root / ("c" * 16)  # stale (auto-cura → não conta)
+        stale.mkdir()
+        _make_lease(stale, age_s=120.0)
+        (root / ("d" * 16)).mkdir()  # task_id sem lease → não conta
+        (root / ".progress").mkdir()  # não-task_id → ignorado
+        assert cws._count_live_leases(root) == 2
+
+    @pytest.mark.unit
+    def test_missing_root_returns_zero(self, tmp_path: Path):
+        assert cws._count_live_leases(tmp_path / "nonexistent") == 0
+
+    @pytest.mark.unit
+    async def test_dispatch_returns_409_at_concurrency_cap(self, tmp_path: Path):
+        """Com >= MAX leases vivas no root, o dispatch é recusado com 409
+        CONCURRENT_DISPATCH_BLOCKED — cap global por lease-count, ANTES de aceitar."""
+        root = tmp_path
+        for tid in ("a" * 16, "b" * 16):
+            d = root / tid
+            d.mkdir()
+            _make_lease(d, age_s=0.0)
+
+        from unittest.mock import AsyncMock as _AM
+
+        request = MagicMock()
+        request.json = _AM(return_value={
+            "brief": "review PR", "stage": "pr_review",
+            "channel_id": "pipeline-mention-pr-99",
+        })
+        request.app = {"auth_token": "test-token"}
+
+        with (
+            patch.object(cws, "_CLAUDE_MAX_CONCURRENT", 2),
+            patch.object(cws, "_LEASE_TTL_S", 30),
+            patch.dict(os.environ, {
+                "DEILE_CLAUDE_WORKER_ROOT": str(root),
+                "HOSTNAME": "pod-test",
+            }),
+        ):
+            response = await cws.dispatch_handler(request)
+
+        assert response.status == 409
+        body = json.loads(response.body)
+        assert body["error_code"] == "CONCURRENT_DISPATCH_BLOCKED"
+        assert body["ok"] is False

--- a/deile/tests/orchestration/pipeline/test_collector_assignee_not_gated_by_mention_done.py
+++ b/deile/tests/orchestration/pipeline/test_collector_assignee_not_gated_by_mention_done.py
@@ -1,17 +1,14 @@
 """Gating dos sticky triggers de PR por ``~mention:processado``.
 
-- **assignee (PR/issue)** — NÃO gateado: roteia para ``work_merge``, que
-  legitimamente re-tenta (CI pendente, threads) até merge/close terminar
-  (descoberta-por-estado, Decisão #45).
-- **reviewer (PR)** — GATEADO: um request de review é one-shot. O GitHub
-  mantém ``deile-one`` em ``requested_reviewers`` até um review *formal* ser
-  submetido, então sem o gate o brief unificado re-rodaria um review completo
-  (caro, em opus) a CADA tick — um 401/falha transiente ou veredito só-comentário
-  nunca limpa o request, e dispatches ``nowait=True`` nem avançam o
-  attempt-ceiling, deixando o loop ilimitado. O humano remove o marker para
-  forçar re-review.
+- **assignee (PR/issue)** — NÃO gateado: roteia para ``work_merge`` (Decisão #45).
+- **reviewer (PR)** — NÃO gateado pelo marker: a CONCORRÊNCIA é responsabilidade
+  do claude-worker (cap global por leases vivas no PVC → 409 quando cheio), NÃO
+  do pipeline somando labels. O pipeline dispara para todo review-request; o
+  worker recusa o excedente. Um review submetido limpa o ``requested_reviewers``
+  no GitHub (some do poll); um review que falhou re-tenta sozinho (sem marker
+  que trave). Ver claude_worker_server ``_count_live_leases``.
 - **body** — GATEADO: corpo é estático e re-dispararia infinitamente sem o
-  marker.
+  marker (não há request que se auto-limpe).
 
 Esse teste valida os três comportamentos.
 """
@@ -98,48 +95,37 @@ class TestStickyPrTriggersUngated:
         assert triggers[0].issue.number == 42
 
 
-class TestReviewerTriggerGated:
-    """``reviewer`` (PR) É gateado por ``~mention:processado``.
+class TestReviewerTriggerNotGated:
+    """``reviewer`` (PR) NÃO é gateado pelo marker nem por soma-de-label.
 
-    Regressão do loop de re-dispatch: com ``deile-one`` requisitado como
-    reviewer, o request persiste na PR até um review formal ser submetido. Sem
-    o gate, todo tick re-dispararia um review opus completo (custo ilimitado;
-    ``nowait=True`` nem avança o attempt-ceiling). O marker, aplicado em
-    sticky-success, corta o re-dispatch; o humano o remove para re-revisar.
+    A concorrência é do claude-worker (cap global por leases vivas no PVC → 409),
+    não do pipeline. O collector dispara para TODO review-request; o worker
+    recusa o excedente. Marker presente ou não, com 1 ou N requests, todos
+    armam — quem limita é o worker.
     """
 
-    async def test_reviewer_pr_with_mention_done_is_skipped(self):
+    async def test_reviewer_pr_with_mention_done_still_arms(self):
+        """Marker presente NÃO bloqueia — review que falhou re-tenta sozinho."""
         monitor = _make_monitor(review_request_prs=[_pr(88, labels=(MENTION_DONE,))])
         triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
-        assert triggers == []
+        assert len(triggers) == 1
+        assert triggers[0].trigger_type == "reviewer"
+        assert triggers[0].pr.number == 88
 
-    async def test_reviewer_pr_without_mention_done_still_arms(self):
-        """O PRIMEIRO request (sem o marker) dispara o review normalmente."""
+    async def test_reviewer_pr_without_mention_done_arms(self):
         monitor = _make_monitor(review_request_prs=[_pr(88)])
         triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
         assert len(triggers) == 1
         assert triggers[0].trigger_type == "reviewer"
-        assert triggers[0].pr is not None
-        assert triggers[0].pr.number == 88
 
-    async def test_reviewer_concurrency_cap_limits_fresh_dispatch(self):
-        """Com ``max_parallel=2`` e 3 requests frescos (sem marker), só 2 armam
-        no tick; o 3º espera (re-entra no próximo tick, sem marker)."""
+    async def test_all_review_requests_arm_no_pipeline_cap(self):
+        """N requests → N triggers (o pipeline NÃO capeia; o worker é a autoridade
+        de concorrência via 409 por lease-count)."""
         monitor = _make_monitor(review_request_prs=[_pr(1), _pr(2), _pr(3)])
         monitor.config.max_parallel = 2
         triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
         reviewer = [t for t in triggers if t.trigger_type == "reviewer"]
-        assert len(reviewer) == 2
-
-    async def test_reviewer_concurrency_counts_in_flight(self):
-        """PRs com o marker (review JÁ em voo) consomem slot: com ``max_parallel=2``
-        e 2 já em voo, nenhum fresco é despachado neste tick."""
-        in_flight = [_pr(1, labels=(MENTION_DONE,)), _pr(2, labels=(MENTION_DONE,))]
-        fresh = [_pr(3), _pr(4)]
-        monitor = _make_monitor(review_request_prs=in_flight + fresh)
-        monitor.config.max_parallel = 2
-        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
-        assert [t for t in triggers if t.trigger_type == "reviewer"] == []
+        assert len(reviewer) == 3
 
 
 class TestBodyTriggerStillGated:

--- a/deile/tests/orchestration/pipeline/test_collector_assignee_not_gated_by_mention_done.py
+++ b/deile/tests/orchestration/pipeline/test_collector_assignee_not_gated_by_mention_done.py
@@ -1,15 +1,19 @@
-"""Sticky triggers PR (assignee/reviewer) deixaram de ser gateados por
-``~mention:processado`` (Decisão #45 — "PR é o quadro").
+"""Gating dos sticky triggers de PR por ``~mention:processado``.
 
-A racional anterior — gatear sticky-PR pelo marker pra evitar storm cross-tick
-— foi substituída por descoberta-por-estado: o brief unificado abre a PR, vê
-o estado real (HEAD vs último review, threads abertas) e comenta curto "sem
-novidade" se nada precisa ser feito. O pipeline marca sticky-success com o
-marker para evitar churn redundante; mudanças reais (HEAD novo) re-armam via
-o trigger natural.
+- **assignee (PR/issue)** — NÃO gateado: roteia para ``work_merge``, que
+  legitimamente re-tenta (CI pendente, threads) até merge/close terminar
+  (descoberta-por-estado, Decisão #45).
+- **reviewer (PR)** — GATEADO: um request de review é one-shot. O GitHub
+  mantém ``deile-one`` em ``requested_reviewers`` até um review *formal* ser
+  submetido, então sem o gate o brief unificado re-rodaria um review completo
+  (caro, em opus) a CADA tick — um 401/falha transiente ou veredito só-comentário
+  nunca limpa o request, e dispatches ``nowait=True`` nem avançam o
+  attempt-ceiling, deixando o loop ilimitado. O humano remove o marker para
+  forçar re-review.
+- **body** — GATEADO: corpo é estático e re-dispararia infinitamente sem o
+  marker.
 
-O gate em **body** continua ATIVO — corpo é estático e re-dispararia
-infinitamente sem o marker. Esse teste valida ambos os comportamentos.
+Esse teste valida os três comportamentos.
 """
 
 from __future__ import annotations
@@ -83,13 +87,6 @@ class TestStickyPrTriggersUngated:
         assert triggers[0].pr is not None
         assert triggers[0].pr.number == 77
 
-    async def test_reviewer_pr_with_mention_done_still_arms(self):
-        """Idem para requested-reviewer em PR."""
-        monitor = _make_monitor(review_request_prs=[_pr(88, labels=(MENTION_DONE,))])
-        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
-        assert len(triggers) == 1
-        assert triggers[0].trigger_type == "reviewer"
-
     async def test_assignee_issue_with_mention_done_still_arms(self):
         """Assignee em ISSUE também não é mais gateado pelo marker — a
         injeção em ``~workflow:nova`` (caminho de routing) cuida da
@@ -99,6 +96,31 @@ class TestStickyPrTriggersUngated:
         assert len(triggers) == 1
         assert triggers[0].issue is not None
         assert triggers[0].issue.number == 42
+
+
+class TestReviewerTriggerGated:
+    """``reviewer`` (PR) É gateado por ``~mention:processado``.
+
+    Regressão do loop de re-dispatch: com ``deile-one`` requisitado como
+    reviewer, o request persiste na PR até um review formal ser submetido. Sem
+    o gate, todo tick re-dispararia um review opus completo (custo ilimitado;
+    ``nowait=True`` nem avança o attempt-ceiling). O marker, aplicado em
+    sticky-success, corta o re-dispatch; o humano o remove para re-revisar.
+    """
+
+    async def test_reviewer_pr_with_mention_done_is_skipped(self):
+        monitor = _make_monitor(review_request_prs=[_pr(88, labels=(MENTION_DONE,))])
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        assert triggers == []
+
+    async def test_reviewer_pr_without_mention_done_still_arms(self):
+        """O PRIMEIRO request (sem o marker) dispara o review normalmente."""
+        monitor = _make_monitor(review_request_prs=[_pr(88)])
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        assert len(triggers) == 1
+        assert triggers[0].trigger_type == "reviewer"
+        assert triggers[0].pr is not None
+        assert triggers[0].pr.number == 88
 
 
 class TestBodyTriggerStillGated:

--- a/deile/tests/orchestration/pipeline/test_collector_assignee_not_gated_by_mention_done.py
+++ b/deile/tests/orchestration/pipeline/test_collector_assignee_not_gated_by_mention_done.py
@@ -122,6 +122,25 @@ class TestReviewerTriggerGated:
         assert triggers[0].pr is not None
         assert triggers[0].pr.number == 88
 
+    async def test_reviewer_concurrency_cap_limits_fresh_dispatch(self):
+        """Com ``max_parallel=2`` e 3 requests frescos (sem marker), só 2 armam
+        no tick; o 3º espera (re-entra no próximo tick, sem marker)."""
+        monitor = _make_monitor(review_request_prs=[_pr(1), _pr(2), _pr(3)])
+        monitor.config.max_parallel = 2
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        reviewer = [t for t in triggers if t.trigger_type == "reviewer"]
+        assert len(reviewer) == 2
+
+    async def test_reviewer_concurrency_counts_in_flight(self):
+        """PRs com o marker (review JÁ em voo) consomem slot: com ``max_parallel=2``
+        e 2 já em voo, nenhum fresco é despachado neste tick."""
+        in_flight = [_pr(1, labels=(MENTION_DONE,)), _pr(2, labels=(MENTION_DONE,))]
+        fresh = [_pr(3), _pr(4)]
+        monitor = _make_monitor(review_request_prs=in_flight + fresh)
+        monitor.config.max_parallel = 2
+        triggers = await _collect_mention_triggers(monitor, "@deile-one", "deile-one")
+        assert [t for t in triggers if t.trigger_type == "reviewer"] == []
+
 
 class TestBodyTriggerStillGated:
     """Por contraste: ``body`` continua gateado por ``MENTION_DONE``.

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -398,21 +398,19 @@ class TestProcessMentionsCrossTickDedup:
         assert monitor.stats.mentions_processed == 1
         github.add_labels.assert_called_once_with("pr", 77, [MENTION_DONE])
 
-    async def test_reviewer_with_mention_done_still_dispatches(self):
-        """Após o refactor "PR é o quadro", o marker ``~mention:processado``
-        em uma PR reviewer NÃO bloqueia o re-dispatch. O brief unificado
-        agora descobre o estado real (se review está APPROVED em HEAD igual,
-        ele comenta curto "sem novidade" e o pipeline re-marca pra cortar
-        churn natural). Mudanças reais de estado (HEAD novo) voltam a
-        entrar pelo trigger natural."""
+    async def test_reviewer_with_mention_done_is_skipped(self):
+        """Um request de review é one-shot: o marker ``~mention:processado``
+        BLOQUEIA o re-dispatch. Sem isso, o request — que persiste na PR até um
+        review formal ser submetido — re-dispararia um review opus completo a
+        cada tick (caro e ilimitado; ``nowait`` nem avança o attempt-ceiling).
+        O humano remove o marker para forçar re-review."""
         monitor, github, notifier = _make_monitor()
         github.list_prs_with_review_requests = AsyncMock(
             return_value=[_pr_ref(88, labels=(MENTION_DONE,))]
         )
         await monitor._process_mentions()
-        assert monitor.stats.mentions_processed == 1
-        # PR sticky-success agora SEMPRE marca (não há mais exceção pra reviewer).
-        github.add_labels.assert_called_once_with("pr", 88, [MENTION_DONE])
+        assert monitor.stats.mentions_processed == 0
+        github.add_labels.assert_not_called()
 
     async def test_body_mention_already_processed_is_skipped(self):
         monitor, github, notifier = _make_monitor()

--- a/deile/tests/orchestration/pipeline/test_mention_handling.py
+++ b/deile/tests/orchestration/pipeline/test_mention_handling.py
@@ -398,19 +398,17 @@ class TestProcessMentionsCrossTickDedup:
         assert monitor.stats.mentions_processed == 1
         github.add_labels.assert_called_once_with("pr", 77, [MENTION_DONE])
 
-    async def test_reviewer_with_mention_done_is_skipped(self):
-        """Um request de review é one-shot: o marker ``~mention:processado``
-        BLOQUEIA o re-dispatch. Sem isso, o request — que persiste na PR até um
-        review formal ser submetido — re-dispararia um review opus completo a
-        cada tick (caro e ilimitado; ``nowait`` nem avança o attempt-ceiling).
-        O humano remove o marker para forçar re-review."""
+    async def test_reviewer_with_mention_done_still_dispatches(self):
+        """Reviewer NÃO é gateado pelo marker: a concorrência é do claude-worker
+        (cap por leases vivas → 409), não do pipeline somando labels. O
+        collector dispara para todo review-request; um review que falhou
+        re-tenta sozinho. (Ver claude_worker_server._count_live_leases.)"""
         monitor, github, notifier = _make_monitor()
         github.list_prs_with_review_requests = AsyncMock(
             return_value=[_pr_ref(88, labels=(MENTION_DONE,))]
         )
         await monitor._process_mentions()
-        assert monitor.stats.mentions_processed == 0
-        github.add_labels.assert_not_called()
+        assert monitor.stats.mentions_processed == 1
 
     async def test_body_mention_already_processed_is_skipped(self):
         monitor, github, notifier = _make_monitor()

--- a/deile/tests/orchestration/pipeline/test_refinement_gate.py
+++ b/deile/tests/orchestration/pipeline/test_refinement_gate.py
@@ -332,6 +332,21 @@ class TestCritique:
         removed = [c.args[2] for c in monitor.github.remove_labels.await_args_list if c.args[1] == 1]
         assert any(REFINAR in lst for lst in removed)
 
+    async def test_blocked_nova_issue_is_not_critiqued(self):
+        """Hard-block: uma issue ``~workflow:nova`` que também carrega
+        ``~workflow:bloqueada`` NÃO é critecada — sem transição nova→em_revisao,
+        sem dispatch (gasto não-intencional). O label congela a issue em TODOS
+        os estágios, não só no auto-resume."""
+        monitor, _, _ = _make_monitor(
+            label_map={WORKFLOW_NEW: [_issue(98, "feature", WORKFLOW_BLOCKED)]},
+            worker_responses=[_resp("VEREDITO: CLARO")],
+        )
+        await monitor._review_one_new_issue()
+        # Sem o filtro, a issue transicionaria nova→em_revisao (1º passo da
+        # crítica). A ausência de QUALQUER transição para #98 prova que ela foi
+        # excluída dos candidatos antes de qualquer processamento/dispatch.
+        assert not any(n == 98 for (n, _f, _to) in _transitions(monitor.github))
+
     async def test_poor_feature_goes_to_arquitetura(self):
         monitor, _, _ = _make_monitor(
             label_map={WORKFLOW_NEW: [_issue(2, "feature")]},

--- a/infra/k8s/claude_worker_server.py
+++ b/infra/k8s/claude_worker_server.py
@@ -221,6 +221,14 @@ _LEASE_TTL_S: int = int(os.environ.get("DEILE_CLAUDE_LEASE_TTL_S", "30"))
 #: Intervalo de atualização do heartbeat em segundos.
 _LEASE_HEARTBEAT_S: int = int(os.environ.get("DEILE_CLAUDE_LEASE_HEARTBEAT_S", "5"))
 
+#: Teto GLOBAL de claude concorrentes neste worker. O registro de leases no PVC
+#: (compartilhado entre réplicas) é a ÚNICA fonte de verdade de "quantos
+#: dispatches estão em voo" — NÃO a soma de labels no pipeline (frágil: ignora
+#: gatilhos não-contados e conta sessões mortas pra sempre) NEM o ``pgrep``
+#: local (cego cross-pod). Conta leases com heartbeat fresco; auto-cura porque
+#: lease de pod morto expira em ``_LEASE_TTL_S``. 0 = sem teto.
+_CLAUDE_MAX_CONCURRENT: int = int(os.environ.get("DEILE_CLAUDE_MAX_CONCURRENT", "2"))
+
 
 # --------------------------------------------------------------------------- #
 # Anthropic quota cache — thread-safe singleton (issue #395)
@@ -1312,6 +1320,38 @@ def _parse_claude_json_output(stdout: str) -> dict:
 # --------------------------------------------------------------------------- #
 
 
+def _count_live_leases(root: Path) -> int:
+    """Conta dispatches EM VOO = leases com ``heartbeat_at`` fresco (< TTL).
+
+    Fonte de verdade da concorrência (cross-pod via PVC compartilhado): cada
+    dispatch grava ``<task_id>/.lease.json`` e o heartbeat o mantém fresco
+    enquanto o pod que o processa está vivo; ao concluir, a lease é removida; se
+    o pod morre, a lease expira em ``_LEASE_TTL_S`` e deixa de contar (auto-cura
+    — sem deadlock por estado fantasma). Best-effort: erros de I/O são pulados.
+    """
+    now = time.time()
+    count = 0
+    try:
+        children = list(root.iterdir())
+    except OSError:
+        return 0
+    for child in children:
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if not _TASK_ID_RE.fullmatch(child.name):
+            continue
+        lease_path = child / ".lease.json"
+        if not lease_path.exists():
+            continue
+        try:
+            data = json.loads(lease_path.read_text(encoding="utf-8"))
+            if (now - float(data.get("heartbeat_at", 0))) < _LEASE_TTL_S:
+                count += 1
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    return count
+
+
 def _find_active_lease(root: Path) -> Optional[dict]:
     """Return the most recent alive lease found under *root*/<task_id>/.lease.json.
 
@@ -2137,6 +2177,29 @@ async def dispatch_handler(request: web.Request) -> web.Response:
         claude_model = match.group(1)
 
     root = Path(os.environ.get("DEILE_CLAUDE_WORKER_ROOT", "/home/claude/work"))
+
+    # Teto GLOBAL de concorrência (cross-pod): o registro de leases no PVC é a
+    # fonte única de "quantos dispatches em voo". Conta ANTES de aceitar; se >=
+    # máximo, recusa com 409 — o caller (pipeline) trata como não-fatal e
+    # re-tenta no próximo tick. Cobre TODO gatilho (reviewer/comment/assignee/
+    # implement) porque a autoridade é o worker que roda os processos, não a
+    # soma de labels. Vale p/ resume E fresh (ambos giram um claude).
+    if _CLAUDE_MAX_CONCURRENT > 0:
+        _live_leases = _count_live_leases(root)
+        if _live_leases >= _CLAUDE_MAX_CONCURRENT:
+            logger.warning(
+                "dispatch BLOCKED — %d leases vivas >= máx %d (channel=%s); "
+                "recusando p/ proteger o pod de contenção",
+                _live_leases, _CLAUDE_MAX_CONCURRENT, _channel_id or "?",
+            )
+            return web.json_response({
+                "ok": False,
+                "error_code": "CONCURRENT_DISPATCH_BLOCKED",
+                "error": (
+                    f"{_live_leases} claude em execução >= máximo "
+                    f"{_CLAUDE_MAX_CONCURRENT}; pipeline aguarda próximo tick"
+                ),
+            }, status=409)
 
     # Resume path: reaproveita workdir + session-id existentes.
     is_resume = bool(resume_session_id and prev_task_id)


### PR DESCRIPTION
## Problema (encontrado em produção nesta sessão)

Ao marcar `deile-one` como **requested reviewer**, o monitor re-disparava review a cada tick — e, pior, a **concorrência** de `claude -p` era inferida somando labels no pipeline. Essa soma é frágil: ignora comment/assignee, conta sessão morta como viva (→ deadlock) e nunca foi a fonte de verdade. Um comentário fora do caminho do gate furou o limite e subiu um 3º `claude -p` concorrente → contention de CPU (pod 2 vCPU) → 2 reviews mortos por SIGTERM.

## Correção (re-arquitetada)

A **fonte de verdade de quantos paralelos existem é o claude-worker** (dono do recurso), não a soma de labels no pipeline:

1. **Cap global por lease viva no claude-worker** (`infra/k8s/claude_worker_server.py`): `_count_live_leases()` conta os `.lease.json` com heartbeat fresco (`< _LEASE_TTL_S`) no PVC compartilhado; `dispatch_handler` devolve **409 `CONCURRENT_DISPATCH_BLOCKED`** quando `>= DEILE_CLAUDE_MAX_CONCURRENT` (default 2), cobrindo resume **e** fresh, em todos os triggers. Cross-pod (PVC compartilhado), auto-curável (lease morta expira no TTL → sem deadlock).
2. **Pipeline vira "burro"**: o trigger `reviewer` dispara para todo review-request (**NÃO** é gateado por `~mention:processado`); se o worker está cheio, recebe 409 e o pipeline re-tenta no próximo tick. O review-request se auto-limpa quando um review formal é submetido (dedup natural). Só `body` continua gateado (corpo estático).
3. **`review_one_new_issue`**: exclui `~workflow:bloqueada` dos candidatos a crítica (coerente com reconcile/implement).

## Testes

- `TestReviewerTriggerNotGated` (reviewer arma com/sem marker; N requests → N triggers); `test_reviewer_with_mention_done_still_dispatches`; `test_blocked_nova_issue_is_not_critiqued`; `TestCountLiveLeases` + `test_dispatch_returns_409_at_concurrency_cap`.
- Subset afetado verde. **Provado E2E em produção**: o worker aceitou 2 dispatches, devolveu 409 no 3º, e ≤2 `claude -p` foram mantidos.

## Nota (não-bloqueante)

O cap limita **concorrência**, não **frequência**. Um review-request que falha rápido (ex.: `WORKER_AUTH_EXPIRED` ~2s, sem segurar lease) pode re-disparar por tick — mas isso **não queima tokens** (o `claude` nem chega a rodar) e já é contido pelo backoff exponencial de auth (Decisão #46g — pausa o target após 3 falhas consecutivas) + dedup per-channel do mesmo PR em voo (`DISPATCH_SKIPPED_STILL_RUNNING`).