### PR TITLE
test(isolation): fix ordering pollution from global ~/.deile paths in tests

### DIFF
--- a/deile/tests/commands/conftest.py
+++ b/deile/tests/commands/conftest.py
@@ -1,0 +1,17 @@
+"""Fixtures de isolamento para testes de comandos.
+
+CostTracker usa um singleton global em cost_tracker._cost_tracker_instance
+cujo caminho padrão é ~/.deile/costs.db.  Em execução paralela (-n auto)
+múltiplos workers competiriam pelo mesmo arquivo SQLite.  Esta fixture
+substitui o singleton por uma instância isolada com tmp_path para cada
+função de teste.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cost_tracker(tmp_path, monkeypatch):
+    from deile.infrastructure.monitoring import cost_tracker as ct_mod
+
+    tracker = ct_mod.CostTracker(db_path=str(tmp_path / "costs.db"))
+    monkeypatch.setattr(ct_mod, "_cost_tracker_instance", tracker)

--- a/deile/tests/infra/test_panel_data.py
+++ b/deile/tests/infra/test_panel_data.py
@@ -13,6 +13,7 @@ de rede. O CostsProvider usa um SQLite temporário.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 import time
@@ -30,6 +31,27 @@ for _p in (_REPO / "infra", _REPO / "infra" / "k8s"):
 
 import _panel as panel  # noqa: E402
 import _panel_data as pd  # noqa: E402
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _isolate_runtime_dir(tmp_path_factory):
+    """Aponta DEILE_RUNTIME_DIR para um dir temporário em toda a suíte do módulo.
+
+    LocalInstancesProvider() e LocalRegistryProvider() criados via
+    PanelData.from_context() sem runtime_dir explícito caem em
+    os.environ["DEILE_RUNTIME_DIR"] ou RUNTIME_DIR = Path.home()/.deile/run.
+    Sem esta fixture, testes que chamam from_context() com logs_dir.is_dir()
+    lêem do home real do runner (ordering pollution documentado em CLAUDE.md).
+    """
+    rt = tmp_path_factory.mktemp("panel_runtime")
+    prev = os.environ.get("DEILE_RUNTIME_DIR")
+    os.environ["DEILE_RUNTIME_DIR"] = str(rt)
+    yield rt
+    if prev is None:
+        os.environ.pop("DEILE_RUNTIME_DIR", None)
+    else:
+        os.environ["DEILE_RUNTIME_DIR"] = prev
+
 
 # ===== Cache TTL ============================================================
 


### PR DESCRIPTION
## Entrega vs Critérios de Aceitação

### AC1 — Nenhum teste lê `~/.deile/` real durante a suíte

**Status: IMPLEMENTADO ✅** (verificável localmente; AC completo requer `HOME=$(mktemp -d) python3 -m pytest deile/tests/ -n auto` no CI)

**Fontes encontradas e corrigidas:**

| Arquivo fonte | Caminho global | Testes afetados | Fix |
|---|---|---|---|
| `infra/k8s/_panel_data.py:6847/6851` | `~/.deile/run` (via `LocalInstancesProvider()` / `LocalRegistryProvider()` sem `runtime_dir`) | `TestPanelDataFromContext`, `TestLocalInstancesInPanelData` | fixture `_isolate_runtime_dir` (autouse, scope=module) em `test_panel_data.py` seta `DEILE_RUNTIME_DIR` |
| `deile/infrastructure/monitoring/cost_tracker.py:112` | `~/.deile/costs.db` (via singleton `get_cost_tracker()` → `CostTracker()`) | `test_cost_command.py` (22 testes) | conftest `_isolated_cost_tracker` (autouse, scope=function) substitui singleton por instância com `tmp_path` |

**Fonte monitorada (sem fix ativo — sem testes diretos):**
- `deile/core/intent_metrics.py:107,149` — `_setup_logging()` cria `~/.deile/logs/` via `mkdir`. Nenhum teste em `deile/tests/` instancia `IntentMetrics` diretamente. Risco latente para testes futuros — documentado para follow-up.

### AC2 — Suíte verde em 5 seeds distintas

**Status: PARCIALMENTE VERIFICADO ⚠️**

`pytest-randomly` não está instalado neste pod. Verificações realizadas:

- 246 testes em `test_panel_data.py` — 0 falhas (full module run)
- 1001 testes em `deile/tests/commands/` — 0 falhas (1 skip pré-existente)
- 213 testes em `deile/tests/runtime/` + `tests/observability/` — 0 falhas
- Ordering manual: cross-module em ordem reversa — 48 testes, 0 falhas

Seeds 0/1/2/42/last com `--randomly-seed` requerem `pytest-randomly` instalado no CI.

## Mudanças

### `deile/tests/infra/test_panel_data.py`
Fixture `_isolate_runtime_dir` (autouse, scope=module) adicionada logo após os imports. Define `DEILE_RUNTIME_DIR` via `tmp_path_factory.mktemp("panel_runtime")` antes do primeiro teste do módulo e restaura o valor original no teardown.

### `deile/tests/commands/conftest.py` (novo)
Fixture `_isolated_cost_tracker` (autouse, scope=function) que substitui `cost_tracker._cost_tracker_instance` por uma instância com `db_path=tmp_path/"costs.db"` em cada teste — via `monkeypatch.setattr`, que restaura automaticamente após cada função.

Refs #759.