### PR TITLE
fix(orchestration): grava _cache_timestamps em _get_tasks_for_list

### DIFF
--- a/deile/orchestration/sqlite_task_manager.py
+++ b/deile/orchestration/sqlite_task_manager.py
@@ -459,6 +459,7 @@ class SQLiteTaskManager:
 
                 # Atualiza cache
                 self._task_cache[list_id] = tasks
+                self._cache_timestamps[list_id] = asyncio.get_event_loop().time()
                 return tasks
 
     async def get_next_tasks(self, list_id: str) -> List[Task]:

--- a/deile/tests/orchestration/test_sqlite_task_manager_cache.py
+++ b/deile/tests/orchestration/test_sqlite_task_manager_cache.py
@@ -1,0 +1,70 @@
+"""Regression test for SQLiteTaskManager._get_tasks_for_list cache timestamp bug.
+
+Bug: after fetching tasks from DB and writing _task_cache[list_id], the method
+never wrote _cache_timestamps[list_id]. Since _is_cache_valid returns False when
+list_id is absent from _cache_timestamps, the freshly-populated task cache was
+immediately invalid on the next call, causing a DB round-trip every time.
+
+Fix: _get_tasks_for_list now writes _cache_timestamps[list_id] after _task_cache,
+mirroring the pattern in load_task_list (lines 432-434).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import aiosqlite
+import pytest
+
+from deile.orchestration.sqlite_task_manager import SQLiteTaskManager
+
+
+@pytest.fixture()
+async def manager(tmp_path):
+    m = SQLiteTaskManager(db_path=tmp_path / "tasks.db")
+    await m._ensure_schema()
+    return m
+
+
+@pytest.mark.unit
+async def test_get_tasks_for_list_populates_cache_timestamp(manager) -> None:
+    """After _get_tasks_for_list, list_id must be in _cache_timestamps and cache must be valid."""
+    list_id = "list-abc"
+
+    await manager._get_tasks_for_list(list_id)
+
+    assert list_id in manager._cache_timestamps, (
+        "_cache_timestamps must contain list_id after _get_tasks_for_list"
+    )
+    assert manager._is_cache_valid(list_id), (
+        "_is_cache_valid must return True immediately after _get_tasks_for_list"
+    )
+
+
+@pytest.mark.unit
+async def test_get_tasks_for_list_second_call_uses_cache(tmp_path) -> None:
+    """Second call to _get_tasks_for_list must be served from cache without hitting the DB."""
+    manager = SQLiteTaskManager(db_path=tmp_path / "tasks.db")
+    await manager._ensure_schema()
+
+    list_id = "list-xyz"
+
+    # First call: hits DB and populates cache
+    first_result = await manager._get_tasks_for_list(list_id)
+
+    # Wrap aiosqlite.connect with a spy; second call must not trigger it
+    connect_calls: list = []
+    original_connect = aiosqlite.connect
+
+    def spy_connect(*args, **kwargs):
+        connect_calls.append(args)
+        return original_connect(*args, **kwargs)
+
+    with patch("deile.orchestration.sqlite_task_manager.aiosqlite.connect", new=spy_connect):
+        second_result = await manager._get_tasks_for_list(list_id)
+
+    assert connect_calls == [], (
+        f"Cache miss on second call: DB was accessed {len(connect_calls)} time(s). "
+        "The cache timestamp was not written by the first call."
+    )
+    assert second_result == first_result


### PR DESCRIPTION
## Problema

`_get_tasks_for_list` (linha 461) populava `_task_cache[list_id]` mas nunca gravava `_cache_timestamps[list_id]`. Como `_is_cache_valid` retorna `False` quando `list_id` não está em `_cache_timestamps` (linha 584), o cache de tasks recém-populado era imediatamente inválido na próxima chamada — causando refetch do DB toda vez que `_get_tasks_for_list` era chamado isoladamente (sem `load_task_list` antes).

## Fix

Uma linha em `_get_tasks_for_list`, espelhando o padrão já usado em `load_task_list` (linhas 432-434):

```python
self._cache_timestamps[list_id] = asyncio.get_event_loop().time()
```

Arquivo alterado: `deile/orchestration/sqlite_task_manager.py` (superfície disjunta, sem toque em outros caminhos).

## Entrega vs Critérios de Aceite

| AC | Status | Evidência |
|---|---|---|
| Todos os testes existentes passam sem modificação | ✅ VERIFICADO | `20 passed` em `test_default_paths.py` + `test_workflow_executor.py` (todos os testes impactados por grep) |
| ZERO regressão — fix não altera caminho não-relacionado | ✅ VERIFICADO | Mudança é um único `self._cache_timestamps[list_id] = ...` dentro do bloco `if list_id in self._task_cache` já existente; nenhum outro path toca esta linha |
| Teste novo: segunda chamada NÃO bate no DB (hit de cache) | ✅ VERIFICADO | `test_get_tasks_for_list_second_call_uses_cache` — monkeypatcha `aiosqlite.connect` após primeira chamada; `connect_calls == []` confirma cache hit |
| Teste novo: após `_get_tasks_for_list`, `list_id` em `_cache_timestamps` e `_is_cache_valid` True | ✅ VERIFICADO | `test_get_tasks_for_list_populates_cache_timestamp` — ambos os asserts passam |
| Suíte completa ≥ 80% cobertura | NÃO-VERIFICADO pelo worker | Revisor executa `pytest deile/tests/ -q` com cobertura conforme AC; worker não executa suíte completa por instrução de impacto seletivo |

Closes #694.