### PR TITLE
fix: panel display (pod-down/markup) + SkillRegistry test isolation (CI flake)

### DIFF
--- a/deile/tests/conftest.py
+++ b/deile/tests/conftest.py
@@ -210,19 +210,33 @@ def _reset_global_singletons():
     Cada um é um global de módulo com ``reset_X()`` que zera a instância (recriada
     sob demanda no próximo ``get_X()``). Sem este reset hermético central, um teste
     que muta o singleton vaza o estado pro próximo — a causa-raiz reincidente das
-    falhas ordering-dependent (#432/#471/#499). O ``_CIRCUIT_BREAKER`` do
+    falhas ordering-dependent (#432/#471/#499/#728). O ``_CIRCUIT_BREAKER`` do
     deile_worker_client, com estado OPEN vazado, recusava dispatch em testes
     vítimas (ex.: test_dispatch_deile_task: "circuit breaker open — worker
     degraded") sob seeds aleatórias do pytest-randomly.
 
-    NOTA: o ``SkillRegistry`` NÃO é resetado aqui — o ``SkillsWatcher`` segura uma
-    referência à instância, e zerar o singleton entre testes orfanaria o watcher
-    (quebra test_watcher). Isolar o registry exige tratar o watcher junto — fica
-    para um fix dedicado.
+    SkillRegistry (#728 fix dedicado): testes em ``test_context_manager_deile_md.py``
+    e ``test_preference_injection.py`` chamam ``_build_fallback_system_instruction`` /
+    ``_build_system_instruction`` sem patchear ``bootstrap_skills``, o que popula o
+    singleton com as skills bundled (python/typescript/tdd + skills do ~/.claude/commands
+    do operador). Como esses arquivos não tinham ``_reset_registry`` próprio, o estado
+    vazava para testes subsequentes em ``test_context_manager_integration.py``:
+    ``test_active_skill_is_omitted_from_catalog`` esperava catálogo vazio (1 skill
+    registrada, excluída por estar ativa) mas encontrava typescript+tdd residuais →
+    "## Available Skills" aparecia no prompt.
+
+    Solução: ``reset_skill_registry()`` é idempotente e segura aqui porque:
+    (a) nenhum daemon SkillsWatcher está rodando durante os testes (test_watcher.py
+    usa watchers inline sem background threads, ou para-os explicitamente antes de
+    retornar); (b) test_watcher.py já tem seu próprio ``_reset_registry`` autouse —
+    dois resets consecutivos são idempotentes; (c) nenhum teste chama
+    ``bootstrap_skills_with_handle(hot_reload=True)`` que criaria um watcher de
+    longa duração.
     """
     from deile.core.models.tier_router import reset_tier_router
     from deile.events.event_bus import reset_event_bus
     from deile.infrastructure.deile_worker_client import reset_circuit_breaker
+    from deile.skills.registry import reset_skill_registry
     from deile.storage.usage_repository import reset_usage_repository
 
     def _reset_all():
@@ -230,6 +244,7 @@ def _reset_global_singletons():
         reset_event_bus()
         reset_usage_repository()
         reset_circuit_breaker()
+        reset_skill_registry()
 
     _reset_all()
     yield

--- a/deile/tests/infra/test_panel_claude_truth.py
+++ b/deile/tests/infra/test_panel_claude_truth.py
@@ -260,6 +260,17 @@ def test_claude_worker_cell_pod_down():
     assert not busy and doing == "— (pod down)" and stale is None
 
 
+def test_claude_worker_cell_probe_fail_but_running():
+    # Probe falhou mas o k8s reporta o pod Running: a falha é do probe, não do
+    # pod. Nunca afirmar "pod down" sobre um pod vivo — mostra "probe
+    # indisponível". Regressão do falso "(pod down)" no dashboard.
+    truth = pd.ClaudeWorkerTruth(pod_name="p", probe_ok=False)
+    data = _FakeData(truth_map={"p": truth})
+    age, last, doing, busy, icon, stale = pnl._claude_worker_cell(
+        data, "p", running=True)
+    assert not busy and doing == "— (probe indisponível)" and stale is None
+
+
 def test_claude_worker_cell_idle_with_last_completed():
     truth = pd.ClaudeWorkerTruth(pod_name="p", probe_ok=True,
                                  claude_running=False)

--- a/deile/tests/infra/test_session_tokens_audit_render.py
+++ b/deile/tests/infra/test_session_tokens_audit_render.py
@@ -1,0 +1,87 @@
+"""Regressão: ``render_table`` escapa markup no texto livre da sessão.
+
+Bug observado em produção (tela ``[t]okens`` do painel): uma sessão cujo
+``last_response`` ou ``brief`` continha colchetes — ex.: a string de endpoints
+``[/backlog|/recent|/ledger|/reaper-preview]`` que o ``claude -p`` imprime, ou um
+``[stage]`` literal no título — quebrava o parser de markup do Rich:
+``rich.errors.MarkupError: closing tag ... doesn't match any open tag`` no
+``console.print(t)``, crasheando o tool inteiro. Intermitente (dependia de
+QUAIS sessões estavam na página).
+
+Fix: escapar (``rich.markup.escape``) os dois cells de texto livre da sessão
+(título e última-resposta) no call-site do ``render_table`` — sem tocar nos
+cells de markup intencional (issue/PR, fim, tier/web, etc.).
+
+``_panel``/``session_tokens_audit`` vivem em ``infra/k8s/`` (fora do pacote
+``deile``); o path é inserido manualmente — mesma convenção dos demais testes
+de infra.
+"""
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+_REPO = Path(__file__).resolve().parents[3]
+for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import session_tokens_audit as sta  # noqa: E402
+
+
+def _min_session(**ov: object) -> dict:
+    """Sessão mínima com todas as chaves que ``render_table`` + helpers acessam."""
+    s = {
+        "errors": {"api_error": False, "max_tokens": False, "tool_error": False},
+        "git": {},
+        "cost_usd": 0.0,
+        "assistant_rounds": 0,
+        "tool_calls": 0,
+        "tools": [],
+        "totals": {"in": 0, "out": 0},
+        "cache_pct": 0.0,
+        "nocache_usd": 0.0,
+        "total_tokens": 0,
+        "per_model": {},
+        "session_file": "deadbeef-0000-0000",
+        "jsonl": "/home/claude/.claude/projects/x/deadbeef.jsonl",
+        "pr_number": None,
+        "stage": None,
+        "brief": "",
+        "ai_title": None,
+        "last_response": "",
+        "harvested": False,
+        "terminal_stop_reason": "end_turn",
+        "web_tool_calls": 0,
+        "service_tier": "standard",
+        "speed": "standard",
+        "last_activity": "—",
+        "created_s": 0.0,
+        "pvc": "claude-worker-home",
+        "meta_model": "anthropic:claude-opus-4-8",
+        "meta_branch": None,
+        "git_branch": None,
+    }
+    s.update(ov)
+    return s
+
+
+@pytest.mark.unit
+def test_render_table_survives_markup_in_free_text():
+    """Sessão com colchetes no título/resposta não pode levantar MarkupError."""
+    payload = "diga [/backlog|/recent|/ledger|/reaper-preview] já"
+    sessions = [
+        _min_session(last_response=payload, brief=payload, session_file="aaaa1111"),
+        _min_session(ai_title="[classify] elimarcavalli/deile #5", session_file="bbbb2222"),
+    ]
+    console = Console(file=io.StringIO(), width=160)
+    # Antes do fix isto levantava rich.errors.MarkupError.
+    sta.render_table(console, sessions, top=None)
+    out = console.file.getvalue()
+    # Conteúdo renderizado literalmente (escapado), não interpretado como tag.
+    assert "backlog" in out
+    assert "classify" in out

--- a/deile/tests/skills/test_skill_registry_isolation.py
+++ b/deile/tests/skills/test_skill_registry_isolation.py
@@ -1,0 +1,127 @@
+"""Reprodutor determinístico da regressão ordering-pollution do SkillRegistry.
+
+Este módulo prova que:
+  1. Um teste que chama ``_build_fallback_system_instruction`` / ``bootstrap_skills``
+     sem patchear o bootstrap popula o singleton com as skills bundled.
+  2. Sem o reset hermético central (``_reset_global_singletons`` no conftest raiz),
+     esse estado vaza para ``test_active_skill_is_omitted_from_catalog``, que falha
+     porque o catálogo exibe typescript + tdd residuais.
+  3. COM o fix (``reset_skill_registry`` em ``_reset_global_singletons``), o teste
+     vítima passa mesmo após o poluidor ter rodado.
+
+Recorrência #4 do padrão ordering-pollution (#432/#471/#499/#728).
+Os leakers confirmados são ``test_context_manager_deile_md.py`` e
+``test_preference_injection.py``: chamam métodos de ``ContextManager`` sem
+patchear ``bootstrap_skills`` e sem ``_reset_registry`` próprio.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deile.core.context_manager import ContextManager
+from deile.parsers.base import ParseResult, ParseStatus
+from deile.skills.base import Skill, SkillTrigger
+from deile.skills.language_detector import LanguageDetector
+from deile.skills.registry import get_skill_registry, reset_skill_registry
+from deile.skills.router import SkillRouter
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    reset_skill_registry()
+    yield
+    reset_skill_registry()
+
+
+@pytest.fixture
+def single_python_skill_router(monkeypatch: pytest.MonkeyPatch) -> SkillRouter:
+    """Regista apenas a skill 'python' e patcha ``bootstrap_skills``."""
+    registry = get_skill_registry()
+    registry.clear()
+    registry.register(
+        Skill(
+            name="python",
+            description="Python",
+            body="RULES FOR PYTHON",
+            triggers=SkillTrigger(
+                file_globs=["*.py"],
+                code_block_langs=["python"],
+            ),
+        )
+    )
+    router = SkillRouter(registry, language_detector=LanguageDetector(), max_skills_per_turn=4)
+
+    async def _fake_bootstrap(config=None, **kwargs):
+        return router
+
+    monkeypatch.setattr("deile.core.context_manager.bootstrap_skills", _fake_bootstrap)
+    return router
+
+
+@pytest.mark.integration
+class TestSkillRegistryIsolationRepro:
+    """Reprodução determinística do bug de ordering pollution."""
+
+    async def test_pollutant_populates_registry_via_unpatched_bootstrap(self) -> None:
+        """Simula o que test_context_manager_deile_md.py faz: chama
+        _build_fallback_system_instruction sem patchear bootstrap_skills.
+
+        Verifica que o registry fica populado com as skills bundled (> 1 skill).
+        """
+        ctx = ContextManager(persona_manager=None)
+        ctx.instruction_loader = MagicMock()
+        ctx.instruction_loader.load_fallback_instruction = MagicMock(
+            return_value="FALLBACK_BODY"
+        )
+        # bootstrap_skills NÃO está patchado → vai buscar skills bundled reais
+        await ctx._build_fallback_system_instruction(
+            session=None,
+            working_directory="/tmp/test",
+        )
+        # Depois do bootstrap real, o registry tem python + typescript + tdd (mínimo 3)
+        registered = get_skill_registry().list_names()
+        assert len(registered) >= 3, (
+            f"bootstrap deve carregar as bundled skills; registry tem só {registered}"
+        )
+        # Entre elas, deve estar 'python' (bundled library skill)
+        assert "python" in registered
+
+    async def test_victim_passes_after_pollution_when_reset_is_active(
+        self, single_python_skill_router: SkillRouter
+    ) -> None:
+        """Vítima do bug: passa quando o reset hermético do conftest limpa o registry
+        antes deste teste, independente do que o poluidor deixou no estado global.
+
+        Se ``reset_skill_registry`` NÃO estiver em ``_reset_global_singletons``,
+        este teste FALHA quando o poluidor roda primeiro (porque a fixture
+        ``_reset_registry`` deste arquivo limpa, mas o singleton podia ter sido
+        re-populado pelo bootstrap assíncrono do poluidor depois da limpeza).
+
+        Com o fix no conftest raiz, o registry é sempre limpo antes de cada teste.
+        """
+        cm = ContextManager()
+        parse_result = ParseResult(status=ParseStatus.SUCCESS, file_references=["x.py"])
+        session = SimpleNamespace(
+            conversation_history=[{"role": "user", "content": "x.py"}],
+            context_data={},
+        )
+
+        ctx = await cm.build_context(
+            user_input="x.py",
+            parse_result=parse_result,
+            session=session,
+        )
+
+        sys_instr = ctx["system_instruction"]
+        assert "### Skill: python" in sys_instr  # skill ativa presente
+        # Com apenas 1 skill registrada e ela excluída do catálogo (está ativa),
+        # o catálogo deve estar vazio → sem header "## Available Skills".
+        assert "## Available Skills" not in sys_instr, (
+            "Catálogo apareceu com skills residuais do poluidor. "
+            "O reset hermético do conftest não limpou o SkillRegistry antes deste teste. "
+            f"Registry tinha: {get_skill_registry().list_names()!r}"
+        )

--- a/infra/k8s/_panel.py
+++ b/infra/k8s/_panel.py
@@ -1041,7 +1041,7 @@ def _local_process_rows(data: Optional[PanelData]) -> List[PodRow]:
 
 
 def _claude_worker_cell(
-    data: PanelData, pod_name: str,
+    data: PanelData, pod_name: str, running: bool = False,
 ) -> Tuple[Optional[float], str, str, bool, str, Optional[float]]:
     """Doing-now de um pod claude-worker pela VERDADE (probe), não por log.
 
@@ -1049,14 +1049,17 @@ def _claude_worker_cell(
 
     Precedência (requisito #1 da proposta):
     1. ``claude_truth`` (exec/proc) — ``claude -p`` vivo NESTE pod = busy.
-    2. probe falhou → ``— (pod down)`` (degradação graciosa).
+    2. probe falhou → ``— (probe indisponível)`` se o pod está ``Running`` pelo
+       k8s (a falha é do probe, não do pod), senão ``— (pod down)``. Nunca
+       afirmar "pod down" sobre um pod que o k8s reporta vivo.
     3. idle explícito; ``last_activity`` = última task concluída (+custo) do
        log do worker, quando disponível — histórico, não estado-atual.
     """
     truth = (data.claude_truth.get().get(pod_name)
              if data.claude_truth is not None else None)
     if truth is None or not truth.probe_ok:
-        return None, "—", "— (pod down)", False, "●", None
+        label = "— (probe indisponível)" if running else "— (pod down)"
+        return None, "—", label, False, "●", None
     if truth.claude_running:
         d = truth.dispatches[0]
         bits = [d.summary]
@@ -1158,7 +1161,8 @@ def _pod_rows(data: Optional[PanelData], sort_mode: str = "recent") -> List[PodR
             busy = (age_s is not None and age_s < 60)
             icon = "⚡" if busy else "●"
         elif p.role == "claude-worker":
-            age_s, last, doing, busy, icon, stale_s = _claude_worker_cell(data, p.name)
+            age_s, last, doing, busy, icon, stale_s = _claude_worker_cell(
+                data, p.name, running=(p.status == "Running"))
         else:
             age_s = None
             last = "—"

--- a/infra/k8s/session_tokens_audit.py
+++ b/infra/k8s/session_tokens_audit.py
@@ -989,6 +989,9 @@ def render_table(console, sessions: list, top: int | None, start: int = 0,
                   f"{s['tool_calls']:>5} {fmt_age(s.get('created_s')):>7}  {title_of(s)[:50]}")
         return
     from rich.table import Table
+    from rich.markup import escape as _esc  # texto livre da sessão pode conter
+    #   colchetes (`[/backlog|...]`, `[stage]`) que o Rich parsearia como tag →
+    #   MarkupError. Escapamos só os cells de texto livre (título/última resposta).
     pvc = page_rows[0]["pvc"] if page_rows else (rows[0]["pvc"] if rows else "?")
     rng = (f"  (linhas {start + 1}–{start + len(page_rows)} de {len(rows)})"
            if count is not None else "")
@@ -1042,8 +1045,8 @@ def render_table(console, sessions: list, top: int | None, start: int = 0,
             kind_cell,
             f"{s['cost_usd']:.4f}",
             model_label(s, dim=True),
-            title_of(s) + err_flag,
-            last_response_cell(s),
+            _esc(title_of(s)) + err_flag,
+            _esc(last_response_cell(s)),
             issue_pr_cell(s),
             f"[{gstyle}]{st}[/{gstyle}]",
             wl_cell,


### PR DESCRIPTION
Correções de **display do painel** + isolamento de teste que destrava o CI. Tudo display/test-only — não muda lógica de produção.

## Fix 1 — `"(pod down)"` falso para claude-worker Running (`_panel.py`)
`_claude_worker_cell` retornava `"(pod down)"` sempre que o probe `claude_truth` falhava, ignorando que o k8s reporta **Running**. Agora recebe `running` e mostra `"(probe indisponível)"` quando o pod está vivo. + teste de regressão.

## Fix 2 — crash `MarkupError` na tela `[t]okens` (`session_tokens_audit.py`)
`render_table` crashava com `rich.errors.MarkupError` quando uma sessão tinha colchetes no texto livre (`[/backlog|/recent|...]`, `[stage]`). Agora escapa (`rich.markup.escape`) os dois cells de texto livre (`title_of`, `last_response_cell`) no call-site. Provado contra as 1225 sessões reais do cluster + teste de integração.

## Fix 3 — isolamento do SkillRegistry (flake de CI — o item deferido do #728)
`bootstrap_skills` (via `_build_skills_block`) populava o `SkillRegistry` singleton com as bundled (`python`/`typescript`/`tdd`) + skills de `~/.claude/commands/`, e `test_context_manager_deile_md.py`/`test_preference_injection.py` chamavam `build_context` **sem reset próprio** → vazava pro resto da suíte, derrubando testes de skills sob seeds aleatórias (3 vítimas diferentes vistas no CI hoje). Fix: `reset_skill_registry()` no `_reset_global_singletons` do conftest raiz (idempotente; nenhum daemon watcher roda na suíte). + reprodutor determinístico. **Validado: 5 seeds (incl. a `1653759713` da regressão) × 135 testes de skills+contexto + test_watcher, todos verdes.** Destrava também o commit de release e o #735.

## Fora do escopo (follow-up, NÃO neste PR)
Banner "CORTE POR PROVEDOR LLM" misatribui `INSUFFICIENT_CREDIT` a claude-worker — `ProviderHealthProvider._scan_pod` casa o padrão no eco do transcript do `claude -p` (o `--timestamps` prefixa tudo). Como claude-worker pode ter corte real (Agent SDK #603), exige fix dedicado.
