### PR TITLE
fix(pipeline): guard DISPATCH_SKIPPED_STILL_RUNNING no caminho mention sticky

### DIFF
--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -782,6 +782,19 @@ async def _dispatch_mention_group(
         logger.warning("mention dispatch error for %s: %s", dedup_key, exc)
         return
 
+    # Skip-because-still-running is NOT a real attempt — the previous dispatch
+    # is still alive in the worker, so no new work happened this tick. Return
+    # BEFORE ``update_from_worker`` (which bumps attempt +1 per call): a long
+    # resume spanning more ticks than ``resume_max_attempts`` would otherwise
+    # burn its whole budget on no-op skips and block a healthy PR in progress
+    # (same root cause as the implement #509 and pr_review regressions).
+    if not outcome.ok and "DISPATCH_SKIPPED_STILL_RUNNING" in (outcome.error or ""):
+        logger.info(
+            "mention %s: dispatch skipped (claude ainda alive) — sem consumir tentativa",
+            dedup_key,
+        )
+        return
+
     if sticky:
         # Absorb the worker's ground-truth bookkeeping (attempt/fingerprint)
         # so the ceiling advances and a stuck loop is bounded.

--- a/deile/tests/orchestration/pipeline/test_mention_dispatch_nowait.py
+++ b/deile/tests/orchestration/pipeline/test_mention_dispatch_nowait.py
@@ -212,3 +212,115 @@ class TestMentionPrConcurrencyGuardPreserved:
         assert not outcome.ok
         # O guard retorna DISPATCH_SKIPPED_CONCURRENT (ou similar) — basta ok=False.
         assert outcome.error, "error deve estar preenchido quando bloqueado"
+
+
+# ---------------------------------------------------------------------------
+# Regressão #713: DISPATCH_SKIPPED_STILL_RUNNING não deve consumir tentativa
+# ---------------------------------------------------------------------------
+
+class TestMentionSkipStillRunningGuard:
+    """Guard: DISPATCH_SKIPPED_STILL_RUNNING não consome tentativa de resume.
+
+    Sem o guard, ``_dispatch_mention_group`` chamava ``update_from_worker``
+    incondicionalmente — mesmo quando o dispatch foi *pulado* porque o
+    claude-worker já estava rodando. Isso incrementava ``attempt`` +1 por tick
+    até ``resume_max_attempts``, disparando ``_comment_mention_gave_up`` e
+    abandonando uma PR saudável em progresso.
+    """
+
+    async def test_attempt_not_incremented_on_skip_still_running(self):
+        """attempt NÃO deve mudar quando DISPATCH_SKIPPED_STILL_RUNNING é retornado.
+
+        Sem o guard:
+          attempt = resume_max - 1  → tick skip → attempt = resume_max
+          → próximo tick: ceiling dispara → PR abandonada.
+        Com o guard: attempt permanece em resume_max - 1 enquanto o worker vive.
+        """
+        from deile.orchestration.pipeline.stages import (
+            MentionTrigger, _dispatch_mention_group,
+        )
+        from deile.orchestration.pipeline.labels import MENTION_DONE
+
+        # _make_monitor sobrescreve impl.mention quando impl é MagicMock —
+        # por isso configuramos o outcome DEPOIS de criar o monitor.
+        monitor, github = _make_monitor()
+        monitor.implementer.mention = AsyncMock(
+            return_value=WorkOutcome(
+                ok=False, text="",
+                error="DISPATCH_SKIPPED_STILL_RUNNING: dispatch #123 still alive",
+            )
+        )
+
+        pr_number = 99
+        resume_max = monitor.config.resume_max_attempts  # default 10
+        # Semeia attempt no limite − 1: sem o guard o próximo tick alcança o teto.
+        state = monitor._resume_tracker.get(pr_number)
+        state.attempt = resume_max - 1
+
+        pr = _pr_ref(pr_number)
+        group = [MentionTrigger(trigger_type="assignee", pr=pr)]
+        dedup_key = f"pr:{pr_number}:assignee"
+
+        await _dispatch_mention_group(monitor, dedup_key, group, "deile-one", 0.0)
+
+        # (a) attempt NÃO deve ter sido incrementado.
+        after = monitor._resume_tracker.get(pr_number).attempt
+        assert after == resume_max - 1, (
+            f"DISPATCH_SKIPPED_STILL_RUNNING deve preservar attempt; "
+            f"esperado {resume_max - 1}, obtido {after}"
+        )
+
+        # (b) ~mention:processado NÃO deve ter sido aplicado.
+        for call_args in github.add_labels.call_args_list:
+            labels = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("labels", [])
+            assert MENTION_DONE not in labels, (
+                f"~mention:processado não deve ser aplicado em DISPATCH_SKIPPED_STILL_RUNNING; "
+                f"encontrado em add_labels({call_args})"
+            )
+
+    async def test_gave_up_not_triggered_after_multiple_skips(self):
+        """Múltiplos ticks de DISPATCH_SKIPPED_STILL_RUNNING não devem dar gave_up.
+
+        Demonstra que o guard bloqueia a regressão: sem ele, após 2 ticks
+        (attempt sobe de resume_max-1 para resume_max, depois dispara o ceiling)
+        a PR seria abandonada. Com o guard, 2 ticks são inofensivos.
+        """
+        from deile.orchestration.pipeline.stages import (
+            MentionTrigger, _dispatch_mention_group,
+        )
+        from deile.orchestration.pipeline.labels import MENTION_DONE
+
+        monitor, github = _make_monitor()
+        monitor.implementer.mention = AsyncMock(
+            return_value=WorkOutcome(
+                ok=False, text="",
+                error="DISPATCH_SKIPPED_STILL_RUNNING: dispatch #456 still alive",
+            )
+        )
+
+        pr_number = 100
+        resume_max = monitor.config.resume_max_attempts
+        state = monitor._resume_tracker.get(pr_number)
+        state.attempt = resume_max - 1
+
+        pr = _pr_ref(pr_number)
+        group = [MentionTrigger(trigger_type="assignee", pr=pr)]
+        dedup_key = f"pr:{pr_number}:assignee"
+
+        # Dois ticks consecutivos de skip.
+        await _dispatch_mention_group(monitor, dedup_key, group, "deile-one", 0.0)
+        await _dispatch_mention_group(monitor, dedup_key, group, "deile-one", 0.0)
+
+        # Attempt permanece inalterado após 2 ticks.
+        after = monitor._resume_tracker.get(pr_number).attempt
+        assert after == resume_max - 1, (
+            f"Dois ticks de DISPATCH_SKIPPED_STILL_RUNNING não devem queimar o ceiling; "
+            f"esperado {resume_max - 1}, obtido {after}"
+        )
+
+        # ~mention:processado nunca deve ter sido aplicado.
+        for call_args in github.add_labels.call_args_list:
+            labels = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("labels", [])
+            assert MENTION_DONE not in labels, (
+                "~mention:processado não deve ser aplicado em DISPATCH_SKIPPED_STILL_RUNNING"
+            )


### PR DESCRIPTION
## Resumo

Adiciona o guard `DISPATCH_SKIPPED_STILL_RUNNING` à função `_dispatch_mention_group` em `stages.py`, espelhando o mesmo padrão já aplicado nos caminhos `implement` (linha 2483) e `pr_review` (linha 3080).

## Bug corrigido

Quando um trigger sticky (reviewer/assignee/body) sobre uma PR disparava resume e o claude-worker ainda estava rodando o dispatch anterior, `WorkerImplementer.mention` retornava `WorkOutcome(ok=False, error='DISPATCH_SKIPPED_STILL_RUNNING: ...')`. De volta em `_dispatch_mention_group`, o bloco `if sticky:` chamava `monitor._resume_tracker.update_from_worker(...)` **incondicionalmente**, incrementando `state.attempt` em +1 por tick mesmo sem trabalho novo. Quando `attempt` atingia `resume_max_attempts`, `_comment_mention_gave_up` era disparado e a PR saudável em progresso era abandonada.

## Solução

O guard retorna imediatamente antes do `update_from_worker`, preservando `attempt` intacto. O lock natural (o claude já está vivo no worker) mantém a consistência; o trigger sticky re-dispara no próximo tick e o claude termina a PR normalmente.

## Entrega vs. Critérios de Aceite

- [x] **AC 1** — Correção implementada conforme descrito, superfície mínima. Arquivos alterados: `deile/orchestration/pipeline/stages.py` (+13 linhas: guard + logger.info + return), `deile/tests/orchestration/pipeline/test_mention_dispatch_nowait.py` (+112 linhas: `TestMentionSkipStillRunningGuard` com 2 testes).
- [x] **AC 2** — Teste novo cobrindo o defeito (`TestMentionSkipStillRunningGuard::test_attempt_not_incremented_on_skip_still_running` e `test_gave_up_not_triggered_after_multiple_skips`). Ambos **falhariam** no código anterior (attempt seria incrementado até o ceiling, depois PR seria abandonada) e **passam** com o guard.
- [x] **AC 3** — Todos os testes existentes passam: 6/6 `test_mention_dispatch_nowait.py`, 59/59 testes mention-related (handling, done_marked_always, collector_assignee).
- [ ] **AC 4** — Portão de regressão (CI 100%) — a ser verificado pelo revisor. Suíte completa é tarefa do revisor conforme `_IMPACT_TEST_STRATEGY`.

Closes #713.