### PR TITLE
fix(k8s): validar deployment contra allowlist em _cmd_restart

### DIFF
--- a/deile/commands/builtin/k8s_command.py
+++ b/deile/commands/builtin/k8s_command.py
@@ -365,6 +365,14 @@ async def _cmd_restart(namespace: str, deployment: str) -> CommandResult:
     if deployment.lower() == "all":
         targets = list(K8S_DEPLOYMENTS)
     else:
+        resolved = _LOG_TARGET_MAP.get(deployment)
+        if resolved is not None:
+            deployment = resolved
+        elif deployment not in K8S_DEPLOYMENTS:
+            valid = ", ".join(sorted(_LOG_TARGET_MAP.keys()) + ["all"])
+            return CommandResult.error_result(
+                f"Unknown deployment '{deployment}'. Valid: {valid}"
+            )
         targets = [deployment]
 
     lines = []

--- a/deile/tests/commands/test_k8s_command.py
+++ b/deile/tests/commands/test_k8s_command.py
@@ -321,6 +321,25 @@ class TestCmdRestart:
         # Result depends on outcomes — just confirm it runs without crashing
         assert result is not None
 
+    async def test_restart_unknown_deployment_rejected(self):
+        with patch("deile.commands.builtin.k8s_command._run_kubectl") as mock_kubectl:
+            result = await _cmd_restart("deile", "kube-dns")
+        assert result.success is False
+        mock_kubectl.assert_not_called()
+
+    async def test_restart_allowlisted_deployment_passes(self):
+        call_count = [0]
+
+        async def fake_run(args, timeout=30.0):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return True, "restarted", ""
+            return True, "rolled out", ""
+
+        with patch("deile.commands.builtin.k8s_command._run_kubectl", side_effect=fake_run):
+            result = await _cmd_restart("deile", "deile-worker")
+        assert result.success is True
+
 
 # ---------------------------------------------------------------------------
 # _cmd_status


### PR DESCRIPTION
## Resumo

`/k8s restart --deployment <qualquer-nome>` repassava o nome cru ao `kubectl rollout restart` sem validar contra `K8S_DEPLOYMENTS`, permitindo reiniciar deployments fora do controle do DEILE (incluindo deployments de terceiros no mesmo namespace). O caminho irmão `/k8s logs` já fazia essa validação.

## Mudanças

**`deile/commands/builtin/k8s_command.py`** — `_cmd_restart` (superfície mínima: +8 linhas):
- Quando `deployment != 'all'`, verifica primeiro `_LOG_TARGET_MAP` (aceita apelidos como `pipeline`, `worker`, resolvendo para nome canônico)
- Se não for apelido, verifica `K8S_DEPLOYMENTS` (aceita nome completo como `deile-worker`)
- Caso contrário, retorna `CommandResult.error_result` com lista de alvos válidos — sem invocar `kubectl`

**`deile/tests/commands/test_k8s_command.py`** (+19 linhas):
- `test_restart_unknown_deployment_rejected`: `_cmd_restart('deile', 'kube-dns')` → `success=False`, `_run_kubectl` nunca chamado
- `test_restart_allowlisted_deployment_passes`: `_cmd_restart('deile', 'deile-worker')` → `success=True`

## Confronto com os ACs

- [x] **AC1** — Correção implementada conforme descrito na issue; superfície mínima: apenas `k8s_command.py` e `test_k8s_command.py`.
- [x] **AC2** — Dois novos testes cobrindo o defeito: rejeição de alvo fora da allowlist (sem kubectl) e aceitação de alvo allowlisted.
- [x] **AC3** — 106/106 testes existentes passam (`python3 -m pytest deile/tests/commands/test_k8s_command.py -p no:cov -q`).
- [x] **AC4** — Portão de regressão: 106 passed, 0 failed, 0 errors.

Closes #714.