### PR TITLE
fix(security): anchor whitelist patterns to prevent real secrets from being silently dropped

### DIFF
--- a/deile/security/secrets_scanner.py
+++ b/deile/security/secrets_scanner.py
@@ -147,9 +147,9 @@ class SecretsScanner:
         whitelist = [
             # Common placeholders
             re.compile(r'(your_api_key_here|replace_with_your_key|example_key|dummy_token)', re.IGNORECASE),
-            re.compile(r'(lorem ipsum|sample|test|demo|placeholder)', re.IGNORECASE),
+            re.compile(r'^(lorem ipsum|sample|test|demo|placeholder)$', re.IGNORECASE),
             re.compile(r'^[X\*]+$'),  # Masked values
-            re.compile(r'(123456|password|secret|token)$', re.IGNORECASE),  # Common examples
+            re.compile(r'^(123456|password|secret|token)$', re.IGNORECASE),  # Common examples
             
             # File paths and URLs without sensitive info
             re.compile(r'^(https?://|file://|/[a-zA-Z0-9/_\-\.]+)$'),

--- a/deile/tests/security/test_secrets_scanner_redact.py
+++ b/deile/tests/security/test_secrets_scanner_redact.py
@@ -65,3 +65,42 @@ def test_redact_text_multiline_with_secrets() -> None:
     assert len(redacted_lines) == len(original_lines)
     for orig, red in zip(original_lines, redacted_lines):
         assert len(red) == len(orig), (orig, red)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #707 — whitelist substring match silently drops
+# real secrets whose value contains a placeholder word like 'test' or 'demo'.
+# ---------------------------------------------------------------------------
+
+def test_github_token_with_test_substring_is_detected() -> None:
+    """A valid ghp_ PAT whose body contains 'test' must NOT be whitelisted."""
+    # ghp_ + 36 alphanum chars; the first four are 'test' — triggers the bug.
+    token = "ghp_testABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+    text = f'github_token = "{token}"'
+    scanner = SecretsScanner()
+    matches = scanner.scan_text(text)
+    secret_values = [m.matched_text for m in matches]
+    assert any(token in v or v in token for v in secret_values), (
+        f"Expected token {token!r} to be detected but scan returned: {secret_values!r}"
+    )
+
+
+def test_aws_key_with_demo_substring_is_redacted() -> None:
+    """A valid AKIA key whose body contains 'demo' must be detected and redacted."""
+    # AKIA + 16 uppercase alphanum; 'DEMO' appears at offset 4.
+    key = "AKIADEMOZ23456789012"
+    scanner = SecretsScanner()
+    redacted, matches = scanner.redact_text(key)
+    assert matches, f"Expected at least one match for {key!r} but got none"
+    assert key not in redacted, f"Secret {key!r} was not redacted; output: {redacted!r}"
+
+
+def test_literal_placeholder_still_whitelisted() -> None:
+    """The exact placeholder string 'your_api_key_here' must remain whitelisted."""
+    text = 'api_key = "your_api_key_here"'
+    scanner = SecretsScanner()
+    matches = scanner.scan_text(text)
+    placeholder_matches = [m for m in matches if m.matched_text == "your_api_key_here"]
+    assert not placeholder_matches, (
+        f"Placeholder 'your_api_key_here' should be whitelisted but was flagged: {placeholder_matches!r}"
+    )


### PR DESCRIPTION
## Resumo

`SecretsScanner._is_whitelisted` aplicava `re.search` não-ancorado contra o **valor** do segredo extraído. Dois padrões casavam como substring:

- `(lorem ipsum|sample|test|demo|placeholder)` → qualquer segredo cujo corpo contivesse 'test'/'demo'/'sample' era descartado.
- `(123456|password|secret|token)$` → qualquer segredo terminado em 'token'/'secret' era descartado.

Resultado: `scan_text` retornava `[]` para `ghp_test...`, `AKIADEMO...`, `xoxb-sample...` — e `redact_text` passava esses segredos sem redactar.

## Correção (superfície mínima)

Âncoras `^...$` nas duas patterns ofensivas em `_load_whitelist_patterns`. O `re.search` com `^...$` só casa quando o valor **É exatamente** o placeholder — não quando a palavra aparece como substring no interior do segredo.

```python
# ANTES (vulnerável)
re.compile(r'(lorem ipsum|sample|test|demo|placeholder)', re.IGNORECASE),
re.compile(r'(123456|password|secret|token)$', re.IGNORECASE),

# DEPOIS (corrigido)
re.compile(r'^(lorem ipsum|sample|test|demo|placeholder)$', re.IGNORECASE),
re.compile(r'^(123456|password|secret|token)$', re.IGNORECASE),
```

Nenhuma mudança em `_is_whitelisted` — as âncoras já corrigem o comportamento.

## Entrega vs Critérios de Aceite

| AC | Status | Evidência |
|---|---|---|
| Correção implementada, superfície mínima (`secrets_scanner.py`, `test_secrets_scanner_redact.py`) | ✅ | 2 linhas alteradas em `_load_whitelist_patterns` |
| Teste novo: caso de ataque (secret com substring de whitelist detectado) | ✅ | `test_github_token_with_test_substring_is_detected` + `test_aws_key_with_demo_substring_is_redacted` |
| Teste novo: caso legítimo (placeholder real ainda whitelisted) | ✅ | `test_literal_placeholder_still_whitelisted` |
| Todos os testes existentes passam | ✅ | 20/20 testes de `test_secrets_scanner_*.py` verdes |
| Portão de regressão verde | ✅ | 20 passed, 0 failed — todos os testes de `secrets_scanner` passam |

## Testes executados

```
python3 -m pytest deile/tests/security/test_secrets_scanner_bot.py \
                  deile/tests/security/test_secrets_scanner_gitlab.py \
                  deile/tests/security/test_secrets_scanner_redact.py \
                  -p no:cov -q
20 passed in 9.51s
```

Closes #707.