### PR TITLE
fix(memory): preserve stored_at in store_knowledge when already set

### DIFF
--- a/deile/memory/semantic_memory.py
+++ b/deile/memory/semantic_memory.py
@@ -51,7 +51,7 @@ class SemanticMemory:
         bloquear o loop nesse caminho viola o princípio 03 §1.
         """
         record = dict(knowledge)
-        record['stored_at'] = record.get('extracted_at', 0)
+        record['stored_at'] = record.get('extracted_at', record.get('stored_at', 0))
         self._knowledge_base.append(record)
 
         await asyncio.to_thread(_append_jsonl_record, self.knowledge_file, record)

--- a/deile/tests/memory/test_semantic_memory_stored_at.py
+++ b/deile/tests/memory/test_semantic_memory_stored_at.py
@@ -1,0 +1,48 @@
+"""Regression tests for ``SemanticMemory.store_knowledge`` stored_at precedence.
+
+Bug: store_knowledge() unconditionally overwrote stored_at with extracted_at,
+destroying the stored_at that store_correction() had already calculated.
+
+Fix: record.get('extracted_at', record.get('stored_at', 0)) preserves any
+stored_at already present (correction flow) while still deriving from
+extracted_at in the normal flow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deile.memory.semantic_memory import SemanticMemory
+
+
+async def test_store_correction_preserves_stored_at(tmp_path: Path) -> None:
+    """store_correction() sets stored_at via loop time; store_knowledge must not
+    overwrite it with 0 (the extracted_at fallback) when extracted_at is absent."""
+    sm = SemanticMemory(storage_dir=tmp_path)
+    await sm.initialize()
+    try:
+        await sm.store_correction("id1", {"foo": "bar"})
+
+        stored = sm._knowledge_base[-1]
+        assert stored["stored_at"] > 0, (
+            "stored_at should be the event-loop timestamp set by store_correction, "
+            f"got {stored['stored_at']!r}"
+        )
+    finally:
+        await sm.shutdown()
+
+
+async def test_store_knowledge_with_extracted_at_derives_stored_at(tmp_path: Path) -> None:
+    """Normal flow: a record that carries extracted_at should still derive
+    stored_at from extracted_at (not lose it to the store_correction path)."""
+    sm = SemanticMemory(storage_dir=tmp_path)
+    await sm.initialize()
+    try:
+        await sm.store_knowledge({"topic": "embeddings", "extracted_at": 99999})
+
+        stored = sm._knowledge_base[-1]
+        assert stored["stored_at"] == 99999, (
+            f"stored_at should equal extracted_at (99999), got {stored['stored_at']!r}"
+        )
+    finally:
+        await sm.shutdown()


### PR DESCRIPTION
## Problema

store_knowledge() (semantic_memory.py:54) sobrescrevia incondicionalmente stored_at:
`record['stored_at'] = record.get('extracted_at', 0)`

Como o dict de correção não tem 'extracted_at', store_correction() tinha seu timestamp silenciosamente zerado. Toda correção persistia com stored_at=0.

## Correção (superfície mínima)

```python
# antes
record['stored_at'] = record.get('extracted_at', 0)
# depois
record['stored_at'] = record.get('extracted_at', record.get('stored_at', 0))
```

Preserva stored_at se já presente (correções), deriva de extracted_at se disponível (fluxo normal), cai para 0 apenas como último recurso.

## Critérios de Aceite

- [x] **AC1**: Correção implementada em deile/memory/semantic_memory.py, superfície mínima (1 linha alterada).
- [x] **AC2**: Teste novo cobrindo o defeito — verifica que stored_at > 0 após store_correction(). Testes: ["test_store_correction_preserves_stored_at","test_store_knowledge_with_extracted_at_derives_stored_at"].
- [x] **AC3**: Testes existentes passam — 4 passed in 4.50s.
- [x] **AC4**: Zero regressão — suíte impactada verde: ["deile/tests/memory/test_semantic_memory_immutability.py","deile/tests/memory/test_semantic_memory_stored_at.py"].

## Evidência de testes

```
collected 4 items

deile/tests/memory/test_semantic_memory_immutability.py ..               [ 50%]
deile/tests/memory/test_semantic_memory_stored_at.py ..                  [100%]

============================== 4 passed in 4.50s ===============================
```

Closes #711.