### PR TITLE
test(commands): cobertura de timeout em ensure_gh_authenticated

### DIFF
--- a/deile/tests/commands/test_standup_command.py
+++ b/deile/tests/commands/test_standup_command.py
@@ -470,6 +470,19 @@ class TestEnsureChecks:
             sc.ensure_gh_authenticated()
         assert "auten" in str(exc_info.value).lower() or "auth" in str(exc_info.value).lower()
 
+    def test_gh_auth_timeout_raises_command_error(self, monkeypatch):
+        # gh auth status sem timeout podia travar indefinidamente (issue #655).
+        # TimeoutExpired deve ser mapeado para CommandError PT-BR.
+        monkeypatch.setattr(gh.shutil, "which", lambda exe: f"/usr/bin/{exe}")
+
+        def _raise_timeout(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd=["gh", "auth", "status"], timeout=30)
+
+        monkeypatch.setattr(gh.subprocess, "run", _raise_timeout)
+        with pytest.raises(CommandError) as exc_info:
+            sc.ensure_gh_authenticated()
+        assert "timeout" in str(exc_info.value).lower()
+
 
 # ---------------------------------------------------------------------------
 # execute() — fluxo completo


### PR DESCRIPTION
## Contexto

A implementação da issue #655 foi realizada diretamente em `main` no commit `23d70fd` (\"refactor(commands): harden slash command subsystem\"), que já aplicou as 3 correções de alto valor:

1. **Async (Pilar 1):** `backlog_command.execute` e `_standup_collectors.collect_standup_data` isolam os gates síncronos (`ensure_git_repo`, `ensure_gh_authenticated`, `_resolve_repo_from_git`) em `asyncio.to_thread`
2. **Robustez:** `_git_helpers.ensure_gh_authenticated` recebeu `timeout=30s` + mapeamento de `TimeoutExpired` → `CommandError` PT-BR
3. **Observabilidade (Pilar 6):** `model_command` ganhou `logger.debug` nos blocos de swap de TierRouter que suprimiam silenciosamente

O que faltava era cobertura de teste para o comportamento novo do timeout.

## Entrega vs Critérios de Aceite

| AC | Status | Evidência |
|---|---|---|
| Todos os testes existentes passam | ✅ VERIFICADO | `test_standup_command.py`: 48 passed; `test_backlog_command.py`: 64 passed |
| Nenhuma mudança de comportamento observável | ✅ VERIFICADO | O commit desta PR é test-only; a implementação (commit `23d70fd`) já está em `main` |
| Cobertura ≥ 80% | ✅ (não cai) | Adicionados 13 linhas de teste; zero código de produção removido |

## O que esta PR adiciona

Teste `test_gh_auth_timeout_raises_command_error` na classe `TestEnsureChecks` de `test_standup_command.py`:

- Verifica que `subprocess.TimeoutExpired` durante `gh auth status` é mapeado para `CommandError` com "timeout" na mensagem (PT-BR)
- Cobre o novo mapeamento `TimeoutExpired → CommandError` introduzido pelo commit `23d70fd`

## Deferido (follow-up)

Convenção de `except Exception: pass` remanescente (~11 blocos) em `export_command`, `memory_command`, `loc_command` — defensáveis (subsistema indisponível não deve abortar o comando), mas divergem da convenção `_shared.emit_audit_event`. Conversão exige adicionar logger de módulo em 3 arquivos; baixo valor para esta PR coesa. Ver follow-up dedicada.

Closes #655