### PR TITLE
fix(todo): coluna Idade exibia sempre '?' — normaliza chaves do blame porcelain

### DIFF
--- a/deile/commands/builtin/todo_command.py
+++ b/deile/commands/builtin/todo_command.py
@@ -202,7 +202,7 @@ class TodoCommand(DirectCommand):
                 elif " " in raw_line:
                     # key-value (primeiro espaço separa chave do valor)
                     idx = raw_line.index(" ")
-                    key = raw_line[:idx]
+                    key = raw_line[:idx].replace("-", "_")
                     value = raw_line[idx + 1:]
                     if current_line is not None:
                         current_info[key] = value

--- a/deile/tests/commands/test_todo_command.py
+++ b/deile/tests/commands/test_todo_command.py
@@ -301,6 +301,37 @@ class TestHACKandXXX:
         assert "XXX" in rendered
 
 
+class TestAgeColumn:
+    async def test_age_column_shows_days(self, tmp_path: Path):
+        """Coluna Idade exibe Nd (ex.: 1d) em vez de '?' — regressão do bug #690.
+
+        O git blame --line-porcelain emite 'committer-time' (hífen); o fix
+        normaliza para 'committer_time' (underscore) antes de armazenar no
+        blame_map, garantindo que _calc_age_days receba o timestamp correto.
+        """
+        import re
+
+        repo = tmp_path / "age_repo"
+        repo.mkdir()
+        _run_git(repo, "init")
+
+        (repo / "todo_age.py").write_text("# TODO: check age column\n")
+        _run_git(repo, "add", "todo_age.py")
+        _run_git(repo, "commit", "-m", "commit with todo")
+
+        with _cd(repo):
+            result = await _cmd().execute(_ctx())
+
+        assert result.success
+        rendered = _render(result.content)
+        # A coluna Idade deve conter ao menos um valor numérico (ex.: "0d", "1d")
+        assert re.search(r"\d+d", rendered), (
+            f"Expected a numeric age like '0d' or '1d' in table, got:\n{rendered}"
+        )
+        # Não deve exibir "?" para arquivos corretamente comitados
+        assert "?" not in rendered.split("Idade")[-1].split("\n")[0]
+
+
 # ---------------------------------------------------------------------------
 # Helper: change directory as context manager
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Resumo

Corrige o bug #690: a coluna "Idade" do `/todo` nunca exibia a idade real dos marcadores, sempre mostrando `?`.

### Causa raiz

`git blame --line-porcelain` emite chaves com hífen (`committer-time`), mas `_scan_markers` buscava `committer_time` (underscore). O `blame.get("committer_time")` retornava sempre `None`; `_calc_age_days(None)` devolvia `"?"`.

### Correção (`todo_command.py:205`)

```python
# antes
key = raw_line[:idx]
# depois
key = raw_line[:idx].replace("-", "_")
```

Normaliza **todas** as chaves porcelain (author-time, committer-time, etc.) ao gravar em `_git_blame_file`, cobrindo qualquer chave futura com hífen.

---

## Entrega vs Critérios de Aceite

| AC | Status | Evidência |
|---|---|---|
| Todos os testes existentes passam sem modificação | ✅ VERIFICADO | 20 testes pré-existentes passaram; nenhum foi alterado |
| Teste novo cobrindo o defeito: `\d+d` na coluna Idade (não `?`) | ✅ VERIFICADO | `TestAgeColumn.test_age_column_shows_days` — cria repo git real, commita, assere `re.search(r"\d+d", rendered)` e ausência de `?`; 21/21 passaram |
| ZERO regressão: fix não altera caminho não-relacionado | ✅ VERIFICADO | O replace só executa na extração de chave dentro de `_git_blame_file`; output/tabela/lógica de scan inalterados |
| Suíte completa verde + cobertura ≥ 80% | ⚠️ NÃO-VERIFICADO pelo worker | Suíte completa é responsabilidade do revisor (conforme `_IMPACT_TEST_STRATEGY`); worker rodou apenas o subconjunto impactado (`deile/tests/commands/test_todo_command.py -p no:cov -q` → 21 passed) |

Closes #690.