### PR TITLE
refactor(observability): consolidar tríade de redação em _redaction.py (#760)

### DIFF
--- a/deile/observability/_redaction.py
+++ b/deile/observability/_redaction.py
@@ -1,0 +1,33 @@
+"""Tríade de redação de segredos — módulo-folha compartilhado.
+
+Exporta ``_REDACT_RE``, ``_redact`` e ``_safe_attrs`` para uso em
+``dispatch_export.py`` e ``dispatch_log_export.py``. Depende apenas de
+stdlib (``re`` + ``typing``) — sem imports DEILE; ciclo impossível.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+__all__ = ["_REDACT_RE", "_redact", "_safe_attrs"]
+
+_REDACT_RE = re.compile(
+    r"(ghp_[A-Za-z0-9]{36,}|glpat-[A-Za-z0-9_-]{20,}|gldt-[A-Za-z0-9_-]{20,}"
+    r"|sk-[A-Za-z0-9]{20,}|Bearer\s+\S{10,}|xox[baprs]-[A-Za-z0-9-]{10,}"
+    r"|AKIA[A-Z0-9]{16,}|[A-Za-z0-9+/]{40,}={0,2})",
+    re.ASCII,
+)
+
+
+def _redact(value: str) -> str:
+    """Substitui padrões de token/segredo por ``[REDACTED]``."""
+    return _REDACT_RE.sub("[REDACTED]", value)
+
+
+def _safe_attrs(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Aplica redact em todos os valores string do dict."""
+    out: Dict[str, Any] = {}
+    for k, v in raw.items():
+        out[k] = _redact(str(v)) if isinstance(v, str) else v
+    return out

--- a/deile/observability/dispatch_export.py
+++ b/deile/observability/dispatch_export.py
@@ -44,7 +44,7 @@ from deile.observability.dispatch_schema import (ATTR_POD, ATTR_ROLE,
                                                  ForgePrReviewAttrs,
                                                  GitCommitAttrs, GitPushAttrs,
                                                  get_pod_metadata)
-from deile.observability._redaction import _REDACT_RE, _redact, _safe_attrs
+from deile.observability._redaction import _redact, _safe_attrs
 from deile.observability.semconv_mapping import apply_semconv_attrs
 from deile.observability.tracer import OtlpTracer, get_tracer, otel_available
 

--- a/deile/observability/dispatch_export.py
+++ b/deile/observability/dispatch_export.py
@@ -24,7 +24,6 @@ Regras críticas:
 from __future__ import annotations
 
 import logging
-import re
 import threading
 import time
 from typing import Any, Dict, Optional
@@ -45,6 +44,7 @@ from deile.observability.dispatch_schema import (ATTR_POD, ATTR_ROLE,
                                                  ForgePrReviewAttrs,
                                                  GitCommitAttrs, GitPushAttrs,
                                                  get_pod_metadata)
+from deile.observability._redaction import _REDACT_RE, _redact, _safe_attrs
 from deile.observability.semconv_mapping import apply_semconv_attrs
 from deile.observability.tracer import OtlpTracer, get_tracer, otel_available
 
@@ -64,32 +64,10 @@ __all__ = [
 
 _logger = logging.getLogger(__name__)
 
-# ── redaction ─────────────────────────────────────────────────────────────
-
-_REDACT_RE = re.compile(
-    r"(ghp_[A-Za-z0-9]{36,}|glpat-[A-Za-z0-9_-]{20,}|gldt-[A-Za-z0-9_-]{20,}"
-    r"|sk-[A-Za-z0-9]{20,}|Bearer\s+\S{10,}|xox[baprs]-[A-Za-z0-9-]{10,}"
-    r"|AKIA[A-Z0-9]{16,}|[A-Za-z0-9+/]{40,}={0,2})",
-    re.ASCII,
-)
-
-
-def _redact(value: str) -> str:
-    """Substitui padrões de token/segredo por ``[REDACTED]``."""
-    return _REDACT_RE.sub("[REDACTED]", value)
-
 
 def _safe_str(value: Any) -> str:
     """Converte para str com redact aplicado."""
     return _redact(str(value) if value is not None else "")
-
-
-def _safe_attrs(raw: Dict[str, Any]) -> Dict[str, Any]:
-    """Aplica redact em todos os valores string do dict."""
-    out: Dict[str, Any] = {}
-    for k, v in raw.items():
-        out[k] = _redact(str(v)) if isinstance(v, str) else v
-    return out
 
 
 # ── drop counter ──────────────────────────────────────────────────────────

--- a/deile/observability/dispatch_log_export.py
+++ b/deile/observability/dispatch_log_export.py
@@ -50,7 +50,7 @@ import threading
 import time
 from typing import Any, Dict, Optional, Tuple
 
-from deile.observability._redaction import _REDACT_RE, _redact, _safe_attrs
+from deile.observability._redaction import _redact, _safe_attrs
 from deile.observability.config import get_observability_config
 from deile.observability.dispatch_schema import (ATTR_POD, ATTR_ROLE,
                                                  ATTR_SCHEMA_VERSION,

--- a/deile/observability/dispatch_log_export.py
+++ b/deile/observability/dispatch_log_export.py
@@ -46,11 +46,11 @@ Regras críticas:
 from __future__ import annotations
 
 import logging
-import re as _re
 import threading
 import time
 from typing import Any, Dict, Optional, Tuple
 
+from deile.observability._redaction import _REDACT_RE, _redact, _safe_attrs
 from deile.observability.config import get_observability_config
 from deile.observability.dispatch_schema import (ATTR_POD, ATTR_ROLE,
                                                  ATTR_SCHEMA_VERSION,
@@ -68,29 +68,6 @@ __all__ = [
 ]
 
 _logger = logging.getLogger(__name__)
-
-# ── redaction (mirrors dispatch_export._REDACT_RE — same regex) ──────────────
-
-_REDACT_RE = _re.compile(
-    r"(ghp_[A-Za-z0-9]{36,}|glpat-[A-Za-z0-9_-]{20,}|gldt-[A-Za-z0-9_-]{20,}"
-    r"|sk-[A-Za-z0-9]{20,}|Bearer\s+\S{10,}|xox[baprs]-[A-Za-z0-9-]{10,}"
-    r"|AKIA[A-Z0-9]{16,}|[A-Za-z0-9+/]{40,}={0,2})",
-    _re.ASCII,
-)
-
-
-def _redact(value: str) -> str:
-    """Substitui padrões de token/segredo por ``[REDACTED]``."""
-    return _REDACT_RE.sub("[REDACTED]", value)
-
-
-def _safe_attrs(raw: Dict[str, Any]) -> Dict[str, Any]:
-    """Aplica redact em todos os valores string do dict."""
-    out: Dict[str, Any] = {}
-    for k, v in raw.items():
-        out[k] = _redact(str(v)) if isinstance(v, str) else v
-    return out
-
 
 # ── severity matrix (D4 — first-match wins) ──────────────────────────────────
 # OTel SeverityNumber: INFO=9, WARN=13, ERROR=17 (per OTLP spec)


### PR DESCRIPTION
## Resumo

Extrai a tríade de redação de segredos duplicada byte-a-byte — `_REDACT_RE` / `_redact` / `_safe_attrs` — para o módulo-folha `deile/observability/_redaction.py` (stdlib pura: `re` + `typing`, sem imports DEILE, ciclo impossível por construção). Os dois consumidores (`dispatch_export.py` e `dispatch_log_export.py`) passam a importar via `from ._redaction import ...`. Os imports órfãos de `re` / `re as _re` foram removidos. `_safe_str` permanece local em `dispatch_export.py` (não estava duplicada — scope creep evitado).

## Entrega vs. ACs

| AC | Status | Evidência |
|---|---|---|
| Módulo-folha `_redaction.py` criado (stdlib pura: `re` + `typing`) | ✅ PRONTO | `deile/observability/_redaction.py:1-33` — única dependência é `re` e `typing` |
| `_REDACT_RE` / `_redact` / `_safe_attrs` removidos de `dispatch_export.py` | ✅ PRONTO | diff: 24 linhas removidas; import `from ._redaction import ...` adicionado |
| `_REDACT_RE` / `_redact` / `_safe_attrs` removidos de `dispatch_log_export.py` | ✅ PRONTO | diff: 25 linhas removidas + import `re as _re` órfão removido; import `from ._redaction import ...` adicionado |
| `_safe_str` permanece local em `dispatch_export.py` | ✅ PRONTO | Não movida (não estava duplicada) |
| Comentário `# mirrors dispatch_export._REDACT_RE` removido | ✅ PRONTO | O comentário não faz mais sentido; bloco inteiro foi substituído |
| Imports órfãos removidos (conforme `ruff F401`) | ✅ PRONTO | `import re` removido de `dispatch_export.py`; `import re as _re` removido de `dispatch_log_export.py` |
| Comportamento idêntico — testes comportamentais de redação verdes | ✅ PRONTO | **132 passed, 144 skipped** (skips = integração sem endpoint OTLP, esperado) |
| Ciclo de import impossível | ✅ PRONTO | `_redaction.py` não tem nenhum `deile.*` import — verificado em `_redaction.py:1-10` |

## Testes executados (análise de impacto)

```
deile/tests/observability/test_dispatch_export.py          ✅
deile/tests/observability/test_dispatch_log_export.py      ✅
deile/tests/observability/test_dispatch_log_export_redaction.py  ✅
deile/tests/observability/ (suíte completa)                ✅  132 passed, 144 skipped
```

Closes #760.