### PR TITLE
feat(reasoning): /reasoning use <nível> — hard override (forced_reasoning_effort)

### DIFF
--- a/deile/commands/builtin/reasoning_command.py
+++ b/deile/commands/builtin/reasoning_command.py
@@ -50,8 +50,15 @@ Reasoning Command — esforço de raciocínio do turno
 
 USAGE:
     /reasoning                 Mostra o esforço atual e os níveis válidos
-    /reasoning <nível>         Fixa o esforço para esta sessão
-    /reasoning clear           Remove o override (volta ao global)
+    /reasoning <nível>         Fixa o esforço SOFT para esta sessão
+    /reasoning clear           Remove o override SOFT (volta ao global)
+    /reasoning use <nível>     Hard override — vence injeção per-turn do worker
+    /reasoning use clear       Remove o hard override (idempotente)
+
+EIXOS:
+    SOFT (/reasoning <nível>)  — grava session.context_data["reasoning_effort"]
+    HARD (/reasoning use <n>)  — grava session.context_data["forced_reasoning_effort"],
+                                  lido antes do SOFT em resolve_session_reasoning
 
 NÍVEIS:
     anthropic / claude-worker: low | medium | high | xhigh | max | ultracode | auto
@@ -59,9 +66,14 @@ NÍVEIS:
     gemini:   off | minimal | low | medium | high | auto
     deepseek: off | high | max | auto
 
+    /reasoning use auto  → armazena "auto" (provider-default forçado, NÃO é clear)
+    /reasoning use clear → limpa o hard override (_CLEAR_KEYWORDS: clear/reset/...)
+
 EXEMPLOS:
     /reasoning high
-    /reasoning ultracode
+    /reasoning use ultracode
+    /reasoning use auto
+    /reasoning use clear
     /reasoning clear
 """
 
@@ -69,6 +81,9 @@ EXEMPLOS:
         args = split_args(context)
         if not args or args[0].lower() in ("show", "status"):
             return self._show(context)
+        if args[0].lower() == "use":
+            target = args[1].strip().lower() if len(args) > 1 else ""
+            return self._use(target, context)
         target = args[0].strip().lower()
         if target in _CLEAR_KEYWORDS:
             return self._clear(context)
@@ -90,8 +105,11 @@ EXEMPLOS:
         return session.context_data
 
     def _current_effort(self, context: CommandContext) -> tuple:
-        """Retorna ``(valor, fonte)`` do esforço efetivo: sessão > global > default."""
+        """Retorna ``(valor, fonte)`` do esforço efetivo: forced > sessão > global > default."""
         cd = self._ctx_data(context) or {}
+        forced = normalize_effort(cd.get("forced_reasoning_effort"))
+        if forced:
+            return forced, "forced (hard)"
         v = normalize_effort(cd.get("reasoning_effort"))
         if v:
             return v, "session (/reasoning)"
@@ -125,6 +143,73 @@ EXEMPLOS:
                 border_style="cyan",
             ),
             metadata={"reasoning_effort": current, "source": source},
+        )
+
+    def _use(self, target: str, context: CommandContext) -> CommandResult:
+        """Despacha ``/reasoning use <nível|clear>`` — eixo HARD."""
+        if not target:
+            return CommandResult(
+                success=False,
+                content=Panel(
+                    Text("Usage: /reasoning use <nível>  ou  /reasoning use clear", style="yellow"),
+                    title="Reasoning effort",
+                    border_style="yellow",
+                ),
+            )
+        if target in _CLEAR_KEYWORDS:
+            return self._use_clear(context)
+        return self._use_set(target, context)
+
+    def _use_set(self, target: str, context: CommandContext) -> CommandResult:
+        """Grava ``forced_reasoning_effort`` (hard override)."""
+        if not is_valid_effort(target):
+            return CommandResult(
+                success=False,
+                content=Panel(
+                    Text(
+                        f"Nível inválido '{target}'.\n"
+                        "Anthropic/claude: " + " | ".join(CLAUDE_CODE_EFFORTS) + "\n"
+                        "openai: " + " | ".join(OPENAI_EFFORTS) + "\n"
+                        "gemini: " + " | ".join(GEMINI_EFFORTS) + "\n"
+                        "deepseek: " + " | ".join(DEEPSEEK_EFFORTS),
+                        style="yellow",
+                    ),
+                    title="[bold red]Reasoning effort inválido[/bold red]",
+                    border_style="red",
+                ),
+            )
+        cd = self._ctx_data(context)
+        if cd is None:
+            return CommandResult(
+                success=False,
+                content=Panel(Text("Sessão indisponível.", style="red"),
+                              title="Error", border_style="red"),
+            )
+        cd["forced_reasoning_effort"] = target
+        logger.info("forced_reasoning_effort setado em '%s'", target)
+        return CommandResult(
+            success=True,
+            content=Panel(
+                Text(f"Hard override: esforço fixado em '{target}' (vence injeção per-turn do worker)."),
+                title="Reasoning effort — hard override",
+                border_style="green",
+            ),
+            metadata={"forced_reasoning_effort": target},
+        )
+
+    def _use_clear(self, context: CommandContext) -> CommandResult:
+        """Remove ``forced_reasoning_effort`` (idempotente)."""
+        cd = self._ctx_data(context)
+        if cd is not None:
+            cd.pop("forced_reasoning_effort", None)
+        logger.info("forced_reasoning_effort limpo")
+        return CommandResult(
+            success=True,
+            content=Panel(
+                Text("Hard override removido — esforço volta ao slot SOFT / global / default."),
+                title="Reasoning effort — hard override",
+                border_style="green",
+            ),
         )
 
     def _set(self, target: str, context: CommandContext) -> CommandResult:

--- a/deile/core/models/reasoning.py
+++ b/deile/core/models/reasoning.py
@@ -30,7 +30,10 @@ mais novo que o SDK instalado.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 # ── Conjuntos de níveis por contexto ──────────────────────────────────────
 
@@ -188,11 +191,25 @@ def request_overrides(provider_id: str, model_id: str, effort: Any) -> Dict[str,
 def resolve_session_reasoning(session: Any) -> Optional[str]:
     """Esforço efetivo para o turno do agente (deile-worker / CLI).
 
-    Precedência: ``session.context_data["reasoning_effort"]`` (injetado pelo
-    worker a partir do ``DispatchPayload``, ou setado pelo comando ``/reasoning``)
-    > ``settings.reasoning_effort`` (global, configurável no DEILE CLI) > ``None``.
+    Precedência: ``session.context_data["forced_reasoning_effort"]`` (hard
+    override — comando ``/reasoning use <nível>``, vence injeção per-turn do
+    worker) > ``session.context_data["reasoning_effort"]`` (injetado pelo
+    worker a partir do ``DispatchPayload``, ou setado pelo comando
+    ``/reasoning``) > ``settings.reasoning_effort`` (global, configurável no
+    DEILE CLI) > ``None``.
     Best-effort: nunca levanta.
     """
+    try:
+        cd = getattr(session, "context_data", None) or {}
+        forced = normalize_effort(cd.get("forced_reasoning_effort"))
+        if forced:
+            logger.debug(
+                "resolve_session_reasoning: forced (hard) '%s' vence session/global",
+                forced,
+            )
+            return forced
+    except Exception:  # noqa: BLE001
+        pass
     try:
         cd = getattr(session, "context_data", None) or {}
         v = normalize_effort(cd.get("reasoning_effort"))

--- a/deile/tests/commands/builtin/test_reasoning_command.py
+++ b/deile/tests/commands/builtin/test_reasoning_command.py
@@ -61,3 +61,109 @@ async def test_clear_removes_override():
 def test_has_effort_alias():
     cmd = ReasoningCommand()
     assert "effort" in (cmd.aliases or [])
+
+
+# ── /reasoning use <nível> — eixo HARD ────────────────────────────────────
+
+@pytest.mark.unit
+async def test_use_set_stores_forced():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use high")
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert ctx.session.context_data["forced_reasoning_effort"] == "high"
+    assert "reasoning_effort" not in ctx.session.context_data
+
+
+@pytest.mark.unit
+async def test_use_set_auto_stores_not_clears():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use auto")
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert ctx.session.context_data["forced_reasoning_effort"] == "auto"
+
+
+@pytest.mark.unit
+async def test_use_set_normalizes_case():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use ULTRACODE")
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert ctx.session.context_data["forced_reasoning_effort"] == "ultracode"
+
+
+@pytest.mark.unit
+async def test_use_set_invalid_rejected():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use bogus")
+    res = await cmd.execute(ctx)
+    assert res.success is False
+    assert "forced_reasoning_effort" not in ctx.session.context_data
+
+
+@pytest.mark.unit
+async def test_use_clear_removes_forced():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use clear", context_data={"forced_reasoning_effort": "high", "reasoning_effort": "low"})
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert "forced_reasoning_effort" not in ctx.session.context_data
+    # soft slot must be untouched
+    assert ctx.session.context_data.get("reasoning_effort") == "low"
+
+
+@pytest.mark.unit
+async def test_use_clear_idempotent():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use clear", context_data={})
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert "forced_reasoning_effort" not in ctx.session.context_data
+
+
+@pytest.mark.unit
+async def test_use_reset_clears_forced():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use reset", context_data={"forced_reasoning_effort": "max"})
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert "forced_reasoning_effort" not in ctx.session.context_data
+
+
+@pytest.mark.unit
+async def test_use_no_target_fails():
+    cmd = ReasoningCommand()
+    ctx = _ctx("use")
+    res = await cmd.execute(ctx)
+    assert res.success is False
+
+
+@pytest.mark.unit
+async def test_show_reports_forced_source():
+    cmd = ReasoningCommand()
+    ctx = _ctx("", context_data={"forced_reasoning_effort": "max", "reasoning_effort": "low"})
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert res.metadata.get("source") == "forced (hard)"
+    assert res.metadata.get("reasoning_effort") == "max"
+
+
+@pytest.mark.unit
+async def test_show_falls_back_to_soft_when_no_forced():
+    cmd = ReasoningCommand()
+    ctx = _ctx("", context_data={"reasoning_effort": "low"})
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert res.metadata.get("source") == "session (/reasoning)"
+    assert res.metadata.get("reasoning_effort") == "low"
+
+
+@pytest.mark.unit
+async def test_soft_clear_does_not_touch_forced():
+    cmd = ReasoningCommand()
+    ctx = _ctx("clear", context_data={"forced_reasoning_effort": "high", "reasoning_effort": "max"})
+    res = await cmd.execute(ctx)
+    assert res.success is True
+    assert "reasoning_effort" not in ctx.session.context_data
+    assert ctx.session.context_data.get("forced_reasoning_effort") == "high"

--- a/deile/tests/core/models/test_reasoning.py
+++ b/deile/tests/core/models/test_reasoning.py
@@ -171,3 +171,81 @@ class TestSessionResolver:
 
         assert R.resolve_session_reasoning(_S()) is None
         reset_settings()
+
+    def test_forced_wins_over_soft(self, monkeypatch):
+        monkeypatch.delenv("DEILE_REASONING_EFFORT", raising=False)
+        from deile.config.settings import reset_settings
+        reset_settings()
+
+        class _S:
+            context_data = {
+                "forced_reasoning_effort": "ultracode",
+                "reasoning_effort": "low",
+            }
+
+        assert R.resolve_session_reasoning(_S()) == "ultracode"
+        reset_settings()
+
+    def test_forced_wins_over_settings(self, monkeypatch):
+        from deile.config.settings import get_settings, reset_settings
+        monkeypatch.delenv("DEILE_REASONING_EFFORT", raising=False)
+        reset_settings()
+        get_settings().reasoning_effort = "high"
+
+        class _S:
+            context_data = {"forced_reasoning_effort": "max"}
+
+        assert R.resolve_session_reasoning(_S()) == "max"
+        reset_settings()
+
+    def test_forced_auto_stores_not_clears(self, monkeypatch):
+        monkeypatch.delenv("DEILE_REASONING_EFFORT", raising=False)
+        from deile.config.settings import reset_settings
+        reset_settings()
+
+        class _S:
+            context_data = {"forced_reasoning_effort": "auto"}
+
+        assert R.resolve_session_reasoning(_S()) == "auto"
+        reset_settings()
+
+    def test_soft_used_when_no_forced(self, monkeypatch):
+        monkeypatch.delenv("DEILE_REASONING_EFFORT", raising=False)
+        from deile.config.settings import reset_settings
+        reset_settings()
+
+        class _S:
+            context_data = {"reasoning_effort": "medium"}
+
+        assert R.resolve_session_reasoning(_S()) == "medium"
+        reset_settings()
+
+    def test_worker_clobber_beaten_by_forced(self, monkeypatch):
+        """Simula injeção per-turn do worker em reasoning_effort: o forced vence."""
+        monkeypatch.delenv("DEILE_REASONING_EFFORT", raising=False)
+        from deile.config.settings import reset_settings
+        reset_settings()
+
+        class _S:
+            context_data = {
+                "forced_reasoning_effort": "xhigh",
+                "reasoning_effort": "low",  # worker injetou low
+            }
+
+        assert R.resolve_session_reasoning(_S()) == "xhigh"
+        reset_settings()
+
+    def test_forced_debug_log_emitted(self, monkeypatch, caplog):
+        import logging
+        monkeypatch.delenv("DEILE_REASONING_EFFORT", raising=False)
+        from deile.config.settings import reset_settings
+        reset_settings()
+
+        class _S:
+            context_data = {"forced_reasoning_effort": "high"}
+
+        with caplog.at_level(logging.DEBUG, logger="deile.core.models.reasoning"):
+            R.resolve_session_reasoning(_S())
+
+        assert any("forced (hard)" in r.message for r in caplog.records)
+        reset_settings()


### PR DESCRIPTION
## Resumo

Implementa o eixo HARD de reasoning effort via `/reasoning use <nível>`, que **vence a injeção per-turn do worker** (`worker_server.py:703` grava `reasoning_effort` a cada dispatch). Antes desta PR, não havia como o usuário fixar um esforço que sobrevivesse ao próximo ciclo do pipeline.

## Entrega vs Critérios de Aceite

| AC | Status | Evidência |
|---|---|---|
| **Hard set** — `/reasoning use high` grava `cd["forced_reasoning_effort"]="high"` | ✅ PRONTO | `test_use_set_stores_forced`: assert direto no dict |
| **Hard store `auto`** — `/reasoning use auto` armazena `"auto"` (NÃO é clear) | ✅ PRONTO | `test_use_set_auto_stores_not_clears` |
| **Hard clear** — `/reasoning use clear` faz pop (idempotente, não toca soft) | ✅ PRONTO | `test_use_clear_removes_forced` + `test_use_clear_idempotent` + `test_soft_clear_does_not_touch_forced` |
| **Enum** — `is_valid_effort` valida; nível inválido rejeitado | ✅ PRONTO | `test_use_set_invalid_rejected` |
| **Precedência hard > soft** (3 sub-casos: forced>soft, forced>settings, forced>none) | ✅ PRONTO | `TestSessionResolver.test_forced_wins_over_soft` + `test_forced_wins_over_settings` + `test_soft_used_when_no_forced` |
| **Vence o worker** (anti-clobber: worker injeta soft, hard sobrevive) | ✅ PRONTO | `test_worker_clobber_beaten_by_forced`: cd tem `forced=xhigh` + `reasoning_effort=low` (worker) → resolver retorna `xhigh` |
| **Show** — `/reasoning` distingue `"forced (hard)"` como fonte | ✅ PRONTO | `test_show_reports_forced_source`: `metadata["source"] == "forced (hard)"` |
| **Observabilidade** — `logger.debug` emitido quando forced vence | ✅ PRONTO | `test_forced_debug_log_emitted` via `caplog` |

**50 testes unitários, todos verdes** (`pytest deile/tests/commands/builtin/test_reasoning_command.py deile/tests/core/models/test_reasoning.py -p no:cov -q` → `50 passed in 2.40s`).

## Mudanças

- `deile/core/models/reasoning.py` — `resolve_session_reasoning` lê `forced_reasoning_effort` antes de `reasoning_effort`; `logger.debug` quando forced vence.
- `deile/commands/builtin/reasoning_command.py` — `execute` roteia `use` para `_use`; novos métodos `_use`, `_use_set`, `_use_clear`; `_current_effort` verifica forced primeiro; `help_text` atualizado com ambos os eixos.
- Testes novos em `test_reasoning_command.py` e `test_reasoning.py`.

Closes #452