### PR TITLE
fix(config): env_store — unset_var conditional pop + _save_raw orphan tmp cleanup

### DIFF
--- a/deile/config/env_store.py
+++ b/deile/config/env_store.py
@@ -49,6 +49,7 @@ def _load_raw(path):
 
 
 def _save_raw(path, data):
+    tmp_name = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with tempfile.NamedTemporaryFile(
@@ -59,11 +60,12 @@ def _save_raw(path, data):
             suffix=".tmp",
             delete=False,
         ) as tmp:
+            tmp_name = tmp.name  # capture before any write so except can clean up
             json.dump(data, tmp, indent=2)
             tmp.flush()
             os.fsync(tmp.fileno())
-            tmp_name = tmp.name
         os.replace(tmp_name, path)
+        tmp_name = None  # atomic replace succeeded; nothing left to clean up
         try:
             os.chmod(path, 0o600)
         except OSError:
@@ -71,6 +73,11 @@ def _save_raw(path, data):
         return True
     except (OSError, TypeError, ValueError) as exc:
         logger.error("env_store: cannot write %s: %s", path, exc)
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
         return False
 
 
@@ -162,12 +169,13 @@ def unset_var(key, home=None):
         data = _load_raw(path)
         exports = dict(_get_exports(data))
         existed = key in exports
+        ok = False
         if existed:
             del exports[key]
             _set_exports(data, exports)
-            _save_raw(path, data)
+            ok = _save_raw(path, data)
 
-    if existed:
+    if existed and ok:
         os.environ.pop(key, None)
     return existed
 

--- a/deile/tests/test_env_store.py
+++ b/deile/tests/test_env_store.py
@@ -257,6 +257,35 @@ class TestUnsetVar:
         result = unset_var("GHOST", home=tmp_path)
         assert result is False
 
+    def test_disk_failure_preserves_environ(self, tmp_path, monkeypatch):
+        # Bug A: when _save_raw returns False, the key must NOT be removed from
+        # os.environ — otherwise memory and disk diverge (credencial reaparece no boot).
+        import deile.config.env_store as _m
+        from deile.config.env_store import store_var, unset_var
+
+        monkeypatch.delenv("BUGTEST_TOKEN", raising=False)
+        store_var("BUGTEST_TOKEN", "secretval", home=tmp_path)
+
+        monkeypatch.setattr(_m, "_save_raw", lambda _path, _data: False)
+
+        result = unset_var("BUGTEST_TOKEN", home=tmp_path)
+        assert result is True  # key existed in store
+        assert os.environ.get("BUGTEST_TOKEN") == "secretval"  # environ unchanged
+
+
+@pytest.mark.unit
+class TestSaveRawOrphanCleanup:
+    def test_no_orphan_tmp_on_json_type_error(self, tmp_path):
+        # Bug B: a failed json.dump must not leave a .tmp file in ~/.deile.
+        from deile.config.env_store import _save_raw
+
+        path = tmp_path / ".deile" / "settings.json"
+        result = _save_raw(path, {"key": object()})  # object() is not JSON-serializable
+
+        assert result is False
+        tmp_files = list((tmp_path / ".deile").glob("*.tmp"))
+        assert tmp_files == [], f"Orphan tmp files found: {tmp_files}"
+
 
 @pytest.mark.unit
 class TestListVars:


### PR DESCRIPTION
## Resumo

Dois bugs independentes em `deile/config/env_store.py`, ambos corrigidos neste PR.

---

### Bug A — `unset_var` removia variável de `os.environ` mesmo quando gravação falhou

**Causa raiz:** `unset_var` chamava `_save_raw(path, data)` na linha 168 mas ignorava o retorno. O `os.environ.pop(key)` nas linhas 170-171 era executado incondicionalmente, divergindo estado em memória do estado persistido.

**Fix:** `ok = _save_raw(path, data)` + `os.environ.pop` protegido por `if existed and ok:`, espelhando o padrão já correto de `store_var` (linha 146).

**Teste novo:** `TestUnsetVar::test_disk_failure_preserves_environ` — monkey-patcha `_save_raw` para retornar `False`, confirma que `os.environ["BUGTEST_TOKEN"]` permanece intacto.

AC: ✅ corrigido com teste cobrindo o caminho de falha de gravação.

---

### Bug B — `_save_raw` deixava arquivo `.tmp` órfão em `~/.deile` em falha de escrita

**Causa raiz:** `tmp_name` era atribuído somente após `json.dump`+`fsync`; se `json.dump` levantasse `TypeError` (valor não-serializável) ou `fsync` falhasse com `ENOSPC`, o `except` capturava o erro mas nunca removia o arquivo temporário criado com `delete=False`.

**Fix:** `tmp_name = tmp.name` capturado imediatamente após a abertura do arquivo (antes de qualquer escrita). Em caso de exceção, `os.unlink(tmp_name)` best-effort no bloco `except`. Após `os.replace` bem-sucedido, `tmp_name = None` descarta o sentinel.

**Teste novo:** `TestSaveRawOrphanCleanup::test_no_orphan_tmp_on_json_type_error` — passa `object()` não-serializável, confirma `retorno is False` e que nenhum `*.tmp` permanece no diretório.

AC: ✅ corrigido com teste cobrindo o caminho de falha de json.dump.

---

### Critérios de Aceite

| AC | Evidência |
|---|---|
| Bug A corrigido com teste | ✅ `test_disk_failure_preserves_environ` — 42/42 passam |
| Bug B corrigido com teste | ✅ `test_no_orphan_tmp_on_json_type_error` — 42/42 passam |
| Todos os testes existentes passam | ✅ `pytest deile/tests/test_env_store.py -p no:cov -q` → 42 passed |
| ZERO regressão — nenhum caminho não-relacionado alterado | ✅ Somente `env_store.py` e `test_env_store.py` modificados |

Closes #688.