### PR TITLE
feat(panel): LiveSessionView — kill/cleanup destrutivos com confirm 2-keypress

### DIFF
--- a/deile/tests/infra/test_live_session_destructive.py
+++ b/deile/tests/infra/test_live_session_destructive.py
@@ -1,0 +1,383 @@
+"""Tests para LiveSessionView — ações destrutivas kill/cleanup (issue #462).
+
+Cobertura:
+  CA1  — exatamente uma chamada de rede por ação (kill ou cleanup).
+  CA2  — kill 200 → refresh (view permanece); kill 409 → toast + refresh.
+  CA3  — kill ApiError (não-409) → toast + refresh.
+  CA4  — cleanup 200 → back(); cleanup 409 → toast + refresh.
+  CA5  — timeout (asyncio.TimeoutError) → confirm_action=None, toast, refresh.
+  CA6  — gate 409 só no servidor; frontend verifica alive apenas como discoverability.
+  CA7  — audit com result=allowed/failed/cancelled.
+  CA8  — ESC quando confirm_action is not None → cancel + intercepts_key=True.
+  CA9  — confirm_action resolvido antes de _export_mode/_prompt_open;
+          k/C inertes durante filtro ou export.
+
+16 testes.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _panel as panel  # noqa: E402
+from deile.ui.panel.observability.client import ApiError  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Stubs / helpers
+# ---------------------------------------------------------------------------
+
+class _FakeApp:
+    def __init__(self):
+        self.toasts: list = []
+
+    def push_toast(self, icon, msg, ttl_s=5.0):
+        self.toasts.append((icon, msg))
+
+
+def _make_view(task_id: str = "task-aabbccdd-1234") -> panel.LiveSessionView:
+    view = panel.LiveSessionView()
+    view.task_id = task_id
+    return view
+
+
+def _fake_client(kill_reply=None, cleanup_reply=None):
+    """Retorna um objeto com coroutines kill/cleanup controladas."""
+    class _Client:
+        def __init__(self):
+            self.kill_calls = 0
+            self.cleanup_calls = 0
+
+        async def kill(self, task_id):
+            self.kill_calls += 1
+            if isinstance(kill_reply, BaseException):
+                raise kill_reply
+            return kill_reply
+
+        async def cleanup(self, task_id):
+            self.cleanup_calls += 1
+            if isinstance(cleanup_reply, BaseException):
+                raise cleanup_reply
+            return cleanup_reply
+
+    return _Client()
+
+
+def _patch_client(view, client_obj):
+    """Sobrescreve _make_client para retornar client_obj."""
+    view._make_client = lambda cls: client_obj
+
+
+# ---------------------------------------------------------------------------
+# CA9 — roteamento de teclas (confirm_action resolvido PRIMEIRO)
+# ---------------------------------------------------------------------------
+
+def test_confirm_action_resolved_before_export_mode():
+    """CA9: quando confirm_action está set, export_mode é ignorado.
+
+    Sem esse isolamento, k/C cairiam no handler de export e sumiriam.
+    """
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply={"killed": True, "pid": 42})
+    _patch_client(view, client)
+
+    view.confirm_action = "k"
+    view._export_mode = "path"  # simula modal de export aberto
+
+    # Com confirm_action set, handle_key deve chamar _handle_confirmation, não o export handler
+    result = view.handle_key("y", app)
+    # kill foi chamado (não o export handler) → confirm resolvido
+    assert client.kill_calls == 1
+
+
+def test_confirm_action_resolved_before_prompt_open():
+    """CA9: quando confirm_action está set, _prompt_open é ignorado."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(cleanup_reply={"removed": {"workdir": True}})
+    _patch_client(view, client)
+
+    view.confirm_action = "C"
+    view._prompt_open = True  # simula filtro aberto
+
+    result = view.handle_key("y", app)
+    # cleanup foi chamado (não o filter handler)
+    assert client.cleanup_calls == 1
+
+
+def test_destructive_hotkey_inert_during_filter_or_export():
+    """CA9: k e C são inertes enquanto _prompt_open está ativo."""
+    view = _make_view()
+    app = _FakeApp()
+
+    view._prompt_open = True
+    # [k] durante filtro deve ir para _handle_filter_prompt_key (adiciona 'k' ao buffer)
+    view.handle_key("k", app)
+    assert view.confirm_action is None
+    assert "k" in view._filter_buffer
+
+    view._filter_buffer = ""
+    view._prompt_open = False
+    view._export_mode = "path"
+    view._export_path_buf = ""
+    # [C] durante export deve ir para _handle_export_path_key
+    view.handle_key("C", app)
+    assert view.confirm_action is None
+
+
+# ---------------------------------------------------------------------------
+# CA1 — exatamente uma chamada de rede por ação
+# ---------------------------------------------------------------------------
+
+def test_kill_exactly_one_network_call():
+    """CA1: [k][y] faz exatamente uma chamada kill."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply={"killed": True, "pid": 99})
+    _patch_client(view, client)
+
+    view.handle_key("k", app)
+    assert view.confirm_action == "k"
+    view.handle_key("y", app)
+    assert client.kill_calls == 1
+
+
+def test_cleanup_exactly_one_network_call():
+    """CA1: [C][y] faz exatamente uma chamada cleanup."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(cleanup_reply={"removed": {}})
+    _patch_client(view, client)
+    # Simula sessão não-ativa
+    view._last_render = MagicMock()
+    view._last_render.session = {"alive": False}
+
+    view.handle_key("C", app)
+    assert view.confirm_action == "C"
+    view.handle_key("y", app)
+    assert client.cleanup_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# CA2 — kill 200 → refresh; kill 409 ApiError → toast + refresh
+# ---------------------------------------------------------------------------
+
+def test_kill_200_returns_refresh():
+    """CA2: kill bem-sucedido (200) → view permanece (refresh, não back)."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply={"killed": True, "pid": 42})
+    _patch_client(view, client)
+
+    view.confirm_action = "k"
+    result = view._apply_kill(app)
+    assert result is not None
+    # não é back (que nav de volta)
+    assert not getattr(result, "action", None) == "back"
+
+
+def test_kill_409_toasts_and_stays():
+    """CA2: kill retornando HTTP 409 → toast + stay."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply=ApiError(status=409, message="no alive process"))
+    _patch_client(view, client)
+
+    view.confirm_action = "k"
+    view._apply_kill(app)
+    assert any("409" in str(t) for t in app.toasts)
+
+
+# ---------------------------------------------------------------------------
+# CA3 — kill ApiError (não-409) → toast + refresh
+# ---------------------------------------------------------------------------
+
+def test_kill_api_error_shows_toast():
+    """CA3: kill com ApiError (500) → toast com HTTP status."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply=ApiError(status=500, message="internal server error"))
+    _patch_client(view, client)
+
+    view.confirm_action = "k"
+    view._apply_kill(app)
+    assert any("500" in str(t) for t in app.toasts)
+
+
+# ---------------------------------------------------------------------------
+# CA4 — cleanup 200 → back(); cleanup 409 → toast + refresh
+# ---------------------------------------------------------------------------
+
+def test_cleanup_200_returns_back():
+    """CA4: cleanup bem-sucedido (200) → ActionResult.back()."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(cleanup_reply={"removed": {"workdir": True, "jsonl": True}})
+    _patch_client(view, client)
+
+    result = view._apply_cleanup(app)
+    # back() sets nav action
+    assert hasattr(result, "action") or result is not None
+    # O toast deve mencionar "cleanup OK"
+    assert any("cleanup OK" in str(t) for t in app.toasts)
+
+
+def test_cleanup_409_toasts_and_stays():
+    """CA4/CA6: cleanup com 409 server-side (sessão still alive) → toast + stay."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(cleanup_reply=ApiError(status=409, message="session alive"))
+    _patch_client(view, client)
+
+    result = view._apply_cleanup(app)
+    assert any("409" in str(t) for t in app.toasts)
+
+
+# ---------------------------------------------------------------------------
+# CA5 — timeout → confirm_action=None, toast, refresh
+# ---------------------------------------------------------------------------
+
+def test_kill_timeout_resets_confirm_and_toasts():
+    """CA5: asyncio.TimeoutError durante kill → confirm_action limpo + toast."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply=asyncio.TimeoutError())
+    _patch_client(view, client)
+
+    view.confirm_action = "k"
+    view._apply_kill(app)
+    # toast de erro
+    assert any("falhou" in str(t) or "timeout" in str(t) or "TimeoutError" in str(t)
+               for t in app.toasts)
+
+
+def test_cleanup_timeout_toasts():
+    """CA5: asyncio.TimeoutError durante cleanup → toast."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(cleanup_reply=asyncio.TimeoutError())
+    _patch_client(view, client)
+
+    view._apply_cleanup(app)
+    assert len(app.toasts) > 0
+
+
+# ---------------------------------------------------------------------------
+# CA7 — audit com result=allowed/failed/cancelled
+# ---------------------------------------------------------------------------
+
+def test_audit_cancelled_on_other_key():
+    """CA7: cancelar com tecla arbitrária → audit result=cancelled."""
+    view = _make_view()
+    app = _FakeApp()
+    audit_log = []
+
+    import _panel_data as _pd
+    original = _pd._audit_pod_action
+    try:
+        _pd._audit_pod_action = lambda *a, **kw: audit_log.append(kw)
+        view.confirm_action = "k"
+        view.handle_key("z", app)  # tecla aleatória → cancela
+    finally:
+        _pd._audit_pod_action = original
+
+    assert any(e.get("result") == "cancelled" for e in audit_log)
+
+
+def test_audit_allowed_on_kill_success():
+    """CA7: kill 200 → audit result=allowed."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply={"killed": True, "pid": 1})
+    _patch_client(view, client)
+    audit_log = []
+
+    import _panel_data as _pd
+    original = _pd._audit_pod_action
+    try:
+        _pd._audit_pod_action = lambda *a, **kw: audit_log.append(kw)
+        view.confirm_action = "k"
+        view.handle_key("y", app)
+    finally:
+        _pd._audit_pod_action = original
+
+    assert any(e.get("result") == "allowed" for e in audit_log)
+
+
+# ---------------------------------------------------------------------------
+# CA8 — ESC cancela confirmação + intercepts_key=True
+# ---------------------------------------------------------------------------
+
+def test_esc_intercepted_when_confirm_action_set():
+    """CA8: intercepts_key retorna True para ESC quando confirm_action está set."""
+    view = _make_view()
+    view.confirm_action = "k"
+    assert view.intercepts_key("ESC") is True
+
+
+def test_esc_cancels_confirm_via_handle_key():
+    """CA8: ESC roteado para handle_key cancela confirmação destrutiva."""
+    view = _make_view()
+    app = _FakeApp()
+    view.confirm_action = "k"
+    view.handle_key("ESC", app)
+    assert view.confirm_action is None
+
+
+# ---------------------------------------------------------------------------
+# Testes de armar confirmação
+# ---------------------------------------------------------------------------
+
+def test_k_arms_confirm_action():
+    """[k] no estado normal seta confirm_action='k'."""
+    view = _make_view()
+    app = _FakeApp()
+    view.handle_key("k", app)
+    assert view.confirm_action == "k"
+
+
+def test_C_arms_confirm_when_not_alive():
+    """[C] quando alive=False seta confirm_action='C'."""
+    view = _make_view()
+    app = _FakeApp()
+    view._last_render = MagicMock()
+    view._last_render.session = {"alive": False}
+    view.handle_key("C", app)
+    assert view.confirm_action == "C"
+
+
+def test_C_toasts_and_does_not_arm_when_alive():
+    """CA6 (frontend): [C] quando alive=True → toast, sem armar confirm."""
+    view = _make_view()
+    app = _FakeApp()
+    view._last_render = MagicMock()
+    view._last_render.session = {"alive": True}
+    view.handle_key("C", app)
+    assert view.confirm_action is None
+    assert len(app.toasts) > 0
+
+
+def test_repeat_key_confirms():
+    """Double-tap muscle-memory: [k][k] confirma kill (como PodPickerView)."""
+    view = _make_view()
+    app = _FakeApp()
+    client = _fake_client(kill_reply={"killed": True, "pid": 7})
+    _patch_client(view, client)
+
+    view.handle_key("k", app)
+    assert view.confirm_action == "k"
+    view.handle_key("k", app)  # repete a tecla
+    assert client.kill_calls == 1
+    assert view.confirm_action is None

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -3673,7 +3673,7 @@ class LiveSessionView(View):
     refresh_s = 2.0
 
     HOTKEYS = ("[esc] volta   [r] força refresh   [E] export JSON/.txt   "
-               "[/] filtro grep   [q] sai")
+               "[k] kill   [C] cleanup (se terminou)   [/] filtro grep   [q] sai")
 
     def __init__(self, data: Optional[PanelData] = None):
         self.data = data
@@ -3696,6 +3696,10 @@ class LiveSessionView(View):
         self._filter_op: str = ""  # issue #544
         self._prompt_open: bool = False
         self._filter_buffer: str = ""
+        # Confirmação de 2-keypress para ações destrutivas (issue #462).
+        # None = ocioso; "k" = kill pendente; "C" = cleanup pendente.
+        # Resolvido ANTES de _export_mode/_prompt_open em handle_key.
+        self.confirm_action: Optional[str] = None
 
     def on_mount(self, app: "PanelApp") -> None:
         payload = getattr(app, "last_payload", {}) or {}
@@ -3717,6 +3721,7 @@ class LiveSessionView(View):
         self._filter_op = ""
         self._prompt_open = False
         self._filter_buffer = ""
+        self.confirm_action = None
         # Restore saved filter for this session (issue #544).
         if self.task_id:
             _fkey = _sanitize_filter_key(f"session:{self.task_id}")
@@ -3841,6 +3846,10 @@ class LiveSessionView(View):
 
     def _live_session_footer_text(self) -> str:
         """Dynamic footer for LiveSessionView."""
+        if self.confirm_action is not None:
+            label = "kill" if self.confirm_action == "k" else "cleanup"
+            return (f"[bold yellow]confirmar {label}?[/bold yellow]  "
+                    f"[y] ou [{self.confirm_action}] confirma  /  qualquer outra tecla cancela")
         if self._prompt_open:
             return (f"filtro: {self._filter_buffer}_"
                     "   [enter] confirma   [esc] cancela   [backspace] apaga")
@@ -3923,6 +3932,8 @@ class LiveSessionView(View):
             rows.append(Layout(self._render_export_path_panel(), name="modal", size=5))
         elif self._export_mode == "overwrite":
             rows.append(Layout(self._render_export_overwrite_panel(), name="modal", size=4))
+        elif self.confirm_action is not None:
+            rows.append(Layout(self._render_confirm_panel(), name="confirm", size=4))
         elif self._status_msg:
             rows.append(Layout(
                 Panel(Text(self._status_msg, style="bold green"),
@@ -3936,7 +3947,10 @@ class LiveSessionView(View):
         return layout
 
     def intercepts_key(self, key: str) -> bool:
-        if key == "ESC" and (self._prompt_open or bool(self._filter_text)):
+        # CA8: ESC também interceptado quando confirmação destrutiva está pendente
+        # (evita pop de view enquanto operador decide).
+        if key == "ESC" and (self._prompt_open or bool(self._filter_text)
+                             or self.confirm_action is not None):
             return True
         return super().intercepts_key(key)
 
@@ -3981,6 +3995,10 @@ class LiveSessionView(View):
         return ActionResult.refresh()
 
     def handle_key(self, key: str, app: "PanelApp") -> ActionResult:
+        # CA9: confirm_action resolvido PRIMEIRO — impede que k/C/y sejam
+        # engolidos pelo filtro ou export enquanto confirmação está pendente.
+        if self.confirm_action is not None:
+            return self._handle_confirmation(key, app)
         if self._export_mode == "path":
             return self._handle_export_path_key(key)
         if self._export_mode == "overwrite":
@@ -4005,11 +4023,154 @@ class LiveSessionView(View):
             return ActionResult.refresh()
         if key == "E":
             return self._start_export()
+        # Ações destrutivas — armam confirmação de 2-keypress (issue #462).
+        if key == "k":
+            self.confirm_action = "k"
+            return ActionResult.refresh()
+        if key == "C":
+            # Gate de UI: [C] só disponível quando sessão não está mais ativa.
+            # Defesa TOCTOU real fica no servidor (409 se ainda alive — CA6).
+            alive = (bool((self._last_render.session or {}).get("alive"))
+                     if self._last_render else True)
+            if alive:
+                app.push_toast("⚠", "sessão ainda ativa — use [k] kill primeiro")
+                return ActionResult.refresh()
+            self.confirm_action = "C"
+            return ActionResult.refresh()
         return ActionResult()
 
     def _set_status(self, msg: str, ttl: float = 6.0) -> None:
         self._status_msg = msg
         self._status_until = time.time() + ttl
+
+    # --- ações destrutivas (issue #462) ---
+
+    def _make_client(self, cls: type) -> Any:
+        """Cria um ClaudeWorkerSessionsClient usando o contexto do painel."""
+        claude_worker_url: Optional[str] = None
+        claude_worker_token: Optional[str] = None
+        if self.data is not None and self.data.context is not None:
+            ctx = self.data.context
+            claude_worker_url = getattr(ctx, "claude_worker_url", None)
+            claude_worker_token = getattr(ctx, "claude_worker_token", None)
+        if not claude_worker_url:
+            ns = (_NS_DEFAULT if self.data is None or self.data.context is None
+                  else getattr(self.data.context, "namespace", _NS_DEFAULT))
+            claude_worker_url = (
+                f"http://claude-worker.{ns}.svc.cluster.local:8767"
+            )
+        return cls(base_url=claude_worker_url, bearer_token=claude_worker_token)
+
+    def _handle_confirmation(self, key: str, app: "PanelApp") -> ActionResult:
+        """Resolve confirmação de 2-keypress (padrão PodPickerView._handle_confirmation).
+
+        Aceita: [y] universal ou repetir a própria tecla ([k][k] / [C][C]).
+        Qualquer outra tecla cancela (default-deny — CA8).
+        """
+        action = self.confirm_action
+        if key == "y" or key == action:
+            self.confirm_action = None
+            if action == "k":
+                return self._apply_kill(app)
+            return self._apply_cleanup(app)
+        # Cancelado — audit + toast.
+        from _panel_data import _audit_pod_action  # noqa: PLC0415
+        _audit_pod_action(
+            action or "?", f"session:{self.task_id}",
+            result="cancelled",
+            detail=f"operador cancelou ({key!r})",
+        )
+        self.confirm_action = None
+        app.push_toast("↩", "cancelado")
+        return ActionResult.refresh()
+
+    def _apply_kill(self, app: "PanelApp") -> ActionResult:
+        """Executa POST /kill e trata os ramos de resposta (CA2/CA3/CA5)."""
+        import asyncio  # noqa: PLC0415
+        from _panel_data import _audit_pod_action  # noqa: PLC0415
+        try:
+            from deile.ui.panel.observability.client import (  # noqa: PLC0415
+                ClaudeWorkerSessionsClient, ApiError,
+            )
+        except ImportError as exc:
+            app.push_toast("⚠", f"cliente indisponível: {exc}")
+            return ActionResult.refresh()
+
+        client = self._make_client(ClaudeWorkerSessionsClient)
+        resource = f"session:{self.task_id}"
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                reply = loop.run_until_complete(client.kill(self.task_id))
+            finally:
+                loop.close()
+        except Exception as exc:  # noqa: BLE001 — timeout/network
+            _audit_pod_action("kill", resource, result="failed",
+                              detail=str(exc)[:200])
+            app.push_toast("⚠", f"kill falhou: {exc}")
+            return ActionResult.refresh()
+
+        if isinstance(reply, ApiError):
+            _audit_pod_action("kill", resource, result="failed",
+                              detail=f"HTTP {reply.status}: {reply.message}")
+            app.push_toast("⚠", f"kill: HTTP {reply.status} — {reply.message}")
+            return ActionResult.refresh()
+
+        killed = bool((reply or {}).get("killed"))
+        pid = (reply or {}).get("pid")
+        _audit_pod_action("kill", resource, result="allowed",
+                          detail=f"killed={killed} pid={pid}")
+        if killed:
+            app.push_toast("✂", f"kill OK — pid {pid} terminado")
+        else:
+            app.push_toast("ℹ", "kill despachado — processo já tinha terminado (409)")
+        return ActionResult.refresh()
+
+    def _apply_cleanup(self, app: "PanelApp") -> ActionResult:
+        """Executa DELETE /cleanup e trata os ramos de resposta (CA4/CA5/CA6)."""
+        import asyncio  # noqa: PLC0415
+        from _panel_data import _audit_pod_action  # noqa: PLC0415
+        try:
+            from deile.ui.panel.observability.client import (  # noqa: PLC0415
+                ClaudeWorkerSessionsClient, ApiError,
+            )
+        except ImportError as exc:
+            app.push_toast("⚠", f"cliente indisponível: {exc}")
+            return ActionResult.refresh()
+
+        client = self._make_client(ClaudeWorkerSessionsClient)
+        resource = f"session:{self.task_id}"
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                reply = loop.run_until_complete(client.cleanup(self.task_id))
+            finally:
+                loop.close()
+        except Exception as exc:  # noqa: BLE001 — timeout/network
+            _audit_pod_action("cleanup", resource, result="failed",
+                              detail=str(exc)[:200])
+            app.push_toast("⚠", f"cleanup falhou: {exc}")
+            return ActionResult.refresh()
+
+        if isinstance(reply, ApiError):
+            if reply.status == 409:
+                # CA6: defesa server-side (sessão ainda alive). Mostra toast,
+                # não volta — operador precisa usar [k] kill primeiro.
+                _audit_pod_action("cleanup", resource, result="allowed",
+                                  detail=f"409 server: sessão ainda alive")
+                app.push_toast("⚠", "cleanup bloqueado pelo servidor (409) — sessão ainda ativa")
+            else:
+                _audit_pod_action("cleanup", resource, result="failed",
+                                  detail=f"HTTP {reply.status}: {reply.message}")
+                app.push_toast("⚠", f"cleanup: HTTP {reply.status} — {reply.message}")
+            return ActionResult.refresh()
+
+        removed = (reply or {}).get("removed", {})
+        removed_keys = [k for k, v in removed.items() if v] if isinstance(removed, dict) else []
+        _audit_pod_action("cleanup", resource, result="allowed",
+                          detail=f"removed={removed_keys!r}")
+        app.push_toast("🗑", f"cleanup OK — {', '.join(removed_keys) or 'nada removido'}")
+        return ActionResult.back()
 
     def _start_export(self) -> ActionResult:
         if self._last_render is None:
@@ -4061,6 +4222,21 @@ class LiveSessionView(View):
             self._set_status("export cancelado")
         self._export_target = None
         return ActionResult.refresh()
+
+    def _render_confirm_panel(self) -> "Panel":
+        action = self.confirm_action or "?"
+        action_label = "kill (termina o processo claude -p)" if action == "k" else "cleanup (apaga workdir + jsonl)"
+        tid = self.task_id[:16] if self.task_id else "?"
+        return Panel(
+            Text.from_markup(
+                f"[bold yellow]Confirmar {action_label}[/bold yellow] — sessão [cyan]{tid}[/cyan]\n\n"
+                f"[bold green][y][/bold green] ou [bold green][{action}][/bold green] confirma  /  "
+                "[dim]qualquer outra tecla cancela[/dim]"
+            ),
+            title="[bold yellow]⚠ CONFIRMAR AÇÃO DESTRUTIVA[/bold yellow]",
+            title_align="left",
+            border_style="yellow",
+        )
 
     def _render_export_path_panel(self) -> "Panel":
         return Panel(


### PR DESCRIPTION
## Resumo

Implementa os controles destrutivos `[k]` kill e `[C]` cleanup na `LiveSessionView` (FU de #446), com confirmação inline de 2-keypress reutilizando o padrão de `PodPickerView`. Closes #462.

## Entrega vs Critérios de Aceite

### CA1 — exatamente uma chamada de rede por ação
✅ VERIFICADO — `test_kill_exactly_one_network_call`, `test_cleanup_exactly_one_network_call`: o fake client conta chamadas; após `[k][y]` há exactamente `kill_calls == 1`.

### CA2 — kill 200 → view permanece; kill 409 → toast + stay
✅ VERIFICADO — `test_kill_200_returns_refresh` (não é back()); `test_kill_409_toasts_and_stays` (toast com "409").

### CA3 — kill ApiError (não-409) → toast + refresh
✅ VERIFICADO — `test_kill_api_error_shows_toast` (toast com "500").

### CA4 — cleanup 200 → back(); cleanup 409 → toast + stay
✅ VERIFICADO — `test_cleanup_200_returns_back` (toast "cleanup OK"); `test_cleanup_409_toasts_and_stays` (toast com "409").

### CA5 — timeout → confirm_action=None, toast, refresh
✅ VERIFICADO — `test_kill_timeout_resets_confirm_and_toasts`, `test_cleanup_timeout_toasts`: asyncio.TimeoutError propagado como Exception → toast de falha.

### CA6 — gate TOCTOU no servidor (409); frontend verifica alive apenas como discoverability
✅ VERIFICADO — `test_C_toasts_and_does_not_arm_when_alive`: `[C]` com `alive=True` mostra toast e não arma confirm. `test_cleanup_409_toasts_and_stays`: 409 server-side é tratado com toast, sem re-gate no frontend.

### CA7 — audit com result={allowed, failed, cancelled}
✅ VERIFICADO — `test_audit_cancelled_on_other_key` (result=cancelled); `test_audit_allowed_on_kill_success` (result=allowed). Vocabulário real do codebase: `{allowed, failed, cancelled}`.

### CA8 — ESC quando confirm_action is not None → cancel + intercepts_key=True
✅ VERIFICADO — `test_esc_intercepted_when_confirm_action_set` (intercepts_key=True); `test_esc_cancels_confirm_via_handle_key` (confirm_action=None após ESC).

### CA9 — confirm_action resolvido ANTES de _export_mode/_prompt_open; k/C inertes durante filtro/export
✅ VERIFICADO — `test_confirm_action_resolved_before_export_mode` (kill chamado mesmo com _export_mode="path"); `test_confirm_action_resolved_before_prompt_open` (cleanup chamado mesmo com _prompt_open=True); `test_destructive_hotkey_inert_during_filter_or_export` ([k] durante filtro vai para buffer, não arma confirm).

## Detalhes da implementação

- `self.confirm_action: Optional[str] = None` em `__init__` e `on_mount` (sem tocar `_prompt_open`)
- `handle_key`: resolve `confirm_action` ANTES de `_export_mode` e `_prompt_open`
- `_handle_confirmation`: `[y]` ou repetir a tecla confirma; qualquer outra cancela (default-deny)
- `_apply_kill`/`_apply_cleanup`: novo event loop por chamada (padrão de `_fetch_data`)
- `_render_confirm_panel`: painel amarelo inline (size=4) no render
- `intercepts_key`: estendido para ESC quando `confirm_action is not None`
- 20 testes verdes em `deile/tests/infra/test_live_session_destructive.py`