### PR TITLE
feat(activity): activity sources configuráveis via settings.panel.activity_sources

### DIFF
--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -276,6 +276,57 @@ def _to_optional_reasoning_effort(value: Any) -> Optional[str]:
     return stripped
 
 
+# DNS-1123 label regex for validating deployment names in activity sources.
+# Mirrors _POD_NAME_RE in infra/k8s/_panel_data.py — keep in sync.
+# Allows single-character names (e.g. "x") and names up to 253 chars.
+_ACTIVITY_DEPLOYMENT_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$")
+
+
+def _to_activity_sources(value: Any) -> List[Dict[str, str]]:
+    """Strict converter for ``panel.activity_sources`` entries (issue #447).
+
+    Accepts a list of dicts, each with ``deployment`` (DNS-1123), ``role``
+    (non-empty str) and ``color`` (non-empty str). Empty list → [] (sentinel
+    for "use V1 default"). Duplicate ``deployment`` keys → rejected.
+    ``role`` duplicates are allowed (cosmetic, not a security boundary).
+    """
+    if not isinstance(value, list):
+        raise TypeError(f"expected list, got {type(value).__name__}")
+    if not value:
+        return []
+    seen_deployments: set = set()
+    result: List[Dict[str, str]] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise TypeError(
+                f"activity_sources[{idx}]: expected dict, got {type(item).__name__}"
+            )
+        deployment = item.get("deployment", "")
+        if not isinstance(deployment, str) or not deployment:
+            raise ValueError(
+                f"activity_sources[{idx}].deployment: missing or empty"
+            )
+        if not _ACTIVITY_DEPLOYMENT_RE.match(deployment):
+            raise ValueError(
+                f"activity_sources[{idx}].deployment={deployment!r}: "
+                "must match DNS-1123 (lowercase alphanumeric + hyphens, "
+                "start/end with alphanumeric, max 253 chars)"
+            )
+        if deployment in seen_deployments:
+            raise ValueError(
+                f"activity_sources[{idx}].deployment={deployment!r}: duplicate"
+            )
+        seen_deployments.add(deployment)
+        role = item.get("role", "")
+        if not isinstance(role, str) or not role:
+            raise ValueError(f"activity_sources[{idx}].role: missing or empty")
+        color = item.get("color", "")
+        if not isinstance(color, str) or not color:
+            raise ValueError(f"activity_sources[{idx}].color: missing or empty")
+        result.append({"deployment": deployment, "role": role, "color": color})
+    return result
+
+
 def _to_optional_positive_decimal(value: Any) -> Optional[Decimal]:
     """Strict converter for per-stage cost cap entries (issue #392).
 
@@ -412,6 +463,11 @@ _OVERRIDE_HANDLERS: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
     "security.sandbox_code_execution": ("sandbox_code_execution", _to_bool),
     "security.encrypt_logs": ("encrypt_logs", _to_bool),
     "monitoring.generate_compliance_reports": ("generate_compliance_reports", _to_bool),
+    # ACTIVITY widget configurable sources (issue #447). Strict-only: the
+    # list-of-dicts type cannot be handled by _set_typed / _apply_nested_dict.
+    # Apply via apply_overrides() which is called after _apply_nested_dict in
+    # each layer function. Empty list sentinel = "use V1 default".
+    "panel.activity_sources": ("panel_activity_sources", _to_activity_sources),
 }
 
 
@@ -728,6 +784,14 @@ class Settings:
     sandbox_code_execution: bool = False
     encrypt_logs: bool = False
     generate_compliance_reports: bool = False
+
+    # ACTIVITY widget configurable sources (issue #447).
+    # Empty list (default) = use the V1 default (_MULTI_SOURCE_DEFS in
+    # infra/k8s/_panel_data.py). Non-empty = override the tail sources list.
+    # Each dict: {"deployment": str, "role": str, "color": str}.
+    # Validated by _to_activity_sources (DNS-1123 deployment, no dups).
+    # Hot-reload is deferred to #606; sources are read once at provider init.
+    panel_activity_sources: List[Dict[str, str]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         for attr in ("working_directory", "config_directory", "logs_directory", "cache_directory"):
@@ -1065,11 +1129,16 @@ def _build_json_field_map() -> Dict[str, str]:
     refactor is observably no-op vs. the previous hand-maintained mapping.
     """
     # Keys present strict-only by design — preserve historical asymmetry.
+    # panel.activity_sources is strict-only because _set_typed cannot handle
+    # list-of-dicts (it stores raw dicts without validation/conversion). The
+    # layer functions call settings.apply_overrides(data) after _apply_nested_dict
+    # to process strict-only keys via their typed converters.
     _STRICT_ONLY = {
         "debug",
         "deile_md.user_path",
         "pipeline.max_parallel",
         "pipeline.refine_max_attempts",
+        "panel.activity_sources",
     }
     derived = {
         key_path: field_name
@@ -1457,8 +1526,14 @@ def _apply_user_layer(settings: "Settings", global_path: Path) -> None:
     Always safe to call — a missing file results in a no-op. Loads the
     trust allowlist as a side effect (consumed by
     :func:`_apply_project_layer_if_trusted`).
+
+    After the loose ``_apply_nested_dict`` pass, also runs
+    ``apply_overrides`` so strict-only complex keys (e.g.
+    ``panel.activity_sources``) are picked up via their typed converters.
     """
-    _apply_nested_dict(settings, _load_json_file(global_path))
+    data = _load_json_file(global_path)
+    _apply_nested_dict(settings, data)
+    settings.apply_overrides(data)
 
 
 def _apply_project_layer_if_trusted(
@@ -1493,7 +1568,9 @@ def _apply_project_layer_if_trusted(
                 project_path,
                 str(cwd),
             )
-        _apply_nested_dict(settings, _load_json_file(project_path))
+        data = _load_json_file(project_path)
+        _apply_nested_dict(settings, data)
+        settings.apply_overrides(data)
     else:
         logger.warning(
             "settings: ignoring project layer %s — cwd %s is not in "

--- a/deile/tests/config/test_settings_activity_sources.py
+++ b/deile/tests/config/test_settings_activity_sources.py
@@ -1,0 +1,274 @@
+"""Tests for issue #447: panel.activity_sources settings key.
+
+Coverage:
+  1.  _to_activity_sources: empty list → []  (sentinel for "use default V1").
+  2.  _to_activity_sources: valid list of dicts → validated list.
+  3.  _to_activity_sources: non-list → TypeError.
+  4.  _to_activity_sources: item is not a dict → TypeError.
+  5.  _to_activity_sources: deployment missing → ValueError.
+  6.  _to_activity_sources: deployment fails DNS-1123 regex → ValueError.
+  7.  _to_activity_sources: role missing/empty → ValueError.
+  8.  _to_activity_sources: color missing/empty → ValueError.
+  9.  _to_activity_sources: duplicate deployment → ValueError.
+  10. _to_activity_sources: duplicate role → allowed (cosmetic).
+  11. apply_overrides: valid panel.activity_sources loaded correctly.
+  12. apply_overrides: invalid panel.activity_sources → field stays at [].
+  13. Layered loading: user layer applies panel.activity_sources.
+  14. Layered loading: project layer overrides user layer (3 > 5, D3).
+  15. Layered loading: missing key → field stays at default [].
+  16. panel_activity_sources NOT in _LIST_ATTRS.
+  17. panel.activity_sources in _OVERRIDE_HANDLERS.
+  18. panel.activity_sources NOT in _JSON_FIELD_MAP (strict-only).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from deile.config.settings import (
+    Settings,
+    _OVERRIDE_HANDLERS,
+    _JSON_FIELD_MAP,
+    _LIST_ATTRS,
+    _to_activity_sources,
+    get_settings,
+    reset_settings,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1–10: _to_activity_sources unit tests
+# ---------------------------------------------------------------------------
+
+class TestToActivitySources:
+    def test_empty_list_is_valid_sentinel(self):
+        result = _to_activity_sources([])
+        assert result == []
+
+    def test_valid_list(self):
+        raw = [
+            {"deployment": "deile-pipeline", "role": "pipeline", "color": "bright_black"},
+            {"deployment": "deile-worker",   "role": "worker",   "color": "cyan"},
+        ]
+        result = _to_activity_sources(raw)
+        assert len(result) == 2
+        assert result[0] == {"deployment": "deile-pipeline", "role": "pipeline", "color": "bright_black"}
+        assert result[1] == {"deployment": "deile-worker", "role": "worker", "color": "cyan"}
+
+    def test_non_list_raises_type_error(self):
+        with pytest.raises(TypeError, match="expected list"):
+            _to_activity_sources("not a list")
+
+    def test_item_not_dict_raises_type_error(self):
+        with pytest.raises(TypeError, match="expected dict"):
+            _to_activity_sources(["not a dict"])
+
+    def test_deployment_missing_raises_value_error(self):
+        with pytest.raises(ValueError, match="deployment.*missing or empty"):
+            _to_activity_sources([{"role": "worker", "color": "cyan"}])
+
+    def test_deployment_invalid_dns_raises_value_error(self):
+        with pytest.raises(ValueError, match="DNS-1123"):
+            _to_activity_sources([
+                {"deployment": "Invalid_NAME", "role": "worker", "color": "cyan"}
+            ])
+
+    def test_deployment_with_uppercase_fails(self):
+        with pytest.raises(ValueError, match="DNS-1123"):
+            _to_activity_sources([
+                {"deployment": "MyDeployment", "role": "w", "color": "c"}
+            ])
+
+    def test_deployment_starting_with_hyphen_fails(self):
+        with pytest.raises(ValueError, match="DNS-1123"):
+            _to_activity_sources([
+                {"deployment": "-invalid", "role": "w", "color": "c"}
+            ])
+
+    def test_role_missing_raises_value_error(self):
+        with pytest.raises(ValueError, match="role.*missing or empty"):
+            _to_activity_sources([
+                {"deployment": "my-deploy", "role": "", "color": "cyan"}
+            ])
+
+    def test_color_missing_raises_value_error(self):
+        with pytest.raises(ValueError, match="color.*missing or empty"):
+            _to_activity_sources([
+                {"deployment": "my-deploy", "role": "worker", "color": ""}
+            ])
+
+    def test_duplicate_deployment_raises_value_error(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            _to_activity_sources([
+                {"deployment": "deile-worker", "role": "w1", "color": "c1"},
+                {"deployment": "deile-worker", "role": "w2", "color": "c2"},
+            ])
+
+    def test_duplicate_role_is_allowed(self):
+        raw = [
+            {"deployment": "deile-worker",   "role": "worker", "color": "cyan"},
+            {"deployment": "deile-pipeline",  "role": "worker", "color": "blue"},
+        ]
+        result = _to_activity_sources(raw)
+        assert len(result) == 2
+
+    def test_seven_sources_accepted(self):
+        """AC: 7 fontes incluindo nome novo são aceitas."""
+        raw = [
+            {"deployment": f"deploy-{i}", "role": f"role-{i}", "color": "cyan"}
+            for i in range(7)
+        ]
+        result = _to_activity_sources(raw)
+        assert len(result) == 7
+
+    def test_single_char_deployment_valid(self):
+        """DNS-1123: single char is valid."""
+        result = _to_activity_sources([{"deployment": "x", "role": "r", "color": "c"}])
+        assert result[0]["deployment"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# 11–12: apply_overrides integration
+# ---------------------------------------------------------------------------
+
+class TestApplyOverridesActivitySources:
+    def test_valid_sources_loaded(self):
+        s = Settings()
+        s.apply_overrides({
+            "panel": {
+                "activity_sources": [
+                    {"deployment": "deile-pipeline", "role": "pipeline", "color": "bright_black"},
+                    {"deployment": "deile-worker",   "role": "worker",   "color": "cyan"},
+                    {"deployment": "deile-monitor",  "role": "monitor",  "color": "blue"},
+                ]
+            }
+        })
+        assert len(s.panel_activity_sources) == 3
+        assert s.panel_activity_sources[0]["deployment"] == "deile-pipeline"
+
+    def test_invalid_sources_keeps_default(self):
+        s = Settings()
+        s.apply_overrides({
+            "panel": {
+                "activity_sources": [
+                    {"deployment": "INVALID-UPPER", "role": "r", "color": "c"},
+                ]
+            }
+        })
+        assert s.panel_activity_sources == []
+
+    def test_empty_sources_sets_empty_list(self):
+        s = Settings()
+        s.panel_activity_sources = [
+            {"deployment": "x", "role": "r", "color": "c"}
+        ]
+        s.apply_overrides({"panel": {"activity_sources": []}})
+        assert s.panel_activity_sources == []
+
+    def test_non_list_value_keeps_previous(self):
+        s = Settings()
+        s.apply_overrides({"panel": {"activity_sources": "not-a-list"}})
+        assert s.panel_activity_sources == []
+
+
+# ---------------------------------------------------------------------------
+# 13–15: Layered loading via settings files
+# ---------------------------------------------------------------------------
+
+class TestLayeredLoadingActivitySources:
+    def test_user_layer_applies_sources(self, tmp_path: Path):
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({
+            "panel": {
+                "activity_sources": [
+                    {"deployment": "my-pod", "role": "myrole", "color": "green"},
+                ]
+            }
+        }))
+        import deile.config.settings as _sm
+        orig_resolve = _sm._resolve_global_settings_path
+        _sm._resolve_global_settings_path = lambda: settings_file
+        reset_settings()
+        try:
+            s = get_settings()
+            assert len(s.panel_activity_sources) == 1
+            assert s.panel_activity_sources[0]["deployment"] == "my-pod"
+        finally:
+            _sm._resolve_global_settings_path = orig_resolve
+            reset_settings()
+
+    def test_project_layer_overrides_user_layer(self, tmp_path: Path):
+        """D3: last layer wins — 3-source project layer overrides 5-source user layer."""
+        user_file = tmp_path / "user_settings.json"
+        user_file.write_text(json.dumps({
+            "panel": {
+                "activity_sources": [
+                    {"deployment": f"deploy-{i}", "role": f"r{i}", "color": "c"}
+                    for i in range(5)
+                ]
+            }
+        }))
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        project_settings = project_dir / ".deile" / "settings.json"
+        project_settings.parent.mkdir(parents=True)
+        project_settings.write_text(json.dumps({
+            "panel": {
+                "activity_sources": [
+                    {"deployment": "proj-pod-0", "role": "pr0", "color": "blue"},
+                    {"deployment": "proj-pod-1", "role": "pr1", "color": "red"},
+                    {"deployment": "proj-pod-2", "role": "pr2", "color": "green"},
+                ]
+            },
+            "trust": {"project_layer_dirs": [str(project_dir)]},
+        }))
+        import deile.config.settings as _sm
+        orig_resolve = _sm._resolve_global_settings_path
+        orig_cwd = os.getcwd()
+        _sm._resolve_global_settings_path = lambda: user_file
+        reset_settings()
+        os.chdir(project_dir)
+        try:
+            s = get_settings()
+            # Project layer (3 sources) must win over user layer (5 sources).
+            assert len(s.panel_activity_sources) == 3
+            assert s.panel_activity_sources[0]["deployment"] == "proj-pod-0"
+        finally:
+            os.chdir(orig_cwd)
+            _sm._resolve_global_settings_path = orig_resolve
+            reset_settings()
+
+    def test_missing_key_keeps_default(self, tmp_path: Path):
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({"logging": {"level": "INFO"}}))
+        import deile.config.settings as _sm
+        orig_resolve = _sm._resolve_global_settings_path
+        _sm._resolve_global_settings_path = lambda: settings_file
+        reset_settings()
+        try:
+            s = get_settings()
+            assert s.panel_activity_sources == []
+        finally:
+            _sm._resolve_global_settings_path = orig_resolve
+            reset_settings()
+
+
+# ---------------------------------------------------------------------------
+# 16–18: Schema / map membership invariants
+# ---------------------------------------------------------------------------
+
+class TestSchemaInvariants:
+    def test_panel_activity_sources_not_in_list_attrs(self):
+        assert "panel_activity_sources" not in _LIST_ATTRS
+
+    def test_panel_activity_sources_in_override_handlers(self):
+        assert "panel.activity_sources" in _OVERRIDE_HANDLERS
+
+    def test_panel_activity_sources_not_in_json_field_map(self):
+        """Strict-only: _apply_nested_dict must not process it directly."""
+        assert "panel.activity_sources" not in _JSON_FIELD_MAP

--- a/deile/tests/infra/test_panel_activity_sources_provider.py
+++ b/deile/tests/infra/test_panel_activity_sources_provider.py
@@ -1,0 +1,216 @@
+"""Tests for issue #447: MultiSourceActivityProvider with configurable sources.
+
+Coverage:
+  1.  ActivitySource dataclass is immutable (frozen=True).
+  2.  MultiSourceActivityProvider defaults to 5 V1 sources when sources=None.
+  3.  MultiSourceActivityProvider accepts custom sources list.
+  4.  _fetch iterates self._sources (not the module-level constant).
+  5.  Seven sources produce seven concurrent tail calls.
+  6.  Empty sources list → falls back to default V1.
+  7.  Custom sources update _ROLE_COLOR_MAP in-place.
+  8.  _sources_from_settings returns None when settings has empty list.
+  9.  _sources_from_settings converts dicts to ActivitySource objects.
+  10. _sources_from_settings returns None on import failure (graceful).
+  11. Default V1 deployment names match _MULTI_SOURCE_DEFS exactly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+from typing import List
+from unittest.mock import MagicMock, patch
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import pytest
+
+import _panel_data as pd  # noqa: E402
+
+
+def _make_source(deployment: str = "my-deploy",
+                 role: str = "my-role",
+                 color: str = "cyan") -> pd.ActivitySource:
+    return pd.ActivitySource(deployment=deployment, role=role, color=color)
+
+
+# ---------------------------------------------------------------------------
+# 1: ActivitySource dataclass
+# ---------------------------------------------------------------------------
+
+class TestActivitySourceDataclass:
+    def test_immutable(self):
+        src = _make_source()
+        with pytest.raises(Exception):  # frozen=True → FrozenInstanceError
+            src.deployment = "other"  # type: ignore[misc]
+
+    def test_fields(self):
+        src = pd.ActivitySource(deployment="deile-worker", role="worker", color="cyan")
+        assert src.deployment == "deile-worker"
+        assert src.role == "worker"
+        assert src.color == "cyan"
+
+
+# ---------------------------------------------------------------------------
+# 2–6: MultiSourceActivityProvider construction
+# ---------------------------------------------------------------------------
+
+class TestProviderConstruction:
+    def test_default_sources_is_five(self):
+        prov = pd.MultiSourceActivityProvider(enabled=False)
+        assert len(prov._sources) == 5
+
+    def test_default_source_names_match_defs(self):
+        prov = pd.MultiSourceActivityProvider(enabled=False)
+        expected = {d for d, _, _ in pd._MULTI_SOURCE_DEFS}
+        actual = {s.deployment for s in prov._sources}
+        assert actual == expected
+
+    def test_custom_sources_override_defaults(self):
+        custom = [
+            _make_source("my-pod-1", "role1", "cyan"),
+            _make_source("my-pod-2", "role2", "blue"),
+        ]
+        prov = pd.MultiSourceActivityProvider(enabled=False, sources=custom)
+        assert len(prov._sources) == 2
+        assert prov._sources[0].deployment == "my-pod-1"
+
+    def test_empty_sources_falls_back_to_default(self):
+        prov = pd.MultiSourceActivityProvider(enabled=False, sources=[])
+        assert len(prov._sources) == 5
+
+    def test_seven_sources_accepted(self):
+        """AC: 7 fontes incluindo nome novo → provider stores all 7."""
+        sources = [
+            _make_source(f"my-pod-{i}", f"role-{i}", "cyan")
+            for i in range(7)
+        ]
+        prov = pd.MultiSourceActivityProvider(enabled=False, sources=sources)
+        assert len(prov._sources) == 7
+
+
+# ---------------------------------------------------------------------------
+# 7: Color map update
+# ---------------------------------------------------------------------------
+
+class TestColorMapUpdate:
+    def test_custom_sources_update_role_color_map(self):
+        sources = [
+            pd.ActivitySource(deployment="special-pod", role="special-role", color="yellow"),
+        ]
+        pd.MultiSourceActivityProvider(enabled=False, sources=sources)
+        assert pd._ROLE_COLOR_MAP.get("special-role") == "yellow"
+
+    def test_default_colors_preserved(self):
+        prov = pd.MultiSourceActivityProvider(enabled=False)
+        for _, role, color in pd._MULTI_SOURCE_DEFS:
+            assert pd._ROLE_COLOR_MAP.get(role) == color
+
+
+# ---------------------------------------------------------------------------
+# 4–5: _fetch uses self._sources
+# ---------------------------------------------------------------------------
+
+class TestFetchUsesCustomSources:
+    def _empty_kubectl(self) -> CompletedProcess:
+        return CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    def test_fetch_calls_each_source(self):
+        sources = [
+            pd.ActivitySource(deployment="pod-a", role="ra", color="cyan"),
+            pd.ActivitySource(deployment="pod-b", role="rb", color="blue"),
+            pd.ActivitySource(deployment="pod-c", role="rc", color="red"),
+        ]
+        prov = pd.MultiSourceActivityProvider(enabled=True, sources=sources)
+        prov._kubectl = "/usr/bin/kubectl"
+
+        called_deploys = []
+
+        def fake_run(cmd, **kwargs):
+            # Extract deployment name from "deploy/<name>" argument
+            for arg in cmd:
+                if arg.startswith("deploy/"):
+                    called_deploys.append(arg[len("deploy/"):])
+                    break
+            return self._empty_kubectl()
+
+        with patch("subprocess.run", side_effect=fake_run):
+            prov._fetch()
+
+        assert set(called_deploys) == {"pod-a", "pod-b", "pod-c"}
+
+    def test_fetch_seven_sources(self):
+        """AC: 7 fontes → 7 tail calls."""
+        sources = [
+            pd.ActivitySource(deployment=f"deploy-{i}", role=f"r{i}", color="cyan")
+            for i in range(7)
+        ]
+        prov = pd.MultiSourceActivityProvider(enabled=True, sources=sources)
+        prov._kubectl = "/usr/bin/kubectl"
+
+        call_count = [0]
+
+        def fake_run(cmd, **kwargs):
+            call_count[0] += 1
+            return self._empty_kubectl()
+
+        with patch("subprocess.run", side_effect=fake_run):
+            prov._fetch()
+
+        assert call_count[0] == 7
+
+
+# ---------------------------------------------------------------------------
+# 8–10: _sources_from_settings helper
+# ---------------------------------------------------------------------------
+
+class TestSourcesFromSettings:
+    def test_returns_none_when_settings_empty(self):
+        mock_settings = MagicMock()
+        mock_settings.panel_activity_sources = []
+        with patch("deile.config.settings.get_settings", return_value=mock_settings):
+            result = pd._sources_from_settings()
+        assert result is None
+
+    def test_converts_dicts_to_activity_sources(self):
+        mock_settings = MagicMock()
+        mock_settings.panel_activity_sources = [
+            {"deployment": "my-pod", "role": "my-role", "color": "cyan"},
+        ]
+        with patch("deile.config.settings.get_settings", return_value=mock_settings):
+            result = pd._sources_from_settings()
+        assert result is not None
+        assert len(result) == 1
+        assert isinstance(result[0], pd.ActivitySource)
+        assert result[0].deployment == "my-pod"
+        assert result[0].role == "my-role"
+        assert result[0].color == "cyan"
+
+    def test_returns_none_on_import_error(self):
+        original = sys.modules.get("deile.config.settings")
+        sys.modules["deile.config.settings"] = None  # type: ignore[assignment]
+        try:
+            result = pd._sources_from_settings()
+            assert result is None
+        finally:
+            if original is None:
+                sys.modules.pop("deile.config.settings", None)
+            else:
+                sys.modules["deile.config.settings"] = original
+
+
+# ---------------------------------------------------------------------------
+# 11: V1 defaults
+# ---------------------------------------------------------------------------
+
+class TestDefaultV1:
+    def test_default_deployments(self):
+        prov = pd.MultiSourceActivityProvider(enabled=False)
+        deployments = [s.deployment for s in prov._sources]
+        expected = ["deile-pipeline", "deile-worker", "claude-worker",
+                    "deilebot", "deile-monitor"]
+        assert sorted(deployments) == sorted(expected)

--- a/infra/k8s/_panel_data.py
+++ b/infra/k8s/_panel_data.py
@@ -2048,9 +2048,26 @@ _MULTI_SOURCE_DEFS: Tuple[Tuple[str, str, str], ...] = (
     ("deile-monitor",  "monitor",      "blue"),
 )
 
+
+@dataclass(frozen=True)
+class ActivitySource:
+    """Fonte de tail para o widget ACTIVITY (issue #447).
+
+    Campos:
+      deployment — nome DNS-1123 do Deployment (alvo de ``kubectl logs deploy/``).
+      role       — label exibido na coluna actor do widget.
+      color      — cor Rich do actor (ex: ``"cyan"``, ``"orange1"``).
+    """
+    deployment: str
+    role: str
+    color: str
+
+
 _SOURCE_ROLE_MAP: Dict[str, str] = {d: r for d, r, _ in _MULTI_SOURCE_DEFS}
 _SOURCE_COLOR_MAP: Dict[str, str] = {d: c for d, _, c in _MULTI_SOURCE_DEFS}
 # Maps role_label → color; used by _activity_panel for correct color lookup.
+# Mutated in-place by MultiSourceActivityProvider when custom sources are loaded,
+# so _panel.py's module-level import of this dict sees the updated values.
 _ROLE_COLOR_MAP: Dict[str, str] = {r: c for _, r, c in _MULTI_SOURCE_DEFS}
 
 _MULTI_BUFFER_CAP = 200
@@ -2180,8 +2197,33 @@ class MultiSourceActivityState:
         return sorted(self.events, key=lambda e: e.ts, reverse=True)[:n]
 
 
+def _sources_from_settings() -> Optional[List[ActivitySource]]:
+    """Lê ``panel_activity_sources`` do Settings singleton e converte para
+    ``List[ActivitySource]``. Retorna ``None`` se a lista estiver vazia (sentinela
+    para "usar default V1") ou se o import falhar (ambiente sem ``deile``).
+
+    A importação é lazy para que ``_panel_data`` funcione em ambientes onde o
+    pacote ``deile`` não está no ``sys.path`` (alguns testes de integração).
+    """
+    try:
+        from deile.config.settings import get_settings  # noqa: PLC0415
+        raw = get_settings().panel_activity_sources
+        if not raw:
+            return None
+        return [
+            ActivitySource(deployment=d["deployment"], role=d["role"], color=d["color"])
+            for d in raw
+        ]
+    except Exception:  # noqa: BLE001 — ImportError, KeyError, etc.
+        return None
+
+
 class MultiSourceActivityProvider(_KubectlProviderMixin):
-    """Tail em paralelo de 5 deployments → buffer rolling-window de eventos.
+    """Tail em paralelo de N deployments → buffer rolling-window de eventos.
+
+    Fontes padrão (V1): os 5 deployments de ``_MULTI_SOURCE_DEFS``. Fontes
+    customizáveis via ``settings.panel_activity_sources`` (issue #447) ou
+    passando ``sources`` diretamente ao construtor.
 
     Usa ``--since=10s --tail=80 --timestamps`` por source. Cada refresh
     mescla todas as linhas num buffer capped em 200, ordenado por timestamp.
@@ -2190,10 +2232,23 @@ class MultiSourceActivityProvider(_KubectlProviderMixin):
     """
 
     def __init__(self, ttl_s: float = 3.0, namespace: str = NS,
-                 enabled: bool = True):
+                 enabled: bool = True,
+                 sources: Optional[List[ActivitySource]] = None):
         self._kubectl = kubectl_bin()
         self._namespace = namespace
         self._enabled = enabled
+        # D4 (issue #447): fontes configuráveis; None/vazio → default V1.
+        if sources:
+            self._sources: List[ActivitySource] = sources
+        else:
+            self._sources = [
+                ActivitySource(deployment=d, role=r, color=c)
+                for d, r, c in _MULTI_SOURCE_DEFS
+            ]
+        # Update module-level role→color map so _panel.py's rendering picks up
+        # custom colors. Mutação in-place preserva a referência importada por
+        # _panel.py (``from _panel_data import _ROLE_COLOR_MAP``).
+        _ROLE_COLOR_MAP.update({s.role: s.color for s in self._sources})
         self._cache: Cache[MultiSourceActivityState] = Cache(
             ttl_s, self._fetch, fallback=MultiSourceActivityState(),
         )
@@ -2264,11 +2319,13 @@ class MultiSourceActivityProvider(_KubectlProviderMixin):
             raise RuntimeError("kubectl não encontrado")
 
         # AC3: parallel fetch via ThreadPoolExecutor.
+        # D4 (issue #447): iterate self._sources (set in __init__) instead of
+        # the module-level constant; supports configurable source lists.
         pool: List[ActivityEvent] = []
-        with futures.ThreadPoolExecutor(max_workers=5) as executor:
+        with futures.ThreadPoolExecutor(max_workers=len(self._sources) or 1) as executor:
             future_map = {
-                executor.submit(self._fetch_source, deploy, role): deploy
-                for deploy, role, _ in _MULTI_SOURCE_DEFS
+                executor.submit(self._fetch_source, src.deployment, src.role): src.deployment
+                for src in self._sources
             }
             for fut in futures.as_completed(future_map):
                 deploy = future_map[fut]
@@ -6883,9 +6940,11 @@ class PanelData:
                 if k8s_on else None
             ),
             # MultiSourceActivityProvider (issue #436): only when k8s is on.
+            # issue #447: pass configurable sources from settings (lazy import).
             activity=(
                 MultiSourceActivityProvider(namespace=context.namespace,
-                                            enabled=k8s_on)
+                                            enabled=k8s_on,
+                                            sources=_sources_from_settings())
                 if k8s_on else None
             ),
             # ProviderHealthProvider (issue #445): só com k8s — varre logs de


### PR DESCRIPTION
## Resumo

Implementa #447: o widget ACTIVITY agora permite configurar quais deployments são tail-iados (lista, deployment, role, cor, ordem) via `settings.json`, sem editar Python nem re-deployar.

Closes #447.

---

## Entrega vs Critérios de Aceite

### AC: Validação por regex DNS-1123 (`deployment`), não por `_ALLOWED_DEPLOYMENTS_FULL`
✅ `_to_activity_sources` valida `deployment` contra `_ACTIVITY_DEPLOYMENT_RE` (`^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$`). `_ALLOWED_DEPLOYMENTS_FULL` não foi tocado.

### AC: 5 casos de rejeição de validação (deployment/role/color inválidos, duplicata, lista não-lista)
✅ Testados em `test_settings_activity_sources.py` (testes 3–9):
- `deployment` inválido (uppercase, hífen inicial, etc.) → `ValueError` com mensagem "DNS-1123"
- `role` vazio → `ValueError`
- `color` vazio → `ValueError`
- `deployment` duplicado → `ValueError` "duplicate"
- valor não é lista → `TypeError`
- item não é dict → `TypeError`

### AC: Fallback ao default V1 em config inválida sem derrubar o painel
✅ `apply_overrides` engole `(ValueError, TypeError)` e deixa `panel_activity_sources = []`. Testado em `test_invalid_sources_keeps_default`. O provider recebe `None`/vazio e usa `_MULTI_SOURCE_DEFS` (5 pods).

### AC: Default = 5 deployments de `_MULTI_SOURCE_DEFS`
✅ `MultiSourceActivityProvider(sources=None)` → `self._sources` tem 5 entradas com exatamente os deployments de `_MULTI_SOURCE_DEFS`. Testado em `test_default_sources_is_five` e `test_default_deployments`.

### AC: Merge entre camadas = substituição total, última-camada-vence (D3)
✅ Testado em `test_project_layer_overrides_user_layer`: user layer com 5 fontes + project layer com 3 fontes → resultado final tem 3 fontes (project vence). `_apply_user_layer` e `_apply_project_layer_if_trusted` chamam `settings.apply_overrides(data)` após `_apply_nested_dict`.

### AC: Teste com 7 fontes (incl. nome novo) → 7 tails
✅ Testado em `test_fetch_seven_sources` (provider) e `test_seven_sources_accepted` (settings). 7 chamadas ao `subprocess.run` confirmadas.

### AC: `deployment` duplicado na lista é rejeitado
✅ `_to_activity_sources` mantém `seen_deployments: set` e levanta `ValueError("duplicate")`.

### AC: `role` duplicado é permitido (cosmético)
✅ Testado em `test_duplicate_role_is_allowed`.

### AC: Injeção no provider (D4)
✅ `MultiSourceActivityProvider.__init__` aceita `sources: Optional[List[ActivitySource]] = None`. `_fetch` itera `self._sources`. Call-site `PanelData.from_context` passa `_sources_from_settings()`.

### AC: Cores customizadas chegam ao render (D4)
✅ `_ROLE_COLOR_MAP` é mutado in-place em `__init__` com as cores das fontes configuradas. Como `_panel.py` importa a referência ao dict (`from _panel_data import _ROLE_COLOR_MAP`), o render verá as cores atualizadas.

### AC: `panel_activity_sources` NÃO entra em `_LIST_ATTRS` (D2)
✅ Confirmado por teste `test_panel_activity_sources_not_in_list_attrs`.

### AC: `panel.activity_sources` em `_OVERRIDE_HANDLERS` + strict-only (D2)
✅ Confirmado por testes `test_panel_activity_sources_in_override_handlers` e `test_panel_activity_sources_not_in_json_field_map`.

### Out-of-scope (adiados para #606)
- Hot-reload das fontes
- `enabled` por fonte
- Timeout por fonte
- `_ALLOWED_DEPLOYMENTS_FULL` não foi tocado (gatea ações destrutivas)

---

## Testes
- **39 testes novos** (24 unit settings + 15 provider) — todos verdes
- **249 testes existentes** — todos verdes, sem regressões