### PR TITLE
fix(config): cost-cap global via settings.json morto + get_config_manager() não thread-safe

### DIFF
--- a/deile/config/manager.py
+++ b/deile/config/manager.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -895,12 +896,18 @@ def _remove_persona_from_yaml(config_file: Path, persona_id: str) -> None:
 
 # Singleton instance
 _config_manager: Optional[ConfigManager] = None
+_config_manager_lock = threading.Lock()
 
 
 def get_config_manager() -> ConfigManager:
-    """Retorna instância singleton do ConfigManager"""
+    """Retorna instância singleton do ConfigManager.
+
+    Thread-safe via double-checked locking (espelha get_settings(), Decisão #11).
+    """
     global _config_manager
     if _config_manager is None:
-        _config_manager = ConfigManager()
-        _config_manager.create_default_configs()  # Cria configs padrão se necessário
+        with _config_manager_lock:
+            if _config_manager is None:
+                _config_manager = ConfigManager()
+                _config_manager.create_default_configs()
     return _config_manager

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -391,6 +391,8 @@ _OVERRIDE_HANDLERS: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
     "pipeline.cost_caps_usd.implement":  ("pipeline_cost_cap_usd_implement",  _to_optional_positive_decimal),
     "pipeline.cost_caps_usd.pr_review":  ("pipeline_cost_cap_usd_pr_review",  _to_optional_positive_decimal),
     "pipeline.cost_caps_usd.follow_ups": ("pipeline_cost_cap_usd_follow_ups", _to_optional_positive_decimal),
+    # Global cost cap fallback (issue #666) — applies to all stages when no per-stage cap set.
+    "pipeline.cost_cap_usd":             ("pipeline_cost_cap_usd",            _to_optional_positive_decimal),
     # Sub-DEILEs paralelos (issue #257)
     "subagent.runner": ("subagent_runner", lambda v: str(v).strip().lower()),
     "subagent.max_parallel": ("subagent_max_parallel", _to_pos_int),
@@ -668,6 +670,10 @@ class Settings:
     pipeline_cost_cap_usd_implement: Optional[Decimal] = None
     pipeline_cost_cap_usd_pr_review: Optional[Decimal] = None
     pipeline_cost_cap_usd_follow_ups: Optional[Decimal] = None
+    # Global cost cap fallback (issue #666) — level-4 fallback in
+    # resolve_stage_cost_cap_usd when no per-stage cap and no global env var.
+    # Persisted under ``pipeline.cost_cap_usd`` in settings.json.
+    pipeline_cost_cap_usd: Optional[Decimal] = None
 
     # Sub-DEILEs paralelos em sessão CLI (issue #257)
     # `subagent_runner`        — "local" (default; in-process via asyncio.gather de

--- a/deile/tests/config/test_config_manager_thread_safety.py
+++ b/deile/tests/config/test_config_manager_thread_safety.py
@@ -1,0 +1,75 @@
+"""Thread-safety test for get_config_manager() singleton — issue #666.
+
+Verifica que get_config_manager() usa double-checked locking e não cria
+múltiplas instâncias em init concorrente, espelhando get_settings().
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from deile.config.manager import ConfigManager, get_config_manager
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Reset the singleton before and after each test."""
+    import deile.config.manager as mgr_mod
+    mgr_mod._config_manager = None
+    yield
+    mgr_mod._config_manager = None
+
+
+@pytest.mark.unit
+def test_get_config_manager_returns_same_instance():
+    """Successive calls return the identical singleton object."""
+    a = get_config_manager()
+    b = get_config_manager()
+    assert a is b
+
+
+@pytest.mark.unit
+def test_get_config_manager_concurrent_init_single_instance():
+    """Concurrent first-time calls must produce exactly one ConfigManager instance."""
+    import deile.config.manager as mgr_mod
+    mgr_mod._config_manager = None
+
+    instances: list[ConfigManager] = []
+    lock = threading.Lock()
+    errors: list[Exception] = []
+
+    def worker():
+        try:
+            inst = get_config_manager()
+            with lock:
+                instances.append(inst)
+        except Exception as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"threads raised: {errors}"
+    assert len(instances) == 20
+    # All threads must have received the same instance
+    first = instances[0]
+    assert all(inst is first for inst in instances), (
+        "get_config_manager() returned different instances under concurrent init"
+    )
+
+
+@pytest.mark.unit
+def test_get_config_manager_lock_exists():
+    """_config_manager_lock must be a threading.Lock (mirrors _settings_lock)."""
+    import deile.config.manager as mgr_mod
+    assert hasattr(mgr_mod, "_config_manager_lock"), (
+        "_config_manager_lock not found in deile.config.manager"
+    )
+    assert isinstance(mgr_mod._config_manager_lock, type(threading.Lock())), (
+        "_config_manager_lock is not a threading.Lock instance"
+    )

--- a/deile/tests/config/test_settings_cost_caps.py
+++ b/deile/tests/config/test_settings_cost_caps.py
@@ -72,6 +72,11 @@ class TestSettingsCostCapFields:
         assert s.pipeline_cost_cap_usd_pr_review is None
         assert s.pipeline_cost_cap_usd_follow_ups is None
 
+    def test_global_field_default_is_none(self):
+        """Global pipeline_cost_cap_usd field must exist and default to None (issue #666)."""
+        s = Settings()
+        assert s.pipeline_cost_cap_usd is None
+
     def test_fields_accept_decimal(self):
         s = Settings(
             pipeline_cost_cap_usd_implement=Decimal("5.00"),
@@ -79,6 +84,11 @@ class TestSettingsCostCapFields:
         )
         assert s.pipeline_cost_cap_usd_implement == Decimal("5.00")
         assert s.pipeline_cost_cap_usd_classify == Decimal("1.50")
+
+    def test_global_field_accepts_decimal(self):
+        """Global cost cap field accepts a Decimal value."""
+        s = Settings(pipeline_cost_cap_usd=Decimal("3.00"))
+        assert s.pipeline_cost_cap_usd == Decimal("3.00")
 
 
 class TestSettingsJsonLoadingCostCap:
@@ -120,3 +130,24 @@ class TestSettingsJsonLoadingCostCap:
         assert s.pipeline_cost_cap_usd_implement is None
         # Valid value applied
         assert s.pipeline_cost_cap_usd_classify == Decimal("5.00")
+
+    def test_json_loads_global_cost_cap(self):
+        """pipeline.cost_cap_usd key in settings.json is loaded into pipeline_cost_cap_usd (issue #666)."""
+        cfg = {"pipeline": {"cost_cap_usd": "7.50"}}
+        s = Settings()
+        s.apply_overrides(cfg)
+        assert s.pipeline_cost_cap_usd == Decimal("7.50")
+
+    def test_global_cost_cap_independent_of_per_stage(self):
+        """Global and per-stage cost caps coexist without interference."""
+        cfg = {
+            "pipeline": {
+                "cost_cap_usd": "2.00",
+                "cost_caps_usd": {"implement": "5.00"},
+            }
+        }
+        s = Settings()
+        s.apply_overrides(cfg)
+        assert s.pipeline_cost_cap_usd == Decimal("2.00")
+        assert s.pipeline_cost_cap_usd_implement == Decimal("5.00")
+        assert s.pipeline_cost_cap_usd_classify is None

--- a/deile/tests/orchestration/pipeline/test_resolve_stage_cost_cap_global_settings.py
+++ b/deile/tests/orchestration/pipeline/test_resolve_stage_cost_cap_global_settings.py
@@ -1,0 +1,77 @@
+"""Wiring test: resolve_stage_cost_cap_usd level-4 (global settings.json) — issue #666.
+
+Verifica que ``pipeline.cost_cap_usd`` em settings.json é lido como fallback
+global pelo resolver quando não há cap por-estágio nem env var global.
+"""
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+import pytest
+
+from deile.config.settings import get_settings, reset_settings
+from deile.orchestration.pipeline.dispatch_resolver import (
+    PIPELINE_STAGES, resolve_stage_cost_cap_usd)
+
+
+def _clear_env(monkeypatch):
+    for stage in PIPELINE_STAGES:
+        monkeypatch.delenv(f"DEILE_PIPELINE_COST_CAP_USD_{stage.upper()}", raising=False)
+    monkeypatch.delenv("DEILE_PIPELINE_COST_CAP_USD", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    _clear_env(monkeypatch)
+    reset_settings()
+    _deile_logger = logging.getLogger("deile")
+    _saved = _deile_logger.propagate
+    _deile_logger.propagate = True
+    yield
+    reset_settings()
+    _deile_logger.propagate = _saved
+
+
+class TestLevel4GlobalSettings:
+    def test_global_settings_returned_when_no_other_cap(self):
+        """Level 4: pipeline_cost_cap_usd in settings is the fallback for all stages."""
+        get_settings().pipeline_cost_cap_usd = Decimal("3.50")
+        for stage in PIPELINE_STAGES:
+            assert resolve_stage_cost_cap_usd(stage) == Decimal("3.50"), (
+                f"stage {stage!r} did not pick up global settings cap"
+            )
+
+    def test_global_settings_beaten_by_env_global(self, monkeypatch):
+        """Level 3 (env global) beats level 4 (global settings)."""
+        get_settings().pipeline_cost_cap_usd = Decimal("3.50")
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD", "1.00")
+        assert resolve_stage_cost_cap_usd("implement") == Decimal("1.00")
+
+    def test_global_settings_beaten_by_per_stage_settings(self):
+        """Level 2 (per-stage settings) beats level 4 (global settings)."""
+        get_settings().pipeline_cost_cap_usd = Decimal("3.50")
+        get_settings().pipeline_cost_cap_usd_implement = Decimal("8.00")
+        assert resolve_stage_cost_cap_usd("implement") == Decimal("8.00")
+        # Other stages still fall back to global
+        assert resolve_stage_cost_cap_usd("classify") == Decimal("3.50")
+
+    def test_global_settings_beaten_by_env_per_stage(self, monkeypatch):
+        """Level 1 (env per-stage) beats level 4 (global settings)."""
+        get_settings().pipeline_cost_cap_usd = Decimal("3.50")
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "2.00")
+        assert resolve_stage_cost_cap_usd("implement") == Decimal("2.00")
+        assert resolve_stage_cost_cap_usd("classify") == Decimal("3.50")
+
+    def test_none_when_global_settings_not_set(self):
+        """Level 5 (no cap) returned when global settings not set."""
+        assert resolve_stage_cost_cap_usd("implement") is None
+
+    def test_invalid_global_settings_falls_through_to_none(self, caplog):
+        """Invalid global settings value is ignored gracefully → None."""
+        settings = get_settings()
+        # Bypass the validator by directly setting an invalid value
+        object.__setattr__(settings, "pipeline_cost_cap_usd", Decimal("-1"))
+        with caplog.at_level(logging.WARNING, logger="deile.orchestration.pipeline.dispatch_resolver"):
+            result = resolve_stage_cost_cap_usd("implement")
+        assert result is None


### PR DESCRIPTION
## Resumo

Dois achados da auditoria de `deile/config/` (run de hardening 2026-06-10), deferidos da auditoria anterior para esta issue de rastreamento.

---

## Entrega vs Critérios de Aceite

### AC 1 — `pipeline.cost_cap_usd` global em settings.json (Achado 1)

**AC:** `resolve_stage_cost_cap_usd` lê uma chave `pipeline.cost_cap_usd` real (campo em `Settings` + handler no loader), com teste de fiação provando o nível 4.

**Entrega:**
- `deile/config/settings.py`: adicionado `pipeline_cost_cap_usd: Optional[Decimal] = None` à dataclass `Settings`
- `deile/config/settings.py`: adicionado `"pipeline.cost_cap_usd": ("pipeline_cost_cap_usd", _to_optional_positive_decimal)` ao mapa de chaves (`_SETTINGS_KEY_MAP`)
- `deile/orchestration/pipeline/dispatch_resolver.py:525` — código existente `getattr(settings, "pipeline_cost_cap_usd", None)` agora resolve corretamente (campo existe)
- Teste de fiação: `deile/tests/orchestration/pipeline/test_resolve_stage_cost_cap_global_settings.py` — 6 cenários de precedência (level-4 retorna global, é batido pelos levels 1–3, None quando não setado, graceful em valor inválido)
- Testes de Settings: `test_settings_cost_caps.py` expandido com 4 novos casos (campo existe, default None, aceita Decimal, carregamento via JSON)

**Status: ✅ VERIFICADO** — 27/27 testes verdes.

---

### AC 2 — `get_config_manager()` thread-safe (Achado 2)

**AC:** `get_config_manager()` com double-checked locking espelhando `get_settings()` (Decisão #11).

**Entrega:**
- `deile/config/manager.py`: adicionado `import threading`
- `deile/config/manager.py`: adicionado `_config_manager_lock = threading.Lock()`
- `get_config_manager()` reescrita com double-checked locking idêntico ao padrão de `get_settings()`
- Teste: `deile/tests/config/test_config_manager_thread_safety.py` — 3 casos: singleton idêntico, 20 threads concorrentes produzem uma única instância, existência do lock

**Status: ✅ VERIFICADO** — 3/3 testes verdes, 20 threads concorrentes → instância única.

---

## Testes impactados executados

```
deile/tests/config/test_settings_cost_caps.py                        18 passed
deile/tests/config/test_config_manager_thread_safety.py               3 passed
deile/tests/orchestration/pipeline/test_resolve_stage_cost_cap_global_settings.py  6 passed
deile/tests/orchestration/pipeline/test_dispatch_resolver_settings.py  14 passed
deile/tests/orchestration/pipeline/test_dispatch_resolver.py          34 passed
deile/tests/orchestration/pipeline/test_implementer_cost_cap_gating.py  5 passed
Total: 80 passed, 0 failed
```

Closes #666