### PR TITLE
fix(bash_tool): prevenir re-execução de comando via subprocess após PTY timeout

### DIFF
--- a/deile/tests/tools/test_bash_tool_timeout_no_reexec.py
+++ b/deile/tests/tools/test_bash_tool_timeout_no_reexec.py
@@ -1,0 +1,61 @@
+"""Regression test: PTY timeout must NOT re-execute the command via subprocess.
+
+Before the fix, TimeoutError raised inside _execute_with_pty_unix was caught by
+the outer `except Exception` handler which then called _execute_with_subprocess
+with the same command — causing double execution of any side-effects.
+
+After the fix, an explicit `except TimeoutError: raise` placed before the generic
+handler ensures the timeout propagates directly to the caller; the subprocess path
+is never entered.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from deile.tools.bash_tool import BashExecuteTool
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="PTY path is Unix-only"
+)
+
+
+@pytest.fixture()
+def tool() -> BashExecuteTool:
+    return BashExecuteTool()
+
+
+@pytest.fixture(autouse=True)
+def _suppress_realtime_output(tool, monkeypatch):
+    monkeypatch.setattr(tool, "_should_show_output", lambda: False)
+
+
+def test_pty_timeout_propagates_and_does_not_call_subprocess(
+    tool, tmp_path, monkeypatch
+):
+    """TimeoutError must propagate; _execute_with_subprocess must not be called."""
+    subprocess_call_count = 0
+
+    def spy(*args, **kwargs):
+        nonlocal subprocess_call_count
+        subprocess_call_count += 1
+        # Return sentinel so we can detect if it was reached.
+        return ("", "", 1, False)
+
+    monkeypatch.setattr(tool, "_execute_with_subprocess", spy)
+
+    with pytest.raises(TimeoutError):
+        tool._execute_with_pty_unix(
+            command="sleep 5",
+            working_dir=tmp_path,
+            env=dict(os.environ),
+            timeout=0.1,
+        )
+
+    assert subprocess_call_count == 0, (
+        f"_execute_with_subprocess was called {subprocess_call_count} time(s) "
+        "after a PTY timeout — double execution of side-effects detected"
+    )

--- a/deile/tools/bash_tool.py
+++ b/deile/tools/bash_tool.py
@@ -163,9 +163,15 @@ class BashExecuteTool(SyncTool):
                     except Exception:  # noqa: BLE001 - best effort cleanup
                         pass
 
+        except TimeoutError:
+            # Command legitimately timed out — propagate to caller instead of
+            # re-executing the same command via subprocess (which would cause
+            # double execution of any side-effects and double the wall-time).
+            raise
         except Exception as e:
             logger.error(f"PTY execution failed: {e}")
-            # Fallback to regular subprocess
+            # Fallback to regular subprocess only for PTY setup/IO errors
+            # (e.g. OSError from pty.openpty).
             return self._execute_with_subprocess(command, working_dir, env, timeout)
     
     def _execute_with_subprocess(self,


### PR DESCRIPTION
## Resumo

Corrige dupla execução de side-effects quando um comando estoura o timeout no PTY.

## Causa raiz

Em `_execute_with_pty_unix`, a `TimeoutError` levantada na linha 124 (dentro do loop) propagava para o `except Exception as e:` externo (linha 166). Como `TimeoutError` herda de `OSError → Exception`, esse handler a capturava e chamava `_execute_with_subprocess` com o mesmo comando — executando-o novamente do zero. Para comandos com side-effects (`git push`, deploy, escritas em disco), isso causava execução dupla; no melhor caso, dobrava o wall-time.

## Correção

Adicionado `except TimeoutError: raise` explicitamente **antes** do handler genérico (`bash_tool.py:166`). Somente erros reais de setup/IO do PTY (e.g. `OSError` de `pty.openpty`) continuam caindo no fallback de subprocess. O comportamento de todos os outros caminhos permanece inalterado.

## Entrega vs Critérios de Aceite

| AC | Status | Evidência |
|---|---|---|
| Todos os testes existentes passam sem modificação | ✅ PRONTO | `test_bash_tool_fd_leak.py` passa — o teste usa `except TimeoutError` em seus callers, o que funciona igualmente antes e depois do fix |
| Zero regressão: caminhos não-relacionados inalterados | ✅ PRONTO | Apenas o `except` clause em `_execute_with_pty_unix` foi alterado; os caminhos PTY normal, subprocess e Windows são idênticos |
| Teste novo: spy em `_execute_with_subprocess`, `TimeoutError` propaga e spy não é chamado | ✅ PRONTO | `test_bash_tool_timeout_no_reexec.py::test_pty_timeout_propagates_and_does_not_call_subprocess` — 1 execução, 2 passed |
| Suite completa verde (cobertura ≥ 80%) | ⚠️ NÃO VERIFICADO | A suíte completa é responsabilidade do revisor (per briefs.py e issue brief). A cobertura não é gate hard (`--cov-fail-under` ausente do `pytest.ini`). |

**Testes impactados executados:**
```
python3 -m pytest deile/tests/tools/test_bash_tool_timeout_no_reexec.py deile/tests/tools/test_bash_tool_fd_leak.py -p no:cov -q
2 passed in 9.08s
```

Closes #689.