### PR TITLE
ci: gates de qualidade leves (interrogate, radon, doc-consistency) — etapa 3/3 sem reformat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,11 @@ jobs:
           fail_ci_if_error: false
 
   # ──────────────────────────────────────────────────────────────────────────
-  # QUALIDADE DE CÓDIGO — advisory (continue-on-error: permanece)
+  # QUALIDADE DE CÓDIGO — gates reais de docstring + complexidade ciclomática;
+  # formatação (black/isort/ruff) e mypy são do #735 (pós-reformat).
   # ──────────────────────────────────────────────────────────────────────────
   code-quality:
-    name: Code quality (advisory)
+    name: Code quality
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -194,27 +195,42 @@ jobs:
 
       - name: Install quality tools
         run: |
-          pip install -r requirements.txt
-          pip install flake8 black isort radon
+          pip install interrogate radon mypy
 
-      - name: Check code formatting with Black
+      # GATE: cobertura de docstrings ≥ 39% (baseline 39.9% medido em 2026-06-16).
+      # Configurado via [tool.interrogate] em pyproject.toml.
+      # Ratchet: só pode aumentar — suba 1 ponto por ciclo de limpeza.
+      - name: Interrogate — cobertura de docstrings (GATING)
         run: |
-          black --check --diff deile/
-        continue-on-error: true
+          interrogate deile/ --fail-under=39
 
-      - name: Check import sorting with isort
+      # GATE: complexidade ciclomática média ≤ B (teto 10.0).
+      # Baseline medido em 2026-06-16: A (3.24). Falha se a média cruzar o teto B.
+      - name: Radon CC — complexidade ciclomática (GATING)
         run: |
-          isort --check-only --diff deile/
-        continue-on-error: true
+          OUTPUT=$(radon cc deile/ -a)
+          echo "$OUTPUT"
+          # Extrai o valor numérico da média e falha se >= 10.0 (nota B → C)
+          AVG=$(echo "$OUTPUT" | grep "Average complexity" | grep -oE '[0-9]+\.[0-9]+')
+          if [ -z "$AVG" ]; then
+            echo "::error::Não foi possível extrair a média de complexidade do radon"
+            exit 1
+          fi
+          python3 -c "
+          avg = float('$AVG')
+          print(f'Complexidade média: {avg:.4f}')
+          if avg >= 10.0:
+              print(f'::error::Complexidade média {avg:.4f} excede o teto B (10.0) — refatore antes de mergear')
+              exit(1)
+          print('OK: complexidade dentro do teto B')
+          "
 
-      - name: Calculate code complexity
+      # ADVISORY — mypy com --ignore-missing-imports.
+      # NÃO gateia: baseline de 3.11 com erros de tipo legados; gate real com
+      # baseline completo na issue #735 (pós-reformat).
+      - name: mypy — verificação de tipos (advisory — NÃO gateia; gate real no #735)
         run: |
-          radon cc deile/ -a
-        continue-on-error: true
-
-      - name: Generate complexity report
-        run: |
-          radon mi deile/
+          mypy deile/ --ignore-missing-imports || true
         continue-on-error: true
 
   # ──────────────────────────────────────────────────────────────────────────
@@ -441,10 +457,10 @@ jobs:
           "
 
   # ──────────────────────────────────────────────────────────────────────────
-  # DOCUMENTAÇÃO — advisory
+  # DOCUMENTAÇÃO — gate de consistência doc↔código + pymarkdown advisory
   # ──────────────────────────────────────────────────────────────────────────
   documentation:
-    name: Documentation (advisory)
+    name: Documentation
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -461,18 +477,21 @@ jobs:
 
       - name: Install documentation tools
         run: |
-          pip install -r requirements.txt
-          pip install sphinx sphinx-rtd-theme || echo "Sphinx not configured"
+          pip install pymarkdownlnt
 
-      - name: Validate documentation files
+      # GATE: invariantes doc↔código (cross-refs de system_design, cov-fail-under
+      # no ci.yml, gate de testes presente).
+      - name: Validate doc consistency (GATING)
         run: |
-          find docs/ -name "*.md" -exec echo "Checking {}" \; -exec head -5 {} \; || echo "No docs directory"
-          ls -la docs/ || echo "No docs directory found"
+          python3 scripts/validate_doc_consistency.py
 
-      - name: Check README
+      # ADVISORY — ~40 violações legadas de Markdown; não gateia.
+      # Configurado via .pymarkdown na raiz do repo.
+      # Gate real planejado após limpeza sistemática dos docs (issue #735).
+      - name: pymarkdown lint (advisory — NÃO gateia; ~40 violações legadas)
         run: |
-          test -f README.md && echo "README.md exists" || echo "No README.md found"
-          test -f README_NEW_ARCHITECTURE.md && echo "Architecture README exists" || echo "No architecture README"
+          pymarkdown scan docs/ || true
+        continue-on-error: true
 
   # ──────────────────────────────────────────────────────────────────────────
   # NOTIFICAÇÃO DE FALHA
@@ -480,7 +499,7 @@ jobs:
   notify-on-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [test, secret-scan, security-scan, code-quality, functional-tests]
+    needs: [test, secret-scan, security-scan, code-quality, documentation, functional-tests]
     if: failure()
     permissions:
       contents: read
@@ -497,7 +516,7 @@ jobs:
     name: Deployment ready
     runs-on: ubuntu-latest
     needs:
-      [test, secret-scan, security-scan, code-quality, functional-tests, build-and-package]
+      [test, secret-scan, security-scan, code-quality, documentation, functional-tests, build-and-package]
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.pymarkdown
+++ b/.pymarkdown
@@ -1,0 +1,13 @@
+{
+  "plugins": {
+    "md013": {
+      "enabled": false
+    },
+    "md033": {
+      "enabled": false
+    },
+    "md041": {
+      "enabled": false
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,15 @@ exclude = ["deilebot*", "tests*"]
 
 [tool.setuptools.package-data]
 "deile.core.schemas" = ["*.json"]
+
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-semiprivate = true
+ignore-private = true
+ignore-module = true
+# Baseline medido em 2026-06-16: 39.9% (gate em ci.yml: --fail-under=39).
+# Ratchet: só pode aumentar — suba 1 ponto do threshold a cada ciclo de limpeza de docstrings.
+verbose = 0
+quiet = true

--- a/scripts/validate_doc_consistency.py
+++ b/scripts/validate_doc_consistency.py
@@ -1,0 +1,160 @@
+"""
+Validação de consistência doc↔código.
+
+Verifica invariantes do projeto que são declarados nos docs mas que devem
+estar presentes no código/CI. Falha com exit code != 0 quando há divergência.
+
+Invariantes verificados:
+1. cov-fail-under: deve estar no comando pytest do CI (ci.yml), NÃO no pytest.ini
+   (gate global em pytest.ini quebra runs de subconjunto local — decisão arquitetural).
+2. cross-refs de docs/system_design/ apontam para arquivos existentes
+3. ci.yml roda pytest (gate real de testes presente)
+4. ci.yml usa --cov quando roda pytest
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+DOCS_DIR = REPO_ROOT / "docs" / "system_design"
+PYTEST_INI = REPO_ROOT / "pytest.ini"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+FAILURES: list[str] = []
+WARNINGS: list[str] = []
+
+
+def check(condition: bool, msg: str) -> None:
+    if not condition:
+        FAILURES.append(msg)
+
+
+def warn(condition: bool, msg: str) -> None:
+    if not condition:
+        WARNINGS.append(f"[AVISO] {msg}")
+
+
+def check_cov_fail_under() -> None:
+    """--cov-fail-under deve estar no ci.yml (NÃO em pytest.ini/pyproject.toml).
+
+    Decisão arquitetural: o gate de cobertura fica exclusivamente no comando
+    pytest do CI para não bloquear runs de subconjunto locais. Se essa flag
+    aparecer em pytest.ini ou pyproject.toml [tool.pytest.ini_options], é um
+    erro de configuração.
+    """
+    pytest_ini_text = PYTEST_INI.read_text() if PYTEST_INI.exists() else ""
+    pyproject_text = PYPROJECT.read_text() if PYPROJECT.exists() else ""
+    ci_text = CI_WORKFLOW.read_text() if CI_WORKFLOW.exists() else ""
+
+    # Deve estar no CI
+    check(
+        "--cov-fail-under" in ci_text,
+        "INVARIANTE VIOLADO: --cov-fail-under não encontrado em ci.yml. "
+        "Adicione '--cov-fail-under=<N>' ao comando pytest no job 'test' do CI.",
+    )
+
+    # NÃO deve estar em pytest.ini (quebraria runs locais de subconjunto)
+    check(
+        "--cov-fail-under" not in pytest_ini_text,
+        "INVARIANTE VIOLADO: --cov-fail-under encontrado em pytest.ini. "
+        "Remova: o gate de cobertura deve ficar exclusivamente no ci.yml "
+        "(gate em pytest.ini bloqueia runs locais de subconjunto).",
+    )
+
+    # NÃO deve estar em [tool.pytest.ini_options] do pyproject.toml
+    # (equivalente a pytest.ini para propósitos do gate)
+    in_pytest_section = False
+    for line in pyproject_text.splitlines():
+        if "[tool.pytest" in line:
+            in_pytest_section = True
+        elif line.startswith("[") and "[tool.pytest" not in line:
+            in_pytest_section = False
+        if in_pytest_section and "--cov-fail-under" in line:
+            check(
+                False,
+                "INVARIANTE VIOLADO: --cov-fail-under encontrado em "
+                "[tool.pytest.ini_options] do pyproject.toml. "
+                "Remova: equivalente a pytest.ini, quebra runs de subconjunto.",
+            )
+
+
+def check_doc_crossrefs() -> None:
+    """Links relativos entre docs/system_design/*.md devem apontar para arquivos existentes."""
+    if not DOCS_DIR.exists():
+        warn(False, f"docs/system_design/ não encontrado em {DOCS_DIR}")
+        return
+
+    md_files = list(DOCS_DIR.glob("*.md"))
+    link_pattern = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+
+    for md_file in md_files:
+        content = md_file.read_text(errors="replace")
+        for match in link_pattern.finditer(content):
+            target = match.group(2)
+            if target.startswith("http") or target.startswith("#"):
+                continue
+
+            # Remove âncora para checar só o arquivo
+            target_path = target.split("#")[0]
+            if not target_path:
+                continue
+
+            resolved = (DOCS_DIR / target_path).resolve()
+            check(
+                resolved.exists(),
+                f"LINK QUEBRADO em {md_file.name}: [{match.group(1)}]({target}) "
+                f"→ {resolved} não existe",
+            )
+
+
+def check_ci_has_pytest() -> None:
+    """CI deve rodar pytest (gate real)."""
+    if not CI_WORKFLOW.exists():
+        check(False, "ci.yml não encontrado")
+        return
+    ci_text = CI_WORKFLOW.read_text()
+    check(
+        "pytest" in ci_text,
+        "ci.yml não contém 'pytest' — gate de testes ausente",
+    )
+
+
+def check_ci_cov_consistent() -> None:
+    """Se ci.yml roda pytest com --cov, deve ter gate de cobertura."""
+    if not CI_WORKFLOW.exists():
+        return
+    ci_text = CI_WORKFLOW.read_text()
+    has_cov = "--cov" in ci_text
+    has_gate = "--cov-fail-under" in ci_text
+    warn(
+        not (has_cov and not has_gate),
+        "ci.yml usa --cov mas não tem --cov-fail-under (gate de cobertura ausente no CI)",
+    )
+
+
+def main() -> int:
+    print("=== Validação de consistência doc↔código ===\n")
+
+    check_cov_fail_under()
+    check_doc_crossrefs()
+    check_ci_has_pytest()
+    check_ci_cov_consistent()
+
+    if WARNINGS:
+        for w in WARNINGS:
+            print(w)
+        print()
+
+    if FAILURES:
+        print(f"FALHOU: {len(FAILURES)} invariante(s) violado(s):\n")
+        for i, f in enumerate(FAILURES, 1):
+            print(f"  {i}. {f}\n")
+        return 1
+
+    print(f"OK: todos os invariantes verificados ({len(WARNINGS)} aviso(s)).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implementa a issue #731 (etapa 3/3 do hardening do CI), na variante **sem o reformat de 817 arquivos** — o reformat + gates black/isort/ruff/mypy-real foram movidos para a #735 (pós-1.1.0), pra não inflar a release nem disparar o gitleaks-na-diff.

## Gates reais adicionados (passam SEM tocar código)
- **interrogate** `--fail-under=39` (docstring coverage; medido 39.9%).
- **radon CC** teto B (10.0); medido A (3.24).
- **validate_doc_consistency.py** — gate de consistência doc↔código (ex.: o `--cov-fail-under` está no comando do CI, não no pytest.ini).
- `flake8` morto removido.

## Advisory (explícito, NÃO gateiam — ver #735)
- **mypy** `--ignore-missing-imports` + `continue-on-error` (gate real precisa de baseline gerado no 3.11 do CI → #735).
- **pymarkdown** (~40 violações legadas nos docs → normalização dedicada).

## Fora do escopo (→ #735, pós-release)
- Reformat black/isort/ruff de ~817 arquivos + gates `--check`.
- mypy gate real com baseline 3.11.

Zero arquivos `deile/**.py` tocados (diff: ci.yml + pyproject + .pymarkdown + scripts/). Validado local: interrogate/radon/doc-consistency exit 0; YAML válido.

Closes #731