### PR TITLE
fix(pipeline): decouple refinement gate from dispatch_mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -373,6 +373,15 @@ DEILE_CLAUDE_WORKER_TASK_TIMEOUT_S=7200
 # [DEPRECATED → settings.json: pipeline.resume_budget]
 # DEILE_PIPELINE_RESUME_BUDGET=0
 
+# ---- Refino / decomposição de intents --------------------------------------
+
+# Liga o gate de refino/decomposição (crítica → loop de refino → decompose).
+# Default: true. Independente do dispatch_mode (issue #85): o dispatch_resolver
+# decide QUEM executa cada stage; este flag decide SE o pipeline refina/decompõe.
+# Ex.: =0 desliga o gate mesmo sob a frota all-claude (DISPATCH_MODE=claude).
+# [DEPRECATED → settings.json: pipeline.refinement_gate]
+# DEILE_PIPELINE_REFINEMENT_GATE=1
+
 # ---- Dispatch routing (qual worker recebe cada stage) ----------------------
 
 # Worker padrão global para todos os stages.

--- a/deile/config/settings.py
+++ b/deile/config/settings.py
@@ -404,6 +404,7 @@ _OVERRIDE_HANDLERS: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
     "pipeline.resume_max_attempts": ("pipeline_resume_max_attempts", _to_pos_int),
     "pipeline.resume_budget": ("pipeline_resume_budget", _to_nonneg_int),
     # Refinement gate + parallel decomposition (issue #257)
+    "pipeline.refinement_gate": ("pipeline_refinement_gate", _to_bool),
     "pipeline.refine_max_attempts": ("pipeline_refine_max_attempts", _to_pos_int),
     "pipeline.max_parallel": ("pipeline_max_parallel", _to_pos_int_or_auto),
     # Per-stage model override (issue #305) — see _MODEL_SLUG_RE / resolver.
@@ -624,6 +625,8 @@ class Settings:
     pipeline_resume_interval: int = 0
     pipeline_resume_max_attempts: int = 10
     pipeline_resume_budget: int = 0
+    # Gate de refino/decomposição — independente do dispatch_mode; ver issue #85.
+    pipeline_refinement_gate: bool = True
     pipeline_refine_max_attempts: int = 5
     pipeline_max_parallel: int = 2
 
@@ -1318,6 +1321,8 @@ _ENV_OVERRIDES: Tuple[Tuple[str, str, Callable[[str], Any]], ...] = (
     ("DEILE_PIPELINE_BASE_PATH",             "pipeline_base_path",             _resolved_path),
     # Pipeline dispatch mode global (kept — still in use in cluster env vars)
     ("DEILE_PIPELINE_DISPATCH_MODE",         "pipeline_dispatch_mode",         str),
+    # Gate de refino/decomposição — independente do dispatch_mode (issue #85).
+    ("DEILE_PIPELINE_REFINEMENT_GATE",       "pipeline_refinement_gate",       _env_bool),
     # Current knob — pipeline autostart.
     ("DEILE_PIPELINE_AUTOSTART",             "pipeline_autostart",             _env_bool),
     # Kubernetes namespace — used by CLI commands like /pods (issue #414).

--- a/deile/orchestration/pipeline/monitor.py
+++ b/deile/orchestration/pipeline/monitor.py
@@ -169,11 +169,11 @@ class PipelineConfig:
     # agora operam sobre OR dos três TTLs; cada ramo auto-pula quando seu
     # próprio TTL é <= 0.
     reaper_arch_hard_seconds: int = 2 * 60 * 60  # 2h
-    # The refinement gate (critique → refine loop → decompose) is worker-only:
-    # it dispatches type-specific personas (analyst/architect/debugger) to the
-    # deile-worker. On the legacy Claude path it is OFF, so ``review`` keeps its
-    # old no-op transition and refine/decompose no-op. Resolved from dispatch_mode
-    # in ``build_default_pipeline_config`` (mirrors ``enable_resume``).
+    # Gate de refino/decomposição (crítica → loop de refino → decompose) — comportamento
+    # do pipeline, independente do dispatch_mode. O executor é decidido em runtime pelo
+    # dispatch_resolver; este flag decide SE o pipeline refina/decompõe. Resolvido a
+    # partir de ``settings.pipeline_refinement_gate`` (default ON) em
+    # ``build_default_pipeline_config``; dispatch_mode apenas seleciona o executor (issue #85).
     enable_refinement_gate: bool = False
 
 
@@ -275,7 +275,7 @@ def build_default_pipeline_config(*, use_pid_lock: bool = True) -> PipelineConfi
         resume_budget=int(settings.pipeline_resume_budget),
         refine_max_attempts=int(settings.pipeline_refine_max_attempts),
         max_parallel=max_parallel,
-        enable_refinement_gate=(not is_claude_mode(dispatch_mode)),
+        enable_refinement_gate=bool(settings.pipeline_refinement_gate),
     )
 
 

--- a/deile/tests/config/test_settings_refinement_gate.py
+++ b/deile/tests/config/test_settings_refinement_gate.py
@@ -16,7 +16,8 @@ from unittest.mock import patch
 
 import pytest
 
-from deile.config.settings import Settings, reset_settings
+from deile.config.settings import (Settings, _apply_env_overrides,
+                                    reset_settings)
 
 
 @pytest.fixture(autouse=True)
@@ -85,3 +86,59 @@ class TestRefinementGateDecoupling:
         cfg = build_default_pipeline_config()
 
         assert cfg.enable_refinement_gate is True
+
+
+class TestRefinementGateEnvParse:
+    """Parse do env var VIVO via ``_env_bool`` (issue #85).
+
+    Ao contrário do espelho ``enable_resume`` (cujo env var foi REMOVIDO na #309
+    fase 3), ``DEILE_PIPELINE_REFINEMENT_GATE`` está registrado em
+    ``_ENV_OVERRIDES`` — então o parse ``"0"``/``"true"``/``"on"`` → bool é
+    exercido de fato, fechando a malha que os testes acima (que setam o field
+    direto no ``Settings``) deixavam aberta.
+    """
+
+    def test_env_zero_turns_gate_off(self, monkeypatch):
+        """DEILE_PIPELINE_REFINEMENT_GATE=0 → field False."""
+        monkeypatch.setenv("DEILE_PIPELINE_REFINEMENT_GATE", "0")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_refinement_gate is False
+
+    def test_env_true_keeps_gate_on(self, monkeypatch):
+        """DEILE_PIPELINE_REFINEMENT_GATE=true → field True."""
+        monkeypatch.setenv("DEILE_PIPELINE_REFINEMENT_GATE", "true")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_refinement_gate is True
+
+    def test_env_on_is_lenient_truthy(self, monkeypatch):
+        """_env_bool é leniente: "on" também liga (paridade com os demais bools)."""
+        monkeypatch.setenv("DEILE_PIPELINE_REFINEMENT_GATE", "on")
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_refinement_gate is True
+
+    def test_env_unset_preserves_default_true(self, monkeypatch):
+        """Sem o env var, o default (True) é preservado."""
+        monkeypatch.delenv("DEILE_PIPELINE_REFINEMENT_GATE", raising=False)
+        s = Settings()
+        _apply_env_overrides(s)
+        assert s.pipeline_refinement_gate is True
+
+
+class TestRefinementGateSettingsJson:
+    """Override via ``settings.json`` (``pipeline.refinement_gate`` → ``_to_bool``)."""
+
+    def test_apply_overrides_off(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"refinement_gate": False}})
+        assert s.pipeline_refinement_gate is False
+
+    def test_apply_overrides_bool_string_coercion(self):
+        s = Settings()
+        s.apply_overrides({"pipeline": {"refinement_gate": "false"}})
+        assert s.pipeline_refinement_gate is False
+
+    def test_default_is_on(self):
+        assert Settings().pipeline_refinement_gate is True

--- a/deile/tests/config/test_settings_refinement_gate.py
+++ b/deile/tests/config/test_settings_refinement_gate.py
@@ -1,0 +1,87 @@
+"""Testes de regressão para o desacoplamento do gate de refino (issue #85).
+
+Garante que ``enable_refinement_gate`` em ``build_default_pipeline_config``
+é resolvido de ``settings.pipeline_refinement_gate`` e NÃO de
+``dispatch_mode`` — ou seja, rodar frota toda em claude não desliga o gate.
+
+Cenários:
+- DEILE_PIPELINE_DISPATCH_MODE=claude sem override do gate → gate ON (default)
+- DEILE_PIPELINE_DISPATCH_MODE=deile_worker sem override → gate ON (default)
+- DEILE_PIPELINE_REFINEMENT_GATE=0 → gate OFF, independente do dispatch_mode
+- DEILE_PIPELINE_REFINEMENT_GATE=true → gate ON explicitamente
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from deile.config.settings import Settings, reset_settings
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_settings()
+    yield
+    reset_settings()
+
+
+def _patch_build_deps(monkeypatch, settings, tmp_path):
+    monkeypatch.setattr("deile.config.settings.get_settings", lambda: settings)
+    monkeypatch.setattr(
+        "deile.orchestration.pipeline.constants.resolve_pipeline_repo",
+        lambda: "owner/repo",
+    )
+    monkeypatch.setattr(
+        "deile.tools._pipeline_paths.resolve_base_path", lambda: tmp_path
+    )
+
+
+def _make_settings(**kwargs) -> Settings:
+    s = Settings()
+    for k, v in kwargs.items():
+        setattr(s, k, v)
+    return s
+
+
+class TestRefinementGateDecoupling:
+    def test_gate_on_by_default_under_claude_dispatch_mode(self, monkeypatch, tmp_path):
+        """DEILE_PIPELINE_DISPATCH_MODE=claude NÃO desliga o gate (issue #85)."""
+        s = _make_settings(pipeline_dispatch_mode="claude")
+        # pipeline_refinement_gate usa o default (True)
+        _patch_build_deps(monkeypatch, s, tmp_path)
+
+        from deile.orchestration.pipeline.monitor import build_default_pipeline_config
+        cfg = build_default_pipeline_config()
+
+        assert cfg.enable_refinement_gate is True
+
+    def test_gate_on_by_default_under_deile_worker_dispatch_mode(self, monkeypatch, tmp_path):
+        """dispatch_mode=deile_worker também não altera o gate — default ON."""
+        s = _make_settings(pipeline_dispatch_mode="deile_worker")
+        _patch_build_deps(monkeypatch, s, tmp_path)
+
+        from deile.orchestration.pipeline.monitor import build_default_pipeline_config
+        cfg = build_default_pipeline_config()
+
+        assert cfg.enable_refinement_gate is True
+
+    def test_gate_off_when_env_var_is_zero(self, monkeypatch, tmp_path):
+        """DEILE_PIPELINE_REFINEMENT_GATE=0 desliga o gate, independente de dispatch_mode."""
+        s = _make_settings(pipeline_dispatch_mode="claude", pipeline_refinement_gate=False)
+        _patch_build_deps(monkeypatch, s, tmp_path)
+
+        from deile.orchestration.pipeline.monitor import build_default_pipeline_config
+        cfg = build_default_pipeline_config()
+
+        assert cfg.enable_refinement_gate is False
+
+    def test_gate_on_when_env_var_is_true_under_claude(self, monkeypatch, tmp_path):
+        """pipeline_refinement_gate=True explícito sob claude → gate ON."""
+        s = _make_settings(pipeline_dispatch_mode="claude", pipeline_refinement_gate=True)
+        _patch_build_deps(monkeypatch, s, tmp_path)
+
+        from deile.orchestration.pipeline.monitor import build_default_pipeline_config
+        cfg = build_default_pipeline_config()
+
+        assert cfg.enable_refinement_gate is True


### PR DESCRIPTION
## Problema

Issues `[INTENT]` ficavam **presas em `~workflow:revisada`** e nunca eram despachadas (caso real ao vivo: #613). Sob a frota all-claude (`DEILE_PIPELINE_DISPATCH_MODE=claude`), o pipeline classificava a intent mas **nunca a decompunha** — beco sem saída.

## Causa-raiz

`build_default_pipeline_config` derivava o gate de refino/decomposição do **executor**:

```python
enable_refinement_gate=(not is_claude_mode(dispatch_mode))
```

`is_claude_mode("claude") == True` → gate `False` → `decompose_one_reviewed_intent` retorna no-op e `implement_one_reviewed_issue` pula `TYPE_INTENT`. O `dispatch_mode` (QUEM executa) estava indevidamente acoplado a SE o pipeline refina/decompõe.

## Correção

Desacopla — flag própria `pipeline_refinement_gate` (default **ON**), espelhando exatamente o `enable_resume` (que já havia sido desacoplado assim). Configurável por `DEILE_PIPELINE_REFINEMENT_GATE` / `pipeline.refinement_gate`. O `dispatch_mode` volta a decidir só o executor.

## Verificação

- Suíte completa local: **8764 passed**, 0 falhas.
- 4 testes de regressão novos provam: `dispatch=claude` NÃO desliga o gate; `DEILE_PIPELINE_REFINEMENT_GATE=0` desliga independente do modo.
- **Provado ao vivo** no cluster: após deploy, o claude-worker (opus, effort high) decompôs a #613 que estava travada.

Fecha o gap rastreado internamente como #85.
