### PR TITLE
fix(panel): kill-409 auditado como allowed, espelhando cleanup-409

### DIFF
--- a/deile/tests/infra/test_live_session_destructive.py
+++ b/deile/tests/infra/test_live_session_destructive.py
@@ -12,7 +12,7 @@ Cobertura:
   CA9  — confirm_action resolvido antes de _export_mode/_prompt_open;
           k/C inertes durante filtro ou export.
 
-16 testes.
+20 testes.
 """
 from __future__ import annotations
 
@@ -189,15 +189,24 @@ def test_kill_200_returns_refresh():
 
 
 def test_kill_409_toasts_and_stays():
-    """CA2: kill retornando HTTP 409 → toast + stay."""
+    """CA2/CA7: kill retornando HTTP 409 → toast amigável + stay + audit result=allowed."""
     view = _make_view()
     app = _FakeApp()
     client = _fake_client(kill_reply=ApiError(status=409, message="no alive process"))
     _patch_client(view, client)
+    audit_log = []
 
-    view.confirm_action = "k"
-    view._apply_kill(app)
-    assert any("409" in str(t) for t in app.toasts)
+    import _panel_data as _pd
+    original = _pd._audit_pod_action
+    try:
+        _pd._audit_pod_action = lambda *a, **kw: audit_log.append(kw)
+        view.confirm_action = "k"
+        view._apply_kill(app)
+    finally:
+        _pd._audit_pod_action = original
+
+    assert any("já encerrada" in str(t) for t in app.toasts)
+    assert any(e.get("result") == "allowed" for e in audit_log)
 
 
 # ---------------------------------------------------------------------------

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -4111,9 +4111,16 @@ class LiveSessionView(View):
             return ActionResult.refresh()
 
         if isinstance(reply, ApiError):
-            _audit_pod_action("kill", resource, result="failed",
-                              detail=f"HTTP {reply.status}: {reply.message}")
-            app.push_toast("⚠", f"kill: HTTP {reply.status} — {reply.message}")
+            if reply.status == 409:
+                # CA7/CA2: 409 = ação despachada ao servidor, processo já não existe.
+                # Alinha com _apply_cleanup-409: result="allowed" (não "failed").
+                _audit_pod_action("kill", resource, result="allowed",
+                                  detail="409 server: task já encerrada (sem processo vivo)")
+                app.push_toast("ℹ", "task já encerrada (sem processo vivo)")
+            else:
+                _audit_pod_action("kill", resource, result="failed",
+                                  detail=f"HTTP {reply.status}: {reply.message}")
+                app.push_toast("⚠", f"kill: HTTP {reply.status} — {reply.message}")
             return ActionResult.refresh()
 
         killed = bool((reply or {}).get("killed"))


### PR DESCRIPTION
## Escopo

Issue #678 — consistência de audit kill-409 vs cleanup-409 + docstring stale.

## Entrega vs Critérios de Aceite

**AC 1 — `_apply_kill` trata 409 como `result="allowed"`:**
Adicionado branch `if reply.status == 409` em `_apply_kill` (`infra/k8s/_panel.py`) espelhando `_apply_cleanup`. O audit agora emite `result="allowed"` com detail `"409 server: task já encerrada (sem processo vivo)"`. Toast muda de `"HTTP 409"` para `"task já encerrada (sem processo vivo)"`. ✅

**AC 2 — Teste assevera `result="allowed"` no audit do kill-409:**
`test_kill_409_toasts_and_stays` estendido para capturar chamadas de `_audit_pod_action` via monkey-patch de `_panel_data._audit_pod_action` (padrão já usado em `test_audit_allowed_on_kill_success`) e asseverar tanto o toast amigável quanto `result="allowed"`. 20/20 testes passando localmente. ✅

**AC 3 — Docstring stale corrigida:**
`deile/tests/infra/test_live_session_destructive.py` linha 15: `"16 testes"` → `"20 testes"` (conta real das funções `def test_`). ✅

## Arquivos alterados

- `infra/k8s/_panel.py`: +7 linhas no branch `if isinstance(reply, ApiError)` de `_apply_kill`
- `deile/tests/infra/test_live_session_destructive.py`: extensão de `test_kill_409_toasts_and_stays` + correção docstring

Closes #678.