### PR TITLE
fix(commands): substituir f-string de Rich por Group em /apply, /approve, /diff, /patch, /stop

### DIFF
--- a/deile/commands/builtin/apply_command.py
+++ b/deile/commands/builtin/apply_command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -132,7 +133,7 @@ class ApplyCommand(DirectCommand):
             border_style="dim",
         )
 
-        return CommandResult.success_result(f"{table}\n\n{usage_panel}", "rich")
+        return CommandResult.success_result(Group(table, usage_panel), "rich")
 
     def get_help(self) -> str:
         """Get command help."""

--- a/deile/commands/builtin/approve_command.py
+++ b/deile/commands/builtin/approve_command.py
@@ -1,5 +1,6 @@
 """Approve Command - Approve or reject plan steps"""
 
+from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -128,10 +129,7 @@ class ApproveCommand(DirectCommand):
             border_style="dim"
         )
         
-        # Combine table and usage
-        content = f"{table}\n\n{usage_panel}"
-        
-        return CommandResult.success_result(content, "rich")
+        return CommandResult.success_result(Group(table, usage_panel), "rich")
     
     async def _approve_step(self, plan_id: str, step_id: str, approved: bool) -> CommandResult:
         """Approve or reject a specific step"""

--- a/deile/commands/builtin/diff_command.py
+++ b/deile/commands/builtin/diff_command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from rich.console import Group
 from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.table import Table
@@ -130,7 +131,7 @@ class DiffCommand(DirectCommand):
             border_style="dim"
         )
         
-        return CommandResult.success_result(f"{table}\n\n{usage_panel}", "rich")
+        return CommandResult.success_result(Group(table, usage_panel), "rich")
     
     async def _show_plan_diff(self, plan_id: str, format_type: str, show_content: bool) -> CommandResult:
         """Show differences for a specific plan"""

--- a/deile/commands/builtin/patch_command.py
+++ b/deile/commands/builtin/patch_command.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -177,7 +178,7 @@ class PatchCommand(DirectCommand):
             border_style="dim"
         )
         
-        return CommandResult.success_result(f"{table}\n\n{usage_panel}", "rich")
+        return CommandResult.success_result(Group(table, usage_panel), "rich")
     
     async def _generate_patch(self, plan_id: str, output_format: str, 
                             output_path: Optional[str], include_artifacts: bool) -> CommandResult:

--- a/deile/commands/builtin/stop_command.py
+++ b/deile/commands/builtin/stop_command.py
@@ -1,5 +1,6 @@
 """Stop Command - Stop running plan execution"""
 
+from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -111,7 +112,7 @@ class StopCommand(DirectCommand):
             border_style="dim"
         )
         
-        return CommandResult.success_result(f"{table}\n\n{usage_panel}", "rich")
+        return CommandResult.success_result(Group(table, usage_panel), "rich")
     
     async def _stop_plan(self, plan_id: str, force: bool = False) -> CommandResult:
         """Stop a specific plan"""

--- a/deile/tests/commands/test_apply_command.py
+++ b/deile/tests/commands/test_apply_command.py
@@ -1,0 +1,96 @@
+"""Testes para ApplyCommand — foco no bug de repr Rich (issue #691).
+
+O bug original: _show_applicable_patches() passava f"{table}\n\n{usage_panel}"
+como content com content_type="rich". str(Table()) retorna o repr do objeto,
+não o conteúdo renderizado. A correção usa rich.console.Group.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console, Group
+
+from deile.commands.base import CommandContext
+from deile.commands.builtin.apply_command import ApplyCommand
+
+
+def _make_context(args: str = "") -> CommandContext:
+    return CommandContext(user_input=f"/apply {args}", args=args)
+
+
+@pytest.mark.unit
+async def test_show_patches_returns_rich_group_not_str(tmp_path):
+    """Quando há patches, result.content deve ser um renderable Rich, não uma str com repr."""
+    patch_file = tmp_path / "test.patch"
+    patch_file.write_text("--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n")
+
+    cmd = ApplyCommand()
+
+    with patch("deile.commands.builtin.apply_command.PATCHES_DIR", tmp_path), \
+         patch("deile.commands.builtin._shared.PATCHES_DIR", tmp_path):
+        result = await cmd.execute(_make_context())
+
+    assert result.success
+    content = result.content
+
+    # Deve ser um renderable Rich — Group implementa __rich_console__
+    assert hasattr(content, "__rich_console__") or hasattr(content, "__rich__"), (
+        f"result.content deve ser um renderable Rich, mas é {type(content)!r}"
+    )
+
+    # Não deve ser uma str (a falha original era isso)
+    assert not isinstance(content, str), (
+        "result.content não deve ser str — f-string de objeto Rich retorna repr"
+    )
+
+    # Não deve conter o repr do objeto Table
+    if isinstance(content, str):
+        assert "<rich.table.Table object" not in content
+        assert "<rich.panel.Panel object" not in content
+
+
+@pytest.mark.unit
+async def test_show_patches_renders_filename(tmp_path):
+    """O output renderizado deve conter o nome do arquivo de patch."""
+    patch_file = tmp_path / "my_feature.patch"
+    patch_file.write_text("--- a\n+++ b\n")
+
+    cmd = ApplyCommand()
+
+    with patch("deile.commands.builtin.apply_command.PATCHES_DIR", tmp_path), \
+         patch("deile.commands.builtin._shared.PATCHES_DIR", tmp_path):
+        result = await cmd.execute(_make_context())
+
+    assert result.success
+
+    # Renderiza via Console de captura (sem terminal)
+    console = Console(width=120)
+    with console.capture() as cap:
+        console.print(result.content)
+    rendered = cap.get()
+
+    assert "my_feature.patch" in rendered, (
+        f"Nome do patch deve aparecer no output renderizado, mas não está em:\n{rendered}"
+    )
+
+
+@pytest.mark.unit
+async def test_no_patches_returns_panel_not_group(tmp_path):
+    """Quando não há patches, deve retornar um Panel direto (caminho sem bug)."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    cmd = ApplyCommand()
+
+    with patch("deile.commands.builtin.apply_command.PATCHES_DIR", empty_dir), \
+         patch("deile.commands.builtin._shared.PATCHES_DIR", empty_dir):
+        result = await cmd.execute(_make_context())
+
+    assert result.success
+    # O ramo sem patches já estava correto — retorna Panel diretamente
+    from rich.panel import Panel
+    assert isinstance(result.content, Panel)


### PR DESCRIPTION
## Problema

Cinco comandos montavam `rich.table.Table` + `rich.panel.Panel` e os interpolavam
numa f-string: `f"{table}\n\n{usage_panel}"`. `str(Table())` retorna o repr do
objeto (`<rich.table.Table object at 0x...>`), não o conteúdo renderizado. O
content com `content_type="rich"` era uma `str`, que caia no caminho Markdown
de `console_ui.py:446` e renderizava o repr literalmente para o usuário.

## Correção

Substituir a f-string por `rich.console.Group(table, usage_panel)` em cada arquivo.
O padrão correto já existia em `help_command.py:85`.

Arquivos alterados (superfície disjunta):
- `deile/commands/builtin/apply_command.py:136`
- `deile/commands/builtin/approve_command.py:132`
- `deile/commands/builtin/diff_command.py:134`
- `deile/commands/builtin/patch_command.py:181`
- `deile/commands/builtin/stop_command.py:115`

## Critérios de Aceite — ENTREGA vs AC

| AC | Status | Evidência |
|---|---|---|
| Todos os testes existentes passam sem modificação | ✅ VERIFICADO | 89 testes em `test_shared.py`, `builtin/test_shared.py`, `test_table_widths_adaptive.py` — todos verdes |
| A SUÍTE COMPLETA fica verde (cobertura ≥ 80%) | ⚠️ NÃO-VERIFICADO AQUI | Tarefa do revisor per brief; os 3 testes adicionados passam; sem regressão nos módulos tocados |
| ZERO regressão nos caminhos não relacionados | ✅ VERIFICADO | Fix é cirúrgico: apenas 1 linha por arquivo, sem alteração de imports não usados, sem mudança nos ramos `if not patch_files` (já corretos) |
| Teste novo cobrindo o defeito em `test_apply_command.py` | ✅ VERIFICADO | 3 testes adicionados e verdes: (1) `result.content` tem `__rich_console__` e não é str; (2) nome do arquivo .patch aparece no output renderizado via `Console().capture()`; (3) ramo "sem patches" continua retornando `Panel` direto |

Closes #691.