### PR TITLE
fix(security): path traversal em WorktreeTool._remove e WorktreeManager.create_branch_worktree

### DIFF
--- a/deile/orchestration/pipeline/worktree_manager.py
+++ b/deile/orchestration/pipeline/worktree_manager.py
@@ -114,6 +114,12 @@ class WorktreeManager:
             raise WorktreeError(f"branch must be a non-main branch name, got {branch!r}")
         await self.ensure_main()
         target = self.branches_dir / branch
+        try:
+            target.resolve().relative_to(self.branches_dir.resolve())
+        except ValueError:
+            raise WorktreeError(
+                f"path traversal detected: branch {branch!r} resolves outside branches_dir"
+            )
         if (target / ".git").exists():
             if force_recreate:
                 logger.info("force_recreate=True: removing stale worktree %s", target)

--- a/deile/tests/tools/test_worktree_tool.py
+++ b/deile/tests/tools/test_worktree_tool.py
@@ -345,3 +345,91 @@ def test_assert_safe_root_accepts_home_subdir():
     home_sub = Path.home().resolve() / "deile"
     # Should not raise (whether or not the directory actually exists)
     _assert_safe_root(home_sub)
+
+
+# ---------------------------------------------------------------------------
+# 12. Path traversal security tests (issue #708)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+async def test_remove_traversal_branch_rejected(repo_tmp_path, monkeypatch):
+    """branch='../../../../tmp/x' must be rejected before any rmtree call."""
+    import shutil as _shutil
+
+    (repo_tmp_path / ".git").mkdir()
+    (repo_tmp_path / "deile.py").write_text("")
+
+    rmtree_calls = []
+    monkeypatch.setattr(_shutil, "rmtree", lambda *a, **kw: rmtree_calls.append(a))
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="../../../../tmp/x", base_path=str(repo_tmp_path))
+    )
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "PATH_TRAVERSAL"
+    assert rmtree_calls == [], "shutil.rmtree must not be called on a traversal path"
+
+
+@pytest.mark.security
+async def test_remove_traversal_subdir_rejected(repo_tmp_path, monkeypatch):
+    """subdir='..' must be rejected before any rmtree call."""
+    import shutil as _shutil
+
+    (repo_tmp_path / ".git").mkdir()
+    (repo_tmp_path / "deile.py").write_text("")
+
+    rmtree_calls = []
+    monkeypatch.setattr(_shutil, "rmtree", lambda *a, **kw: rmtree_calls.append(a))
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="some-branch", subdir="..", base_path=str(repo_tmp_path))
+    )
+
+    assert result.status == ToolStatus.ERROR
+    assert result.metadata["error_code"] == "PATH_TRAVERSAL"
+    assert rmtree_calls == [], "shutil.rmtree must not be called on a traversal path"
+
+
+@pytest.mark.security
+async def test_remove_traversal_does_not_bypass_protected(repo_tmp_path, monkeypatch):
+    """branch='../main' must not bypass the protected-worktree guard via traversal."""
+    import shutil as _shutil
+
+    (repo_tmp_path / ".git").mkdir()
+    (repo_tmp_path / "deile.py").write_text("")
+    # Lay down a directory that would match .worktrees/../main == .worktrees-sibling
+    (repo_tmp_path / "main").mkdir(parents=True)
+
+    rmtree_calls = []
+    monkeypatch.setattr(_shutil, "rmtree", lambda *a, **kw: rmtree_calls.append(a))
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="../main", base_path=str(repo_tmp_path))
+    )
+
+    assert result.status == ToolStatus.ERROR
+    # Must be stopped by PATH_TRAVERSAL before reaching REMOVE_PROTECTED
+    assert result.metadata["error_code"] == "PATH_TRAVERSAL"
+    assert rmtree_calls == [], "shutil.rmtree must not be called on a traversal path"
+
+
+@pytest.mark.security
+async def test_remove_legitimate_slash_branch_resolves_inside_worktrees(repo_tmp_path):
+    """branch='auto/issue-1' (slash in name) must resolve inside .worktrees/ and succeed."""
+    (repo_tmp_path / ".git").mkdir()
+    (repo_tmp_path / "deile.py").write_text("")
+    branch_dir = repo_tmp_path / ".worktrees" / "auto" / "issue-1"
+    branch_dir.mkdir(parents=True)
+
+    tool = WorktreeTool()
+    result = await tool.execute(
+        _ctx(action="remove", branch="auto/issue-1", base_path=str(repo_tmp_path))
+    )
+
+    assert result.status == ToolStatus.SUCCESS
+    assert not branch_dir.exists()

--- a/deile/tools/worktree_tool.py
+++ b/deile/tools/worktree_tool.py
@@ -44,6 +44,22 @@ logger = logging.getLogger(__name__)
 _PROTECTED_SUBDIRS = {"main"}  # worktrees that must never be removed
 
 
+def _safe_worktree_target(
+    worktrees_dir: Path, subdir: Optional[str], branch: str
+) -> Optional[Path]:
+    """Return the resolved target path if it stays inside worktrees_dir, else None.
+
+    Defends against path traversal: branch='../../../../tmp/x' or subdir='..'
+    both collapse to a path outside worktrees_dir after resolve().
+    """
+    raw = (worktrees_dir / subdir / branch) if subdir else (worktrees_dir / branch)
+    try:
+        raw.resolve().relative_to(worktrees_dir.resolve())
+    except ValueError:
+        return None
+    return raw
+
+
 class WorktreeTool(Tool):
     """Create, list and remove branch worktrees via the LLM."""
 
@@ -227,10 +243,15 @@ class WorktreeTool(Tool):
             )
 
         worktrees_dir = base_path / ".worktrees"
-        if subdir:
-            target = worktrees_dir / subdir / branch
-        else:
-            target = worktrees_dir / branch
+        target = _safe_worktree_target(worktrees_dir, subdir, branch)
+        if target is None:
+            return ToolResult.error_result(
+                message=(
+                    f"path traversal detected: branch={branch!r} subdir={subdir!r} "
+                    "resolves outside .worktrees/"
+                ),
+                error_code="PATH_TRAVERSAL",
+            )
 
         if not target.exists():
             return ToolResult.error_result(


### PR DESCRIPTION
## Vulnerabilidade corrigida

`branch` e `subdir` do `WorktreeTool` (LLM-callable via auto-discover) chegavam crus ao sink `shutil.rmtree` em `_remove` (worktree_tool.py:229-241) e ao `shutil.copytree` em `create_branch_worktree` (worktree_manager.py:~116) sem contenção de caminho. Um valor como `../../../../tmp/victim` escapava do sandbox `.worktrees/` após resolução de Path — permitindo deletar recursivamente qualquer diretório acessível ao processo.

## Entrega vs Critérios de Aceite

### AC1 — Correção implementada (superfície mínima nos 3 arquivos especificados)
✅ **PRONTO**
- `deile/tools/worktree_tool.py`: adicionado helper `_safe_worktree_target(worktrees_dir, subdir, branch)` que resolve o target e verifica contenção via `resolved.relative_to(worktrees_dir.resolve())`. Retorna `None` se escapar. `_remove()` chama o helper antes de qualquer I/O e retorna `ToolResult.error_result(error_code='PATH_TRAVERSAL')` imediatamente.
- `deile/orchestration/pipeline/worktree_manager.py`: adicionada verificação idêntica em `create_branch_worktree()` após montar `target = self.branches_dir / branch`, levantando `WorktreeError` com mensagem clara antes de qualquer I/O.

### AC2 — Testes novos cobrindo vulnerabilidade (caso de ataque + caso legítimo)
✅ **PRONTO** — 4 testes `@pytest.mark.security` em `deile/tests/tools/test_worktree_tool.py`:
1. `test_remove_traversal_branch_rejected` — `branch='../../../../tmp/x'` → `PATH_TRAVERSAL`, `shutil.rmtree` não chamado (spy via monkeypatch)
2. `test_remove_traversal_subdir_rejected` — `subdir='..'` → `PATH_TRAVERSAL`, `shutil.rmtree` não chamado
3. `test_remove_traversal_does_not_bypass_protected` — `branch='../main'` → `PATH_TRAVERSAL` (não `REMOVE_PROTECTED`; contenção intercepta antes)
4. `test_remove_legitimate_slash_branch_resolves_inside_worktrees` — `branch='auto/issue-1'` funciona normalmente dentro de `.worktrees/`

### AC3 — Todos os testes existentes passam
✅ **VERIFICADO** — 25/25 em `test_worktree_tool.py`, 17/17 em `test_worktree_manager.py` (suítes impactadas, zero regressão).

### AC4 — Portão de regressão verde
✅ **VERIFICADO** — suíte impactada 100% verde. Suíte completa é responsabilidade do revisor (conforme `_IMPACT_TEST_STRATEGY` em briefs.py).

Closes #708