### PR TITLE
fix(ci): job de testes roda a suíte real (deile/tests/) sem mascarar falhas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.12"]
+        # 3.11 = versão da imagem de produção (Dockerfile PYTHON_VERSION=3.11.10).
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --cov=deile --cov-report=xml --cov-report=term-missing --maxfail=5 -x || echo "Tests completed"
+          pytest deile/tests/ -q --cov=deile --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Testes de infra (cli_worker_repo_cycle) fazem `git commit` REAL em repos
+      # temporários; o runner não tem identidade git global, causando
+      # "Author identity unknown" (rc=128). Configura uma identidade de CI.
+      - name: Configure git identity (testes que commitam)
+        run: |
+          git config --global user.email "ci@deile.local"
+          git config --global user.name "DEILE CI"
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          # Instala a partir do pyproject.toml (fonte de verdade das deps), não
+          # do requirements.txt — que estava dessincronizado e sem deps core
+          # (ex.: aiohttp), causando 59 erros de coleção no pytest. Extras:
+          # test (plugins pytest) + otel (opentelemetry, exigido pelos testes de
+          # observability). ZERO TEATRO: a suíte tem que COLETAR e rodar de verdade.
+          pip install -e ".[test,otel]"
           pip install pytest-cov pytest-xdist pytest-mock coverage
 
       - name: Lint with ruff (if available)

--- a/deile/core/models/gemini_provider.py
+++ b/deile/core/models/gemini_provider.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import re
 import time
 import uuid
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
@@ -52,12 +53,29 @@ logger = logging.getLogger(__name__)
 #         '_async_httpx_client'")>
 #
 # Two such errors at every worker boot (observed in deile-worker pod logs).
-# The fix upstream needs ``hasattr`` guards (and presumably exists in 2.x,
-# but the major bump is breaking). The local fix is a defensive wrapper that
-# preserves the close-if-initialized semantics and silently no-ops the
-# missing-attribute case — which is exactly what aclose() means anyway.
+# The fix upstream needs ``hasattr`` guards. Across SDK versions the exact set
+# of lazily-initialized internals that aclose() touches DRIFTS: 1.47.0 derefs
+# ``_async_httpx_client`` / ``_aiohttp_session``; 2.x adds ``_http_options``.
+# Hardcoding the names is therefore fragile. The local fix is a defensive
+# wrapper that silently no-ops whenever the original aclose() trips over a
+# never-initialized INTERNAL attribute (underscore-prefixed) on the client —
+# which is exactly what "close a client that never opened" means — while
+# re-raising anything else so genuine bugs stay loud.
 #
 # Idempotent (won't re-patch if our marker is present).
+
+# CPython's missing-attribute message is ``'<Type>' object has no attribute
+# '<name>'``. We swallow only when the missing attribute is INTERNAL
+# (leading underscore) — the lazy-init family — and re-raise otherwise. A
+# missing PUBLIC attribute, or an AttributeError with any other message, is a
+# real bug and must surface.
+_GENAI_LAZY_ATTR_RE = re.compile(r"has no attribute '_")
+
+
+def _is_genai_lazy_attr_error(exc: AttributeError) -> bool:
+    """True if ``exc`` is google-genai's never-initialized-internal signature."""
+    return bool(_GENAI_LAZY_ATTR_RE.search(str(exc)))
+
 
 def _install_genai_aclose_guard() -> None:
     if getattr(_GenaiBaseApiClient.aclose, "_deile_guarded", False):
@@ -68,12 +86,12 @@ def _install_genai_aclose_guard() -> None:
         try:
             await _original_aclose(self)
         except AttributeError as exc:
-            # SDK bug — referencing a lazy attribute that was never created.
-            # Nothing to close, so the close completed trivially.
-            if "_async_httpx_client" in str(exc) or "_aiohttp_session" in str(exc):
+            # SDK bug — referencing a lazy internal attribute that was never
+            # created. Nothing to close, so the close completed trivially.
+            if _is_genai_lazy_attr_error(exc):
                 logger.debug(
-                    "google-genai aclose: lazy client never initialized "
-                    "(%s) — safe no-op",
+                    "google-genai aclose: lazy client internal never "
+                    "initialized (%s) — safe no-op",
                     exc,
                 )
                 return

--- a/deile/tests/core/models/test_genai_aclose_guard.py
+++ b/deile/tests/core/models/test_genai_aclose_guard.py
@@ -1,26 +1,32 @@
 """Regression tests for the google-genai aclose() defensive monkey-patch.
 
-google-genai 1.47.0 has a bug in ``BaseApiClient.aclose()``: it dereferences
-``self._async_httpx_client`` (and ``self._aiohttp_session``) unconditionally,
-but those are LAZY-initialized. When the client is GC'd before any async
-request fires, ``aclose()`` raises ``AttributeError`` — and because it runs
-as a fire-and-forget Task scheduled from ``__del__``, the exception is never
-retrieved and asyncio logs the noisy stack trace twice at every worker boot.
+google-genai's ``BaseApiClient.aclose()`` dereferences lazily-initialized
+internal attributes. When the client is GC'd before any async request fires,
+those attributes never existed, so ``aclose()`` raises ``AttributeError`` — and
+because it runs as a fire-and-forget Task scheduled from ``__del__``, the
+exception is never retrieved and asyncio logs the noisy stack trace at every
+worker boot.
 
-The patch lives in ``deile/core/models/gemini_provider.py`` and:
+The exact set of internals aclose() touches DRIFTS across SDK versions
+(1.47.0: ``_async_httpx_client`` / ``_aiohttp_session``; 2.x adds
+``_http_options``), so the guard in ``deile/core/models/gemini_provider.py``
+keys off the SIGNATURE — a missing underscore-prefixed (internal) attribute on
+the client — not a hardcoded name list. It:
 
 1. Wraps ``BaseApiClient.aclose`` once (idempotent guard).
-2. Catches AttributeError with ``_async_httpx_client`` or ``_aiohttp_session``
-   in the message → silent no-op.
-3. Re-raises any OTHER AttributeError (don't mask unrelated bugs).
-4. Preserves the original close path when attributes ARE initialized.
+2. Swallows AttributeError whose message names a missing INTERNAL attribute
+   (``_is_genai_lazy_attr_error``) → silent no-op.
+3. Re-raises any OTHER AttributeError (missing public attr, unrelated message)
+   so genuine bugs stay loud.
+
+These tests exercise the decision predicate directly (version-independent) plus
+one end-to-end test against a real ``BaseApiClient`` — instead of hand-building
+SimpleNamespace stand-ins that mirror a specific SDK version's aclose() body.
 """
 
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
-from unittest.mock import AsyncMock
 
 import pytest
 from google.genai._api_client import BaseApiClient
@@ -28,6 +34,7 @@ from google.genai._api_client import BaseApiClient
 # Trigger the patch install (idempotent — already done if gemini_provider was
 # imported elsewhere).
 import deile.core.models.gemini_provider  # noqa: F401
+from deile.core.models.gemini_provider import _is_genai_lazy_attr_error
 
 
 def test_aclose_is_guarded():
@@ -45,57 +52,31 @@ def test_install_is_idempotent():
     assert first is second
 
 
-async def test_missing_async_httpx_client_is_silently_swallowed():
-    """The original SDK bug — never-initialized async client — must no-op."""
-    instance = SimpleNamespace()
-    # Bind the patched method to the bare instance — no `_async_httpx_client`.
-    # If the patch missed, this raises AttributeError; with the patch, it
-    # returns None silently.
-    result = await BaseApiClient.aclose(instance)
-    assert result is None
+@pytest.mark.parametrize(
+    "attr",
+    ["_async_httpx_client", "_aiohttp_session", "_http_options", "_some_future_attr"],
+)
+def test_lazy_attr_error_swallowed_for_internal_names(attr):
+    """Any missing INTERNAL (underscore) attribute is the lazy-init family.
+
+    Covers the historical names AND a hypothetical future one — proving the
+    guard survives SDK version drift without a code change.
+    """
+    exc = AttributeError(f"'BaseApiClient' object has no attribute '{attr}'")
+    assert _is_genai_lazy_attr_error(exc) is True
 
 
-async def test_missing_aiohttp_session_is_silently_swallowed():
-    """Same as above but for the second lazy attribute the SDK touches."""
-
-    class _Closeable:
-        def __init__(self):
-            self.aclose = AsyncMock(return_value=None)
-
-    instance = SimpleNamespace(_async_httpx_client=_Closeable())
-    # _aiohttp_session is missing — the original aclose would fail here.
-    # The guard catches it as the same SDK lazy-attr family.
-    result = await BaseApiClient.aclose(instance)
-    assert result is None
-    instance._async_httpx_client.aclose.assert_awaited_once()
-
-
-async def test_unrelated_attribute_error_is_re_raised():
-    """Don't mask unrelated bugs — only the known SDK lazy-attr names are quiet."""
-
-    class _Bomb:
-        async def aclose(self):
-            raise AttributeError("some_completely_unrelated_attr is gone")
-
-    instance = SimpleNamespace(
-        _async_httpx_client=_Bomb(),
-        _aiohttp_session=None,
-    )
-    with pytest.raises(AttributeError, match="some_completely_unrelated_attr"):
-        await BaseApiClient.aclose(instance)
-
-
-async def test_happy_path_with_initialized_clients():
-    """When both lazy attrs are real, aclose() calls through normally."""
-    httpx_client = SimpleNamespace(aclose=AsyncMock(return_value=None))
-    aiohttp_session = SimpleNamespace(close=AsyncMock(return_value=None))
-    instance = SimpleNamespace(
-        _async_httpx_client=httpx_client,
-        _aiohttp_session=aiohttp_session,
-    )
-    await BaseApiClient.aclose(instance)
-    httpx_client.aclose.assert_awaited_once()
-    aiohttp_session.close.assert_awaited_once()
+@pytest.mark.parametrize(
+    "message",
+    [
+        "some_completely_unrelated_attr is gone",  # custom message, not the CPython shape
+        "'BaseApiClient' object has no attribute 'public_thing'",  # public attr = real bug
+        "'GeminiProvider' object has no attribute 'model'",  # unrelated public attr
+    ],
+)
+def test_unrelated_attribute_error_is_not_swallowed(message):
+    """Don't mask unrelated bugs — only missing INTERNAL attrs are quiet."""
+    assert _is_genai_lazy_attr_error(AttributeError(message)) is False
 
 
 async def test_patch_silences_the_real_scenario():
@@ -105,8 +86,11 @@ async def test_patch_silences_the_real_scenario():
     instantiates a client, never sends a request, then GC kicks in and
     schedules aclose(). With the guard, aclose() returns cleanly; without it,
     asyncio would log a 'Task exception was never retrieved' AttributeError.
+
+    Constructed via ``object.__new__`` so NONE of the lazy internals exist —
+    whatever attribute the installed SDK's aclose() reaches for first, the
+    guard must absorb it.
     """
-    # We construct an instance bypassing __init__ so no httpx_client exists.
     client = object.__new__(BaseApiClient)
     # Schedule aclose() exactly like __del__ does — fire-and-forget — and
     # await it deterministically here so the test verifies the no-raise path.

--- a/deile/tests/infra/test_panel_filter_followups.py
+++ b/deile/tests/infra/test_panel_filter_followups.py
@@ -505,9 +505,12 @@ class TestRegexTimeoutAbortsUnder100ms:
         kind, raw, compiled = terms[0]
         assert kind == "regex"
         assert hasattr(compiled, "search")
-        # Should be a regex module pattern, not re module
-        assert type(compiled).__module__.startswith("regex"), (
-            f"Expected regex.Pattern, got {type(compiled)}"
+        # Deve ser um pattern da lib ``regex``, não do ``re`` builtin. Versões
+        # recentes do pacote ``regex`` expõem o Pattern pela extensão C como
+        # ``_regex.Pattern`` (``__module__ == "_regex"``); versões antigas como
+        # ``regex.Pattern``. Ambos pertencem à lib ``regex`` — aceitar os dois.
+        assert type(compiled).__module__ in ("regex", "_regex"), (
+            f"Expected regex/_regex Pattern, got {type(compiled)}"
         )
 
 

--- a/deile/tests/infra/test_panel_filter_followups.py
+++ b/deile/tests/infra/test_panel_filter_followups.py
@@ -145,7 +145,12 @@ class TestHighlightRegexTermTimeoutNoSpans:
         if not _HAS_REGEX:
             pytest.skip("regex module not installed — AC-A5 requires regex>=2024.0")
 
-        line = "a" * 5000
+        # Catastrophic backtracking for (a+)+$ only triggers when the match
+        # FAILS — a string of pure 'a's matches greedily in microseconds and
+        # produces a span. The trailing '!' (no 'a', so '$' can never be
+        # reached) forces the engine through ~2^N partitions until the 0.1s
+        # budget fires TimeoutError.
+        line = "a" * 5000 + "!"
         terms_info = [("regex", "(a+)+$",
                        _regex.compile("(a+)+$", _regex.IGNORECASE))]
         t0 = time.monotonic()

--- a/deile/tests/infra/test_wrapper_monitor.py
+++ b/deile/tests/infra/test_wrapper_monitor.py
@@ -145,10 +145,15 @@ def test_run_monitor_starts_with_monitor_persona(wrapper_mod, tmp_path, monkeypa
     monkeypatch.setattr(wrapper_mod, "_patch_deile_bootstrap", fake_patch_bootstrap)
     monkeypatch.setattr(wrapper_mod, "_install_monitor_negative_whitelist", fake_install_whitelist)
 
-    # Patch the deile.cli import
+    # Patch the deile.cli import. Use monkeypatch.setitem so the ORIGINAL
+    # deile.cli module object is restored at teardown — a bare
+    # ``del sys.modules["deile.cli"]`` would evict the real module, forcing a
+    # fresh re-import elsewhere and orphaning import bindings made at collection
+    # time (e.g. test_cli_flags' ``from deile.cli import main``), which then
+    # patch a different module object than the one cli_main() closes over.
     fake_cli_mod = MagicMock()
     fake_cli_mod.main = fake_deile_main
-    sys.modules["deile.cli"] = fake_cli_mod
+    monkeypatch.setitem(sys.modules, "deile.cli", fake_cli_mod)
 
     rc = wrapper_mod._run_monitor([])
     assert rc == 0
@@ -157,8 +162,6 @@ def test_run_monitor_starts_with_monitor_persona(wrapper_mod, tmp_path, monkeypa
     argv = called.get("argv", [])
     assert argv[0] == "deile"
     assert "--persona" not in argv  # garantia que removemos a flag inválida
-
-    del sys.modules["deile.cli"]
 
 
 # ---------------------------------------------------------------------------

--- a/deile/tests/log_mgmt/test_init.py
+++ b/deile/tests/log_mgmt/test_init.py
@@ -25,6 +25,9 @@ class TestInitLogging:
         log_dir = tmp_path / "logs" / "test-pod"
         monkeypatch.setenv("DEILE_LOG_DIR", str(log_dir))
         monkeypatch.setenv("DEILE_POD_NAME", "test-pod")
+        # Assert the genuine DEFAULT level — must be hermetic against an
+        # ambient DEILE_LOG_LEVEL (the CI workflow sets it to DEBUG globally).
+        monkeypatch.delenv("DEILE_LOG_LEVEL", raising=False)
 
         handler = init_logging(pod_name="test-pod", max_mb=1, backup_count=2)
 

--- a/deile/tests/observability/conftest.py
+++ b/deile/tests/observability/conftest.py
@@ -87,6 +87,16 @@ def in_memory_exporter(monkeypatch):
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     monkeypatch.setattr("deile.observability.tracer._provider", provider)
 
+    # Registra também como TracerProvider GLOBAL do OpenTelemetry. Os testes que
+    # usam a API nativa (``trace.get_tracer`` / ``propagate.inject``) leem o
+    # provider global — sem isto, ``get_tracer_provider()`` devolve o proxy NoOp
+    # (``_TRACER_PROVIDER is None``) e nenhum span/traceparent é gravado. O
+    # ``set_tracer_provider`` oficial só registra uma vez por processo, então em
+    # teste setamos o atributo direto via monkeypatch (revertido no teardown,
+    # não vaza para outros testes).
+    import opentelemetry.trace as _ot_trace
+    monkeypatch.setattr(_ot_trace, "_TRACER_PROVIDER", provider, raising=False)
+
     # Ligar OTLP via env para get_tracer() escolher OtlpTracer.
     monkeypatch.setenv("DEILE_OTLP_ENDPOINT", "http://test-collector:4317")
 


### PR DESCRIPTION
Conserta o ci.yml para rodar a suíte real. **Este PR é a validação ao vivo**: o próprio CI deste PR vai rodar `pytest deile/tests/` no ubuntu-limpo — se ficar verde, o portão de regressão por CI (#85) passa a poder confiar no CI; se vermelho, mostra o que precisa estabilizar antes de ligar o gate. NÃO mergear até o CI passar 100%.