### PR TITLE
test(skills): isolate bootstrap_skills in non-skills tests (fix CI flake)

### DIFF
--- a/deile/tests/core/test_preference_injection.py
+++ b/deile/tests/core/test_preference_injection.py
@@ -20,11 +20,36 @@ import pytest
 from deile.core.context_manager import (ContextManager,
                                         _build_preferences_block,
                                         _resolve_user_id)
+from deile.skills.registry import SkillRegistry
+from deile.skills.router import SkillRouter
 
 # PreferenceStore is imported lazily inside _build_preferences_block via
 # ``from deile.preferences.store import PreferenceStore``.  Patch that
 # target so the mock is used instead of the real store.
 _PREF_STORE = "deile.preferences.store.PreferenceStore"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_bootstrap_skills(monkeypatch):
+    """Patch bootstrap_skills para evitar que os testes de preferência
+    populem o singleton global com skills bundled/do operador.
+
+    Estes testes afirmam blocos de preferências — nunca o bloco de skills.
+    Sem este patch, ``_build_skills_block`` popula o singleton com
+    python/typescript/tdd (+ skills do operador) e contamina testes
+    subsequentes que esperam registry vazio.
+
+    Nota: ``test_prefs_after_deile_md_before_skills`` seta
+    ``ctx._skills_bootstrapped = True`` manualmente, então bootstrap não é
+    chamado para ele — este patch é harmless naquele caso.
+    """
+    _empty_registry = SkillRegistry()  # isolado — nunca afeta o singleton global
+    _empty_router = SkillRouter(_empty_registry)
+
+    async def _fake_bootstrap(config=None, **kwargs):
+        return _empty_router
+
+    monkeypatch.setattr("deile.core.context_manager.bootstrap_skills", _fake_bootstrap)
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────

--- a/deile/tests/skills/test_skill_registry_isolation.py
+++ b/deile/tests/skills/test_skill_registry_isolation.py
@@ -18,7 +18,7 @@ patchear ``bootstrap_skills`` e sem ``_reset_registry`` próprio.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -26,7 +26,7 @@ from deile.core.context_manager import ContextManager
 from deile.parsers.base import ParseResult, ParseStatus
 from deile.skills.base import Skill, SkillTrigger
 from deile.skills.language_detector import LanguageDetector
-from deile.skills.registry import get_skill_registry, reset_skill_registry
+from deile.skills.registry import SkillRegistry, get_skill_registry, reset_skill_registry
 from deile.skills.router import SkillRouter
 
 
@@ -60,6 +60,96 @@ def single_python_skill_router(monkeypatch: pytest.MonkeyPatch) -> SkillRouter:
 
     monkeypatch.setattr("deile.core.context_manager.bootstrap_skills", _fake_bootstrap)
     return router
+
+
+@pytest.mark.integration
+class TestSourceLevelIsolationFix:
+    """Prova determinística de que o fix na fonte funciona.
+
+    O fix em ``test_context_manager_deile_md.py`` e
+    ``test_preference_injection.py`` adiciona um fixture autouse que patcha
+    ``deile.core.context_manager.bootstrap_skills`` para um router vazio
+    isolado (não usa o singleton global). Este teste reproduz exatamente
+    esse padrão e verifica que o singleton global permanece com 0 skills
+    após a chamada — ou seja, a contaminação foi eliminada na fonte.
+
+    Este teste é determinístico: não depende de ordenação de coleta nem de
+    pytest-randomly. Roda na mesma JVM; se o patch funciona, o registry
+    global fica limpo; se não funciona, o assert falha com a lista das skills
+    que vazaram.
+    """
+
+    async def test_patched_polluter_does_not_leak_into_global_registry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Com o patch fonte, bootstrap_skills usa registry isolado → singleton global
+        permanece com 0 skills após chamada ao padrão poluidor."""
+        # Pré-condição: registry global vazio (garantido pelo autouse _reset_registry)
+        assert len(get_skill_registry()) == 0, "pre-condition: global registry must start empty"
+
+        # Configura o patch exatamente como o fixture _isolate_bootstrap_skills faz
+        _isolated_registry = SkillRegistry()
+        _isolated_router = SkillRouter(_isolated_registry, language_detector=LanguageDetector())
+
+        async def _fake_bootstrap(config=None, **kwargs):
+            return _isolated_router
+
+        monkeypatch.setattr("deile.core.context_manager.bootstrap_skills", _fake_bootstrap)
+
+        # Executa o padrão poluidor: ContextManager._build_fallback_system_instruction
+        ctx = ContextManager(persona_manager=None)
+        ctx.instruction_loader = MagicMock()
+        ctx.instruction_loader.load_fallback_instruction = MagicMock(
+            return_value="FALLBACK_BODY"
+        )
+        await ctx._build_fallback_system_instruction(
+            session=None,
+            working_directory="/tmp/test_isolation",
+        )
+
+        # Pós-condição: singleton global ainda tem 0 skills — o bootstrap isolado
+        # nunca tocou no singleton global.
+        leaked = get_skill_registry().list_names()
+        assert len(leaked) == 0, (
+            f"Vazamento detectado! O padrão poluidor populou o singleton global com: {leaked}. "
+            "O fixture _isolate_bootstrap_skills NÃO está sendo aplicado corretamente."
+        )
+
+    async def test_patched_polluter_does_not_leak_via_persona_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mesmo teste pelo caminho da persona (_build_system_instruction com PersonaManager)."""
+        assert len(get_skill_registry()) == 0
+
+        _isolated_registry = SkillRegistry()
+        _isolated_router = SkillRouter(_isolated_registry, language_detector=LanguageDetector())
+
+        async def _fake_bootstrap(config=None, **kwargs):
+            return _isolated_router
+
+        monkeypatch.setattr("deile.core.context_manager.bootstrap_skills", _fake_bootstrap)
+
+        persona = MagicMock()
+        persona.name = "test_persona"
+        persona.build_system_instruction = MagicMock(return_value="PERSONA_BODY")
+
+        # build_system_instruction é async e chamada com await — usar AsyncMock
+        persona.build_system_instruction = AsyncMock(return_value="PERSONA_BODY")
+
+        persona_manager = MagicMock()
+        persona_manager.get_active_persona = MagicMock(return_value=persona)
+
+        ctx = ContextManager(persona_manager=persona_manager)
+        await ctx._build_system_instruction(
+            parse_result=None,
+            session=None,
+            working_directory="/tmp/test_isolation_persona",
+        )
+
+        leaked = get_skill_registry().list_names()
+        assert len(leaked) == 0, (
+            f"Vazamento via persona path: {leaked}"
+        )
 
 
 @pytest.mark.integration

--- a/deile/tests/test_context_manager_deile_md.py
+++ b/deile/tests/test_context_manager_deile_md.py
@@ -14,6 +14,8 @@ import pytest
 from deile.core import context_manager as cm_module
 from deile.core import deile_md_loader as loader_module
 from deile.core.context_manager import ContextManager
+from deile.skills.registry import SkillRegistry
+from deile.skills.router import SkillRouter
 
 
 @pytest.fixture(autouse=True)
@@ -21,6 +23,25 @@ def _isolate_loader_cache():
     loader_module.clear_cache()
     yield
     loader_module.clear_cache()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_bootstrap_skills(monkeypatch):
+    """Patch bootstrap_skills to an empty router so this file never populates
+    the global SkillRegistry with bundled/operator skills.
+
+    Estes testes afirmam apenas camadas DEILE.md — não precisam de skills
+    reais. Sem este patch, ``_build_skills_block`` chama o bootstrap real e
+    popula o singleton com python/typescript/tdd (+ skills do operador),
+    contaminando testes subsequentes que dependem de um registry vazio.
+    """
+    _empty_registry = SkillRegistry()  # isolado — nunca afeta o singleton global
+    _empty_router = SkillRouter(_empty_registry)
+
+    async def _fake_bootstrap(config=None, **kwargs):
+        return _empty_router
+
+    monkeypatch.setattr("deile.core.context_manager.bootstrap_skills", _fake_bootstrap)
 
 
 CORE_MARKER = "CORE_TEST_MARKER_alpha"


### PR DESCRIPTION
## Problema (flake de CI, ordering-dependent)

Testes **não-skills** (`test_context_manager_deile_md.py`, `test_preference_injection.py`) chamavam `_build_system_instruction` / `_build_fallback_system_instruction` **sem patchear `bootstrap_skills`**. Cada execução fazia uma chamada REAL ao bootstrap, que popula o singleton global `SkillRegistry` com as skills bundled (python/typescript/tdd) **+ as skills reais do operador** (`~/.claude/commands`, `~/.deile/skills`) — teste **não-hermético**.

Sob `pytest-xdist -n 2` (os 2 vCPU do runner) + `pytest-randomly`, esse estado vazava para vítimas em `test_context_manager_integration.py` / `test_skill_tools.py` que esperam registry vazio → `## Available Skills` residual → FAILED intermitente. (Não reproduz local de forma confiável: seed→ordem depende da coleção, que difere por ambiente — só o CI é fiel.)

## Fix na fonte (não band-aid)

Cada arquivo poluidor ganha um fixture autouse `_isolate_bootstrap_skills` que patcha `deile.core.context_manager.bootstrap_skills` para retornar um `SkillRouter` sobre um `SkillRegistry` **isolado** — o singleton global nunca é populado. Os testes não-skills passam a ser herméticos (não leem o HOME real nem mexem em estado global).

- **Sem gambiarra:** zero `skip`/`flaky`/`xfail`/`--reruns`/afrouxar assert. As assertions originais dos poluidores (marcadores DEILE.md, blocos de preferência) seguem intactas.
- **Defesa em profundidade mantida:** o `reset_skill_registry()` do conftest (`_reset_global_singletons`) NÃO foi removido.

## Prova determinística (independe de ordem/seed)

`TestSourceLevelIsolationFix` em `test_skill_registry_isolation.py`: roda o caminho poluidor com o patch e assere `len(get_skill_registry()) == 0` depois — pelos dois caminhos (`_build_fallback_system_instruction` e via PersonaManager).

## Verificação

Suíte completa verde em 3 seeds: `1653759713`, `2630445011`, `0` → **8793–8794 passed, 0 failed** em cada. O CI (`-n 2`, onde o flake mora) é a verificação final.
