### PR TITLE
fix(pipeline): filtrar auto-referência em parse_decompose_result

### DIFF
--- a/deile/orchestration/pipeline/implementer.py
+++ b/deile/orchestration/pipeline/implementer.py
@@ -196,19 +196,36 @@ def parse_refine_verdict(text: str) -> str:
     return "unknown"
 
 
-def parse_decompose_result(text: str) -> List[int]:
+def parse_decompose_result(text: str, parent_number: int = 0) -> List[int]:
     """Return the derived issue numbers reported by a decompose outcome.
 
     Two-stage: strict ``DECOMPOSTO: …`` regex first; fallback collects ``#NN``
     references from the last 8 lines (architect frequently lists the created
     issues right above the verdict). Returns an empty list on ambiguity.
+
+    *parent_number* (optional, default 0 = disabled) is the number of the
+    parent issue being decomposed. In the strict path, the parent's own number
+    is excluded (self-reference in DECOMPOSTO: line). In the fallback path,
+    only numbers strictly greater than the parent are kept — GitHub issue
+    numbers are monotonically increasing, so a derived issue always has a
+    higher number than its parent.
     """
     matches = list(_DECOMPOSE_RE.finditer(text or ""))
     if matches:
-        return [int(n) for n in re.findall(r"#(\d+)", matches[-1].group(1))]
+        nums = [int(n) for n in re.findall(r"#(\d+)", matches[-1].group(1))]
+        return [n for n in nums if n != parent_number]
     tail = _tail_text(text, n_lines=8)
-    found = re.findall(r"#(\d+)", tail)
-    return [int(n) for n in found]
+    found = [int(n) for n in re.findall(r"#(\d+)", tail)]
+    if parent_number:
+        filtered = [n for n in found if n > parent_number]
+        discarded = [n for n in found if n <= parent_number]
+        if discarded:
+            logger.warning(
+                "parse_decompose_result: descartou %s (<= pai #%d) no fallback",
+                discarded, parent_number,
+            )
+        return filtered
+    return found
 
 
 class PipelineImplementer(ABC):

--- a/deile/orchestration/pipeline/stages.py
+++ b/deile/orchestration/pipeline/stages.py
@@ -820,7 +820,7 @@ async def _dispatch_mention_group(
     # liberar o slot de in_flight. Sem isso, a issue fica em `em_arquitetura` e
     # a próxima passagem do refino re-decompõe gerando duplicatas.
     if kind == "issue" and mode == "comment":
-        derived_from_mention = parse_decompose_result(outcome.text)
+        derived_from_mention = parse_decompose_result(outcome.text, parent_number=number)
         if derived_from_mention:
             await _apply_decompose_handshake_from_mention(monitor, number, derived_from_mention)
 
@@ -1547,7 +1547,7 @@ async def _apply_refine_verdict(
     # refinar o escopo, aplica o handshake de decomposição em vez de tratar como
     # veredito de refino. Isso garante idempotência (issue vira terminal) e libera
     # o slot de in_flight que `em_arquitetura` consumia indevidamente.
-    derived_from_refine = parse_decompose_result(verdict_text)
+    derived_from_refine = parse_decompose_result(verdict_text, parent_number=target.number)
     if derived_from_refine:
         refine_state_for_decompose = next(
             (s for s in REFINE_WORKFLOW_STATES if s in target.labels),
@@ -1866,7 +1866,7 @@ async def decompose_one_reviewed_intent(
     # The decompose dispatch is wait=True, so it blocks this (sequential) tick —
     # no concurrent re-pick. On success the intent leaves the revisada queue.
     outcome = await monitor.implementer.decompose(monitor, target)
-    derived = parse_decompose_result(outcome.text)
+    derived = parse_decompose_result(outcome.text, parent_number=target.number)
     log_decomposition_fanout(
         intent=target.number,
         derivadas=derived,

--- a/deile/tests/orchestration/pipeline/test_issue568_decompose_handshake.py
+++ b/deile/tests/orchestration/pipeline/test_issue568_decompose_handshake.py
@@ -453,3 +453,64 @@ class TestMentionOneShot_DecomposeHandshake:
         assert WORKFLOW_DECOMPOSED not in all_added, (
             "Outcome com ok=False não deve acionar o handshake de decomposição"
         )
+
+
+# ---------------------------------------------------------------------------
+# AC5: refine path — auto-referência NÃO aciona WORKFLOW_DECOMPOSED
+# ---------------------------------------------------------------------------
+
+class TestRefinePathRejectsAutoReference:
+    """AC5: _apply_refine_verdict com parent_number correto — auto-ref não vira decomposta."""
+
+    async def test_ac5_refine_autoref_does_not_trigger_decomposed(self):
+        """Issue #768 em em_arquitetura; output contém REFINO: OK + auto-referência #768.
+        Sem DECOMPOSTO: — deve seguir o caminho normal de refino, NÃO ir para decomposta.
+        """
+        issue = _issue(768, "feature", WORKFLOW_ARCHITECTURE, REFINAR)
+        monitor, github, _ = _make_refine_monitor(
+            label_map={WORKFLOW_ARCHITECTURE: [issue], REFINAR: [issue]},
+            worker_responses=[{
+                "ok": True,
+                "summary": (
+                    "Refinei a issue conforme solicitado.\n"
+                    "REFINO: OK\n"
+                    "Originada de #768 — ver histórico para detalhes."
+                ),
+            }],
+        )
+        await _refine_then_reconcile(monitor)
+        t = _transitions(github)
+        assert (768, WORKFLOW_ARCHITECTURE, WORKFLOW_DECOMPOSED) not in t, (
+            "Auto-referência #768 nas últimas linhas NÃO deve disparar WORKFLOW_DECOMPOSED "
+            f"(transições reais: {t})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC6: mention path — auto-referência NÃO adiciona WORKFLOW_DECOMPOSED
+# ---------------------------------------------------------------------------
+
+class TestMentionPathRejectsAutoReference:
+    """AC6: _dispatch_mention_group com parent_number correto — auto-ref não vira decomposta."""
+
+    async def test_ac6_mention_autoref_does_not_add_decomposed(self):
+        """Mention one-shot sobre issue #1 (number=1); outcome menciona apenas #1.
+        Sem DECOMPOSTO: — WORKFLOW_DECOMPOSED NÃO deve ser adicionado à issue.
+        """
+        monitor, github = _make_mention_monitor(
+            mention_outcome_text=(
+                "Analisei a issue #1 conforme solicitado.\n"
+                "Ver #1 para o contexto completo."
+            ),
+            issue_labels=(),
+        )
+        await monitor._process_mentions()
+        added_calls = [
+            list(c.args[2]) for c in github.add_labels.await_args_list
+            if len(c.args) >= 3 and c.args[1] == 1
+        ]
+        all_added = {lb for labels in added_calls for lb in labels}
+        assert WORKFLOW_DECOMPOSED not in all_added, (
+            "Auto-referência #1 no mention outcome NÃO deve adicionar WORKFLOW_DECOMPOSED "
+            f"(labels adicionados: {all_added})"
+        )

--- a/deile/tests/orchestration/pipeline/test_parse_decompose_result.py
+++ b/deile/tests/orchestration/pipeline/test_parse_decompose_result.py
@@ -1,0 +1,131 @@
+"""Unit tests for parse_decompose_result — issue #770.
+
+Covers:
+- AC1: fallback descarta auto-referência (n == parent_number)
+- AC2: fallback descarta n <= parent_number, mantém n > parent_number
+- AC3: caminho estrito (DECOMPOSTO:) exclui auto-ref exata
+- AC4: retrocompatibilidade — sem parent_number, comportamento original
+- AC7: warning log quando fallback descarta n <= parent_number
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from deile.orchestration.pipeline.implementer import parse_decompose_result
+
+
+class TestFallbackAutoReferenceFilter:
+    """AC1 e AC2: fallback descarta n <= parent_number."""
+
+    def test_ac1_fallback_discards_self_reference(self):
+        """AC1: output menciona apenas a própria issue — fallback retorna []."""
+        result = parse_decompose_result(
+            "Originada de #768\nVer #768 para detalhes",
+            parent_number=768,
+        )
+        assert result == []
+
+    def test_ac2_fallback_filters_leq_parent_keeps_gt(self):
+        """AC2: #500 (<=768) descartado; #769 e #770 (>768) mantidos."""
+        result = parse_decompose_result(
+            "Mencionei contexto #500\nCriei #769 e #770",
+            parent_number=768,
+        )
+        assert result == [769, 770]
+
+    def test_fallback_all_below_parent_returns_empty(self):
+        """Todos os números são <= pai — retorna []."""
+        result = parse_decompose_result(
+            "#100 #200 #300",
+            parent_number=500,
+        )
+        assert result == []
+
+    def test_fallback_mix_filters_correctly(self):
+        """Mix de n<=pai e n>pai: só n>pai sobrevive."""
+        result = parse_decompose_result(
+            "#100 #500 #501 #600",
+            parent_number=500,
+        )
+        assert result == [501, 600]
+
+
+class TestStrictPathAutoReferenceFilter:
+    """AC3: caminho estrito (DECOMPOSTO:) exclui auto-ref exata."""
+
+    def test_ac3_strict_excludes_self_reference(self):
+        """AC3: DECOMPOSTO: #768 #769 com parent_number=768 → [769]."""
+        result = parse_decompose_result("DECOMPOSTO: #768 #769", parent_number=768)
+        assert result == [769]
+
+    def test_strict_all_others_kept(self):
+        """parent_number não está na lista → retorna todos."""
+        result = parse_decompose_result("DECOMPOSTO: #769 #770", parent_number=768)
+        assert result == [769, 770]
+
+    def test_strict_only_self_reference(self):
+        """DECOMPOSTO: apenas com a própria issue → []."""
+        result = parse_decompose_result("DECOMPOSTO: #42", parent_number=42)
+        assert result == []
+
+
+class TestBackwardCompatibility:
+    """AC4: sem parent_number, comportamento original preservado."""
+
+    def test_ac4_strict_no_parent_number(self):
+        """AC4: DECOMPOSTO: #11 #12 sem parent_number → [11, 12]."""
+        assert parse_decompose_result("DECOMPOSTO: #11 #12") == [11, 12]
+
+    def test_ac4_fallback_no_parent_number_collects_all(self):
+        """AC4: fallback sem parent_number coleta todos os #N."""
+        text = (
+            "Criei as derivadas:\n"
+            "- #401 — split A\n"
+            "- #402 — split B\n"
+        )
+        assert parse_decompose_result(text) == [401, 402]
+
+    def test_ac4_decorated_decomposto_no_parent_number(self):
+        """AC4: formatos decorados sem parent_number ainda funcionam."""
+        assert parse_decompose_result("**DECOMPOSTO:** #11 #12") == [11, 12]
+        assert parse_decompose_result("### DECOMPOSTO: #99") == [99]
+        assert parse_decompose_result("> DECOMPOSTO: #5 e #6 (independentes)") == [5, 6]
+
+
+class TestWarningLog:
+    """AC7: warning emitido quando fallback descarta n <= parent_number."""
+
+    def test_ac7_warning_emitted_on_discard(self, caplog):
+        """AC7: fallback descarta [768] — warning com pai e descartados."""
+        with caplog.at_level(logging.WARNING, logger="deile.orchestration.pipeline.implementer"):
+            parse_decompose_result(
+                "Originada de #768\nVer #768 para detalhes",
+                parent_number=768,
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, f"Esperado 1 warning, obteve {len(warnings)}: {[r.message for r in warnings]}"
+        msg = warnings[0].getMessage()
+        assert "768" in msg, f"Warning deve mencionar pai #768; obteve: {msg}"
+        assert "descartou" in msg.lower() or "descart" in msg.lower() or "768" in msg
+
+    def test_ac7_no_warning_when_no_discard(self, caplog):
+        """Sem descarte, nenhum warning emitido."""
+        with caplog.at_level(logging.WARNING, logger="deile.orchestration.pipeline.implementer"):
+            parse_decompose_result(
+                "Criei #769 e #770",
+                parent_number=768,
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING
+                    and "descartou" in r.getMessage()]
+        assert warnings == []
+
+    def test_ac7_no_warning_without_parent_number(self, caplog):
+        """Sem parent_number, fallback não emite warning (comportamento original)."""
+        with caplog.at_level(logging.WARNING, logger="deile.orchestration.pipeline.implementer"):
+            parse_decompose_result("Ver #100 #200 para contexto")
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING
+                    and "descartou" in r.getMessage()]
+        assert warnings == []


### PR DESCRIPTION
## Problema

O fallback de `parse_decompose_result` (`implementer.py:206-211`) coletava qualquer `#N` das últimas 8 linhas sem filtrar o número da issue-pai. Quando o output do worker mencionava a própria issue (ex.: `"Originada de #768"`, ACs com `#N`, etc.), o fallback retornava `[N]` (truthy) → os 3 call-sites em `stages.py` aplicavam `~workflow:decomposta` (estado terminal) sem que nenhuma derivada real tivesse sido criada.

## Fix

`parse_decompose_result` recebe `parent_number: int = 0` (opcional, default preserva compatibilidade total):

- **Caminho estrito (`DECOMPOSTO:`):** exclui `n == parent_number` (auto-referência exata).
- **Fallback:** mantém apenas `n > parent_number` — números de issue do GitHub são monotônicos, logo derivadas têm sempre número maior que a pai. Emite `WARNING` com os descartados (AC7/observabilidade).
- **3 call-sites** em `stages.py` propagam `parent_number=<number>`.

## Critérios de Aceitação — confronto ENTREGA vs ACs

| AC | Status | Evidência |
|---|---|---|
| **AC1** — fallback auto-ref retorna `[]` | ✅ VERDE | `test_ac1_fallback_discards_self_reference` — 55 passed |
| **AC2** — fallback filtra ≤pai, mantém >pai | ✅ VERDE | `test_ac2_fallback_filters_leq_parent_keeps_gt` |
| **AC3** — estrito exclui auto-ref exata | ✅ VERDE | `test_ac3_strict_excludes_self_reference` |
| **AC4** — retrocompat sem `parent_number` | ✅ VERDE | `test_ac4_*` + `test_loop_guards.py` sem alteração (30 passed, 1 skipped) |
| **AC5** — refine path não aplica decomposta em auto-ref | ✅ VERDE | `TestRefinePathRejectsAutoReference::test_ac5_*` |
| **AC6** — mention path não aplica decomposta em auto-ref | ✅ VERDE | `TestMentionPathRejectsAutoReference::test_ac6_*` |
| **AC7** — warning log ao descartar ≥1 número ≤ pai | ✅ VERDE | `TestWarningLog::test_ac7_warning_emitted_on_discard` (caplog) |
| **AC8** — 3 call-sites passam `parent_number` explicitamente | ✅ VERDE | `grep -n "parse_decompose_result(" stages.py` → nenhuma chamada nua |

**Resultado dos testes:** `55 passed, 1 skipped` (skip pré-existente em `test_loop_guards.py`, não relacionado).

## Arquivos alterados

- `deile/orchestration/pipeline/implementer.py` — assinatura + lógica de filtro
- `deile/orchestration/pipeline/stages.py` — 3 call-sites com `parent_number=`
- `deile/tests/orchestration/pipeline/test_parse_decompose_result.py` (novo) — AC1–AC4, AC7
- `deile/tests/orchestration/pipeline/test_issue568_decompose_handshake.py` — AC5, AC6

Closes #770.