### PR TITLE
test: reset hermético dos singletons lazy no conftest raiz (mata ordering pollution)

### DIFF
--- a/deile/tests/conftest.py
+++ b/deile/tests/conftest.py
@@ -203,6 +203,39 @@ def _reset_settings_singleton():
     reset_settings()
 
 
+@pytest.fixture(autouse=True)
+def _reset_global_singletons():
+    """Reset os singletons lazy de processo antes/depois de cada teste.
+
+    Cada um é um global de módulo com ``reset_X()`` que zera a instância (recriada
+    sob demanda no próximo ``get_X()``). Sem este reset hermético central, um teste
+    que muta o singleton vaza o estado pro próximo — a causa-raiz reincidente das
+    falhas ordering-dependent (#432/#471/#499). O ``_CIRCUIT_BREAKER`` do
+    deile_worker_client, com estado OPEN vazado, recusava dispatch em testes
+    vítimas (ex.: test_dispatch_deile_task: "circuit breaker open — worker
+    degraded") sob seeds aleatórias do pytest-randomly.
+
+    NOTA: o ``SkillRegistry`` NÃO é resetado aqui — o ``SkillsWatcher`` segura uma
+    referência à instância, e zerar o singleton entre testes orfanaria o watcher
+    (quebra test_watcher). Isolar o registry exige tratar o watcher junto — fica
+    para um fix dedicado.
+    """
+    from deile.core.models.tier_router import reset_tier_router
+    from deile.events.event_bus import reset_event_bus
+    from deile.infrastructure.deile_worker_client import reset_circuit_breaker
+    from deile.storage.usage_repository import reset_usage_repository
+
+    def _reset_all():
+        reset_tier_router()
+        reset_event_bus()
+        reset_usage_repository()
+        reset_circuit_breaker()
+
+    _reset_all()
+    yield
+    _reset_all()
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _isolate_audit_logger(tmp_path_factory):
     """Point the global ``AuditLogger`` at a session-scoped temp dir.


### PR DESCRIPTION
## Problema
O CI virou loteria: cada run sorteia uma seed do `pytest-randomly` e uma seed ruim expõe testes order-dependent — singletons module-global cujo estado vaza entre testes. O main `4f7aeae7` ficou vermelho por isso (3 falhas em `test_dispatch_deile_task`: "circuit breaker open — worker degraded").

## Causa-raiz (arqueologia de 27 commits)
Padrão reincidente (#432 → #471 → #499): singletons com `reset_X()` mas **sem fixture autouse no conftest raiz** que a chame. Cada arquivo de teste adicionava reset local — frágil; o próximo poluidor sempre voltava. O culpado atual é o `_CIRCUIT_BREAKER` do `deile_worker_client` (um `CircuitBreaker` module-level, distinto do tier_router).

## Fix
Uma fixture autouse no `deile/tests/conftest.py` que reseta antes/depois de cada teste os 4 singletons lazy com reset limpo:
- `reset_circuit_breaker` (deile_worker_client) — **conserta a falha atual do main**
- `reset_tier_router`, `reset_event_bus`, `reset_usage_repository` — preventivo (mesma classe de bug)

`SkillRegistry` ficou **de fora de propósito**: o `SkillsWatcher` segura referência à instância; zerá-la entre testes quebra `test_watcher`. Isolar o registry exige tratar o watcher junto (fix dedicado, follow-up).

## Validação
Áreas afetadas (events/storage/skills/core/tools/orchestration) em seeds **0/1/42**: 2604 passed, 0 failed (antes do ajuste, seed 0 tinha 4 falhas). A suíte completa sob seed aleatória roda aqui no CI — é o gate real.