### PR TITLE
fix(memory): ProceduralMemory resiliente a patterns.json corrompido

### DIFF
--- a/deile/memory/procedural_memory.py
+++ b/deile/memory/procedural_memory.py
@@ -1,5 +1,6 @@
 """Procedural Memory - Patterns aprendidos e habilidades adquiridas"""
 
+import json
 import logging
 from collections import defaultdict
 from pathlib import Path
@@ -30,8 +31,14 @@ class ProceduralMemory:
             return
 
         if self.patterns_file.exists():
-            data = await read_json(self.patterns_file)
-            self._patterns.update(data)
+            try:
+                data = await read_json(self.patterns_file)
+                self._patterns.update(data)
+            except (json.JSONDecodeError, OSError):
+                logger.warning(
+                    "ProceduralMemory: falha ao ler %s; iniciando com base vazia",
+                    self.patterns_file,
+                )
 
         self._is_initialized = True
         logger.info("ProceduralMemory inicializada")

--- a/deile/tests/memory/test_procedural_memory_async_io.py
+++ b/deile/tests/memory/test_procedural_memory_async_io.py
@@ -89,3 +89,16 @@ async def test_shutdown_offloads_blocking_write(tmp_path: Path, monkeypatch) -> 
 
     await pm.shutdown()
     assert to_thread_called, "shutdown() must offload the blocking write to a thread"
+
+
+async def test_initialize_tolerates_corrupt_patterns_file(tmp_path: Path) -> None:
+    """A corrupt ``patterns.json`` must not crash initialize(); start from empty."""
+    (tmp_path / "patterns.json").write_text("{ not valid json !!!", encoding="utf-8")
+
+    pm = ProceduralMemory(storage_dir=tmp_path, min_frequency=1)
+    await pm.initialize()  # must not raise
+
+    assert pm._is_initialized
+    # No patterns loaded from the corrupt file.
+    relevant = await pm.get_relevant_patterns("anything")
+    assert relevant == []


### PR DESCRIPTION
## Contexto

A issue #662 relatou que `ProceduralMemory` fazia I/O síncrono bloqueante (`open`/`json.load`/`json.dump`) dentro de corrotinas `async def`. Essa violação do princípio 03 §1 (Async-First) foi corrigida na PR #663 via `deile.storage.aio_fileio` (`read_json`/`write_json` com `asyncio.to_thread`).

Esta PR complementa aquela correção com **resiliência a arquivo corrompido**: se `patterns.json` existir mas não for JSON válido (ou houver erro de I/O), `initialize()` agora absorve a exceção, loga um aviso e parte do estado vazio — em vez de propagar a exceção e impedir toda a inicialização do agente.

## Entrega vs Critérios de Aceite da issue #662

| Critério de Aceite | Status | Evidência |
|---|---|---|
| `initialize()` não bloqueia o event loop (princípio 03 §1) | ✅ VERIFICADO | `test_initialize_offloads_blocking_read` confirma `asyncio.to_thread` chamado — 4/4 testes passam |
| `shutdown()` não bloqueia o event loop (princípio 03 §1) | ✅ VERIFICADO | `test_shutdown_offloads_blocking_write` confirma `asyncio.to_thread` chamado — 4/4 testes passam |
| Round-trip de patterns (shutdown/initialize preserva dados) | ✅ VERIFICADO | `test_patterns_round_trip_through_disk` — 4/4 testes passam |
| Resiliência a patterns.json corrompido (adição desta PR) | ✅ VERIFICADO | `test_initialize_tolerates_corrupt_patterns_file` — 4/4 testes passam |

**Resultado dos testes impactados:**
```
deile/tests/memory/test_procedural_memory_async_io.py - 4 passed in 1.02s
```

## Arquivos alterados

- `deile/memory/procedural_memory.py` — `initialize()` adiciona `try/except (json.JSONDecodeError, OSError)` com log de warning
- `deile/tests/memory/test_procedural_memory_async_io.py` — novo teste `test_initialize_tolerates_corrupt_patterns_file`

Closes #662.