### PR TITLE
fix(dispatch_resolver): rejeita NaN/sNaN/Infinity em cost cap

### DIFF
--- a/deile/orchestration/pipeline/dispatch_resolver.py
+++ b/deile/orchestration/pipeline/dispatch_resolver.py
@@ -480,16 +480,20 @@ def resolve_stage_cost_cap_usd(stage: str) -> Optional[Decimal]:
         stripped = raw.strip()
         try:
             d = Decimal(stripped)
+            if not d.is_finite():
+                raise InvalidOperation(f"non-finite value {stripped!r}")
+            if d <= 0:
+                msg = f"cost cap must be positive, got {d} ({context})"
+                if strict:
+                    raise ValueError(msg)
+                logger.warning("dispatch_resolver: %s — ignoring", msg)
+                return None
+        except ValueError:
+            raise
         except InvalidOperation as exc:
             msg = f"invalid decimal {stripped!r} for cost cap ({context})"
             if strict:
                 raise ValueError(msg) from exc
-            logger.warning("dispatch_resolver: %s — ignoring", msg)
-            return None
-        if d <= 0:
-            msg = f"cost cap must be positive, got {d} ({context})"
-            if strict:
-                raise ValueError(msg)
             logger.warning("dispatch_resolver: %s — ignoring", msg)
             return None
         return d

--- a/deile/tests/orchestration/pipeline/test_stage_budget_guard.py
+++ b/deile/tests/orchestration/pipeline/test_stage_budget_guard.py
@@ -146,3 +146,30 @@ class TestResolveStageCostCapUsd:
             resolve_stage_cost_cap_usd
         monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "")
         assert resolve_stage_cost_cap_usd("implement") is None
+
+    def test_nan_env_raises_value_error(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import \
+            resolve_stage_cost_cap_usd
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "NaN")
+        with pytest.raises(ValueError):
+            resolve_stage_cost_cap_usd("implement")
+
+    def test_snan_env_raises_value_error(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import \
+            resolve_stage_cost_cap_usd
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "sNaN")
+        with pytest.raises(ValueError):
+            resolve_stage_cost_cap_usd("implement")
+
+    def test_infinity_env_raises_value_error(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import \
+            resolve_stage_cost_cap_usd
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "Infinity")
+        with pytest.raises(ValueError):
+            resolve_stage_cost_cap_usd("implement")
+
+    def test_finite_positive_env_returns_decimal(self, monkeypatch):
+        from deile.orchestration.pipeline.dispatch_resolver import \
+            resolve_stage_cost_cap_usd
+        monkeypatch.setenv("DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT", "5.00")
+        assert resolve_stage_cost_cap_usd("implement") == Decimal("5.00")


### PR DESCRIPTION
## Problema

`_parse_cap` em `dispatch_resolver.py` tinha a comparação `d <= 0` **fora** do `try/except InvalidOperation`, causando dois defeitos:

- **NaN / sNaN**: `Decimal('NaN') <= 0` lança `InvalidOperation` (subclasse de `ArithmeticError`, não `ValueError`), que vazava não-tratado e era capturado por `except Exception` no consumidor (`implementer.py:1009`), desligando **silenciosamente** a guarda de custo em vez de fail-fast.
- **Infinity**: `Decimal('Infinity') <= 0` retorna `False`, aceito como cap positivo válido — curto-circuitava o fallback e desligava silenciosamente a enforcement no nível 1 da cadeia.

## Correção

Em `_parse_cap`, movida a lógica de validação para dentro do `try` block e adicionada verificação `d.is_finite()` antes de `d <= 0`. Valores não-finitos levantam `InvalidOperation` internamente, que é capturado e convertido em `ValueError` conforme o contrato documentado — garantindo fail-fast uniforme para qualquer entrada inválida.

## Entrega vs Critérios de Aceite

| AC | Status | Evidência |
|---|---|---|
| Todos os testes existentes passam sem modificação | ✅ VERDE | 29/29 passaram: `test_stage_budget_guard`, `test_resolve_stage_cost_cap_global_settings`, `test_implementer_cost_cap_gating` |
| ZERO regressão — fix não altera caminho não-relacionado | ✅ CONFIRMADO | Superfície da mudança disjunta: apenas `_parse_cap` + novos testes; sem mudança em outros caminhos |
| Teste novo cobrindo o defeito: `NaN` → `ValueError` | ✅ VERDE | `test_nan_env_raises_value_error` — `monkeypatch DEILE_PIPELINE_COST_CAP_USD_IMPLEMENT='NaN'` → `pytest.raises(ValueError)` |
| Teste novo: `sNaN` → `ValueError` | ✅ VERDE | `test_snan_env_raises_value_error` |
| Teste novo: `Infinity` → `ValueError` | ✅ VERDE | `test_infinity_env_raises_value_error` |
| Teste novo: valor finito positivo `'5.00'` → `Decimal('5.00')` | ✅ VERDE | `test_finite_positive_env_returns_decimal` |
| Suíte completa verde / cobertura ≥ 80% | ⚠️ NÃO VERIFICADO AQUI | Por spec do brief do implement, a suíte completa é responsabilidade do revisor — apenas o subset impactado foi rodado (green) |

Closes #693.