### PR TITLE
refactor(core): extract intent models to _intent_models.py (#763)

### DIFF
--- a/deile/core/_intent_models.py
+++ b/deile/core/_intent_models.py
@@ -1,0 +1,135 @@
+"""Modelos de intenção — módulo-folha sem dependências externas.
+
+Enums e dataclasses do sistema de análise de intenção."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class IntentType(Enum):
+    """Tipos de intenção detectados pelo sistema"""
+    WORKFLOW_REQUIRED = "workflow_required"
+    MULTI_STEP = "multi_step"
+    SIMPLE_TASK = "simple_task"
+    INFORMATION_QUERY = "information_query"
+    COMPLEX_ANALYSIS = "complex_analysis"
+    UNKNOWN = "unknown"
+
+
+class IntentCategory(Enum):
+    """Categorias principais de intenção"""
+    IMPLEMENTATION = "implementation"
+    ANALYSIS = "analysis"
+    MODIFICATION = "modification"
+    TROUBLESHOOTING = "troubleshooting"
+    INFORMATION = "information"
+    WORKFLOW = "workflow"
+
+
+@dataclass
+class IntentPattern:
+    """Padrão de intenção configurável"""
+    name: str
+    category: IntentCategory
+    keywords: List[str]
+    regex_patterns: List[str]
+    confidence_weight: float = 1.0
+    requires_workflow: bool = False
+    min_complexity_threshold: float = 0.5
+
+
+@dataclass
+class IntentAnalysisResult:
+    """Resultado da análise de intenção"""
+    intent_type: IntentType
+    primary_category: IntentCategory
+    confidence: float
+    complexity_score: float
+    detected_patterns: List[str] = field(default_factory=list)
+    matched_keywords: List[str] = field(default_factory=list)
+    analysis_time: float = 0.0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def requires_workflow(self, confidence_threshold: float = 0.50,
+                         complexity_threshold: float = 0.35,
+                         global_settings: Optional[Dict] = None) -> bool:
+        """Determina se requer workflow baseado em thresholds OTIMIZADOS 2025"""
+
+        # Usa configurações globais se disponíveis
+        if global_settings:
+            # Verifica se é um dicionário ou objeto Settings
+            if hasattr(global_settings, 'get') and callable(getattr(global_settings, 'get')):
+                # É um dicionário
+                confidence_threshold = global_settings.get('default_confidence_threshold', confidence_threshold)
+                complexity_threshold = global_settings.get('default_complexity_threshold', complexity_threshold)
+            elif hasattr(global_settings, 'default_confidence_threshold'):
+                # É um objeto Settings com atributos
+                confidence_threshold = getattr(global_settings, 'default_confidence_threshold', confidence_threshold)
+                complexity_threshold = getattr(global_settings, 'default_complexity_threshold', complexity_threshold)
+            else:
+                # Fallback: converte para dict se possível
+                try:
+                    if hasattr(global_settings, '__dict__'):
+                        settings_dict = global_settings.__dict__
+                        confidence_threshold = settings_dict.get('default_confidence_threshold', confidence_threshold)
+                        complexity_threshold = settings_dict.get('default_complexity_threshold', complexity_threshold)
+                except Exception:
+                    # Se tudo falhar, usa valores padrão
+                    pass
+
+        # Thresholds reduzidos para ser mais inclusivo
+        adjusted_confidence_threshold = confidence_threshold
+        adjusted_complexity_threshold = complexity_threshold
+
+        # Casos especiais com thresholds ainda menores
+        special_patterns = [
+            'implementation_complex', 'analysis_comprehensive',
+            'test_cases_specific', 'workflow_explicit'
+        ]
+
+        has_special_pattern = any(pattern in self.detected_patterns for pattern in special_patterns)
+
+        if has_special_pattern:
+            adjusted_confidence_threshold = max(0.25, confidence_threshold - 0.25)  # Mais agressivo
+            adjusted_complexity_threshold = max(0.15, complexity_threshold - 0.20)  # Mais agressivo
+
+        # Verifica tipo de intenção E thresholds
+        intent_requires = self.intent_type in [
+            IntentType.WORKFLOW_REQUIRED,
+            IntentType.MULTI_STEP,
+            IntentType.COMPLEX_ANALYSIS
+        ]
+
+        confidence_ok = self.confidence >= adjusted_confidence_threshold
+        complexity_ok = self.complexity_score >= adjusted_complexity_threshold
+
+        # Se categoria é implementation ou analysis, é MUITO mais flexível
+        category_flexible = self.primary_category in [
+            IntentCategory.IMPLEMENTATION,
+            IntentCategory.ANALYSIS,
+            IntentCategory.WORKFLOW
+        ]
+
+        if category_flexible and confidence_ok:
+            # Para categorias flexíveis, relaxa MUITO requirement de complexity
+            complexity_ok = self.complexity_score >= (adjusted_complexity_threshold * 0.5)  # 50% do threshold
+
+        # Para casos específicos dos testes, ainda mais flexível
+        if has_special_pattern:
+            return confidence_ok  # Só precisa de confiança, não de complexidade
+
+        return intent_requires and confidence_ok and complexity_ok
+
+    def __str__(self) -> str:
+        return (f"IntentAnalysis({self.intent_type.value}, "
+                f"confidence={self.confidence:.2f}, "
+                f"complexity={self.complexity_score:.2f})")
+
+
+@dataclass
+class IntentCacheEntry:
+    """Entrada do cache de intenções"""
+    result: IntentAnalysisResult
+    timestamp: float
+    hit_count: int = 0

--- a/deile/core/intent_analyzer.py
+++ b/deile/core/intent_analyzer.py
@@ -16,144 +16,18 @@ import logging
 import re
 import time
 from collections import defaultdict, deque
-from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
 
 from ..parsers.base import ParseResult
+from ._intent_models import (  # noqa: F401
+    IntentCacheEntry, IntentAnalysisResult,
+    IntentCategory, IntentPattern, IntentType,
+)
 
 logger = logging.getLogger(__name__)
-
-
-class IntentType(Enum):
-    """Tipos de intenção detectados pelo sistema"""
-    WORKFLOW_REQUIRED = "workflow_required"
-    MULTI_STEP = "multi_step"
-    SIMPLE_TASK = "simple_task"
-    INFORMATION_QUERY = "information_query"
-    COMPLEX_ANALYSIS = "complex_analysis"
-    UNKNOWN = "unknown"
-
-
-class IntentCategory(Enum):
-    """Categorias principais de intenção"""
-    IMPLEMENTATION = "implementation"
-    ANALYSIS = "analysis"
-    MODIFICATION = "modification"
-    TROUBLESHOOTING = "troubleshooting"
-    INFORMATION = "information"
-    WORKFLOW = "workflow"
-
-
-@dataclass
-class IntentPattern:
-    """Padrão de intenção configurável"""
-    name: str
-    category: IntentCategory
-    keywords: List[str]
-    regex_patterns: List[str]
-    confidence_weight: float = 1.0
-    requires_workflow: bool = False
-    min_complexity_threshold: float = 0.5
-
-
-@dataclass
-class IntentAnalysisResult:
-    """Resultado da análise de intenção"""
-    intent_type: IntentType
-    primary_category: IntentCategory
-    confidence: float
-    complexity_score: float
-    detected_patterns: List[str] = field(default_factory=list)
-    matched_keywords: List[str] = field(default_factory=list)
-    analysis_time: float = 0.0
-    metadata: Dict[str, Any] = field(default_factory=dict)
-
-    def requires_workflow(self, confidence_threshold: float = 0.50,
-                         complexity_threshold: float = 0.35,
-                         global_settings: Optional[Dict] = None) -> bool:
-        """Determina se requer workflow baseado em thresholds OTIMIZADOS 2025"""
-
-        # Usa configurações globais se disponíveis
-        if global_settings:
-            # Verifica se é um dicionário ou objeto Settings
-            if hasattr(global_settings, 'get') and callable(getattr(global_settings, 'get')):
-                # É um dicionário
-                confidence_threshold = global_settings.get('default_confidence_threshold', confidence_threshold)
-                complexity_threshold = global_settings.get('default_complexity_threshold', complexity_threshold)
-            elif hasattr(global_settings, 'default_confidence_threshold'):
-                # É um objeto Settings com atributos
-                confidence_threshold = getattr(global_settings, 'default_confidence_threshold', confidence_threshold)
-                complexity_threshold = getattr(global_settings, 'default_complexity_threshold', complexity_threshold)
-            else:
-                # Fallback: converte para dict se possível
-                try:
-                    if hasattr(global_settings, '__dict__'):
-                        settings_dict = global_settings.__dict__
-                        confidence_threshold = settings_dict.get('default_confidence_threshold', confidence_threshold)
-                        complexity_threshold = settings_dict.get('default_complexity_threshold', complexity_threshold)
-                except Exception:
-                    # Se tudo falhar, usa valores padrão
-                    pass
-
-        # Thresholds reduzidos para ser mais inclusivo
-        adjusted_confidence_threshold = confidence_threshold
-        adjusted_complexity_threshold = complexity_threshold
-
-        # Casos especiais com thresholds ainda menores
-        special_patterns = [
-            'implementation_complex', 'analysis_comprehensive',
-            'test_cases_specific', 'workflow_explicit'
-        ]
-
-        has_special_pattern = any(pattern in self.detected_patterns for pattern in special_patterns)
-
-        if has_special_pattern:
-            adjusted_confidence_threshold = max(0.25, confidence_threshold - 0.25)  # Mais agressivo
-            adjusted_complexity_threshold = max(0.15, complexity_threshold - 0.20)  # Mais agressivo
-
-        # Verifica tipo de intenção E thresholds
-        intent_requires = self.intent_type in [
-            IntentType.WORKFLOW_REQUIRED,
-            IntentType.MULTI_STEP,
-            IntentType.COMPLEX_ANALYSIS
-        ]
-
-        confidence_ok = self.confidence >= adjusted_confidence_threshold
-        complexity_ok = self.complexity_score >= adjusted_complexity_threshold
-
-        # Se categoria é implementation ou analysis, é MUITO mais flexível
-        category_flexible = self.primary_category in [
-            IntentCategory.IMPLEMENTATION,
-            IntentCategory.ANALYSIS,
-            IntentCategory.WORKFLOW
-        ]
-
-        if category_flexible and confidence_ok:
-            # Para categorias flexíveis, relaxa MUITO requirement de complexity
-            complexity_ok = self.complexity_score >= (adjusted_complexity_threshold * 0.5)  # 50% do threshold
-
-        # Para casos específicos dos testes, ainda mais flexível
-        if has_special_pattern:
-            return confidence_ok  # Só precisa de confiança, não de complexidade
-
-        return intent_requires and confidence_ok and complexity_ok
-
-    def __str__(self) -> str:
-        return (f"IntentAnalysis({self.intent_type.value}, "
-                f"confidence={self.confidence:.2f}, "
-                f"complexity={self.complexity_score:.2f})")
-
-
-@dataclass
-class IntentCacheEntry:
-    """Entrada do cache de intenções"""
-    result: IntentAnalysisResult
-    timestamp: float
-    hit_count: int = 0
 
 
 class IntentAnalyzer:
@@ -852,3 +726,11 @@ def get_intent_analyzer(config_path: Optional[Path] = None) -> IntentAnalyzer:
     if _intent_analyzer is None:
         _intent_analyzer = IntentAnalyzer(config_path)
     return _intent_analyzer
+
+
+# re-export shim — preserves `from deile.core.intent_analyzer import <model>` compatibility
+__all__ = [
+    "IntentType", "IntentCategory", "IntentPattern",
+    "IntentAnalysisResult", "IntentCacheEntry",
+    "IntentAnalyzer", "get_intent_analyzer",
+]


### PR DESCRIPTION
## Summary

- Extracts 5 intent model symbols (`IntentType`, `IntentCategory`, `IntentPattern`, `IntentAnalysisResult`, `IntentCacheEntry`) from `deile/core/intent_analyzer.py` into a new leaf module `deile/core/_intent_models.py` (stdlib-only, no external dependencies)
- Adds a `from ._intent_models import ... # noqa: F401` shim and `__all__` in `intent_analyzer.py` to preserve full backward compatibility for all existing importers
- No test files or other production files were modified

## ACs verificados

- `wc -l _intent_models.py` = 135 (≤ 135 ✓)
- `wc -l intent_analyzer.py` = 735 (≤ 735 ✓)
- 22 testes impactados: **22 passed**

## Test plan

- [x] `python3 -c "from deile.core._intent_models import IntentType, ..."` → OK
- [x] `python3 -c "from deile.core.intent_analyzer import IntentType, ..."` → OK
- [x] `pytest deile/tests/test_intent_tier_mapper.py deile/tests/test_agent_new_provider_path.py -q` → 22 passed