### PR TITLE
test(infra): close 4 export coverage gaps — _build_pod_watch_json, _redact_for_export recursive, _deile_export_dir 0o700, exact key-sets

### DIFF
--- a/deile/tests/infra/test_panel_export_gaps.py
+++ b/deile/tests/infra/test_panel_export_gaps.py
@@ -1,0 +1,156 @@
+"""Tests: _redact_for_export recursive, _deile_export_dir mode, and exact key-sets (issue #461)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel
+from deile.ui.panel.observability.screens import LiveSessionData
+
+
+class TestRedactForExport:
+    """AC3: _redact_for_export — recursive dict/list and None no-op."""
+
+    def test_none_redactor_returns_value_unchanged(self):
+        assert panel._redact_for_export("hello", None) == "hello"
+
+    def test_none_redactor_none_value(self):
+        assert panel._redact_for_export(None, None) is None
+
+    def test_none_redactor_dict(self):
+        d = {"a": "val", "b": 42}
+        assert panel._redact_for_export(d, None) == d
+
+    def test_none_redactor_list(self):
+        lst = ["x", "y"]
+        assert panel._redact_for_export(lst, None) == lst
+
+    def test_string_redacted(self):
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "C" * 36
+        result = panel._redact_for_export(secret, redactor)
+        assert secret not in result
+
+    def test_dict_keys_preserved(self):
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "C" * 36
+        d = {"key": secret, "other": "safe"}
+        result = panel._redact_for_export(d, redactor)
+        assert set(result.keys()) == {"key", "other"}
+
+    def test_nested_dict_redacted(self):
+        """Recursive: secret inside a nested dict is redacted."""
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "C" * 36
+        nested = {"outer": {"inner": f"token={secret}"}}
+        result = panel._redact_for_export(nested, redactor)
+        assert secret not in json.dumps(result)
+        assert "outer" in result
+        assert "inner" in result["outer"]
+
+    def test_nested_list_redacted(self):
+        """Recursive: secret inside a list item is redacted."""
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "C" * 36
+        lst = [f"token={secret}", "safe"]
+        result = panel._redact_for_export(lst, redactor)
+        assert secret not in json.dumps(result)
+        assert len(result) == 2
+
+    def test_non_string_non_dict_non_list_passthrough(self):
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        assert panel._redact_for_export(42, redactor) == 42
+        assert panel._redact_for_export(3.14, redactor) == 3.14
+        assert panel._redact_for_export(True, redactor) is True
+        assert panel._redact_for_export(None, redactor) is None
+
+
+class TestDeileExportDir:
+    """AC4: _deile_export_dir creates ~/.deile/exports/ with mode 0o700."""
+
+    def test_dir_created(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = panel._deile_export_dir()
+        assert result.exists()
+        assert result.is_dir()
+
+    def test_dir_mode_0o700(self, tmp_path, monkeypatch):
+        import os
+        if os.name == "nt":
+            import pytest
+            pytest.skip("mode bits not enforced on Windows")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = panel._deile_export_dir()
+        mode = oct(result.stat().st_mode & 0o777)
+        assert mode == "0o700", f"Expected 0o700, got {mode}"
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        r1 = panel._deile_export_dir()
+        r2 = panel._deile_export_dir()
+        assert r1 == r2
+
+
+class TestBuildLiveSessionJsonExactKeys:
+    """AC5: _build_live_session_json exact envelope/payload key-sets for v1 and v2."""
+
+    def test_v1_envelope_exact_keys(self):
+        data = LiveSessionData(session=None, command=None, chat=None, api_errors=[])
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert set(obj.keys()) == {"schema_version", "kind", "exported_at", "payload"}
+
+    def test_v1_payload_exact_keys(self):
+        data = LiveSessionData(session=None, command=None, chat=None, api_errors=[])
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert set(obj["payload"].keys()) == {
+            "session", "command", "chat", "api_errors", "stdout"
+        }
+
+    def test_v2_envelope_exact_keys(self):
+        data = LiveSessionData(session=None, command=None, chat=None, api_errors=[])
+        obj = panel._build_live_session_json(data, [], redactor=None, include_history=True)
+        assert set(obj.keys()) == {
+            "schema_version", "kind", "exported_at", "payload", "history"
+        }
+
+    def test_v2_payload_exact_keys(self):
+        data = LiveSessionData(session=None, command=None, chat=None, api_errors=[])
+        obj = panel._build_live_session_json(data, [], redactor=None, include_history=True)
+        assert set(obj["payload"].keys()) == {
+            "session", "command", "chat", "api_errors", "stdout"
+        }
+
+    def test_v1_no_history_key(self):
+        data = LiveSessionData(session=None, command=None, chat=None, api_errors=[])
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert "history" not in obj
+
+    def test_v1_schema_version(self):
+        data = LiveSessionData(session=None, command=None, chat=None, api_errors=[])
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v1"
+
+    def test_v2_schema_version(self):
+        data = LiveSessionData(session=None, command=None, chat=None, api_errors=[])
+        obj = panel._build_live_session_json(data, [], redactor=None, include_history=True)
+        assert obj["schema_version"] == "deile.export.v2"
+
+    def test_v1_json_roundtrip(self):
+        """AC6: v1 result is JSON-serializable and round-trips cleanly."""
+        data = LiveSessionData(
+            session={"task_id": "t1"}, command=None, chat=None, api_errors=[]
+        )
+        obj = panel._build_live_session_json(data, [], redactor=None)
+        restored = json.loads(json.dumps(obj))
+        assert restored["payload"]["session"]["task_id"] == "t1"

--- a/deile/tests/infra/test_panel_export_pod_watch.py
+++ b/deile/tests/infra/test_panel_export_pod_watch.py
@@ -1,0 +1,98 @@
+"""Tests: _build_pod_watch_json schema v1, exact keys, and redaction (issue #461)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel
+
+
+class TestBuildPodWatchJsonSchemaKeys:
+    """AC1: envelope and payload key sets are exact."""
+
+    def test_envelope_exact_keys(self):
+        obj = panel._build_pod_watch_json("my-pod", "worker", [], redactor=None)
+        assert set(obj.keys()) == {"schema_version", "kind", "exported_at", "payload"}
+
+    def test_payload_exact_keys(self):
+        obj = panel._build_pod_watch_json("my-pod", "worker", [], redactor=None)
+        assert set(obj["payload"].keys()) == {"pod", "role", "lines"}
+
+    def test_schema_version_v1(self):
+        obj = panel._build_pod_watch_json("my-pod", "worker", [], redactor=None)
+        assert obj["schema_version"] == "deile.export.v1"
+
+    def test_kind_pod_watch(self):
+        obj = panel._build_pod_watch_json("my-pod", "worker", [], redactor=None)
+        assert obj["kind"] == "pod_watch"
+
+    def test_pod_name_preserved(self):
+        obj = panel._build_pod_watch_json("deile-worker-7d8c", "worker", [], redactor=None)
+        assert obj["payload"]["pod"] == "deile-worker-7d8c"
+
+    def test_role_preserved(self):
+        obj = panel._build_pod_watch_json("my-pod", "claude-worker", [], redactor=None)
+        assert obj["payload"]["role"] == "claude-worker"
+
+    def test_lines_empty_list(self):
+        obj = panel._build_pod_watch_json("my-pod", "worker", [], redactor=None)
+        assert obj["payload"]["lines"] == []
+
+    def test_lines_content_preserved(self):
+        lines = ["line one", "line two"]
+        obj = panel._build_pod_watch_json("my-pod", "worker", lines, redactor=None)
+        assert obj["payload"]["lines"] == lines
+
+    def test_exported_at_present(self):
+        obj = panel._build_pod_watch_json("my-pod", "worker", [], redactor=None)
+        assert obj["exported_at"]
+
+    def test_json_roundtrip(self):
+        """AC6: result is JSON-serializable and round-trips cleanly."""
+        lines = ["hello world", "second line"]
+        obj = panel._build_pod_watch_json("pod-abc", "pipeline", lines, redactor=None)
+        serialized = json.dumps(obj)
+        restored = json.loads(serialized)
+        assert restored["payload"]["lines"] == lines
+
+
+class TestBuildPodWatchJsonRedaction:
+    """AC2: lines are redacted via SecretsScanner; secret absent, line preserved."""
+
+    def test_redaction_removes_secret_from_lines(self):
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "C" * 36
+        lines = [f"token={secret}"]
+        obj = panel._build_pod_watch_json("pod", "worker", lines, redactor=redactor)
+        serialized = json.dumps(obj)
+        assert secret not in serialized
+
+    def test_redaction_preserves_line_count(self):
+        """AC2 anti-drop: line must be present (redacted), not dropped."""
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "C" * 36
+        lines = [f"token={secret}"]
+        obj = panel._build_pod_watch_json("pod", "worker", lines, redactor=redactor)
+        assert len(obj["payload"]["lines"]) == 1
+
+    def test_redaction_line_starts_with_token_prefix(self):
+        """Anti-drop: the 'token=' prefix is preserved, only the secret is replaced."""
+        from deile.security.secrets_scanner import SecretsScanner
+        redactor = SecretsScanner()
+        secret = "ghp_" + "C" * 36
+        lines = [f"token={secret}"]
+        obj = panel._build_pod_watch_json("pod", "worker", lines, redactor=redactor)
+        assert obj["payload"]["lines"][0].startswith("token=")
+
+    def test_no_redactor_leaves_lines_unchanged(self):
+        lines = ["some log line", "another line"]
+        obj = panel._build_pod_watch_json("pod", "worker", lines, redactor=None)
+        assert obj["payload"]["lines"] == lines


### PR DESCRIPTION
## Resumo

Adiciona cobertura de regressão para 4 superfícies do export estruturado (`[E]`) que **não tinham nenhum teste** (`grep -rln <sym> deile/tests/ → 0`), conforme identificado na issue #461.

**Zero arquivos de produção alterados** — entregável exclusivo: 2 arquivos de teste em `deile/tests/infra/`.

## Entrega vs Critérios de Aceite

| AC | Critério | Status | Evidência |
|----|----------|--------|-----------|
| AC0 | `git diff --name-only` toca só `deile/tests/` | ✅ | Apenas 2 arquivos novos em `deile/tests/infra/`; nenhum arquivo de produção editado |
| AC1 | `_build_pod_watch_json` schema v1, chaves exatas `{schema_version,kind,exported_at,payload}`, payload `{pod,role,lines}` | ✅ | `test_panel_export_pod_watch.py::TestBuildPodWatchJsonSchemaKeys` — `set(obj.keys()) == {...}` e `set(obj["payload"].keys()) == {...}` |
| AC2 | Redação via `SecretsScanner` real: `secret not in serialized` + linha preservada (anti-drop) | ✅ | `TestBuildPodWatchJsonRedaction` — `secret not in serialized`, `len(lines)==1`, linha inicia com `"token="` |
| AC3 | `_redact_for_export` recursivo (dict/list aninhados) + `None` no-op | ✅ | `test_panel_export_gaps.py::TestRedactForExport` — nested dict, nested list, None redactor |
| AC4 | `_deile_export_dir` cria diretório com `mode=0o700` | ✅ | `TestDeileExportDir::test_dir_mode_0o700` — `oct(stat().st_mode & 0o777) == "0o700"` |
| AC5 | `_build_live_session_json` chaves exatas v1 e v2 | ✅ | `TestBuildLiveSessionJsonExactKeys` — `set(keys) == {...}` para envelope e payload v1/v2 |
| AC6 | Round-trip `json.loads(json.dumps(...))` | ✅ | `test_json_roundtrip` (pod_watch) e `test_v1_json_roundtrip` (live_session) |

## Resultado dos testes

```
# Novos (34 testes):
deile/tests/infra/test_panel_export_pod_watch.py  . 14 passed
deile/tests/infra/test_panel_export_gaps.py       . 20 passed

# Existentes sem regressão (45 testes):
test_panel_export_history.py   7 passed
test_panel_export_overwrite.py 9 passed
test_panel_export_path.py      11 passed
test_panel_export_stdout.py    6 passed
test_panel_export_txt.py       12 passed
```

Closes #461.