### PR TITLE
fix(monitor): resume command pode liftar pause temporizado ativo (#696)

### DIFF
--- a/deile/tests/infra/test_monitor_tick.py
+++ b/deile/tests/infra/test_monitor_tick.py
@@ -95,6 +95,25 @@ async def test_auto_resume_when_pause_expired(tick, tmp_path, capsys):
 # Steer commands
 # ---------------------------------------------------------------------------
 
+async def test_steer_resume_lifts_active_pause(tick, tmp_path, capsys):
+    """Queued 'resume' command must lift a timed pause that has not yet expired.
+
+    Mirrors test_auto_resume_when_pause_expired but via queued command, not expiry.
+    Covers the bug from issue #696: _process_steer_commands now runs before
+    _handle_kill_switch so the resume is processed before the kill-switch fires.
+    """
+    sd = _state_dir(tmp_path)
+    (sd / "monitor-pause").write_text("")
+    json.dump({"paused_until": "2026-06-02T23:00:00Z"}, open(sd / "monitor-state.json", "w"))
+    (sd / "monitor-commands" / "cmd1").write_text("resume")
+    res = await _run(tick, sd, now=_utc(2026, 6, 2, 11, 0, 0))
+    assert res["paused"] is False
+    assert not (sd / "monitor-pause").exists()
+    state = json.load(open(sd / "monitor-state.json"))
+    assert state["paused_until"] is None
+    assert "monitor.command from=bot kind=resume" in capsys.readouterr().out
+
+
 async def test_steer_pause_creates_flag_and_consumes_file(tick, tmp_path, capsys):
     sd = _state_dir(tmp_path)
     (sd / "monitor-commands" / "cmd1").write_text("pause 30m")

--- a/infra/k8s/monitor_tick.py
+++ b/infra/k8s/monitor_tick.py
@@ -180,13 +180,16 @@ async def run_tick(
     emitter = core.Emitter(str(audit_path), flags, clock=lambda: now, tick_n=tick_n)
     start = now
 
-    # Step 2 — kill-switch / auto-resume.
+    # Steer commands first — a queued 'resume' must be able to lift an active
+    # timed pause before the kill-switch short-circuits the tick (issue #696).
+    _process_steer_commands(sd, state, emitter, now)
+
+    # Kill-switch / auto-resume (re-evaluated after steer commands drain).
     if _handle_kill_switch(sd, state, emitter, now):
         core.save_state(str(state_path), state)
         return {"paused": True, "needs_phase_b": False}
 
-    # Steer commands (may re-pause; re-check).
-    _process_steer_commands(sd, state, emitter, now)
+    # Re-check: a steer 'pause' command applied above may have re-paused.
     if (sd / "monitor-pause").exists() and state.get("paused_until"):
         core.save_state(str(state_path), state)
         return {"paused": True, "needs_phase_b": False}


### PR DESCRIPTION
## Resumo

Corrige o bug onde um comando `resume` enviado ao `deile-monitor` via `monitor-commands/` ficava preso na fila enquanto um `pause` temporizado estivesse ativo, nunca sendo processado até a expiração natural do pause.

## Causa raiz

Em `run_tick` (`infra/k8s/monitor_tick.py`), `_handle_kill_switch` era chamado **antes** de `_process_steer_commands`. Com pause ativo (`monitor-pause` presente e `paused_until` no futuro), o kill-switch retornava `True` na linha ~184 e o tick saía cedo — sem nunca drenar a fila de comandos em `monitor-commands/`. O `resume` só é tratado em `_apply_steer` (via `_process_steer_commands`), que estava em código morto durante o pause.

## Fix

Inverte a ordem no bloco de controle de `run_tick`:

1. `_process_steer_commands` roda **primeiro** — um `resume` enfileirado desunlinka `monitor-pause` e zera `paused_until` antes do kill-switch avaliar
2. `_handle_kill_switch` re-avalia o estado atualizado (se o resume foi processado, não vê mais a flag e retorna `False`)
3. Re-checagem após o kill-switch cobre o caso oposto: comando `pause` recém-aplicado que acabou de criar a flag

Superfície do fix: **dois blocos trocados de ordem** em `run_tick`. Nenhum comportamento não-relacionado foi alterado.

## Confronto ENTREGA vs ACs

| AC | Status | Evidência |
|---|---|---|
| Todos os testes existentes passam sem modificação | ✅ VERDE | `18 passed in 1.13s` — todos os 17 testes pré-existentes passam sem nenhuma modificação |
| ZERO regressão: comportamento antes/depois correto | ✅ VERIFICADO | Análise: pause-sem-comando → kill-switch retorna True (igual antes); expiração-natural → kill-switch auto-resume (igual antes); pause via steer → kill-switch vê nova flag, para (igual antes); apenas o caminho resume-durante-pause-ativo muda (antes: stuck; agora: funciona) |
| Teste novo cobrindo o defeito | ✅ VERDE | `test_steer_resume_lifts_active_pause` em `deile/tests/infra/test_monitor_tick.py`: escreve `monitor-pause` + `paused_until` futuro (23:00), enfileira `monitor-commands/cmd1` com conteúdo `resume`, roda tick com `now=11:00`; assertiva: `res["paused"] is False`, `monitor-pause` removido, `state["paused_until"] is None`, emit `monitor.command from=bot kind=resume` presente |
| Suíte completa ≥ 80% cobertura | ⚠️ NÃO VERIFICADO | AC instrui "revisor faz isso" (brief `_IMPACT_TEST_STRATEGY`); a suíte completa não foi rodada pelo worker (política da plataforma) |

Closes #696.